### PR TITLE
use the client from the protocol repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7399,6 +7399,20 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "record-replay-protocol": {
+      "version": "git://github.com/RecordReplay/protocol.git#81d7fdd99c5a216674594e861a6a7713a51a09a9",
+      "from": "git://github.com/RecordReplay/protocol.git",
+      "requires": {
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+        }
+      }
+    },
     "redux": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-redux": "^5.0.7",
     "react-router-dom": "^5.2.0",
     "react-transition-group": "^2.0.1",
+    "record-replay-protocol": "git://github.com/RecordReplay/protocol.git",
     "redux": "^4.0.5",
     "resize-observer-polyfill": "^1.5.1",
     "style-loader": "^1.2.1",

--- a/src/protocol/mapped-location-cache.ts
+++ b/src/protocol/mapped-location-cache.ts
@@ -1,13 +1,6 @@
-const { sendMessage } = require("./socket");
+const { client } = require("./socket");
 const { defer } = require("./utils");
-
-interface Location {
-  scriptId: string;
-  line: number;
-  column: number;
-}
-
-type MappedLocation = Location[];
+import { Location, MappedLocation } from "record-replay-protocol/js/protocol";
 
 export class MappedLocationCache {
   // Map locations encoded as strings to the corresponding MappedLocations
@@ -35,8 +28,8 @@ export class MappedLocationCache {
 
     const { promise, resolve } = defer();
     this.runningRequests.set(cacheKey, promise);
-    const { mappedLocation } = await sendMessage(
-      "Debugger.getMappedLocation", { location }, this.sessionId
+    const { mappedLocation } = await client.Debugger.getMappedLocation(
+      { location }, this.sessionId
     );
     this.runningRequests.delete(cacheKey);
     resolve(mappedLocation);

--- a/src/protocol/socket.d.ts
+++ b/src/protocol/socket.d.ts
@@ -1,0 +1,3 @@
+import { ProtocolClient } from "record-replay-protocol/js/client";
+
+export const client: ProtocolClient;

--- a/src/protocol/socket.js
+++ b/src/protocol/socket.js
@@ -1,4 +1,5 @@
 const { defer, makeInfallible } = require("./utils");
+const { ProtocolClient } = require("record-replay-protocol/js/client");
 
 let socket;
 let gSocketOpen = false;
@@ -65,6 +66,12 @@ function removeEventListener(method) {
   gEventListeners.delete(method);
 }
 
+const client = new ProtocolClient({
+  sendCommand: sendMessage,
+  addEventListener,
+  removeEventListener,
+});
+
 function onSocketMessage(evt) {
   gReceivedBytes += evt.data.length;
   const msg = JSON.parse(evt.data);
@@ -114,6 +121,7 @@ module.exports = {
   sendMessage,
   addEventListener,
   removeEventListener,
+  client,
   log,
   setStatus,
 };


### PR DESCRIPTION
I considered several options to reference code from the protocol repository in the devtools:
1. add it to `package.json` in the normal way
  this is currently not possible because we don't publish the protocol package in the npm registry (yet?)
  there is also one possible downside to this approach: any changes in the protocol repository would need to be published in the npm registry before they can be used in the devtools (making developing changes that span both repositories harder to do, although `npm link` can help with that)
2. clone the protocol repository next to the devtools and reference it directly in the imports (e.g. `require("../../../../protocol/js/client")`)
  downsides: ugly imports in many files, setting up and building devtools becomes more complicated, typescript tooling has some issues with referencing files from outside of the current package
3. clone the protocol repository next to the devtools and reference them in both `compilerOptions.paths` in `tsconfig.json` and `resolve.modules` or `resolve.alias` in `webpack.config.js`
  downsides: same as 2. minus the ugly imports plus the need to express this dependency twice (in `tsconfig.json` and `webpack.config.js`)
4. clone the protocol repository next to the devtools and reference it in `package.json` using a local path (i.e. `"record-replay-protocol": "../protocol"`)
  downsides: same as 2. minus the ugly imports
5. reference the protocol repository in `package.json` as a git url
  downsides: the result of the typescript compilation of the protocol needs to be checked into git, changes in the protocol repository need to be pushed to github before they can be used in the devtools

Option number 5 seems to be the cleanest solution by far, so I went for that.
