### PR TITLE
Add tabIndex to messages so they are tab navigable

### DIFF
--- a/src/ui/components/Timeline/Message.js
+++ b/src/ui/components/Timeline/Message.js
@@ -85,6 +85,7 @@ class Message extends React.Component {
 
     return (
       <a
+        tabIndex={0}
         className={classnames("message", {
           future: isFuture,
           highlighted: isHighlighted,
@@ -100,6 +101,7 @@ class Message extends React.Component {
         }}
         title={getFormatStr("jumpMessage2", frameLocation)}
         onClick={e => onMarkerClick(e, message)}
+        onFocus={e => onMarkerClick(e, message)}
         onMouseEnter={onMarkerMouseEnter}
         onMouseLeave={onMarkerMouseLeave}
       />

--- a/src/ui/components/Timeline/Message.js
+++ b/src/ui/components/Timeline/Message.js
@@ -100,7 +100,6 @@ class Message extends React.Component {
           zIndex: `${index + 100}`,
         }}
         title={getFormatStr("jumpMessage2", frameLocation)}
-        onClick={e => onMarkerClick(e, message)}
         onFocus={e => onMarkerClick(e, message)}
         onMouseEnter={onMarkerMouseEnter}
         onMouseLeave={onMarkerMouseLeave}


### PR DESCRIPTION
Adds `tabIndex` (because the `<a>` lacks an `href` which would make them focusable by default) and replaces `onClick` handler with `onFocus` handler to make message points tab-navigable.

I looked at adding the same to comments so that users could stop at those as well but they're rendered in a different subtree and so won't as easily participate in natural tab order.