### PR TITLE
Fix positioning of comment markers near timeline's left edge

### DIFF
--- a/src/ui/components/Comments/CommentMarker.js
+++ b/src/ui/components/Comments/CommentMarker.js
@@ -12,7 +12,7 @@ import {
 } from "ui/utils/timeline";
 import Dropdown from "devtools/client/debugger/src/components/shared/Dropdown";
 
-const markerWidth = 15;
+const markerWidth = 19;
 const tolerance = 2;
 
 class CommentMarker extends React.Component {

--- a/src/ui/components/Comments/Comments.css
+++ b/src/ui/components/Comments/Comments.css
@@ -4,12 +4,12 @@
 
 .comments-container {
   position: relative;
+  top: 26px;
 }
 
 .comment-marker {
   width: 19px;
   height: 19px;
-  top: 26px;
   z-index: 2;
   position: absolute;
   background-color: transparent;
@@ -30,7 +30,6 @@
 .create-comment {
   width: 19px;
   height: 19px;
-  top: 26px;
   z-index: 100;
   position: absolute;
   outline: none;

--- a/src/ui/utils/timeline.js
+++ b/src/ui/utils/timeline.js
@@ -15,14 +15,6 @@ export function getVisiblePosition({ time, zoom }) {
     return 0;
   }
 
-  if (time <= zoom.startTime) {
-    return 0;
-  }
-
-  if (time >= zoom.endTime) {
-    return 1;
-  }
-
   return (time - zoom.startTime) / (zoom.endTime - zoom.startTime);
 }
 
@@ -53,7 +45,7 @@ export function getMarkerLeftOffset({ overlayWidth, time, zoom, markerWidth }) {
   const commentMarkerWidth = (markerWidth / overlayWidth) * 100;
   const pausedLocationMarkerWidth = (1 / overlayWidth) * 100;
 
-  return Math.max(position + pausedLocationMarkerWidth - commentMarkerWidth / 2, 0);
+  return position + pausedLocationMarkerWidth - commentMarkerWidth / 2;
 }
 
 // Get the percent value for the midpoint of a time in the timeline.


### PR DESCRIPTION
Fixes #548 Comments markers near the timeline's left edge are now displayed properly.

![image](https://user-images.githubusercontent.com/15959269/91849370-f23b2c80-ec29-11ea-9197-ee412cc0d350.png)
