### PR TITLE
Hide the timeline's scrollbar properly in Firefox

### DIFF
--- a/src/ui/components/Timeline/ScrollContainer.css
+++ b/src/ui/components/Timeline/ScrollContainer.css
@@ -1,5 +1,6 @@
 .replay-player .scroll-container {
   overflow-y: auto;
+  scrollbar-width: none;
   height: 100%;
 }
 


### PR DESCRIPTION
Fixes #730.