### PR TITLE
Add back the console context menu

### DIFF
--- a/src/devtools/client/locales/en-us/webconsole.properties
+++ b/src/devtools/client/locales/en-us/webconsole.properties
@@ -209,7 +209,7 @@ webconsole.menu.selectAll.accesskey=A
 # LOCALIZATION NOTE (webconsole.menu.openInSidebar.label)
 # Label used for a context-menu item displayed for object/variable logs. Clicking on it
 # opens the webconsole sidebar for the logged variable.
-webconsole.menu.openInSidebar.label1=Inspect object in Sidebar
+webconsole.menu.openInSidebar.label=Inspect object in Sidebar
 webconsole.menu.openInSidebar.accesskey=V
 
 # LOCALIZATION NOTE (webconsole.menu.exportSubmenu.label)

--- a/src/devtools/client/webconsole/actions/object.js
+++ b/src/devtools/client/webconsole/actions/object.js
@@ -30,10 +30,9 @@ function copyMessageObject(actor, variableText) {
       const res = await client.evaluateJSAsync("copy(_self)", {
         selectedObjectActor: actor,
       });
-
-      clipboardHelper.copyString(res.helperResult.value);
+      navigator.clipboard.writeText(res.helperResult.value);
     } else {
-      clipboardHelper.copyString(variableText);
+      navigator.clipboard.writeText(variableText);
     }
   };
 }

--- a/src/devtools/client/webconsole/utils/clipboard.js
+++ b/src/devtools/client/webconsole/utils/clipboard.js
@@ -51,6 +51,11 @@ function getElementText(el) {
   return text;
 }
 
+function copyStringToClipboard(string) {
+  navigator.clipboard.writeText(string);
+}
+
 module.exports = {
   getElementText,
+  copyStringToClipboard,
 };

--- a/src/devtools/client/webconsole/utils/context-menu.js
+++ b/src/devtools/client/webconsole/utils/context-menu.js
@@ -8,21 +8,15 @@ const Menu = require("devtools/client/framework/menu");
 const MenuItem = require("devtools/client/framework/menu-item");
 
 const { MESSAGE_SOURCE } = require("devtools/client/webconsole/constants");
-//const clipboardHelper = require("devtools/shared/platform/clipboard");
 const { l10n } = require("devtools/client/webconsole/utils/messages");
 const actions = require("devtools/client/webconsole/actions/index");
 const { openDocLink } = require("devtools/client/shared/link");
+const {
+  getElementText,
+  copyStringToClipboard,
+} = require("devtools/client/webconsole/utils/clipboard");
 
