### PR TITLE
use resize-observer-polyfill instead of the native ResizeObserver (#438)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7197,6 +7197,11 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-router-dom": "^5.2.0",
     "react-transition-group": "^2.0.1",
     "redux": "^4.0.5",
+    "resize-observer-polyfill": "^1.5.1",
     "style-loader": "^1.2.1",
     "url-loader": "^4.1.0",
     "webpack": "^4.43.0",

--- a/src/protocol/graphics.js
+++ b/src/protocol/graphics.js
@@ -5,6 +5,7 @@ const { sendMessage, addEventListener, log } = require("./socket");
 const { assert, binarySearch, defer } = require("./utils");
 const { ScreenshotCache } = require("./screenshot-cache");
 const screenshotCache = new ScreenshotCache();
+const ResizeObserverPolyfill = require("resize-observer-polyfill").default;
 
 // Given a sorted array of items with "time" properties, find the index of
 // the most recent item at or preceding a given time.
@@ -325,7 +326,7 @@ function refreshGraphics() {
 function installObserver() {
   const canvas = document.getElementById("viewer");
   if (canvas) {
-    const observer = new ResizeObserver(() => {
+    const observer = new ResizeObserverPolyfill(() => {
       refreshGraphics();
     });
     observer.observe(canvas);


### PR DESCRIPTION
I've used the polyfill as a "ponyfill" as [recommended by its developers](https://www.npmjs.com/package/resize-observer-polyfill#usage-example). This means that the native implementation isn't used even if it is available. Since we don't use it extensively and in my browser experiments (Firefox, Chrome, Safari, Replay) it worked fine, I don't see a problem with that strategy.