### PR TITLE
remove the context menu items for debugger statements (#193)

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/menus/breakpoints.js
+++ b/src/devtools/client/debugger/src/components/Editor/menus/breakpoints.js
@@ -172,12 +172,12 @@ export function breakpointItems(
     toggleDisabledBreakpointItem(cx, breakpoint, breakpointActions),
   ];
 
-  if (breakpoint.originalText.startsWith("debugger")) {
-    items.push(
-      { type: "separator" },
-      toggleDbgStatementItem(cx, selectedLocation, breakpointActions, breakpoint)
-    );
-  }
+  // if (breakpoint.originalText.startsWith("debugger")) {
+  //   items.push(
+  //     { type: "separator" },
+  //     toggleDbgStatementItem(cx, selectedLocation, breakpointActions, breakpoint)
+  //   );
+  // }
 
   items.push(
     { type: "separator" },
@@ -209,9 +209,9 @@ export function createBreakpointItems(
     items.push(addLogPointItem(location, breakpointActions));
   }
 
-  if (lineText && lineText.startsWith("debugger")) {
-    items.push(toggleDbgStatementItem(cx, location, breakpointActions));
-  }
+  // if (lineText && lineText.startsWith("debugger")) {
+  //   items.push(toggleDbgStatementItem(cx, location, breakpointActions));
+  // }
   return items;
 }
 

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -282,18 +282,18 @@ export default function showContextMenu(props: Props) {
     {
       item: { type: "separator" },
     },
-    {
-      item: enableDbgStatementItem,
-      hidden: () => hideEnableDbgStatementItem,
-    },
-    {
-      item: disableDbgStatementItem,
-      hidden: () => hideDisableDbgStatementItem,
-    },
-    {
-      item: { type: "separator" },
-      hidden: () => hideDisableDbgStatementItem && hideEnableDbgStatementItem,
-    },
+    // {
+    //   item: enableDbgStatementItem,
+    //   hidden: () => hideEnableDbgStatementItem,
+    // },
+    // {
+    //   item: disableDbgStatementItem,
+    //   hidden: () => hideDisableDbgStatementItem,
+    // },
+    // {
+    //   item: { type: "separator" },
+    //   hidden: () => hideDisableDbgStatementItem && hideEnableDbgStatementItem,
+    // },
     {
       item: addConditionItem,
       hidden: () => breakpoint.options.condition,


### PR DESCRIPTION
Fixes #193.
There are 3 places where such context menu items show up:
- right clicking in the (empty) gutter
- right clicking on a breakpoint icon in the gutter
- right clicking on a breakpoint in the Breakpoints panel