### PR TITLE
Make the React-based Rules view functional for Replay

### DIFF
--- a/src/devtools/client/inspector/rules/components/Declaration.js
+++ b/src/devtools/client/inspector/rules/components/Declaration.js
@@ -7,7 +7,7 @@
 const { createRef, PureComponent } = require("react");
 const dom = require("react-dom-factories");
 const PropTypes = require("prop-types");
-const { editableItem } = require("devtools/client/shared/inplace-editor");
+// const { editableItem } = require("devtools/client/shared/inplace-editor");
 
 const { getStr } = require("devtools/client/inspector/rules/utils/l10n");
 const Types = require("devtools/client/inspector/rules/types");
@@ -220,16 +220,15 @@ class Declaration extends PureComponent {
       },
       dom.div(
         { className: "ruleview-propertycontainer" },
-        /*
         dom.input({
           "aria-labelledby": id,
           className: "ruleview-enableproperty",
           checked: isEnabled,
           onChange: this.onToggleDeclarationChange,
           tabIndex: "-1",
+          style: { visibility: "hidden" },
           type: "checkbox",
         }),
-        */
         dom.span(
           { className: "ruleview-namecontainer" },
           dom.span(

--- a/src/devtools/client/inspector/rules/components/Declaration.js
+++ b/src/devtools/client/inspector/rules/components/Declaration.js
@@ -260,8 +260,8 @@ class Declaration extends PureComponent {
           ),
           ";"
         ),
-        this.renderWarning(),
-        this.renderOverriddenFilter()
+        this.renderWarning()
+        // this.renderOverriddenFilter()
       ),
       this.renderComputedPropertyList(),
       this.renderShorthandOverriddenList()

--- a/src/devtools/client/inspector/rules/components/Rule.js
+++ b/src/devtools/client/inspector/rules/components/Rule.js
@@ -109,12 +109,12 @@ class Rule extends PureComponent {
             showSelectorEditor,
             type,
           }),
-          type !== CSSRule.KEYFRAME_RULE
-            ? SelectorHighlighter({
-                onToggleSelectorHighlighter,
-                selector,
-              })
-            : null,
+          // type !== CSSRule.KEYFRAME_RULE
+          //   ? SelectorHighlighter({
+          //       onToggleSelectorHighlighter,
+          //       selector,
+          //     })
+          //   : null,
           dom.span({ className: "ruleview-ruleopen" }, " {")
         ),
         Declarations({

--- a/src/devtools/client/inspector/rules/components/Selector.js
+++ b/src/devtools/client/inspector/rules/components/Selector.js
@@ -126,7 +126,8 @@ class Selector extends PureComponent {
         ref: this.selectorRef,
         tabIndex: 0,
       },
-      this.renderSelector()
+      // this.renderSelector()
+      this.props.selector.selectorText
     );
   }
 }

