### PR TITLE
Issue #531: Use the grid layout for the Console to avoid overflow of the filter toolbar

### DIFF
--- a/src/devtools/client/webconsole/components/App.css
+++ b/src/devtools/client/webconsole/components/App.css
@@ -27,9 +27,7 @@ body {
   --object-inspector-hover-background: transparent;
   --attachment-margin-block-end: 3px;
   --primary-toolbar-height: 29px;
-  display: flex;
-  flex-direction: column;
-  /*display: grid;*/
+  display: grid;
   /*
     * Here's the design we want in in-line mode
     * +----------------------------------------------+
@@ -61,15 +59,15 @@ body {
      *   rows/columns to "auto" to make them collapse when the element
      *   they contain is hidden.
      */
-  /*
-  grid-template-areas: "filter-toolbar           sidebar"
-                       "filter-toolbar-secondary sidebar"
-                       "output-input             sidebar"
-                       "reverse-search           sidebar";
+  grid-template-areas:
+    "filter-toolbar           sidebar"
+    "filter-toolbar-secondary sidebar"
+    "output-input             sidebar"
+    "reverse-search           sidebar";
   grid-template-rows: var(--primary-toolbar-height) auto 1fr auto;
   grid-template-columns: minmax(200px, 1fr) minmax(0, auto);
-  */
   width: 100vw;
+  overflow: hidden;
   color: var(--console-output-color);
   -moz-user-focus: normal;
 }
@@ -90,20 +88,21 @@ body {
 }
 
 .flexible-output-input {
-  position: relative;
-  height: 100%;
   display: flex;
   flex-direction: column;
+  grid-area: output-input;
+  /* Don't take more height than the grid allows to */
+  max-height: 100%;
+  overflow: hidden;
 }
 
 .flexible-output-input .webconsole-output {
-  /* height: calc(100% - 55px); */
-  overflow: hidden auto;
+  flex-shrink: 100000;
+  overflow-x: hidden;
 }
 
 .flexible-output-input > .webconsole-output:not(:empty) {
   min-height: var(--console-row-height);
-  max-height: calc(100% - 60px);
 }
 
 /* webconsole.css | chrome://devtools/skin/webconsole.css */
@@ -117,8 +116,8 @@ body {
 }
 
 .webconsole-app .jsterm-input-container {
-  overflow: hidden;
-  height: 20px;
+  overflow-y: auto;
+  overflow-x: hidden;
   /* We display the open editor button at the end of the input */
   display: grid;
   grid-template-columns: 1fr auto;
@@ -145,7 +144,6 @@ body {
   border-top-color: var(--theme-splitter-color);
   border-top-width: var(--jsterm-border-width);
   border-top-style: solid;
-  flex-grow: 100;
 }
 
 .webconsole-app .webconsole-output:not(:empty) ~ .jsterm-input-container {
@@ -173,6 +171,7 @@ body {
 .webconsole-input-buttons {
   grid-column: -1 / -2;
   display: flex;
+  align-items: flex-start;
 }
 
 :root:dir(rtl) .webconsole-input-openEditorButton {


### PR DESCRIPTION
Fixes #531 

This patch revives the existing grid layout for the Console and replaces the flexbox layout
to prevent the filter toolbar from disappearing due to overflow in the Console.