### PR TITLE
Clean up the React based Rules view to be usable

### DIFF
--- a/src/devtools/client/inspector/inspector.js
+++ b/src/devtools/client/inspector/inspector.js
@@ -90,10 +90,6 @@ const PORTRAIT_MODE_WIDTH_THRESHOLD = 700;
 const SIDE_PORTAIT_MODE_WIDTH_THRESHOLD = 1000;
 
 const THREE_PANE_ENABLED_PREF = "devtools.inspector.three-pane-enabled";
-const THREE_PANE_ENABLED_SCALAR = "devtools.inspector.three_pane_enabled";
-const THREE_PANE_CHROME_ENABLED_PREF = "devtools.inspector.chrome.three-pane-enabled";
-const TELEMETRY_EYEDROPPER_OPENED = "devtools.toolbar.eyedropper.opened";
-const TELEMETRY_SCALAR_NODE_SELECTION_COUNT = "devtools.inspector.node_selection_count";
 
 /**
  * Represents an open instance of the Inspector for a tab.
@@ -1458,7 +1454,6 @@ Inspector.prototype = {
     }
     // turn off node picker when color picker is starting
     this.toolbox.nodePicker.stop().catch(console.error);
-    this.telemetry.scalarSet(TELEMETRY_EYEDROPPER_OPENED, 1);
     this.eyeDropperButton.classList.add("checked");
     this.startEyeDropperListeners();
     return this.inspectorFront.pickColorFromPage({ copyOnSelect: true }).catch(console.error);

--- a/src/devtools/client/inspector/rules/actions/index.js
+++ b/src/devtools/client/inspector/rules/actions/index.js
@@ -34,9 +34,6 @@ createEnum(
     // Updates the rules state with the new list of CSS rules for the selected element.
     "UPDATE_RULES",
 
-    // Updates whether or not the source links are enabled.
-    "UPDATE_SOURCE_LINK_ENABLED",
-
     // Updates the source link information for a given rule.
     "UPDATE_SOURCE_LINK",
   ],

--- a/src/devtools/client/inspector/rules/actions/index.js
+++ b/src/devtools/client/inspector/rules/actions/index.js
@@ -28,14 +28,8 @@ createEnum(
     // Updates whether or not the class list panel is expanded.
     "UPDATE_CLASS_PANEL_EXPANDED",
 
-    // Updates whether or not the color scheme simulation button is hidden.
-    "UPDATE_COLOR_SCHEME_SIMULATION_HIDDEN",
-
     // Updates the highlighted selector.
     "UPDATE_HIGHLIGHTED_SELECTOR",
-
-    // Updates whether or not the print simulation button is hidden.
-    "UPDATE_PRINT_SIMULATION_HIDDEN",
 
     // Updates the rules state with the new list of CSS rules for the selected element.
     "UPDATE_RULES",

--- a/src/devtools/client/inspector/rules/actions/rules.js
+++ b/src/devtools/client/inspector/rules/actions/rules.js
@@ -6,9 +6,7 @@
 
 const {
   UPDATE_ADD_RULE_ENABLED,
-  UPDATE_COLOR_SCHEME_SIMULATION_HIDDEN,
   UPDATE_HIGHLIGHTED_SELECTOR,
-  UPDATE_PRINT_SIMULATION_HIDDEN,
   UPDATE_RULES,
   UPDATE_SOURCE_LINK_ENABLED,
   UPDATE_SOURCE_LINK,
@@ -29,19 +27,6 @@ module.exports = {
   },
 
   /**
-   * Updates whether or not the color scheme simulation button is hidden.
-   *
-   * @param  {Boolean} hidden
-   *         Whether or not the color scheme simulation button is hidden.
-   */
-  updateColorSchemeSimulationHidden(hidden) {
-    return {
-      type: UPDATE_COLOR_SCHEME_SIMULATION_HIDDEN,
-      hidden,
-    };
-  },
-
-  /**
    * Updates the highlighted selector.
    *
    * @param  {String} highlightedSelector
@@ -51,19 +36,6 @@ module.exports = {
     return {
       type: UPDATE_HIGHLIGHTED_SELECTOR,
       highlightedSelector,
-    };
-  },
-
-  /**
-   * Updates whether or not the print simulation button is hidden.
-   *
-   * @param  {Boolean} hidden
-   *         Whether or not the print simulation button is hidden.
-   */
-  updatePrintSimulationHidden(hidden) {
-    return {
-      type: UPDATE_PRINT_SIMULATION_HIDDEN,
-      hidden,
     };
   },
 

