### PR TITLE
Fix panel switching

### DIFF
--- a/src/devtools/client/shared/components/splitter/SplitBox.js
+++ b/src/devtools/client/shared/components/splitter/SplitBox.js
@@ -223,7 +223,14 @@ class SplitBox extends Component {
   // eslint-disable-next-line complexity
   render() {
     const { endPanelControl, splitterSize, vert } = this.state;
-    const { startPanel, endPanel, minSize, maxSize, onSelectContainerElement } = this.props;
+    const {
+      startPanel,
+      endPanel,
+      minSize,
+      maxSize,
+      onSelectContainerElement,
+      initialSize,
+    } = this.props;
 
     const style = Object.assign(
       {
@@ -258,15 +265,17 @@ class SplitBox extends Component {
         width: endPanelControl ? this.state.width : null,
       };
     } else {
+      let height = this.state.height || initialSize;
+
       leftPanelStyle = {
         maxHeight: endPanelControl ? null : maxSize,
         minHeight: endPanelControl ? null : minSize,
-        height: endPanelControl ? null : this.state.height,
+        height: endPanelControl ? null : height,
       };
       rightPanelStyle = {
         maxHeight: endPanelControl ? maxSize : null,
         minHeight: endPanelControl ? minSize : null,
-        height: endPanelControl ? this.state.height : null,
+        height: endPanelControl ? height : null,
       };
     }
 

--- a/src/ui/components/Toolbox.js
+++ b/src/ui/components/Toolbox.js
@@ -391,8 +391,11 @@ class Toolbox extends React.Component {
     const { selectedPanel, splitConsoleOpen } = this.props;
 
     if (selectedPanel == "console") {
+      // We intentionally don't pass in the `initialSize: "0%"` here. This is
+      // important for when the split console is open, and we switch panels from
+      // uncontrolled (console) to controlled (debugger/inspector). This way, the
+      // controlled height is not stuck at 0% until we resize the panel manually.
       return {
-        initialSize: "0%",
         minSize: 0,
         maxSize: 0,
       };


### PR DESCRIPTION
Fixes #334.

The problem specifically happens when you have open the split console, switch panels to the console, then refresh. Upon refreshing, the height of the controlled panel (with debugger/inspector) is set to 0%, and is not updated even after switching to the debugger/inspector.

This made it look like clicking on panels to switch wasn't working and you were stuck in the console. It was, but the split console was taking up 100% of the space.

The fix prevents the console from initializing a value for the controlled panel height. This way when we switch to the debugger/inspector panel, we can (in effect) initialize their height then.