### PR TITLE
Restore regular paste functionality in the console terminal

### DIFF
--- a/src/devtools/client/locales/en-us/webconsole.properties
+++ b/src/devtools/client/locales/en-us/webconsole.properties
@@ -100,16 +100,6 @@ openNodeInInspector=Click to select the node in the inspector
 # cd() is invoked with an invalid argument.
 cdFunctionInvalidArgument=Cannot cd() to the given window. Invalid argument.
 
-# LOCALIZATION NOTE (selfxss.msg): the text that is displayed when
-# a new user of the developer tools pastes code into the console
-# %1 is the text of selfxss.okstring
-selfxss.msg=Scam Warning: Take care when pasting things you don’t understand. This could allow attackers to steal your identity or take control of your computer. Please type ‘%S’ below (no need to press enter) to allow pasting.
-
-# LOCALIZATION NOTE (selfxss.okstring): the string to be typed
-# in by a new user of the developer tools when they receive the sefxss.msg prompt.
-# Please avoid using non-keyboard characters here
-selfxss.okstring=allow pasting
-
 # LOCALIZATION NOTE (messageToggleDetails): the text that is displayed when
 # you hover the arrow for expanding/collapsing the message details. For
 # console.error() and other messages we show the stacktrace.

--- a/src/devtools/client/webconsole/components/Input/JSTerm.js
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.js
@@ -63,8 +63,6 @@ class JSTerm extends Component {
       webConsoleUI: PropTypes.object.isRequired,
       // Needed for opening context menu
       serviceContainer: PropTypes.object.isRequired,
-      // Handler for clipboard 'paste' event (also used for 'drop' event, callback).
-      onPaste: PropTypes.func,
       // Evaluate provided expression.
       evaluateExpression: PropTypes.func.isRequired,
       // Update position in the history after executing an expression (action).
@@ -451,8 +449,6 @@ class JSTerm extends Component {
       this.editor.appendToLocalElement(this.node);
 
       const cm = this.editor.codeMirror;
-      cm.on("paste", (_, event) => this.props.onPaste(event));
-      cm.on("drop", (_, event) => this.props.onPaste(event));
 
       this.node.addEventListener("keydown", event => {
         if (event.keyCode === KeyCodes.DOM_VK_ESCAPE) {


### PR DESCRIPTION
Fixes #496. This removes the self-xss notification in the console to allow pasting.