### PR TITLE
use JSBI instead of the native BigInt (#438)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5436,6 +5436,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbi": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.1.4.tgz",
+      "integrity": "sha512-52QRRFSsi9impURE8ZUbzAMCLjPm4THO7H2fcuIvaaeFTbSysvkodbQQXIVsNgq/ypDbq6dJiuGKL0vZ/i9hUg=="
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "devtools-sprintf-js": "^1.0.3",
     "extract-loader": "^5.0.1",
     "graphql": "^15.3.0",
+    "jsbi": "^3.1.4",
     "lodash": "^4.17.20",
     "logrocket": "^1.0.12",
     "logrocket-react": "^3.0.1",

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.js
@@ -22,6 +22,8 @@ import actions from "../../actions";
 import classnames from "classnames";
 import "./FrameTimeline.css";
 
+import JSBI from "jsbi";
+
 function isSameLocation(frameLocation, selectedLocation) {
   if (!frameLocation || !selectedLocation) {
     return;
@@ -141,7 +143,7 @@ class FrameTimeline extends Component {
     let index = 0;
     for (let i = 0; i < framePositions.positions.length; i++, index++) {
       const { location, point } = framePositions.positions[i];
-      if (BigInt(executionPoint) <= BigInt(point)) {
+      if (JSBI.lessThanOrEqual(JSBI.BigInt(executionPoint), JSBI.BigInt(point))) {
         break;
       }
     }

--- a/src/devtools/client/debugger/src/reducers/pause.js
+++ b/src/devtools/client/debugger/src/reducers/pause.js
@@ -13,6 +13,7 @@
 import { prefs } from "../utils/prefs";
 import { getSelectedFrame, getFramePositions } from "../selectors/pause";
 import { findLast, find } from "lodash";
+import JSBI from "jsbi";
 
 function createPauseState() {
   return {
@@ -401,11 +402,11 @@ export function getResumePoint(state, type) {
   }
 
   if (type == "reverseStepOver" || type == "rewind") {
-    return findLast(framePoints, p => BigInt(p) < BigInt(executionPoint));
+    return findLast(framePoints, p => JSBI.lessThan(JSBI.BigInt(p), JSBI.BigInt(executionPoint)));
   }
 
   if (type == "stepOver" || type == "resume" || type == "stepIn" || type == "stepUp") {
-    return find(framePoints, p => BigInt(p) > BigInt(executionPoint));
+    return find(framePoints, p => JSBI.greaterThan(JSBI.BigInt(p), JSBI.BigInt(executionPoint)));
   }
 }
 

--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -22,7 +22,7 @@ const { pointPrecedes, pointEquals } = require("protocol/execution-point-utils.j
 const { sortBy } = require("lodash");
 const { log } = require("protocol/socket");
 const { assert } = require("protocol/utils");
-const JSBI = require("jsbi").default;
+const JSBI = require("jsbi");
 
 const MessageState = overrides =>
   Object.freeze(

--- a/src/protocol/execution-point-utils.js
+++ b/src/protocol/execution-point-utils.js
@@ -1,9 +1,11 @@
+const JSBI = require("jsbi").default;
+
 function pointEquals(p1, p2) {
   p1 == p2;
 }
 
 function pointPrecedes(p1, p2) {
-  return BigInt(p1) < BigInt(p2);
+  return JSBI.lessThan(JSBI.BigInt(p1), JSBI.BigInt(p2));
 }
 
 function pointToString(p) {

--- a/src/protocol/execution-point-utils.js
+++ b/src/protocol/execution-point-utils.js
@@ -1,4 +1,4 @@
-const JSBI = require("jsbi").default;
+const JSBI = require("jsbi");
 
 function pointEquals(p1, p2) {
   p1 == p2;


### PR DESCRIPTION
there is one more place where BigInt is used: https://github.com/RecordReplay/devtools/blob/3019a433a308451405f949c3c9a43955493ea5b9/src/protocol/thread.js#L341
In this case the BigInt is stored in a ValueFront. More investigation would be needed to find out how to replace it.
However, I think this only affects recordings where the recorded page uses BigInt itself.