### PR TITLE
Show previews of the recording while it's loading

### DIFF
--- a/src/protocol/graphics.js
+++ b/src/protocol/graphics.js
@@ -146,6 +146,12 @@ function getMostRecentPaintPoint(time) {
   return mostRecentEntry(gPaintPoints, time);
 }
 
+function getClosestPaintPoint(time) {
+  const entryBefore = mostRecentEntry(gPaintPoints, time);
+  const entryAfter = nextEntry(gPaintPoints, time);
+  return closerEntry(time, entryBefore, entryAfter);
+}
+
 function getDevicePixelRatio() {
   return gDevicePixelRatio;
 }
@@ -348,4 +354,5 @@ module.exports = {
   getMostRecentPaintPoint,
   refreshGraphics,
   getDevicePixelRatio,
+  getClosestPaintPoint,
 };

--- a/src/ui/actions/app.js
+++ b/src/ui/actions/app.js
@@ -10,13 +10,15 @@ export function setupApp(recordingId, store) {
     }
   );
 
-  const loadingInterval = setInterval(() => store.dispatch(bumpLoading()), 500);
+  const loadingInterval = setInterval(() => store.dispatch(bumpLoading()), 1000);
 }
 
 function bumpLoading() {
   return ({ dispatch, getState }) => {
     const loading = selectors.getLoading(getState());
-    dispatch({ type: "loading", loading: Math.min(loading + 1, 99) });
+    const increment = Math.random() * 4;
+
+    dispatch({ type: "loading", loading: Math.min(loading + increment, 99) });
   };
 }
 

--- a/src/ui/components/Account/Account.css
+++ b/src/ui/components/Account/Account.css
@@ -127,6 +127,14 @@
   color: var(--dark-blue);
 }
 
