### PR TITLE
Fix comment cancel behavior

### DIFF
--- a/src/ui/components/Comments/CommentEditor.js
+++ b/src/ui/components/Comments/CommentEditor.js
@@ -44,10 +44,15 @@ class CommentEditor extends React.Component {
   };
 
   stopEditingComment = e => {
-    const { comment, stopEditing } = this.props;
+    const { removeComment, comment, stopEditing } = this.props;
+    const { inputValue } = this.state;
+    e.stopPropagation();
+
+    if (comment.contents == "" && inputValue == "") {
+      return removeComment(comment);
+    }
 
     this.setState({ inputValue: comment.contents });
-    e.stopPropagation();
     stopEditing();
   };
 


### PR DESCRIPTION
This makes it so that for new comments, clicking cancel on the comment editor deletes the comment. If it's an existing comment, it just discards the changes.