### PR TITLE
Don't show the loading preview screen while the recording is being uploaded

### DIFF
--- a/src/ui/actions/app.js
+++ b/src/ui/actions/app.js
@@ -3,6 +3,9 @@ import { selectors } from "ui/reducers";
 
 export function setupApp(recordingId, store) {
   store.dispatch({ type: "setup_app", recordingId });
+  ThreadFront.waitForSession().then(sessionId =>
+    store.dispatch({ type: "set_session_id", sessionId })
+  );
   ThreadFront.ensureProcessed(_, regions => store.dispatch(onUnprocessedRegions(regions))).then(
     () => {
       clearInterval(loadingInterval);

--- a/src/ui/components/DevTools.js
+++ b/src/ui/components/DevTools.js
@@ -56,12 +56,15 @@ export function DevTools({
   hasFocusedComment,
   updateTimelineDimensions,
   recordingDuration,
+  sessionId,
 }) {
+  const recordingIsUploaded = sessionId !== null;
+  const recordingIsFetchedFromServer = recordingDuration !== null;
   const recordingIsLoading = loading < 100;
 
-  if (recordingDuration === null) {
+  if (!recordingIsFetchedFromServer || !recordingIsUploaded) {
     return <Loader />;
-  } else if (recordingIsLoading) {
+  } else if (!recordingIsLoading) {
     return <RecordingLoadingScreen />;
   }
 
@@ -81,6 +84,7 @@ export default connect(
     tooltip: selectors.getTooltip(state),
     hasFocusedComment: selectors.hasFocusedComment(state),
     recordingDuration: selectors.getRecordingDuration(state),
+    sessionId: selectors.getSessionId(state),
   }),
   {
     updateTimelineDimensions: actions.updateTimelineDimensions,

--- a/src/ui/reducers/app.js
+++ b/src/ui/reducers/app.js
@@ -8,7 +8,7 @@ function initialAppState() {
     selectedPanel: prefs.selectedPanel,
     tooltip: null,
     loading: 4,
-    recordings: null,
+    sessionId: null,
   };
 }
 
@@ -33,6 +33,10 @@ export default function update(state = initialAppState(), action) {
       return { ...state, loading: action.loading };
     }
 
+    case "set_session_id": {
+      return { ...state, sessionId: action.sessionId };
+    }
+
     default: {
       return state;
     }
@@ -44,4 +48,4 @@ export const isSplitConsoleOpen = state => state.app.splitConsoleOpen;
 export const getSelectedPanel = state => state.app.selectedPanel;
 export const getLoading = state => state.app.loading;
 export const getRecordingId = state => state.app.recordingId;
-export const getRecordings = state => state.app.recordings;
+export const getSessionId = state => state.app.sessionId;


### PR DESCRIPTION
Right now, we don't check for the upload status/session status before trying to fetch previews for a recording. 

This puts in a check to make sure that the recording is uploaded before we access it.