+.user-prompt .preview-container {
+  width: 400px;
+  height: 250px;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
 @keyframes jump {
   0%   {transform: translate(0,0);}
   10%  {transform: translate(0,-6px);}

--- a/src/ui/components/Account/index.js
+++ b/src/ui/components/Account/index.js
@@ -16,7 +16,7 @@ const RECORDINGS = gql`
   }
 `;
 
-function UserPrompt({ children }) {
+export function UserPrompt({ children }) {
   return <div className="user-prompt">{children}</div>;
 }
 
@@ -74,7 +74,7 @@ function WelcomePage() {
   );
 }
 
-export default function Account() {
+export function Account() {
   const { isAuthenticated } = useAuth0();
   if (!isAuthenticated) {
     return <WelcomePage />;

--- a/src/ui/components/App.js
+++ b/src/ui/components/App.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { connect } from "react-redux";
 import DevTools from "./DevTools";
-import Account from "./Account";
+import { Account } from "./Account/index";
 import Loader from "./shared/Loader";
 import Error from "./shared/Error";
 import { selectors } from "../reducers";

--- a/src/ui/components/DevTools.js
+++ b/src/ui/components/DevTools.js
@@ -1,4 +1,4 @@
-const React = require("react");
+import React, { useState, useEffect } from "react";
 import { connect } from "react-redux";
 
 import Toolbox from "./Toolbox";
@@ -6,90 +6,73 @@ import Comments from "./Comments";
 import Recordings from "./Recordings/index";
 import Tooltip from "./Tooltip";
 import Header from "./Header";
-
+import Loader from "./shared/Loader";
+import { UserPrompt } from "./Account/index";
 import SplitBox from "devtools/client/shared/components/splitter/SplitBox";
 import RightSidebar from "./RightSidebar";
+import RecordingLoadingScreen from "./RecordingLoadingScreen";
+
 import { actions } from "../actions";
 import { selectors } from "../reducers";
+import { screenshotCache, nextPaintEvent, getClosestPaintPoint } from "protocol/graphics";
 
-class DevTools extends React.Component {
-  state = {
-    orientation: "bottom",
-  };
-
-  renderViewer(toolbox) {
-    const { tooltip } = this.props;
-    return (
-      <div id="outer-viewer">
-        <div id="viewer">
-          <canvas id="graphics"></canvas>
-          <div id="highlighter-root"></div>
-        </div>
-        <RightSidebar toolbox={toolbox} />
-        <Tooltip tooltip={tooltip} />
+function Viewer({ tooltip }) {
+  return (
+    <div id="outer-viewer">
+      <div id="viewer">
+        <canvas id="graphics"></canvas>
+        <div id="highlighter-root"></div>
       </div>
-    );
+      <RightSidebar />
+      <Tooltip tooltip={tooltip} />
+    </div>
+  );
+}
+
+function DevtoolsSplitBox({ updateTimelineDimensions, tooltip }) {
+  const toolbox = <Toolbox />;
+  const viewer = <Viewer tooltip={tooltip} />;
+
+  return (
+    <SplitBox
+      style={{ width: "100vw", overflow: "hidden" }}
+      splitterSize={1}
+      initialSize="50%"
+      minSize="20%"
+      maxSize="80%"
+      vert={false}
+      onMove={num => updateTimelineDimensions()}
+      startPanel={viewer}
+      endPanel={toolbox}
+      endPanelControl={false}
+    />
+  );
+}
+
+export function DevTools({
+  unfocusComment,
+  loading,
+  tooltip,
+  hasFocusedComment,
+  updateTimelineDimensions,
+  recordingDuration,
+}) {
+  const recordingIsLoading = loading < 100;
+
+  if (recordingDuration === null) {
+    return <Loader />;
+  } else if (recordingIsLoading) {
+    return <RecordingLoadingScreen />;
   }
 
-  renderSplitBox() {
-    const { updateTimelineDimensions } = this.props;
-    const { orientation } = this.state;
-
-    let startPanel, endPanel;
-    const vert = orientation != "bottom";
-    const toolbox = <Toolbox />;
-
-    if (orientation == "bottom" || orientation == "right") {
-      startPanel = this.renderViewer(toolbox);
-      endPanel = toolbox;
-    } else {
-      startPanel = toolbox;
-      endPanel = this.renderViewer(toolbox);
-    }
-
-    return (
-      <SplitBox
-        style={{ width: "100vw", overflow: "hidden" }}
-        splitterSize={1}
-        initialSize="50%"
-        minSize="20%"
-        maxSize="80%"
-        vert={vert}
-        onMove={num => updateTimelineDimensions()}
-        startPanel={startPanel}
-        endPanelControl={false}
-        endPanel={endPanel}
-      />
-    );
-  }
-
-  render() {
-    const { unfocusComment, loading, hasFocusedComment } = this.props;
-    const recordingIsLoading = loading < 100;
-
-    if (recordingIsLoading) {
-      return (
-        <>
-          <Header />
-          <div className="loading-bar" style={{ width: `${loading}%` }} />
-        </>
-      );
-    }
-
-    function handleClick() {
-      debugger;
-      unfocusComment();
-    }
-
-    return (
-      <>
-        <Header />
-        <Comments />
-        {hasFocusedComment && <div className="app-mask" onClick={handleClick} />}
-        {this.renderSplitBox()}
-      </>
-    );
-  }
+  return (
+    <>
+      <Header />
+      <Comments />
+      {hasFocusedComment && <div className="app-mask" onClick={unfocusComment} />}
+      <DevtoolsSplitBox tooltip={tooltip} updateTimelineDimensions={updateTimelineDimensions} />
+    </>
+  );
 }
 
 export default connect(
@@ -97,6 +80,7 @@ export default connect(
     loading: selectors.getLoading(state),
     tooltip: selectors.getTooltip(state),
     hasFocusedComment: selectors.hasFocusedComment(state),
+    recordingDuration: selectors.getRecordingDuration(state),
   }),
   {
     updateTimelineDimensions: actions.updateTimelineDimensions,

--- a/src/ui/components/RecordingLoadingScreen.js
+++ b/src/ui/components/RecordingLoadingScreen.js
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from "react";
+import { connect } from "react-redux";
+import Header from "./Header";
+import { UserPrompt } from "./Account/index";
+import { screenshotCache, nextPaintEvent, getClosestPaintPoint } from "protocol/graphics";
+import { selectors } from "../reducers";
+
+function useGetPreviewScreen({ loading, recordingDuration }) {
+  const [screen, setScreen] = useState(null);
+
+  useEffect(() => {
+    async function getAndSetScreen() {
+      const time = (loading / 100) * recordingDuration;
+      let screen;
+
+      try {
+        const closestPaintPoint = getClosestPaintPoint(time);
+        const { point, paintHash } = closestPaintPoint;
+        screen = await screenshotCache.getScreenshotForTooltip(point, paintHash);
+      } catch {
+        const nextPaintPoint = nextPaintEvent(time);
+        const { point, paintHash } = nextPaintPoint;
+        screen = await screenshotCache.getScreenshotForTooltip(point, paintHash);
+      }
+
+      setScreen(screen);
+    }
+
+    getAndSetScreen();
+  }, [loading]);
+
+  return screen;
+}
+
+function PreviewContainer({ screen }) {
+  if (!screen) {
+    return <div className="preview-container empty" />;
+  }
+
+  const image = `url(data:${screen.mimeType};base64,${screen.data})`;
+  return <div className="preview-container" style={{ backgroundImage: image }}></div>;
+}
+
+function RecordingLoadingScreen({ loading, recordingDuration }) {
+  const screen = useGetPreviewScreen({ loading, recordingDuration });
+
+  return (
+    <>
+      <Header />
+      <UserPrompt>
+        <h1>We&apos;re getting your recording ready</h1>
+        <PreviewContainer screen={screen} />
+        <div className="loading-bar" style={{ width: `${loading}%` }} />
+        <p className="tip">{Math.floor(loading)}%</p>
+      </UserPrompt>
+    </>
+  );
+}
+
+export default connect(
+  state => ({
+    loading: selectors.getLoading(state),
+    recordingDuration: selectors.getRecordingDuration(state),
+  }),
+  {}
+)(RecordingLoadingScreen);

--- a/src/ui/reducers/timeline.js
+++ b/src/ui/reducers/timeline.js
@@ -9,7 +9,7 @@ function initialTimelineState() {
     hoveredMessage: null,
     unprocessedRegions: [],
     shouldAnimate: true,
-    recordingDuration: 0,
+    recordingDuration: null,
     screenShot: null,
     timelineDimensions: { left: 1, top: 1, width: 1 },
     mouse: null,


### PR DESCRIPTION
Fixes #705

![Sep-24-2020 13-21-31](https://user-images.githubusercontent.com/15959269/94178316-ee857900-fe68-11ea-9559-7db1374669e6.gif)

This adds a new loading screen for when users are opening a recording. Currently, we only display a white blank screen with a loading bar by the header. This is not a good experience for somebody who, for example, might have to wait 30s for a recording to load.

To keep them from clicking away, this patch adds more obvious visual cues to indicate that things are progressing:
1) Moves the loading bar from the header to the center of the screen.
2) Shows a preview of the recording that displays a preview of the current loading progress