### PR TITLE
Added console filtering from node_modules

### DIFF
--- a/src/devtools/client/locales/en-us/webconsole.properties
+++ b/src/devtools/client/locales/en-us/webconsole.properties
@@ -343,6 +343,12 @@ webconsole.console.settings.menu.item.warningGroups.label=Group Similar Messages
 # LOCALIZATION NOTE (webconsole.console.settings.menu.item.warningGroups.tooltip)
 webconsole.console.settings.menu.item.warningGroups.tooltip=When enabled, similar messages are placed into groups
 
+# LOCALIZATION NOTE (webconsole.console.settings.menu.item.nodeModuleMessages.label)
+# Label for grouping the similar messages in the Web Console
+webconsole.console.settings.menu.item.nodeModuleMessages.label=Hide Node Module Messages
+# LOCALIZATION NOTE (webconsole.console.settings.menu.item.nodeModuleMessages.tooltip)
+webconsole.console.settings.menu.item.nodeModuleMessages.tooltip=While enabled, messages from the node_modules directory are hidden
+
 # LOCALIZATION NOTE (webconsole.console.settings.menu.item.autocomplete.label)
 # Label for enabling autocomplete for input in the Web Console
 webconsole.console.settings.menu.item.autocomplete.label=Enable Autocompletion

--- a/src/devtools/client/webconsole/components/FilterBar/ConsoleSettings.js
+++ b/src/devtools/client/webconsole/components/FilterBar/ConsoleSettings.js
@@ -18,6 +18,8 @@ const MenuButton = createFactory(require("devtools/client/shared/components/menu
 const MenuItem = createFactory(require("devtools/client/shared/components/menu/MenuItem"));
 const MenuList = createFactory(require("devtools/client/shared/components/menu/MenuList"));
 
+const { FILTERS } = require("devtools/client/webconsole/constants");
+
 class ConsoleSettings extends Component {
   static get propTypes() {
     return {
@@ -28,11 +30,12 @@ class ConsoleSettings extends Component {
       timestampsVisible: PropTypes.bool.isRequired,
       webConsoleUI: PropTypes.object.isRequired,
       autocomplete: PropTypes.bool.isRequired,
+      filter: PropTypes.object.isRequired,
     };
   }
 
   renderMenuItems() {
-    const { dispatch, groupWarnings, timestampsVisible } = this.props;
+    const { dispatch, groupWarnings, timestampsVisible, filter } = this.props;
 
     const items = [];
 
@@ -74,6 +77,18 @@ class ConsoleSettings extends Component {
         label: l10n.getStr("webconsole.console.settings.menu.item.warningGroups.label"),
         tooltip: l10n.getStr("webconsole.console.settings.menu.item.warningGroups.tooltip"),
         onClick: () => dispatch(actions.warningGroupsToggle()),
+      })
+    );
+
+    // Timestamps
+    items.push(
+      MenuItem({
+        key: "webconsole-console-settings-add-node-module-messages",
+        checked: !filter[FILTERS.NODEMODULES],
+        className: "menu-item webconsole-console-settings-add-node-module-messages",
+        label: l10n.getStr("webconsole.console.settings.menu.item.nodeModuleMessages.label"),
+        tooltip: l10n.getStr("webconsole.console.settings.menu.item.nodeModuleMessages.tooltip"),
+        onClick: () => dispatch(actions.filterToggle(FILTERS.NODEMODULES)),
       })
     );
 

--- a/src/devtools/client/webconsole/components/FilterBar/FilterBar.js
+++ b/src/devtools/client/webconsole/components/FilterBar/FilterBar.js
@@ -284,6 +284,7 @@ class FilterBar extends Component {
       timestampsVisible,
       webConsoleUI,
       autocomplete,
+      filter,
     } = this.props;
 
     return ConsoleSettings({
@@ -295,6 +296,7 @@ class FilterBar extends Component {
       timestampsVisible,
       webConsoleUI,
       autocomplete,
+      filter,
     });
   }
 

--- a/src/devtools/client/webconsole/constants.js
+++ b/src/devtools/client/webconsole/constants.js
@@ -69,6 +69,7 @@ const prefs = {
       CSS: "filter.css",
       NET: "filter.net",
       NETXHR: "filter.netxhr",
+      NODEMODULES: "filter.nodemodules",
     },
     UI: {
       // Persist is only used by the webconsole.
@@ -109,6 +110,7 @@ const FILTERS = {
   NETXHR: "netxhr",
   TEXT: "text",
   WARN: "warn",
+  NODEMODULES: "nodemodules",
 };
 
 const DEFAULT_FILTERS_VALUES = {
@@ -121,10 +123,12 @@ const DEFAULT_FILTERS_VALUES = {
   [FILTERS.CSS]: false,
   [FILTERS.NET]: false,
   [FILTERS.NETXHR]: false,
+  [FILTERS.NODEMODULES]: false,
 };
 
 const DEFAULT_FILTERS = Object.keys(DEFAULT_FILTERS_VALUES).filter(
-  filter => DEFAULT_FILTERS_VALUES[filter] !== false
+  // We make an exception for node_modules here to keep it hidden by default
+  filter => DEFAULT_FILTERS_VALUES[filter] !== false || filter == "nodemodules"
 );
 
 const chromeRDPEnums = {

--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -969,6 +969,13 @@ function getMessageVisibility(
     };
   }
 
+  if (passNodeModuleFilters(message, filtersState)) {
+    return {
+      visible: false,
+      cause: FILTERS.NODEMODULES,
+    };
+  }
+
   // This should always be the last check, or we might report that a message was hidden
   // because of text search, while it may be hidden because its category is disabled.
   if (!passSearchFilters(message, filtersState)) {
@@ -1007,6 +1014,17 @@ function hasClosedParentGroup(group, messagesUI) {
 
 function isGroupClosed(groupId, messagesUI) {
   return messagesUI.includes(groupId) === false;
+}
+
+/**
+ * Returns true if the message is in node modules and should be hidden
+ *
+ * @param {Object} message - The message to check the filter against.
+ * @param {FilterState} filters - redux "filters" state.
+ * @returns {Boolean}
+ */
+function passNodeModuleFilters(message, filters) {
+  return message.frame?.source?.includes("node_modules") && filters[FILTERS.NODEMODULES] == false;
 }
 
 /**

--- a/src/ui/components/Header.css
+++ b/src/ui/components/Header.css
@@ -36,7 +36,7 @@
   margin-inline-end: 20px;
 }
 
-.avatar:not(.first-player) {
+#header .avatar:not(.first-player) {
   margin-left: -8px;
   box-shadow: 0px 0px 0px 2px white;
 }


### PR DESCRIPTION
This is to reduce clutter in the console when the user has event listener logpoints (e.g. multiple console messages for the same click). 

It allows the console to filter out any messages whose frame source is in the node_modules directory. It's enabled by default, and can be accessed through the console settings dropdown menu.