### PR TITLE
Added a link to the Replay logo to bring the user back to their recordings

### DIFF
--- a/src/ui/components/Header.css
+++ b/src/ui/components/Header.css
@@ -1,18 +1,21 @@
 #header {
   background-color: var(--theme-toolbar-background);
   border-bottom: 1px solid var(--theme-splitter-color);
-  height: 40px;
+  height: 52px;
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  padding: 0 8px;
+  padding: 0 12px;
 }
 
 #header .logo {
-  height: 14px;
-  width: 18px;
+  height: 24px;
+  width: 24px;
   background-repeat: no-repeat;
   background-size: contain;
+  background-position: center;
+  border: 4px solid transparent;
+  box-sizing: content-box;
 }
 
 #status {

--- a/src/ui/components/Header.js
+++ b/src/ui/components/Header.js
@@ -44,8 +44,10 @@ class Header extends React.Component {
   render() {
     return (
       <div id="header">
-        <div className="logo"></div>
-        <div id="status"></div>
+        <a href="/view">
+          <div className="logo" />
+        </a>
+        <div id="status" />
         <div className="links">
           <a id="headway" onClick={this.toggleHeadway}>
             What&apos;s new


### PR DESCRIPTION
This patch:
1) Adds a link to the header logo that brings the user back to their recordings page
2) Modifies the replay logo so that the clickable area is bigger

Fixes #700.