--- a/src/devtools/client/inspector/rules/models/element-style.js
+++ b/src/devtools/client/inspector/rules/models/element-style.js
@@ -86,11 +86,11 @@ class ElementStyle {
 
     this.onRefresh = this.onRefresh.bind(this);
 
-    if (this.ruleView.isNewRulesView) {
-      this.pageStyle.on("stylesheet-updated", this.onRefresh);
-      this.ruleView.inspector.styleChangeTracker.on("style-changed", this.onRefresh);
-      this.ruleView.selection.on("pseudoclass", this.onRefresh);
-    }
+    // if (this.ruleView.isNewRulesView) {
+    //   this.pageStyle.on("stylesheet-updated", this.onRefresh);
+    //   this.ruleView.inspector.styleChangeTracker.on("style-changed", this.onRefresh);
+    //   this.ruleView.selection.on("pseudoclass", this.onRefresh);
+    // }
   }
 
   get unusedCssEnabled() {
@@ -116,11 +116,11 @@ class ElementStyle {
       rule.destroy();
     }
 
-    if (this.ruleView.isNewRulesView) {
-      this.pageStyle.off("stylesheet-updated", this.onRefresh);
-      this.ruleView.inspector.styleChangeTracker.off("style-changed", this.onRefresh);
-      this.ruleView.selection.off("pseudoclass", this.onRefresh);
-    }
+    // if (this.ruleView.isNewRulesView) {
+    //   this.pageStyle.off("stylesheet-updated", this.onRefresh);
+    //   this.ruleView.inspector.styleChangeTracker.off("style-changed", this.onRefresh);
+    //   this.ruleView.selection.off("pseudoclass", this.onRefresh);
+    // }
   }
 
   /**
@@ -183,9 +183,9 @@ class ElementStyle {
     // Mark overridden computed styles.
     this.onRuleUpdated();
 
-    if (this.ruleView.isNewRulesView) {
-      this.subscribeRulesToLocationChange();
-    }
+    // if (this.ruleView.isNewRulesView) {
+    //   this.subscribeRulesToLocationChange();
+    // }
   }
 
   /**
@@ -377,7 +377,7 @@ class ElementStyle {
    *
    * @param {TextProperty} declaration
    *        A TextProperty of a rule.
-   * @param {Set<>String} variableNamesSet
+   * @param {Set<String>} variableNamesSet
    *        A Set of CSS variable names that have been updated.
    */
   _hasUpdatedCSSVariable(declaration, variableNamesSet) {

--- a/src/devtools/client/inspector/rules/models/element-style.js
+++ b/src/devtools/client/inspector/rules/models/element-style.js
@@ -8,7 +8,7 @@ const Services = require("Services");
 const Rule = require("devtools/client/inspector/rules/models/rule");
 const UserProperties = require("devtools/client/inspector/rules/models/user-properties");
 
-const { promiseWarn } = require("devtools/client/inspector/shared/utils");
+// const { promiseWarn } = require("devtools/client/inspector/shared/utils");
 /*
 loader.lazyRequireGetter(
   this,
@@ -49,7 +49,7 @@ const PREF_INACTIVE_CSS_ENABLED = "devtools.inspector.inactive.css.enabled";
  */
 class ElementStyle {
   /**
-   * @param  {Element} element
+   * @param  {NodeFront} element
    *         The element whose style we are viewing.
    * @param  {CssRuleView} ruleView
    *         The instance of the rule-view panel.
@@ -224,12 +224,14 @@ class ElementStyle {
    * Add a rule if it's one we care about. Filters out duplicates and
    * inherited styles with no inherited properties.
    *
-   * @param  {Object} ruleFront
+   * @param  {RuleFront} ruleFront
    *         Rule to add.
    * @return {Boolean} true if we added the rule.
    */
   _maybeAddRule(ruleFront, inherited, pseudoElement) {
     if (ruleFront.isSystem) {
+      // We currently don't display any user agent styles.
+      // See https://github.com/RecordReplay/devtools/issues/546
       return false;
     }
 

--- a/src/devtools/client/inspector/rules/models/rule.js
+++ b/src/devtools/client/inspector/rules/models/rule.js
@@ -129,7 +129,7 @@ class Rule {
       this._sourceLocation = {
         column: this.ruleColumn,
         line: this.ruleLine,
-        url: this.sheet ? this.sheet.href || this.sheet.nodeHref : null,
+        url: this.ruleHref,
       };
     }
 
@@ -917,7 +917,7 @@ class Rule {
       line,
       url,
     };
-    this.store.dispatch(updateSourceLink(this.domRule.actorID, this.sourceLink));
+    this.store.dispatch(updateSourceLink(this.domRule.objectId(), this.sourceLink));
   }
 }
 

--- a/src/devtools/client/inspector/rules/models/text-property.js
+++ b/src/devtools/client/inspector/rules/models/text-property.js
@@ -6,16 +6,7 @@
 
 const { generateUUID } = require("devtools/shared/generate-uuid");
 const { hasCSSVariable } = require("devtools/client/inspector/rules/utils/utils");
-
-/*
-loader.lazyRequireGetter(
-  this,
-  "escapeCSSComment",
-  "devtools/shared/css/parsing-utils",
-  true
-);
-
-*/
+const { escapeCSSComment } = require("devtools/shared/css/parsing-utils");
 
 /**
  * TextProperty is responsible for the following:

--- a/src/devtools/client/inspector/rules/new-rules.js
+++ b/src/devtools/client/inspector/rules/new-rules.js
@@ -9,6 +9,12 @@ const ElementStyle = require("devtools/client/inspector/rules/models/element-sty
 const { createFactory, createElement } = require("react");
 const { Provider } = require("react-redux");
 const EventEmitter = require("devtools/shared/event-emitter");
+const ClassList = require("devtools/client/inspector/rules/models/class-list");
+const { getNodeInfo } = require("devtools/client/inspector/rules/utils/utils");
+const StyleInspectorMenu = require("devtools/client/inspector/shared/style-inspector-menu");
+const { advanceValidate } = require("devtools/client/inspector/shared/utils");
+const AutocompletePopup = require("devtools/client/shared/autocomplete-popup");
+const { InplaceEditor } = require("devtools/client/shared/inplace-editor");
 
 const {
   updateClasses,
@@ -29,17 +35,6 @@ const RulesApp = createFactory(require("devtools/client/inspector/rules/componen
 
 const { LocalizationHelper } = require("devtools/shared/l10n");
 const INSPECTOR_L10N = new LocalizationHelper("devtools/client/locales/inspector.properties");
-
-loader.lazyRequireGetter(this, "ClassList", "devtools/client/inspector/rules/models/class-list");
-loader.lazyRequireGetter(this, "getNodeInfo", "devtools/client/inspector/rules/utils/utils", true);
-loader.lazyRequireGetter(
-  this,
-  "StyleInspectorMenu",
-  "devtools/client/inspector/shared/style-inspector-menu"
-);
-loader.lazyRequireGetter(this, "advanceValidate", "devtools/client/inspector/shared/utils", true);
-loader.lazyRequireGetter(this, "AutocompletePopup", "devtools/client/shared/autocomplete-popup");
-loader.lazyRequireGetter(this, "InplaceEditor", "devtools/client/shared/inplace-editor", true);
 
 const PREF_UA_STYLES = "devtools.inspector.showUserAgentStyles";
 

--- a/src/devtools/client/inspector/rules/new-rules.js
+++ b/src/devtools/client/inspector/rules/new-rules.js
@@ -560,14 +560,14 @@ class RulesView {
     }
 
     if (!element) {
-      this.store.dispatch(disableAllPseudoClasses());
-      this.store.dispatch(updateAddRuleEnabled(false));
-      this.store.dispatch(updateClasses([]));
+      // this.store.dispatch(disableAllPseudoClasses());
+      // this.store.dispatch(updateAddRuleEnabled(false));
+      // this.store.dispatch(updateClasses([]));
       this.store.dispatch(updateRules([]));
       return;
     }
 
-    this.pageStyle = element.inspectorFront.pageStyle;
+    this.pageStyle = undefined;
     this.elementStyle = new ElementStyle(
       element,
       this,
@@ -595,10 +595,10 @@ class RulesView {
   async updateElementStyle() {
     await this.elementStyle.populate();
 
-    const isAddRuleEnabled = this.selection.isElementNode() && !this.selection.isAnonymousNode();
-    this.store.dispatch(updateAddRuleEnabled(isAddRuleEnabled));
-    this.store.dispatch(setPseudoClassLocks(this.elementStyle.element.pseudoClassLocks));
-    this.updateClassList();
+    // const isAddRuleEnabled = this.selection.isElementNode() && !this.selection.isAnonymousNode();
+    // this.store.dispatch(updateAddRuleEnabled(isAddRuleEnabled));
+    // this.store.dispatch(setPseudoClassLocks(this.elementStyle.element.pseudoClassLocks));
+    // this.updateClassList();
     this.updateRules();
   }
 

--- a/src/devtools/client/inspector/rules/reducers/rules.js
+++ b/src/devtools/client/inspector/rules/reducers/rules.js
@@ -92,7 +92,7 @@ function getRuleState(rule) {
     selector: rule.selector,
     // An object containing information about the CSS rule's stylesheet source.
     sourceLink: rule.sourceLink,
-    // The CSS rule type.
+    // The type of CSS rule.
     type: rule.domRule.type,
   };
 }

--- a/src/devtools/client/inspector/rules/reducers/rules.js
+++ b/src/devtools/client/inspector/rules/reducers/rules.js
@@ -74,16 +74,16 @@ function getRuleState(rule) {
   return {
     // Array of CSS declarations.
     declarations: rule.declarations.map(declaration =>
-      getDeclarationState(declaration, rule.domRule.actorID)
+      getDeclarationState(declaration, rule.domRule.objectId())
     ),
     // An unique CSS rule id.
-    id: rule.domRule.actorID,
+    id: rule.domRule.objectId(),
     // An object containing information about the CSS rule's inheritance.
     inheritance: rule.inheritance,
     // Whether or not the rule does not match the current selected element.
     isUnmatched: rule.isUnmatched,
     // Whether or not the rule is an user agent style.
-    isUserAgentStyle: rule.isSystem,
+    isUserAgentStyle: rule.domRule.isSystem,
     // An object containing information about the CSS keyframes rules.
     keyframesRule: rule.keyframesRule,
     // The pseudo-element keyword used in the rule.

--- a/src/devtools/client/inspector/rules/types.js
+++ b/src/devtools/client/inspector/rules/types.js
@@ -168,6 +168,7 @@ exports.rule = {
     title: PropTypes.string,
   }),
 
-  // The CSS rule type.
+  // The type of CSS rule.
+  // See https://developer.mozilla.org/en-US/docs/Web/API/CSSRule#Type_constants
   type: PropTypes.number,
 };

--- a/src/protocol/thread.js
+++ b/src/protocol/thread.js
@@ -970,6 +970,10 @@ RuleFront.prototype = {
     return true;
   },
 
+  /**
+   * The type of CSS rule.
+   * See https://developer.mozilla.org/en-US/docs/Web/API/CSSRule#Type_constants.
+   */
   get type() {
     return this._rule.type;
   },
@@ -1007,6 +1011,9 @@ RuleFront.prototype = {
     return this.parentStyleSheet && this.parentStyleSheet.href;
   },
 
+  /**
+   * Whether or not the rule is an user agent style.
+   */
   get isSystem() {
     return this.parentStyleSheet && this.parentStyleSheet.isSystem;
   },


### PR DESCRIPTION
This patch set makes the React-based Rules view functional for webreplay. To test, you will need to comment out the pref check:

```
diff --git a/src/devtools/client/inspector/inspector.js b/src/devtools/client/inspector/inspector.js
index 7058645e..0da1a676 100644
--- a/src/devtools/client/inspector/inspector.js
+++ b/src/devtools/client/inspector/inspector.js
@@ -920,12 +920,12 @@ Inspector.prototype = {
       */
     ];

-    if (Services.prefs.getBoolPref("devtools.inspector.new-rulesview.enabled")) {
-      sidebarPanels.push({
-        id: "newruleview",
-        title: INSPECTOR_L10N.getStr("inspector.sidebar.ruleViewTitle"),
-      });
-    }
+    // if (Services.prefs.getBoolPref("devtools.inspector.new-rulesview.enabled")) {
+    sidebarPanels.push({
+      id: "newruleview",
+      title: INSPECTOR_L10N.getStr("inspector.sidebar.ruleViewTitle"),
+    });
+    // }
```