### PR TITLE
Refactor App.js

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -86,6 +86,16 @@
   width: 100%;
 }
 
+.loader {
+  margin: auto;
+}
+
+.popup-error {
+  margin: auto;
+  font-size: 1.5em;
+  text-align: center;
+}
+
 @import url("devtools/client/themes/variables.css");
 @import url("devtools/client/themes/webconsole.css");
 @import url("devtools/client/themes/markup.css");

--- a/src/ui/components/Account.js
+++ b/src/ui/components/Account.js
@@ -1,0 +1,36 @@
+import React, { useEffect } from "react";
+import Recordings from "./Recordings/index";
+import { useAuth0 } from "@auth0/auth0-react";
+import Header from "./Header";
+
+function WelcomePage() {
+  const { loginWithRedirect } = useAuth0();
+
+  return (
+    <div className="welcome-screen">
+      <div className="welcome-panel">
+        <img className="logo" src="images/logo.svg" />
+        <img className="atwork" src="images/computer-work.svg" />
+        <button onClick={() => loginWithRedirect()}>Log In</button>
+      </div>
+    </div>
+  );
+}
+
+function AccountPage() {
+  return <Recordings />;
+}
+
+export default function Account() {
+  const { isAuthenticated } = useAuth0();
+  if (!isAuthenticated) {
+    return <WelcomePage />;
+  }
+
+  return (
+    <>
+      <Header />
+      <AccountPage />
+    </>
+  );
+}

--- a/src/ui/components/DevTools.js
+++ b/src/ui/components/DevTools.js
@@ -1,0 +1,101 @@
+const React = require("react");
+import { connect } from "react-redux";
+
+import Toolbox from "./Toolbox";
+import Comments from "./Comments";
+import Recordings from "./Recordings/index";
+import Tooltip from "./Tooltip";
+import Header from "./Header";
+
+import SplitBox from "devtools/client/shared/components/splitter/SplitBox";
+import RightSidebar from "./RightSidebar";
+import { actions } from "../actions";
+import { selectors } from "../reducers";
+
+class DevTools extends React.Component {
+  state = {
+    orientation: "bottom",
+  };
+
+  renderViewer(toolbox) {
+    const { tooltip } = this.props;
+    return (
+      <div id="outer-viewer">
+        <div id="viewer">
+          <canvas id="graphics"></canvas>
+          <div id="highlighter-root"></div>
+        </div>
+        <RightSidebar toolbox={toolbox} />
+        <Tooltip tooltip={tooltip} />
+      </div>
+    );
+  }
+
+  renderSplitBox() {
+    const { updateTimelineDimensions } = this.props;
+    const { orientation } = this.state;
+
+    let startPanel, endPanel;
+    const vert = orientation != "bottom";
+    const toolbox = <Toolbox />;
+
+    if (orientation == "bottom" || orientation == "right") {
+      startPanel = this.renderViewer(toolbox);
+      endPanel = toolbox;
+    } else {
+      startPanel = toolbox;
+      endPanel = this.renderViewer(toolbox);
+    }
+
+    return (
+      <SplitBox
+        style={{ width: "100vw", overflow: "hidden" }}
+        splitterSize={1}
+        initialSize="50%"
+        minSize="20%"
+        maxSize="80%"
+        vert={vert}
+        onMove={num => updateTimelineDimensions()}
+        startPanel={startPanel}
+        endPanelControl={false}
+        endPanel={endPanel}
+      />
+    );
+  }
+
+  render() {
+    const { hideComments, loading, commentVisible } = this.props;
+    const recordingIsLoading = loading < 100;
+
+    if (recordingIsLoading) {
+      return (
+        <>
+          <Header />
+          <div className="loading-bar" style={{ width: `${loading}%` }} />
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Header />
+        <Comments />
+        {commentVisible && <div className="app-mask" onClick={() => hideComments()} />}
+        {this.renderSplitBox()}
+      </>
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    loading: selectors.getLoading(state),
+    user: selectors.getUser(state),
+    tooltip: selectors.getTooltip(state),
+    commentVisible: selectors.commentVisible(state),
+  }),
+  {
+    hideComments: actions.hideComments,
+    updateTimelineDimensions: actions.updateTimelineDimensions,
+  }
+)(DevTools);

--- a/src/ui/components/Recordings/Recordings.css
+++ b/src/ui/components/Recordings/Recordings.css
@@ -122,11 +122,3 @@
   background: #f0f2f5;
   height: 100%;
 }
-
-.loading-pane {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-}

--- a/src/ui/components/Recordings/index.js
+++ b/src/ui/components/Recordings/index.js
@@ -3,25 +3,11 @@ import { connect } from "react-redux";
 import { selectors } from "../../reducers";
 import { Recording } from "./Recording";
 import { useAuth0 } from "@auth0/auth0-react";
-import Lottie from "react-lottie";
-import forwardData from "image/lottie/forward.json";
 import { sortBy } from "lodash";
-import { gql, useQuery, useApolloClient } from "@apollo/client";
+import { gql, useQuery } from "@apollo/client";
+import Loader from "../shared/Loader.js";
 
 import "./Recordings.css";
