### PR TITLE
Hide toolbox while loading

### DIFF
--- a/src/ui/components/App.js
+++ b/src/ui/components/App.js
@@ -25,8 +25,9 @@ class App extends React.Component {
   };
 
   componentDidMount() {
-    const { theme } = this.props;
+    const { theme, initialize } = this.props;
 
+    initialize();
     setTheme(theme);
   }
 
@@ -52,16 +53,21 @@ class App extends React.Component {
   }
 
   render() {
-    const {
-      commentVisible,
-      hideComments,
-      updateTimelineDimensions,
-      loading,
-      initialize,
-    } = this.props;
+    const { commentVisible, hideComments, updateTimelineDimensions, loading } = this.props;
     const { orientation } = this.state;
+    const isLoading = loading < 100;
 
-    const toolbox = <Toolbox initialize={initialize} />;
+    if (isLoading) {
+      return (
+        <>
+          <Header />
+          <div className="loading-bar" style={{ width: `${loading}%` }} />
+        </>
+      );
+    }
+
+    const vert = orientation != "bottom";
+    const toolbox = <Toolbox />;
 
     let startPanel, endPanel;
     if (orientation == "bottom" || orientation == "right") {
@@ -72,12 +78,9 @@ class App extends React.Component {
       endPanel = this.renderViewer(toolbox);
     }
 
-    const vert = orientation != "bottom";
-    const isLoaded = loading === 100;
-
     return (
       <>
-        <Header loading={loading} />
+        <Header />
         <Comments />
         {commentVisible && <div className="app-mask" onClick={() => hideComments()} />}
         <SplitBox

--- a/src/ui/components/Header.css
+++ b/src/ui/components/Header.css
@@ -80,6 +80,5 @@
 .loading-bar {
   height: 4px;
   background: linear-gradient(138.3deg, #236eff 7.98%, #71e5ff 93.53%);
-
-  animation-duration: 500;
+  transition-duration: 300ms;
 }

--- a/src/ui/components/Header.js
+++ b/src/ui/components/Header.js
@@ -42,23 +42,18 @@ class Header extends React.Component {
   }
 
   render() {
-    const { loading } = this.props;
-    const isLoaded = loading == 100;
     return (
-      <>
-        <div id="header">
-          <div className="logo"></div>
-          <div id="status"></div>
-          <div className="links">
-            <a id="headway" onClick={this.toggleHeadway}>
-              What&apos;s new
-            </a>
-            {this.renderAvatars()}
-            {features.auth0 ? <LoginButton /> : null}
-          </div>
+      <div id="header">
+        <div className="logo"></div>
+        <div id="status"></div>
+        <div className="links">
+          <a id="headway" onClick={this.toggleHeadway}>
+            What&apos;s new
+          </a>
+          {this.renderAvatars()}
+          {features.auth0 ? <LoginButton /> : null}
         </div>
-        {!isLoaded && <div className="loading-bar" style={{ width: `${loading}%` }}></div>}
-      </>
+      </div>
     );
   }
 }

--- a/src/ui/components/Toolbox.js
+++ b/src/ui/components/Toolbox.js
@@ -49,9 +49,9 @@ class Toolbox extends React.Component {
   }
 
   async componentDidMount() {
-    const { selectedPanel, initialize } = this.props;
+    const { selectedPanel } = this.props;
 
-    initialize();
+    this.threadFront.initializeToolbox();
     // Open the console so that the timeline gets events
     this.startPanel("console");
     this.selectTool(selectedPanel);


### PR DESCRIPTION
Fixes #600. This hides the toolbox until the recording is fully loaded. 

This patch also delays hiding the loading screen. That means the user will always see the loading bar get to 100% before it disappears. Before, the loading bar would not render the 100% loading state before disappearing. This is less noticeable if it went from 99% - 100%, but can be jarring if it goes from 4% - 100%. [Loom demo](https://www.loom.com/share/2020b870f7d54644815582e48bc28e98)