### PR TITLE
Improve test runner

### DIFF
--- a/.github/actions/test/main.js
+++ b/.github/actions/test/main.js
@@ -1,23 +1,34 @@
-const { spawnSync } = require("child_process");
+const { spawnSync, spawn } = require("child_process");
 
 function spawnChecked(...args) {
+  console.log(`spawn`, args);
   const rv = spawnSync.apply(this, args);
   if (rv.status != 0 || rv.error) {
     throw new Error("Spawned process failed");
   }
 }
 
-console.log(new Date, "Start");
+console.log(new Date(), "Start");
 
 spawnChecked("mv", ["dist/dist.tgz", "dist.tgz"]);
 spawnChecked("tar", ["-xzf", "dist.tgz"]);
 
-console.log(new Date, "Unpackaged distribution");
+console.log(new Date(), "Unpackaged distribution");
 
 spawnChecked("hdiutil", ["attach", "replay/replay.dmg"]);
 spawnChecked("cp", ["-R", "/Volumes/Replay/Replay.app", "/Applications"]);
 spawnChecked("hdiutil", ["detach", "/Volumes/Replay/"]);
 
-console.log(new Date, "Installed replay browser");
+console.log(new Date(), "Installed replay browser");
+
+spawnChecked("ls", {
+  cwd: "..",
+  stdio: "inherit",
+});
+
+spawn("node_modules/.bin/webpack-dev-server", {
+  detached: true,
+  stdio: "inherit",
+});
 
 require("../../../test/run");

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build webpack
         run: ./node_modules/.bin/webpack --mode=development
       - name: Tar up output files
-        run: tar -czf dist.tgz index.html dist
+        run: tar -czf dist.tgz index.html dist node_modules
       - name: Create artifact
         uses: actions/upload-artifact@v2
         with:

--- a/test/header.js
+++ b/test/header.js
@@ -23,10 +23,7 @@ const EventUtils = {
   _EU_Cc: Cc,
 };
 
-Services.scriptloader.loadSubScript(
-  "chrome://remote/content/external/EventUtils.js",
-  EventUtils
-);
+Services.scriptloader.loadSubScript("chrome://remote/content/external/EventUtils.js", EventUtils);
 
 const modules = {};
 XPCOMUtils.defineLazyModuleGetters(modules, {
@@ -72,7 +69,7 @@ async function stopRecordingAndLoadDevtools() {
       dump(`TestHarnessWaitForDevtools\n`);
 
       // This is the server used for hosting the devtools in run.js. This is cheesy...
-      if (await waitForLoad("localhost:8002")) {
+      if (await waitForLoad("localhost:8080")) {
         break;
       }
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,16 +11,23 @@ module.exports = {
     publicPath: "dist",
   },
   devServer: {
+    before: app => {
+      app.get("/view", (req, res) => {
+        res.sendFile("index.html", { root: "." });
+      });
+
+      app.get("/test", (req, res) => {
+        const testFile = req.url.substring(6);
+        res.sendFile(testFile, { root: "./test/scripts" });
+      });
+    },
     contentBase: ".",
     index: "index.html",
     liveReload: false,
   },
   plugins: [new MiniCssExtractPlugin()],
   resolve: {
-    extensions: [
-      ".js",
-      ".ts",
-    ],
+    extensions: [".js", ".ts"],
     modules: [
       "src",
       "src/devtools/client/debugger/dist",
@@ -45,10 +52,7 @@ module.exports = {
         use: {
           loader: "babel-loader",
           options: {
-            presets: [
-              "@babel/preset-typescript",
-              "@babel/preset-react"
-            ],
+            presets: ["@babel/preset-typescript", "@babel/preset-react"],
             plugins: [
               "@babel/plugin-transform-flow-strip-types",
               "@babel/plugin-proposal-class-properties",


### PR DESCRIPTION
1. stop using custom devtools server
2. extract createTestScript

### After this change

* we will need to have the dev server running `npm start`
* We'll no longer need to do a webpack build every time we change the code 🏃 

This should save a lot of time when we're fixing tests