### PR TITLE
fix: intercom app id for mail link

### DIFF
--- a/src/ui/components/RightSidebar/Intercom.js
+++ b/src/ui/components/RightSidebar/Intercom.js
@@ -76,7 +76,7 @@ function setupIntercom() {
 export default function Intercom({}) {
   useEffect(() => bootstrapIntercom(), []);
   return (
-    <a className="intercom-launcher" href="mailto:YOUR_APP_ID@incoming.intercom.io">
+    <a className="intercom-launcher" href=`"mailto:${APP_ID}@incoming.intercom.io"`>
       <div className="intercom-icon-close"></div>
       <div className="intercom-icon-open"></div>
       <span className="intercom-unread-count"></span>

--- a/src/ui/components/RightSidebar/Intercom.js
+++ b/src/ui/components/RightSidebar/Intercom.js
@@ -76,7 +76,7 @@ function setupIntercom() {
 export default function Intercom({}) {
   useEffect(() => bootstrapIntercom(), []);
   return (
-    <a className="intercom-launcher" href=`"mailto:${APP_ID}@incoming.intercom.io"`>
+    <a className="intercom-launcher" href=`mailto:${APP_ID}@incoming.intercom.io`>
       <div className="intercom-icon-close"></div>
       <div className="intercom-icon-open"></div>
       <span className="intercom-unread-count"></span>

--- a/src/ui/components/RightSidebar/Intercom.js
+++ b/src/ui/components/RightSidebar/Intercom.js
@@ -75,8 +75,9 @@ function setupIntercom() {
 
 export default function Intercom({}) {
   useEffect(() => bootstrapIntercom(), []);
+  const intercomMailLink = `mailto:${APP_ID}@incoming.intercom.io`;
   return (
-    <a className="intercom-launcher" href=`mailto:${APP_ID}@incoming.intercom.io`>
+    <a className="intercom-launcher" href={intercomMailLink}>
       <div className="intercom-icon-close"></div>
       <div className="intercom-icon-open"></div>
       <span className="intercom-unread-count"></span>


### PR DESCRIPTION
Inject the app ID for intercom's mail link.
This will allow any mail to get into the replay app account.