### PR TITLE
Use ApolloClient for fetching recordings

### DIFF
--- a/src/protocol/thread.js
+++ b/src/protocol/thread.js
@@ -1934,11 +1934,6 @@ const ThreadFront = {
     callback(value ? JSON.parse(value) : undefined);
   },
 
-  async getRecordings(authId) {
-    const response = await sendMessage("Internal.getRecordings", { authId });
-    return response.recordings;
-  },
-
   async updateMetadata(key, callback) {
     // Keep trying to update the metadata until it succeeds --- we updated it
     // before anyone else did. Use the callback to compute the new value in

--- a/src/ui/actions/metadata.js
+++ b/src/ui/actions/metadata.js
@@ -173,12 +173,5 @@ export function updateUser(authUser = {}) {
     const updatedUser = { id, avatarID, picture, name };
 
     dispatch({ type: "register_user", user: updatedUser });
-
-    if (authUser.sub) {
-      try {
-        const recordings = await ThreadFront.getRecordings(authUser.sub);
-        dispatch({ type: "set_recordings", recordings });
-      } catch (e) {}
-    }
   };
 }

--- a/src/ui/reducers/app.js
+++ b/src/ui/reducers/app.js
@@ -33,10 +33,6 @@ export default function update(state = initialAppState(), action) {
       return { ...state, loading: action.loading };
     }
 
-    case "set_recordings": {
-      return { ...state, recordings: action.recordings };
-    }
-
     default: {
       return state;
     }

--- a/src/ui/utils/apolloClient.js
+++ b/src/ui/utils/apolloClient.js
@@ -23,7 +23,7 @@ export const createApolloClient = async auth0Client => {
     }
 
     return new HttpLink({
-      uri: "http://graphql.replay.io/v1/graphql",
+      uri: "https://graphql.replay.io/v1/graphql",
       headers: {
         ...headers,
         Authorization: `Bearer ${hasuraToken}`,
@@ -39,16 +39,5 @@ export const createApolloClient = async auth0Client => {
     cache: new InMemoryCache(),
   });
 
-  client
-    .query({
-      query: gql`
-        query MyRecordingsQuery {
-          recordings {
-            id
-          }
-        }
-      `,
-    })
-    .then(result => console.log(result));
   return client;
 };


### PR DESCRIPTION
This patch:
1) Removes the previous method of fetching recordings, which is by sending a request to the backend
2) Uses the new ApolloClient to fetch recordings directly from GraphQL