### PR TITLE
Adds elegant spacing between toolbar buttons

### DIFF
--- a/src/ui/components/Toolbox.css
+++ b/src/ui/components/Toolbox.css
@@ -48,12 +48,13 @@
 .toolbar-panel-button {
   float: left;
   display: flex;
-  margin-left: 10px;
   cursor: default;
   line-height: 35px;
   font-size: 1.1rem;
   color: var(--theme-toolbar-color);
   align-items: center;
+  padding-left: 8px;
+  padding-right: 8px;
 }
 
 .toolbar-panel-button:hover {


### PR DESCRIPTION
Makes it such that toolbar button item texts are no longer flush against each other.

Just want to make a small contribution to this future legendary project :)