-
-function Forward() {
-  const defaultOptions = {
-    loop: true,
-    autoplay: true,
-    animationData: forwardData,
-    rendererSettings: {
-      preserveAspectRatio: "xMidYMid slice",
-    },
-  };
-
-  return <Lottie options={defaultOptions} height={50} width={200} />;
-}
 
 const RECORDINGS = gql`
   query MyRecordingsQuery {
@@ -42,50 +28,13 @@ const RECORDINGS = gql`
 `;
 
 const Recordings = props => {
-  const { loginWithRedirect, isAuthenticated, isLoading } = useAuth0();
-  const [recordings, setRecordings] = useState(null);
-  const apolloClient = useApolloClient();
+  const { data, loading } = useQuery(RECORDINGS);
 
-  useEffect(() => {
-    async function getResults() {
-      const client = await apolloClient;
-
-      // Our ApolloClient is created asynchronously. If that client is not yet
-      // ready, we should bail.
-      if (client) {
-        // We intentionally don't use Apollo's useQuery method here. UseQuery is
-        // a hook, and making a hook run conditionally is a big React no-no
-        // (Rules of Hooks). Instead, we extract the query logic from the useQuery
-        // hook and just call it here directly.
-        const response = await client.query({ query: RECORDINGS });
-        setRecordings(response.data.recordings);
-      }
-    }
-
-    getResults();
-  });
-
-  if (isLoading || (isAuthenticated && recordings === null)) {
-    return (
-      <div className="loading-pane">
-        <Forward />
-      </div>
-    );
+  if (loading) {
+    return <Loader />;
   }
 
-  if (!isAuthenticated) {
-    return (
-      <div className="welcome-screen">
-        <div className="welcome-panel">
-          <img className="logo" src="images/logo.svg" />
-          <img className="atwork" src="images/computer-work.svg" />
-          <button onClick={() => loginWithRedirect()}>Log In</button>
-        </div>
-      </div>
-    );
-  }
-
-  const sortedRecordings = sortBy(recordings, recording => -new Date(recording.date));
+  const sortedRecordings = sortBy(data.recordings, recording => -new Date(recording.date));
 
   return (
     <div className="recordings">

--- a/src/ui/components/shared/Error.js
+++ b/src/ui/components/shared/Error.js
@@ -1,0 +1,22 @@
+import React, { useEffect } from "react";
+
+function getBrowser() {
+  if (navigator.vendor === "Google Inc.") {
+    return "chrome";
+  } else if (navigator.appCodeName === "Mozilla") {
+    return "firefox";
+  } else {
+    return null;
+  }
+}
+
+export default function Error() {
+  const browser = getBrowser();
+
+  return (
+    <div className="popup-error">
+      <h3>Uh oh</h3>
+      <p>Please turn off your pop-up blocker and refresh this page.</p>
+    </div>
+  );
+}

--- a/src/ui/components/shared/Loader.js
+++ b/src/ui/components/shared/Loader.js
@@ -1,0 +1,20 @@
+import React, { useEffect } from "react";
+import Lottie from "react-lottie";
+import forwardData from "image/lottie/forward.json";
+
+export default function Loader() {
+  const defaultOptions = {
+    loop: true,
+    autoplay: true,
+    animationData: forwardData,
+    rendererSettings: {
+      preserveAspectRatio: "xMidYMid slice",
+    },
+  };
+
+  return (
+    <div className="loader">
+      <Lottie options={defaultOptions} height={50} width={200} />
+    </div>
+  );
+}

--- a/src/ui/utils/apolloClient.js
+++ b/src/ui/utils/apolloClient.js
@@ -6,21 +6,7 @@ export const createApolloClient = async auth0Client => {
     return;
   }
   const createHttpLink = async headers => {
-    let hasuraToken;
-
-    try {
-      hasuraToken = await auth0Client.getAccessTokenSilently({
-        audience: "hasura-api",
-      });
-    } catch (e) {
-      if (e.error !== "login_required") {
-        throw e;
-      }
-
-      hasuraToken = await auth0Client.getAccessTokenWithPopup({
-        audience: "hasura-api",
-      });
-    }
+    let hasuraToken = await getToken(auth0Client);
 
     return new HttpLink({
       uri: "https://graphql.replay.io/v1/graphql",
@@ -41,3 +27,23 @@ export const createApolloClient = async auth0Client => {
 
   return client;
 };
+
+async function getToken(auth0Client) {
+  try {
+    return await auth0Client.getAccessTokenSilently({
+      audience: "hasura-api",
+    });
+  } catch (e) {
+    if (e.error !== "login_required" && e.error !== "consent_required") {
+      throw e;
+    }
+
+    try {
+      return await auth0Client.getAccessTokenWithPopup({
+        audience: "hasura-api",
+      });
+    } catch (e) {
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
This patch:
- Refactors `App.js` to simplify its structure
- Wraps `App.js` children with a new `ApolloProvider` that then passes down the correct `ApolloClient` context
- Adds an error page for when Auth0 needs to display a popup to get the user's consent, but is not able to