### PR TITLE
Display recordings in replay.io/view and localhost:8000/index.html

### DIFF
--- a/src/protocol/thread.js
+++ b/src/protocol/thread.js
@@ -1928,6 +1928,11 @@ const ThreadFront = {
     callback(value ? JSON.parse(value) : undefined);
   },
 
+  async getRecordings(authId) {
+    const response = await sendMessage("Internal.getRecordings", { authId });
+    return response.recordings;
+  },
+
   async updateMetadata(key, callback) {
     // Keep trying to update the metadata until it succeeds --- we updated it
     // before anyone else did. Use the callback to compute the new value in

--- a/src/ui/actions/app.js
+++ b/src/ui/actions/app.js
@@ -3,16 +3,14 @@ import { selectors } from "ui/reducers";
 
 export function setupApp(recordingId, store) {
   store.dispatch({ type: "setup_app", recordingId });
-  if (recordingId) {
-    ThreadFront.ensureProcessed(_, regions => store.dispatch(onUnprocessedRegions(regions))).then(
-      () => {
-        clearInterval(loadingInterval);
-        store.dispatch({ type: "loading", loading: 100 });
-      }
-    );
+  ThreadFront.ensureProcessed(_, regions => store.dispatch(onUnprocessedRegions(regions))).then(
+    () => {
+      clearInterval(loadingInterval);
+      store.dispatch({ type: "loading", loading: 100 });
+    }
+  );
 
-    const loadingInterval = setInterval(() => store.dispatch(bumpLoading()), 500);
-  }
+  const loadingInterval = setInterval(() => store.dispatch(bumpLoading()), 500);
 }
 
 function bumpLoading() {

--- a/src/ui/actions/metadata.js
+++ b/src/ui/actions/metadata.js
@@ -172,12 +172,19 @@ export function getActiveUsers() {
 }
 
 export function updateUser(authUser = {}) {
-  return ({ dispatch, getState }) => {
+  return async ({ dispatch, getState }) => {
     const user = selectors.getUser(getState());
     const { picture, name } = authUser;
     const { id, avatarID } = user;
     const updatedUser = { id, avatarID, picture, name };
 
     dispatch({ type: "register_user", user: updatedUser });
+
+    if (authUser.sub) {
+      try {
+        const recordings = await ThreadFront.getRecordings(authUser.sub);
+        dispatch({ type: "set_recordings", recordings });
+      } catch (e) {}
+    }
   };
 }

--- a/src/ui/components/App.js
+++ b/src/ui/components/App.js
@@ -6,6 +6,7 @@ import Toolbox from "./Toolbox";
 import Tooltip from "./Tooltip";
 import Comments from "./Comments";
 import Header from "./Header";
+import Recordings from "./Recordings";
 
 import SplitBox from "devtools/client/shared/components/splitter/SplitBox";
 import RightSidebar from "./RightSidebar";
@@ -25,9 +26,7 @@ class App extends React.Component {
   };
 
   componentDidMount() {
-    const { theme, initialize } = this.props;
-
-    initialize();
+    const { theme } = this.props;
     setTheme(theme);
   }
 
@@ -67,7 +66,11 @@ class App extends React.Component {
       return (
         <>
           <Header />
-          {recordingId && <div className="loading-bar" style={{ width: `${loading}%` }} />}
+          {recordingId ? (
+            <div className="loading-bar" style={{ width: `${loading}%` }} />
+          ) : (
+            <Recordings />
+          )}
         </>
       );
     }
@@ -113,6 +116,7 @@ export default connect(
     commentVisible: selectors.commentVisible(state),
     loading: selectors.getLoading(state),
     recordingId: selectors.getRecordingId(state),
+    user: selectors.getUser(state),
   }),
   {
     updateTheme: actions.updateTheme,

--- a/src/ui/components/Recordings.css
+++ b/src/ui/components/Recordings.css
@@ -1,0 +1,78 @@
+.recordings {
+  margin: 40px auto 0;
+  /* width: 100%;
+  max-width: 1200px; */
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.recording {
+  max-width: 420px;
+  min-width: 300px;
+  padding: 40px;
+}
+
+.recording .title {
+  font-size: 16px;
+  overflow: hidden;
+  margin-top: 12px;
+  line-height: 26px;
+  font-weight: 600;
+  margin: 0.6em 0 0.2em;
+  color: var(--primary-color);
+  padding: 0;
+  background: none;
+  border: none;
+}
+
+.recording .secondary {
+  color: var(--secondary-color);
+  line-height: 20px;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.recording .screenshot {
+  width: 100%;
+  height: 240px;
+  background: #ccc;
+  justify-content: center;
+  display: flex;
+  position: relative;
+}
+
+.recording .screenshot img {
+  height: 100%;
+  object-fit: contain;
+  width: 100%;
+}
+
+.recording .screenshot:hover .overlay {
+  visibility: visible;
+}
+
+.recording .overlay {
+  display: none;
+  position: absolute;
+  top: 0;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  visibility: hidden;
+  border-radius: 2px;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0,0,0,.3);
+}
+
+.recording button.link {
+  width: 50px;
+  height: 50px;
+  background: white;
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px 1px rgba(0, 0, 0, 0.2);
+}

--- a/src/ui/components/Recordings.js
+++ b/src/ui/components/Recordings.js
@@ -1,0 +1,54 @@
+const React = require("react");
+import { connect } from "react-redux";
+import { selectors } from "../reducers";
+
+import "./Recordings.css";
+
+const Recordings = props => (
+  <div className="recordings">
+    {props.recordings &&
+      props.recordings.map((recording, i) => <Recording data={recording} key={i} />)}
+  </div>
+);
+
+const Recording = props => {
+  let dateString = new Date(props.data.date).toString().split(" ");
+  let date = `${dateString[1]} ${dateString[2]}, ${dateString[4].slice(0, 5)}`;
+  return (
+    <div className="recording">
+      <div className="screenshot">
+        <img
+          src={`data:image/png;base64, ${props.data.last_screen_data}`}
+          alt="recording screenshot"
+        />
+        {/* <Dropdown
+          overlay={<OverlayMenu onDelete={onDelete} onRename={onRename} />}
+          trigger={['click']}
+          placement="bottomRight"
+          onVisibleChange={handleVisibleChange}
+          visible={dropdownVisible}
+        >
+          <Button type="text" className="more-btn">
+            &middot;&middot;&middot;
+          </Button>
+        </Dropdown> */}
+        <div className="overlay" onClick={() => window.open(props.data.url, "_blank")} />
+        {/* <button icon={<LinkIconSvg />} onClick={() => window.open(props.data.url, "_blank")} /> */}
+      </div>
+      <div className="title" onClick={() => window.open(props.data.url, "_blank")}>
+        {props.data.recordingTitle || props.data.title}
+      </div>
+      {/* <div className="title" onClick={() => setEnableTitleEdit(true)}>
+        {props.data.recordingTitle || props.data.title}
+      </div> */}
+      <div className="secondary">{date}</div>
+    </div>
+  );
+};
+
+export default connect(
+  state => ({
+    recordings: selectors.getRecordings(state),
+  }),
+  {}
+)(Recordings);

--- a/src/ui/reducers/app.js
+++ b/src/ui/reducers/app.js
@@ -8,6 +8,7 @@ function initialAppState() {
     selectedPanel: prefs.selectedPanel,
     tooltip: null,
     loading: 4,
+    recordings: null,
   };
 }
 
@@ -32,6 +33,10 @@ export default function update(state = initialAppState(), action) {
       return { ...state, loading: action.loading };
     }
 
+    case "set_recordings": {
+      return { ...state, recordings: action.recordings };
+    }
+
     default: {
       return state;
     }
@@ -43,3 +48,4 @@ export const isSplitConsoleOpen = state => state.app.splitConsoleOpen;
 export const getSelectedPanel = state => state.app.selectedPanel;
 export const getLoading = state => state.app.loading;
 export const getRecordingId = state => state.app.recordingId;
+export const getRecordings = state => state.app.recordings;


### PR DESCRIPTION
Similar to recordings.replay.io, this lets a logged-in user browse their recordings when they go to the viewer without a recording id (e.g. `replay.io/view`).

![image](https://user-images.githubusercontent.com/15959269/92986851-b1de7880-f48b-11ea-9338-e3fe77e16985.png)
