### PR TITLE
Save the logged in user's picture and name for use in comments

### DIFF
--- a/src/ui/actions/metadata.js
+++ b/src/ui/actions/metadata.js
@@ -169,3 +169,14 @@ export function getActiveUsers() {
     return activeUsers;
   };
 }
+
+export function updateUser(authUser = {}) {
+  return ({ dispatch, getState }) => {
+    const user = selectors.getUser(getState());
+    const { picture, name } = authUser;
+    const { id, avatarID } = user;
+    const updatedUser = { id, avatarID, picture, name };
+
+    dispatch({ type: "register_user", user: updatedUser });
+  };
+}

--- a/src/ui/components/Avatar.js
+++ b/src/ui/components/Avatar.js
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+
+import { connect } from "react-redux";
+import { selectors } from "ui/reducers";
+import { actions } from "ui/actions";
+import { getAvatarColor } from "ui/utils/user";
+
+const Avatar = props => {
+  let { player, isFirstPlayer, updateUser, isLoggedIn, setLoggedIn, setLoggedOut } = props;
+  let auth = useAuth0();
+
+  if (auth.isAuthenticated && isFirstPlayer) {
+    if (!player.name) {
+      // Check if the user has just logged out. If so, update and add the associated
+      // picture and name from the user metadata.
+      updateUser(auth.user);
+    }
+
+    return (
+      <div className={`avatar authenticated first-player`}>
+        <img src={auth.user.picture} alt={auth.user.name} />
+        <span className="avatar-name">{auth.user.name}</span>
+      </div>
+    );
+  }
+
+  // Check if the user has just logged out. If so, update and remove the associated
+  // picture and name from the user metadata.
+  if (!auth.isAuthenticated && isFirstPlayer && player.name) {
+    updateUser();
+  }
+
+  return (
+    <div
+      className={`avatar ${isFirstPlayer ? "first-player" : ""}`}
+      style={{ background: getAvatarColor(player?.avatarID) }}
+    />
+  );
+};
+
+export default connect(null, {
+  updateUser: actions.updateUser,
+})(Avatar);

--- a/src/ui/components/Header.js
+++ b/src/ui/components/Header.js
@@ -4,32 +4,10 @@ import { connect } from "react-redux";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
 import LoginButton from "ui/components/LoginButton";
-import { getAvatarColor } from "ui/utils/user";
+import Avatar from "ui/components/Avatar";
 import "./Header.css";
 
-import { useAuth0 } from "@auth0/auth0-react";
 import { features } from "ui/utils/prefs";
-
-const Avatar = props => {
-  let { player, isFirstPlayer } = props;
-  let auth = useAuth0();
-
-  if (auth.isAuthenticated && isFirstPlayer) {
-    return (
-      <div className={`avatar authenticated first-player`}>
-        <img src={auth.user.picture} alt={auth.user.name} />
-        <span className="avatar-name">{auth.user.name}</span>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      className={`avatar ${isFirstPlayer ? "first-player" : ""}`}
-      style={{ background: getAvatarColor(player?.avatarID) }}
-    />
-  );
-};
 
 class Header extends React.Component {
   componentDidMount() {
@@ -60,16 +38,6 @@ class Header extends React.Component {
           <Avatar player={player} isFirstPlayer={false} key={player.id} />
         ))}
       </div>
-    );
-  }
-
-  renderAvatar(player, isFirstPlayer) {
-    return (
-      <div
-        key={player.avatarID}
-        className={`avatar ${isFirstPlayer ? "first-player" : ""}`}
-        style={{ background: this.getAvatarColor(player.avatarID) }}
-      ></div>
     );
   }
 

--- a/src/ui/components/RightSidebar/Comment.js
+++ b/src/ui/components/RightSidebar/Comment.js
@@ -81,16 +81,15 @@ class Comment extends React.Component {
 
   renderAvatar() {
     const { comment } = this.props;
-
-    // Comments that have been made prior to adding the users feature don't
-    // have an associated user. We just give those comments a grey circle.
-    // This should be removed eventually.
+    const { picture, name } = comment.user;
 
     return (
       <div
         className="comment-avatar"
         style={{ background: getAvatarColor(comment?.user.avatarID) }}
-      ></div>
+      >
+        {picture ? <img src={picture} alt={name} /> : null}
+      </div>
     );
   }
 

--- a/src/ui/components/RightSidebar/EventsTimeline.css
+++ b/src/ui/components/RightSidebar/EventsTimeline.css
@@ -77,6 +77,12 @@
   flex-shrink: 0;
 }
 
+.events-timeline-comments .comment-avatar img {
+  width: inherit;
+  height: inherit;
+  border-radius: 50%;
+}
+
 .events-timeline-comments .comment-body {
   align-self: center;
   flex-grow: 1;


### PR DESCRIPTION
Follow up to #442.

When the user logs in using auth0, this saves their associated picture and name in the user metadata. Now, we can display the user's picture alongside their comments in the right sidebar.

Note that the login doesn't persist after refresh when using Auth0's "Sign up with Google" feature. However, it does persist if you sign up for an Auth0 account and use that instead. 

![image](https://user-images.githubusercontent.com/15959269/91235127-d7852700-e702-11ea-86a7-e1af7a83e07f.png)
