### PR TITLE
[Console] Add the source location and delete button for each console message

### DIFF
--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -7,8 +7,8 @@
   /* Minimum height of a message (excluding borders) */
   --console-row-height: 20px;
   /* We need a unitless line-height to render formatted messages correctly.
-   * Target line-height computed value is 14px, for a 11px font-size. */
-  --console-output-line-height: calc(14 / 11);
+   * Target line-height computed value is 16px, for a 11px font-size. */
+  --console-output-line-height: calc(16 / 11);
   --console-output-vertical-padding: 3px;
   /* Additional vertical padding used on the JSTerm and EagerEvaluation
    * containers. Set to 0 to make the messages and input seamless. */
@@ -118,7 +118,7 @@
 
 @media (min-width: 1000px) {
   .webconsole-app .message {
-    padding-inline-end: 12px;
+    padding-inline-end: 6px;
   }
 }
 
@@ -312,7 +312,7 @@
   max-width: 40vw;
   flex-shrink: 0;
   color: var(--frame-link-source);
-  margin-left: 1ch;
+  margin: 0 1ch;
   /* Makes the file name truncated (and ellipsis shown) on the left side */
   direction: rtl;
   white-space: nowrap;

--- a/src/devtools/client/webconsole/actions/messages.js
+++ b/src/devtools/client/webconsole/actions/messages.js
@@ -63,10 +63,13 @@ function messagesClearEvaluations() {
   };
 }
 
-function messagesClearEvaluation(messageId) {
+function messagesClearEvaluation(messageId, messageType) {
+  // The messageType is only used for logging purposes to determine what type of messages
+  // are typically cleared.
   return {
     type: MESSAGES_CLEAR_EVALUATION,
     messageId,
+    messageType,
   };
 }
 

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -427,7 +427,7 @@ class Message extends Component {
           repeat,
           " ",
           location,
-          type == "command" ? this.renderDeleteButton() : null
+          type == MESSAGE_TYPE.COMMAND ? this.renderDeleteButton() : null
         ),
         attachment,
         ...notesNodes

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -191,10 +191,10 @@ class Message extends Component {
   }
 
   renderDeleteButton() {
-    const { dispatch, message } = this.props;
+    const { dispatch, message, type } = this.props;
 
     return createElement(CloseButton, {
-      handleClick: () => dispatch(actions.messagesClearEvaluation(message.id)),
+      handleClick: () => dispatch(actions.messagesClearEvaluation(message.id, type)),
     });
   }
 

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -427,7 +427,7 @@ class Message extends Component {
           repeat,
           " ",
           location,
-          type == MESSAGE_TYPE.COMMAND ? this.renderDeleteButton() : null
+          this.renderDeleteButton()
         ),
         attachment,
         ...notesNodes

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -4,7 +4,6 @@
 
 "use strict";
 
-// React & Redux
 const { Component, createFactory, createElement } = require("react");
 const dom = require("react-dom-factories");
 const { l10n } = require("devtools/client/webconsole/utils/messages");
@@ -427,6 +426,7 @@ class Message extends Component {
           repeat ? " " : null,
           repeat,
           " ",
+          location,
           type == "command" ? this.renderDeleteButton() : null
         ),
         attachment,

--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -345,7 +345,7 @@ function messages(state = MessageState(), action, filtersState, prefsState, uiSt
     case constants.MESSAGES_CLEAR_EVALUATIONS: {
       const removedIds = [];
       for (const [id, message] of messagesById) {
-        if (message.type === "command" || message.type === "result") {
+        if (message.type === MESSAGE_TYPE.COMMAND || message.type === MESSAGE_TYPE.RESULT) {
           removedIds.push(id);
         }
       }

--- a/src/styles.css
+++ b/src/styles.css
@@ -82,7 +82,8 @@
   z-index: 99;
 }
 
-.A11y-mouse, .A11y-keyboard {
+.A11y-mouse,
+.A11y-keyboard {
   width: 100%;
 }
 
@@ -98,6 +99,7 @@
 
 @import url("devtools/client/themes/variables.css");
 @import url("devtools/client/themes/webconsole.css");
+@import url("devtools/client/themes/components-frame.css");
 @import url("devtools/client/themes/markup.css");
 @import url("devtools/client/themes/common.css");
 @import url("devtools/client/debugger/dist/vendors.css");


### PR DESCRIPTION
It's probably easier to review individual commits.

Before:

<img width="1677" alt="Screen Shot 2020-09-24 at 12 11 54 AM" src="https://user-images.githubusercontent.com/1190888/94100113-bfd0b980-fdfa-11ea-8911-766ed6037328.png">

After:

<img width="1680" alt="Screen Shot 2020-09-24 at 12 12 41 AM" src="https://user-images.githubusercontent.com/1190888/94100121-c52e0400-fdfa-11ea-92d9-5476120827b3.png">

I experimented with showing the Delete button for every message since there's no longer a way to just clear all the messages. I think this will help with filtering unwanted messages from a user's perspective. Let me know what yall think.