-/*
 loader.lazyRequireGetter(this, "saveAs", "devtools/shared/DevToolsUtils", true);
-
-loader.lazyRequireGetter(
-  this,
-  "getElementText",
-  "devtools/client/webconsole/utils/clipboard",
-  true
-);
-*/
 
 /**
  * Create a Menu instance for the webconsole.
@@ -76,73 +70,73 @@ function createContextMenu(event, message, webConsoleWrapper) {
   const menu = new Menu({ id: "webconsole-menu" });
 
   // Copy URL for a network request.
-  menu.append(
-    new MenuItem({
-      id: "console-menu-copy-url",
-      label: l10n.getStr("webconsole.menu.copyURL.label"),
-      accesskey: l10n.getStr("webconsole.menu.copyURL.accesskey"),
-      visible: source === MESSAGE_SOURCE.NETWORK,
-      click: () => {
-        if (!request) {
-          return;
-        }
-        clipboardHelper.copyString(request.url);
-      },
-    })
-  );
+  // menu.append(
+  //   new MenuItem({
+  //     id: "console-menu-copy-url",
+  //     label: l10n.getStr("webconsole.menu.copyURL.label"),
+  //     accesskey: l10n.getStr("webconsole.menu.copyURL.accesskey"),
+  //     visible: source === MESSAGE_SOURCE.NETWORK,
+  //     click: () => {
+  //       if (!request) {
+  //         return;
+  //       }
+  //       copyStringToClipboard(request.url);
+  //     },
+  //   })
+  // );
 
-  // Open Network message in the Network panel.
-  if (toolbox && request) {
-    menu.append(
-      new MenuItem({
-        id: "console-menu-open-in-network-panel",
-        label: l10n.getStr("webconsole.menu.openInNetworkPanel.label"),
-        accesskey: l10n.getStr("webconsole.menu.openInNetworkPanel.accesskey"),
-        visible: source === MESSAGE_SOURCE.NETWORK,
-        click: () => dispatch(actions.openNetworkPanel(message.messageId)),
-      })
-    );
-  }
+  // // Open Network message in the Network panel.
+  // if (toolbox && request) {
+  //   menu.append(
+  //     new MenuItem({
+  //       id: "console-menu-open-in-network-panel",
+  //       label: l10n.getStr("webconsole.menu.openInNetworkPanel.label"),
+  //       accesskey: l10n.getStr("webconsole.menu.openInNetworkPanel.accesskey"),
+  //       visible: source === MESSAGE_SOURCE.NETWORK,
+  //       click: () => dispatch(actions.openNetworkPanel(message.messageId)),
+  //     })
+  //   );
+  // }
 
-  // Resend Network message.
-  if (toolbox && request) {
-    menu.append(
-      new MenuItem({
-        id: "console-menu-resend-network-request",
-        label: l10n.getStr("webconsole.menu.resendNetworkRequest.label"),
-        accesskey: l10n.getStr("webconsole.menu.resendNetworkRequest.accesskey"),
-        visible: source === MESSAGE_SOURCE.NETWORK,
-        click: () => dispatch(actions.resendNetworkRequest(messageId)),
-      })
-    );
-  }
+  // // Resend Network message.
+  // if (toolbox && request) {
+  //   menu.append(
+  //     new MenuItem({
+  //       id: "console-menu-resend-network-request",
+  //       label: l10n.getStr("webconsole.menu.resendNetworkRequest.label"),
+  //       accesskey: l10n.getStr("webconsole.menu.resendNetworkRequest.accesskey"),
+  //       visible: source === MESSAGE_SOURCE.NETWORK,
+  //       click: () => dispatch(actions.resendNetworkRequest(messageId)),
+  //     })
+  //   );
+  // }
 
-  // Open URL in a new tab for a network request.
-  menu.append(
-    new MenuItem({
-      id: "console-menu-open-url",
-      label: l10n.getStr("webconsole.menu.openURL.label"),
-      accesskey: l10n.getStr("webconsole.menu.openURL.accesskey"),
-      visible: source === MESSAGE_SOURCE.NETWORK,
-      click: () => {
-        if (!request) {
-          return;
-        }
-        openDocLink(request.url);
-      },
-    })
-  );
+  // // Open URL in a new tab for a network request.
+  // menu.append(
+  //   new MenuItem({
+  //     id: "console-menu-open-url",
+  //     label: l10n.getStr("webconsole.menu.openURL.label"),
+  //     accesskey: l10n.getStr("webconsole.menu.openURL.accesskey"),
+  //     visible: source === MESSAGE_SOURCE.NETWORK,
+  //     click: () => {
+  //       if (!request) {
+  //         return;
+  //       }
+  //       openDocLink(request.url);
+  //     },
+  //   })
+  // );
 
   // Store as global variable.
-  menu.append(
-    new MenuItem({
-      id: "console-menu-store",
-      label: l10n.getStr("webconsole.menu.storeAsGlobalVar.label"),
-      accesskey: l10n.getStr("webconsole.menu.storeAsGlobalVar.accesskey"),
-      disabled: !actor,
-      click: () => dispatch(actions.storeAsGlobal(actor)),
-    })
-  );
+  // menu.append(
+  //   new MenuItem({
+  //     id: "console-menu-store",
+  //     label: l10n.getStr("webconsole.menu.storeAsGlobalVar.label"),
+  //     accesskey: l10n.getStr("webconsole.menu.storeAsGlobalVar.accesskey"),
+  //     disabled: !actor,
+  //     click: () => dispatch(actions.storeAsGlobal(actor)),
+  //   })
+  // );
 
   // Copy message or grip.
   menu.append(
@@ -156,9 +150,9 @@ function createContextMenu(event, message, webConsoleWrapper) {
         if (selection.isCollapsed) {
           // If the selection is empty/collapsed, copy the text content of the
           // message for which the context menu was opened.
-          clipboardHelper.copyString(clipboardText);
+          copyStringToClipboard(clipboardText);
         } else {
-          clipboardHelper.copyString(selection.toString());
+          copyStringToClipboard(selection.toString());
         }
       },
     })
@@ -190,65 +184,65 @@ function createContextMenu(event, message, webConsoleWrapper) {
     })
   );
 
-  const exportSubmenu = new Menu({
-    id: "export-submenu",
-  });
+  // const exportSubmenu = new Menu({
+  //   id: "export-submenu",
+  // });
 
-  // Export to clipboard
-  exportSubmenu.append(
-    new MenuItem({
-      id: "console-menu-export-clipboard",
-      label: l10n.getStr("webconsole.menu.exportSubmenu.exportCliboard.label"),
-      disabled: false,
-      click: () => {
-        const webconsoleOutput = parentNode.querySelector(".webconsole-output");
-        clipboardHelper.copyString(getElementText(webconsoleOutput));
-      },
-    })
-  );
+  // // Export to clipboard
+  // exportSubmenu.append(
+  //   new MenuItem({
+  //     id: "console-menu-export-clipboard",
+  //     label: l10n.getStr("webconsole.menu.exportSubmenu.exportCliboard.label"),
+  //     disabled: false,
+  //     click: () => {
+  //       const webconsoleOutput = parentNode.querySelector(".webconsole-output");
+  //       copyStringToClipboard(getElementText(webconsoleOutput));
+  //     },
+  //   })
+  // );
 
-  // Export to file
-  exportSubmenu.append(
-    new MenuItem({
-      id: "console-menu-export-file",
-      label: l10n.getStr("webconsole.menu.exportSubmenu.exportFile.label"),
-      disabled: false,
-      // Note: not async, but returns a promise for the actual save.
-      click: () => {
-        const date = new Date();
-        const suggestedName =
-          `console-export-${date.getFullYear()}-` +
-          `${date.getMonth() + 1}-${date.getDate()}_${date.getHours()}-` +
-          `${date.getMinutes()}-${date.getSeconds()}.txt`;
-        const webconsoleOutput = parentNode.querySelector(".webconsole-output");
-        const data = new TextEncoder().encode(getElementText(webconsoleOutput));
-        return saveAs(window, data, suggestedName);
-      },
-    })
-  );
+  // // Export to file
+  // exportSubmenu.append(
+  //   new MenuItem({
+  //     id: "console-menu-export-file",
+  //     label: l10n.getStr("webconsole.menu.exportSubmenu.exportFile.label"),
+  //     disabled: false,
+  //     // Note: not async, but returns a promise for the actual save.
+  //     click: () => {
+  //       const date = new Date();
+  //       const suggestedName =
+  //         `console-export-${date.getFullYear()}-` +
+  //         `${date.getMonth() + 1}-${date.getDate()}_${date.getHours()}-` +
+  //         `${date.getMinutes()}-${date.getSeconds()}.txt`;
+  //       const webconsoleOutput = parentNode.querySelector(".webconsole-output");
+  //       const data = new TextEncoder().encode(getElementText(webconsoleOutput));
+  //       return saveAs(window, data, suggestedName);
+  //     },
+  //   })
+  // );
 
-  menu.append(
-    new MenuItem({
-      id: "console-menu-export",
-      label: l10n.getStr("webconsole.menu.exportSubmenu.label"),
-      disabled: false,
-      submenu: exportSubmenu,
-    })
-  );
+  // menu.append(
+  //   new MenuItem({
+  //     id: "console-menu-export",
+  //     label: l10n.getStr("webconsole.menu.exportSubmenu.label"),
+  //     disabled: false,
+  //     submenu: exportSubmenu,
+  //   })
+  // );
 
-  // Open object in sidebar.
-  const shouldOpenSidebar = store.getState().prefs.sidebarToggle;
-  if (shouldOpenSidebar) {
-    menu.append(
-      new MenuItem({
-        id: "console-menu-open-sidebar",
-        label: l10n.getStr("webconsole.menu.openInSidebar.label"),
-        accesskey: l10n.getStr("webconsole.menu.openInSidebar.accesskey"),
-        disabled: !rootActorId,
-        click: () => dispatch(actions.openSidebar(messageId, rootActorId)),
-      })
-    );
-  }
+  // // Open object in sidebar.
+  // const shouldOpenSidebar = store.getState().prefs.sidebarToggle;
+  // if (shouldOpenSidebar) {
+  //   menu.append(
+  //     new MenuItem({
+  //       id: "console-menu-open-sidebar",
+  //       label: l10n.getStr("webconsole.menu.openInSidebar.label"),
+  //       accesskey: l10n.getStr("webconsole.menu.openInSidebar.accesskey"),
+  //       disabled: !rootActorId,
+  //       click: () => dispatch(actions.openSidebar(messageId, rootActorId)),
+  //     })
+  //   );
+  // }
 
   // Add time warp option if available.
   if (executionPoint) {
@@ -263,32 +257,32 @@ function createContextMenu(event, message, webConsoleWrapper) {
   }
 
   if (url) {
-    menu.append(
-      new MenuItem({
-        id: "console-menu-open-url",
-        label: l10n.getStr("webconsole.menu.openURL.label"),
-        accesskey: l10n.getStr("webconsole.menu.openURL.accesskey"),
-        click: () =>
-          openDocLink(url, {
-            inBackground: true,
-            relatedToCurrent: true,
-          }),
-      })
-    );
+    // menu.append(
+    //   new MenuItem({
+    //     id: "console-menu-open-url",
+    //     label: l10n.getStr("webconsole.menu.openURL.label"),
+    //     accesskey: l10n.getStr("webconsole.menu.openURL.accesskey"),
+    //     click: () =>
+    //       openDocLink(url, {
+    //         inBackground: true,
+    //         relatedToCurrent: true,
+    //       }),
+    //   })
+    // );
     menu.append(
       new MenuItem({
         id: "console-menu-copy-url",
         label: l10n.getStr("webconsole.menu.copyURL.label"),
         accesskey: l10n.getStr("webconsole.menu.copyURL.accesskey"),
-        click: () => clipboardHelper.copyString(url),
+        click: () => copyStringToClipboard(url),
       })
     );
   }
 
   // Emit the "menu-open" event for testing.
-  const { screenX, screenY } = event;
+  const { clientX, clientY } = event;
   menu.once("open", () => webConsoleWrapper.emitForTests("menu-open"));
-  menu.popup(screenX, screenY, hud.chromeWindow.document);
+  menu.popup(clientX, clientY, window.document);
 
   return menu;
 }


### PR DESCRIPTION
Fixes #462

This adds back a barebones context menu in the console with `Copy Message`, `Copy Object`, `Select All`, `Jump Here` and `Copy URL`.

![image](https://user-images.githubusercontent.com/15959269/91872468-e78e9080-ec45-11ea-9443-681f8fae0664.png)