--- a/src/devtools/client/inspector/rules/actions/rules.js
+++ b/src/devtools/client/inspector/rules/actions/rules.js
@@ -8,7 +8,6 @@ const {
   UPDATE_ADD_RULE_ENABLED,
   UPDATE_HIGHLIGHTED_SELECTOR,
   UPDATE_RULES,
-  UPDATE_SOURCE_LINK_ENABLED,
   UPDATE_SOURCE_LINK,
 } = require("devtools/client/inspector/rules/actions/index");
 
@@ -49,19 +48,6 @@ module.exports = {
     return {
       type: UPDATE_RULES,
       rules,
-    };
-  },
-
-  /**
-   * Updates whether or not the source links are enabled.
-   *
-   * @param  {Boolean} enabled
-   *         Whether or not the source links are enabled.
-   */
-  updateSourceLinkEnabled(enabled) {
-    return {
-      type: UPDATE_SOURCE_LINK_ENABLED,
-      enabled,
     };
   },
 

--- a/src/devtools/client/inspector/rules/components/Rule.js
+++ b/src/devtools/client/inspector/rules/components/Rule.js
@@ -23,7 +23,6 @@ const Types = require("devtools/client/inspector/rules/types");
 class Rule extends PureComponent {
   static get propTypes() {
     return {
-      onOpenSourceLink: PropTypes.func.isRequired,
       onToggleDeclaration: PropTypes.func.isRequired,
       onToggleSelectorHighlighter: PropTypes.func.isRequired,
       rule: PropTypes.shape(Types.rule).isRequired,
@@ -76,7 +75,6 @@ class Rule extends PureComponent {
 
   render() {
     const {
-      onOpenSourceLink,
       onToggleDeclaration,
       onToggleSelectorHighlighter,
       rule,
@@ -97,7 +95,6 @@ class Rule extends PureComponent {
       SourceLink({
         id,
         isUserAgentStyle,
-        onOpenSourceLink,
         sourceLink,
         type,
       }),

--- a/src/devtools/client/inspector/rules/components/Rules.js
+++ b/src/devtools/client/inspector/rules/components/Rules.js
@@ -14,7 +14,6 @@ const Types = require("devtools/client/inspector/rules/types");
 class Rules extends PureComponent {
   static get propTypes() {
     return {
-      onOpenSourceLink: PropTypes.func.isRequired,
       onToggleDeclaration: PropTypes.func.isRequired,
       onToggleSelectorHighlighter: PropTypes.func.isRequired,
       rules: PropTypes.arrayOf(PropTypes.shape(Types.rule)).isRequired,
@@ -27,7 +26,6 @@ class Rules extends PureComponent {
 
   render() {
     const {
-      onOpenSourceLink,
       onToggleDeclaration,
       onToggleSelectorHighlighter,
       rules,
@@ -40,7 +38,6 @@ class Rules extends PureComponent {
     return rules.map(rule => {
       return Rule({
         key: rule.id,
-        onOpenSourceLink,
         onToggleDeclaration,
         onToggleSelectorHighlighter,
         rule,

--- a/src/devtools/client/inspector/rules/components/RulesApp.js
+++ b/src/devtools/client/inspector/rules/components/RulesApp.js
@@ -25,7 +25,6 @@ class RulesApp extends PureComponent {
     return {
       onAddClass: PropTypes.func.isRequired,
       onAddRule: PropTypes.func.isRequired,
-      onOpenSourceLink: PropTypes.func.isRequired,
       onSetClassState: PropTypes.func.isRequired,
       onToggleClassPanelExpanded: PropTypes.func.isRequired,
       onToggleDeclaration: PropTypes.func.isRequired,
@@ -47,7 +46,6 @@ class RulesApp extends PureComponent {
 
   getRuleProps() {
     return {
-      onOpenSourceLink: this.props.onOpenSourceLink,
       onToggleDeclaration: this.props.onToggleDeclaration,
       onToggleSelectorHighlighter: this.props.onToggleSelectorHighlighter,
       showDeclarationNameEditor: this.props.showDeclarationNameEditor,

--- a/src/devtools/client/inspector/rules/components/RulesApp.js
+++ b/src/devtools/client/inspector/rules/components/RulesApp.js
@@ -29,8 +29,6 @@ class RulesApp extends PureComponent {
       onSetClassState: PropTypes.func.isRequired,
       onToggleClassPanelExpanded: PropTypes.func.isRequired,
       onToggleDeclaration: PropTypes.func.isRequired,
-      onTogglePrintSimulation: PropTypes.func.isRequired,
-      onToggleColorSchemeSimulation: PropTypes.func.isRequired,
       onTogglePseudoClass: PropTypes.func.isRequired,
       onToggleSelectorHighlighter: PropTypes.func.isRequired,
       rules: PropTypes.arrayOf(PropTypes.shape(Types.rule)).isRequired,
@@ -203,8 +201,6 @@ class RulesApp extends PureComponent {
         onAddRule: this.props.onAddRule,
         onSetClassState: this.props.onSetClassState,
         onToggleClassPanelExpanded: this.props.onToggleClassPanelExpanded,
-        onTogglePrintSimulation: this.props.onTogglePrintSimulation,
-        onToggleColorSchemeSimulation: this.props.onToggleColorSchemeSimulation,
         onTogglePseudoClass: this.props.onTogglePseudoClass,
       }),
       dom.div(

--- a/src/devtools/client/inspector/rules/components/RulesApp.js
+++ b/src/devtools/client/inspector/rules/components/RulesApp.js
@@ -13,7 +13,7 @@ const { connect } = require("react-redux");
 const Accordion = createFactory(require("devtools/client/shared/components/Accordion"));
 const Rule = createFactory(require("devtools/client/inspector/rules/components/Rule"));
 const Rules = createFactory(require("devtools/client/inspector/rules/components/Rules"));
-const Toolbar = createFactory(require("devtools/client/inspector/rules/components/Toolbar"));
+// const Toolbar = createFactory(require("devtools/client/inspector/rules/components/Toolbar"));
 
 const { getStr } = require("devtools/client/inspector/rules/utils/l10n");
 const Types = require("devtools/client/inspector/rules/types");
@@ -196,13 +196,13 @@ class RulesApp extends PureComponent {
         id: "sidebar-panel-ruleview",
         className: "theme-sidebar inspector-tabpanel",
       },
-      Toolbar({
-        onAddClass: this.props.onAddClass,
-        onAddRule: this.props.onAddRule,
-        onSetClassState: this.props.onSetClassState,
-        onToggleClassPanelExpanded: this.props.onToggleClassPanelExpanded,
-        onTogglePseudoClass: this.props.onTogglePseudoClass,
-      }),
+      // Toolbar({
+      //   onAddClass: this.props.onAddClass,
+      //   onAddRule: this.props.onAddRule,
+      //   onSetClassState: this.props.onSetClassState,
+      //   onToggleClassPanelExpanded: this.props.onToggleClassPanelExpanded,
+      //   onTogglePseudoClass: this.props.onTogglePseudoClass,
+      // }),
       dom.div(
         {
           id: "ruleview-container",

--- a/src/devtools/client/inspector/rules/components/SourceLink.js
+++ b/src/devtools/client/inspector/rules/components/SourceLink.js
@@ -7,8 +7,6 @@
 const { PureComponent } = require("react");
 const dom = require("react-dom-factories");
 const PropTypes = require("prop-types");
-const { connect } = require("react-redux");
-const { ELEMENT_STYLE } = require("devtools/client/inspector/rules/constants");
 
 const Types = require("devtools/client/inspector/rules/types");
 
@@ -16,9 +14,7 @@ class SourceLink extends PureComponent {
   static get propTypes() {
     return {
       id: PropTypes.string.isRequired,
-      isSourceLinkEnabled: PropTypes.bool.isRequired,
       isUserAgentStyle: PropTypes.bool.isRequired,
-      onOpenSourceLink: PropTypes.func.isRequired,
       sourceLink: PropTypes.shape(Types.sourceLink).isRequired,
       type: PropTypes.number.isRequired,
     };
@@ -26,27 +22,6 @@ class SourceLink extends PureComponent {
 
   constructor(props) {
     super(props);
-    this.onSourceClick = this.onSourceClick.bind(this);
-  }
-
-  /**
-   * Whether or not the source link is enabled. The source link is enabled when the
-   * Style Editor is enabled and the rule is not a user agent or element style.
-   */
-  get isSourceLinkEnabled() {
-    return (
-      this.props.isSourceLinkEnabled &&
-      !this.props.isUserAgentStyle &&
-      this.props.type !== ELEMENT_STYLE
-    );
-  }
-
-  onSourceClick(event) {
-    event.stopPropagation();
-
-    if (this.isSourceLinkEnabled) {
-      this.props.onOpenSourceLink(this.props.id);
-    }
   }
 
   render() {
@@ -54,9 +29,7 @@ class SourceLink extends PureComponent {
 
     return dom.div(
       {
-        className:
-          "ruleview-rule-source theme-link" + (!this.isSourceLinkEnabled ? " disabled" : ""),
-        onClick: this.onSourceClick,
+        className: "ruleview-rule-source theme-link",
       },
       dom.span(
         {
@@ -69,10 +42,4 @@ class SourceLink extends PureComponent {
   }
 }
 
-const mapStateToProps = state => {
-  return {
-    isSourceLinkEnabled: state.rules.isSourceLinkEnabled,
-  };
-};
-
-module.exports = connect(mapStateToProps)(SourceLink);
+module.exports = SourceLink;

--- a/src/devtools/client/inspector/rules/components/Toolbar.js
+++ b/src/devtools/client/inspector/rules/components/Toolbar.js
@@ -8,7 +8,6 @@ const { createFactory, PureComponent } = require("react");
 const dom = require("react-dom-factories");
 const PropTypes = require("prop-types");
 const { connect } = require("react-redux");
-const { COLOR_SCHEMES } = require("devtools/client/inspector/rules/constants");
 
 const SearchBox = createFactory(require("devtools/client/inspector/rules/components/SearchBox"));
 
@@ -26,14 +25,10 @@ class Toolbar extends PureComponent {
     return {
       isAddRuleEnabled: PropTypes.bool.isRequired,
       isClassPanelExpanded: PropTypes.bool.isRequired,
-      isColorSchemeSimulationHidden: PropTypes.bool.isRequired,
-      isPrintSimulationHidden: PropTypes.bool.isRequired,
       onAddClass: PropTypes.func.isRequired,
       onAddRule: PropTypes.func.isRequired,
       onSetClassState: PropTypes.func.isRequired,
       onToggleClassPanelExpanded: PropTypes.func.isRequired,
-      onToggleColorSchemeSimulation: PropTypes.func.isRequired,
-      onTogglePrintSimulation: PropTypes.func.isRequired,
       onTogglePseudoClass: PropTypes.func.isRequired,
     };
   }
@@ -42,18 +37,12 @@ class Toolbar extends PureComponent {
     super(props);
 
     this.state = {
-      // Which of the color schemes is simulated, if any.
-      currentColorScheme: 0,
-      // Whether or not the print simulation button is enabled.
-      isPrintSimulationEnabled: false,
       // Whether or not the pseudo class panel is expanded.
       isPseudoClassPanelExpanded: false,
     };
 
     this.onAddRuleClick = this.onAddRuleClick.bind(this);
     this.onClassPanelToggle = this.onClassPanelToggle.bind(this);
-    this.onColorSchemeSimulationClick = this.onColorSchemeSimulationClick.bind(this);
-    this.onPrintSimulationToggle = this.onPrintSimulationToggle.bind(this);
     this.onPseudoClassPanelToggle = this.onPseudoClassPanelToggle.bind(this);
   }
 
@@ -76,23 +65,6 @@ class Toolbar extends PureComponent {
     });
   }
 
-  onColorSchemeSimulationClick(event) {
-    event.stopPropagation();
-
-    this.props.onToggleColorSchemeSimulation();
-    this.setState(prevState => ({
-      currentColorScheme: (prevState.currentColorScheme + 1) % COLOR_SCHEMES.length,
-    }));
-  }
-
-  onPrintSimulationToggle(event) {
-    event.stopPropagation();
-    this.props.onTogglePrintSimulation();
-    this.setState(prevState => ({
-      isPrintSimulationEnabled: !prevState.isPrintSimulationEnabled,
-    }));
-  }
-
   onPseudoClassPanelToggle(event) {
     event.stopPropagation();
 
@@ -106,13 +78,8 @@ class Toolbar extends PureComponent {
   }
 
   render() {
-    const {
-      isAddRuleEnabled,
-      isClassPanelExpanded,
-      isColorSchemeSimulationHidden,
-      isPrintSimulationHidden,
-    } = this.props;
-    const { isPrintSimulationEnabled, isPseudoClassPanelExpanded } = this.state;
+    const { isAddRuleEnabled, isClassPanelExpanded } = this.props;
+    const { isPseudoClassPanelExpanded } = this.state;
 
     return dom.div(
       {
@@ -145,24 +112,7 @@ class Toolbar extends PureComponent {
             disabled: !isAddRuleEnabled,
             onClick: this.onAddRuleClick,
             title: getStr("rule.addRule.tooltip"),
-          }),
-          isColorSchemeSimulationHidden
-            ? dom.button({
-                id: "color-scheme-simulation-toggle",
-                className: "devtools-button",
-                onClick: this.onColorSchemeSimulationClick,
-                state: COLOR_SCHEMES[this.state.currentColorScheme],
-                title: getStr("rule.colorSchemeSimulation.tooltip"),
-              })
-            : null,
-          !isPrintSimulationHidden
-            ? dom.button({
-                id: "print-simulation-toggle",
-                className: "devtools-button" + (isPrintSimulationEnabled ? " checked" : ""),
-                onClick: this.onPrintSimulationToggle,
-                title: getStr("rule.printSimulation.tooltip"),
-              })
-            : null
+          })
         )
       ),
       isClassPanelExpanded
@@ -184,8 +134,6 @@ const mapStateToProps = state => {
   return {
     isAddRuleEnabled: state.rules.isAddRuleEnabled,
     isClassPanelExpanded: state.classList.isClassPanelExpanded,
-    isColorSchemeSimulationHidden: state.rules.isColorSchemeSimulationHidden,
-    isPrintSimulationHidden: state.rules.isPrintSimulationHidden,
   };
 };
 

--- a/src/devtools/client/inspector/rules/new-rules.js
+++ b/src/devtools/client/inspector/rules/new-rules.js
@@ -319,13 +319,7 @@ class RulesView {
    * Returns true if the rules panel is visible, and false otherwise.
    */
   isPanelVisible() {
-    return (
-      this.inspector &&
-      this.inspector.toolbox &&
-      this.inspector.sidebar &&
-      this.inspector.toolbox.currentToolId === "inspector" &&
-      this.inspector.sidebar.getCurrentTabID() === "newruleview"
-    );
+    return this.inspector?.sidebar?.getCurrentTabID() === "newruleview";
   }
 
   /**

--- a/src/devtools/client/inspector/rules/new-rules.js
+++ b/src/devtools/client/inspector/rules/new-rules.js
@@ -50,7 +50,6 @@ class RulesView {
     this.inspector = inspector;
     this.selection = inspector.selection;
     this.store = inspector.store;
-    this.telemetry = inspector.telemetry;
     this.toolbox = inspector.toolbox;
     this.isNewRulesView = true;
 
@@ -155,7 +154,6 @@ class RulesView {
     this.selection = null;
     this.showUserAgentStyles = null;
     this.store = null;
-    this.telemetry = null;
     this.toolbox = null;
   }
 
@@ -358,9 +356,6 @@ class RulesView {
    */
   onToggleDeclaration(ruleId, declarationId) {
     this.elementStyle.toggleDeclaration(ruleId, declarationId);
-    this.telemetry.recordEvent("edit_rule", "ruleview", null, {
-      session_id: this.toolbox.sessionId,
-    });
   }
 
   /**
@@ -443,9 +438,6 @@ class RulesView {
         }
 
         await this.elementStyle.modifyDeclarationName(ruleId, declarationId, name);
-        this.telemetry.recordEvent("edit_rule", "ruleview", null, {
-          session_id: this.toolbox.sessionId,
-        });
       },
       element,
       popup: this.autocompletePopup,
@@ -486,9 +478,6 @@ class RulesView {
         }
 
         await this.elementStyle.modifyDeclarationValue(ruleId, declarationId, value);
-        this.telemetry.recordEvent("edit_rule", "ruleview", null, {
-          session_id: this.toolbox.sessionId,
-        });
       },
       element,
       maxWidth: () => {
@@ -527,9 +516,6 @@ class RulesView {
         }
 
         this.elementStyle.addNewDeclaration(ruleId, value);
-        this.telemetry.recordEvent("edit_rule", "ruleview", null, {
-          session_id: this.toolbox.sessionId,
-        });
       },
       element,
       popup: this.autocompletePopup,

--- a/src/devtools/client/inspector/rules/new-rules.js
+++ b/src/devtools/client/inspector/rules/new-rules.js
@@ -233,36 +233,6 @@ class RulesView {
   }
 
   /**
-   * Returns the grid line names of the grid that the currently selected element is
-   * contained in.
-   *
-   * @return {Object} that contains the names of the cols and rows as arrays
-   * { cols: [], rows: [] }.
-   */
-  async getGridlineNames() {
-    const gridLineNames = { cols: [], rows: [] };
-    const layoutInspector = await this.inspector.walker.getLayoutInspector();
-    const gridFront = await layoutInspector.getCurrentGrid(this.selection.nodeFront);
-
-    if (gridFront) {
-      const gridFragments = gridFront.gridFragments;
-
-      for (const gridFragment of gridFragments) {
-        for (const rowLine of gridFragment.rows.lines) {
-          gridLineNames.rows = gridLineNames.rows.concat(rowLine.names);
-        }
-        for (const colLine of gridFragment.cols.lines) {
-          gridLineNames.cols = gridLineNames.cols.concat(colLine.names);
-        }
-      }
-    }
-
-    // This event is emitted for testing purposes.
-    this.inspector.emit("grid-line-names-updated");
-    return gridLineNames;
-  }
-
-  /**
    * Get the type of a given node in the Rules view.
    *
    * @param {DOMNode} node
@@ -521,7 +491,6 @@ class RulesView {
         });
       },
       element,
-      getGridLineNames: this.getGridlineNames,
       maxWidth: () => {
         // Return the width of the closest declaration container element.
         const containerElement = element.closest(".ruleview-propertycontainer");

--- a/src/devtools/client/inspector/rules/reducers/rules.js
+++ b/src/devtools/client/inspector/rules/reducers/rules.js
@@ -8,7 +8,6 @@ const {
   UPDATE_ADD_RULE_ENABLED,
   UPDATE_HIGHLIGHTED_SELECTOR,
   UPDATE_RULES,
-  UPDATE_SOURCE_LINK_ENABLED,
   UPDATE_SOURCE_LINK,
 } = require("devtools/client/inspector/rules/actions/index");
 
@@ -17,11 +16,6 @@ const INITIAL_RULES = {
   highlightedSelector: "",
   // Whether or not the add new rule button should be enabled.
   isAddRuleEnabled: false,
-  // Whether or not the source links are enabled. This is determined by
-  // whether or not the style editor is registered.
-  isSourceLinkEnabled: true /*Services.prefs.getBoolPref(
-    "devtools.styleeditor.enabled"
-  )*/,
   // Array of CSS rules.
   rules: [],
 };
@@ -122,15 +116,7 @@ const reducers = {
     return {
       highlightedSelector: rules.highlightedSelector,
       isAddRuleEnabled: rules.isAddRuleEnabled,
-      isSourceLinkEnabled: rules.isSourceLinkEnabled,
       rules: newRules.map(rule => getRuleState(rule)),
-    };
-  },
-
-  [UPDATE_SOURCE_LINK_ENABLED](rules, { enabled }) {
-    return {
-      ...rules,
-      isSourceLinkEnabled: enabled,
     };
   },
 
@@ -138,7 +124,6 @@ const reducers = {
     return {
       highlightedSelector: rules.highlightedSelector,
       isAddRuleEnabled: rules.isAddRuleEnabled,
-      isSourceLinkEnabled: rules.isSourceLinkEnabled,
       rules: rules.rules.map(rule => {
         if (rule.id !== ruleId) {
           return rule;

--- a/src/devtools/client/inspector/rules/reducers/rules.js
+++ b/src/devtools/client/inspector/rules/reducers/rules.js
@@ -4,13 +4,9 @@
 
 "use strict";
 
-const Services = require("Services");
-
 const {
   UPDATE_ADD_RULE_ENABLED,
-  UPDATE_COLOR_SCHEME_SIMULATION_HIDDEN,
   UPDATE_HIGHLIGHTED_SELECTOR,
-  UPDATE_PRINT_SIMULATION_HIDDEN,
   UPDATE_RULES,
   UPDATE_SOURCE_LINK_ENABLED,
   UPDATE_SOURCE_LINK,
@@ -21,10 +17,6 @@ const INITIAL_RULES = {
   highlightedSelector: "",
   // Whether or not the add new rule button should be enabled.
   isAddRuleEnabled: false,
-  // Whether or not the color scheme simulation button is hidden.
-  isColorSchemeSimulationHidden: false,
-  // Whether or not the print simulation button is hidden.
-  isPrintSimulationHidden: false,
   // Whether or not the source links are enabled. This is determined by
   // whether or not the style editor is registered.
   isSourceLinkEnabled: true /*Services.prefs.getBoolPref(
@@ -119,13 +111,6 @@ const reducers = {
     };
   },
 
-  [UPDATE_COLOR_SCHEME_SIMULATION_HIDDEN](rules, { hidden }) {
-    return {
-      ...rules,
-      isColorSchemeSimulationHidden: hidden,
-    };
-  },
-
   [UPDATE_HIGHLIGHTED_SELECTOR](rules, { highlightedSelector }) {
     return {
       ...rules,
@@ -133,18 +118,10 @@ const reducers = {
     };
   },
 
-  [UPDATE_PRINT_SIMULATION_HIDDEN](rules, { hidden }) {
-    return {
-      ...rules,
-      isPrintSimulationHidden: hidden,
-    };
-  },
-
   [UPDATE_RULES](rules, { rules: newRules }) {
     return {
       highlightedSelector: rules.highlightedSelector,
       isAddRuleEnabled: rules.isAddRuleEnabled,
-      isPrintSimulationHidden: rules.isPrintSimulationHidden,
       isSourceLinkEnabled: rules.isSourceLinkEnabled,
       rules: newRules.map(rule => getRuleState(rule)),
     };

--- a/src/devtools/client/themes/rules.css
+++ b/src/devtools/client/themes/rules.css
@@ -752,32 +752,6 @@
   font-weight: 600;
 }
 
-#print-simulation-toggle::before {
-  background-image: url("chrome://devtools/skin/images/rules-view-print-simulation.svg");
-}
-
-#color-scheme-simulation-toggle::before {
-  -moz-context-properties: fill, fill-opacity;
-  background-image: url("chrome://mozapps/skin/extensions/category-themes.svg");
-  background-size: 12px;
-}
-
-#color-scheme-simulation-toggle[state="dark"] {
-  background-color: #333;
-}
-
-#color-scheme-simulation-toggle[state="dark"]::before {
-  fill: white;
-}
-
-#color-scheme-simulation-toggle[state="light"]::before {
-  fill: #bbb;
-}
-
-#color-scheme-simulation-toggle[state="no-preference"]::before {
-  fill-opacity: 0.5;
-}
-
 .flash-out {
   transition: background 1s;
 }


### PR DESCRIPTION
This patch set mostly removes unnecessary code that we don't intend to support because we are focused on the read-only experience for the time being and don't currently support having a style editor.