### PR TITLE
fix(auth): do not use localstorage for tokens

### DIFF
--- a/src/ui/utils/auth0.js
+++ b/src/ui/utils/auth0.js
@@ -19,7 +19,6 @@ const Auth0ProviderWithHistory = ({ children }) => {
       clientId={"4FvFnJJW4XlnUyrXQF8zOLw6vNAH1MAo"}
       redirectUri={origin + pathname}
       onRedirectCallback={onRedirectCallback}
-      cacheLocation="localstorage"
     >
       {children}
     </Auth0Provider>


### PR DESCRIPTION
localstorage exposes the auth tokens to any 3rd party scripts.
Sticking to cookies directly allows the browser to control
authentication to some extent through the same origin policy.