### PR TITLE
Handle blank recordingIds when calling app.local() and app.prod()

### DIFF
--- a/src/ui/utils/bootstrap.js
+++ b/src/ui/utils/bootstrap.js
@@ -90,11 +90,22 @@ function setupAppHelper(store) {
       JSON.stringify({ features: features.toJSON(), prefs: prefs.toJSON() }, null, 2),
     local: () => {
       const params = new URLSearchParams(document.location.search.substring(1));
-      window.location = `http://localhost:8080/index.html?id=${params.get("id")}`;
+
+      if (params.get("id")) {
+        window.location = `http://localhost:8080/index.html?id=${params.get("id")}`;
+      } else {
+        window.location = "http://localhost:8080/index.html";
+      }
     },
     prod: () => {
       const params = new URLSearchParams(document.location.search.substring(1));
-      window.location = `http://replay.io/view?id=${params.get("id")}`;
+      console.log(">>", params.get("id"), typeof params.get("id"));
+
+      if (params.get("id")) {
+        window.location = `http://replay.io/view?id=${params.get("id")}`;
+      } else {
+        window.location = "http://replay.io/view";
+      }
     },
   };
 }


### PR DESCRIPTION
We should properly handle the switch between local and prod when viewing the main recordings page (`http://localhost:8080/index.html`, `https://replay.io/view`).