### PR TITLE
Make sure that the user is flushed from the browser pref upon logout

### DIFF
--- a/src/ui/components/Account/index.js
+++ b/src/ui/components/Account/index.js
@@ -5,6 +5,7 @@ import Header from "../Header";
 import Loader from "../shared/Loader";
 import { gql, useQuery } from "@apollo/client";
 import classnames from "classnames";
+import { setUserInBrowserPrefs } from "../../utils/browser";
 
 import "./Account.css";
 
@@ -62,6 +63,10 @@ function AccountPage() {
 
 function WelcomePage() {
   const { loginWithRedirect } = useAuth0();
+
+  useEffect(() => {
+    setUserInBrowserPrefs(null);
+  }, []);
 
   return (
     <div className="welcome-screen">

--- a/src/ui/components/Avatar.js
+++ b/src/ui/components/Avatar.js
@@ -4,27 +4,14 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { connect } from "react-redux";
 import { actions } from "ui/actions";
 import { getAvatarColor } from "ui/utils/user";
-
-function sendUserToBrowser(user) {
-  user = user === null ? "" : user;
-  if (typeof window == "object") {
-    window.dispatchEvent(
-      new window.CustomEvent("WebChannelMessageToChrome", {
-        detail: JSON.stringify({
-          id: "record-replay",
-          message: { user },
-        }),
-      })
-    );
-  }
-}
+import { setUserInBrowserPrefs } from "../utils/browser";
 
 const Avatar = props => {
   let { player, isFirstPlayer, updateUser } = props;
   let auth = useAuth0();
 
   useEffect(() => {
-    sendUserToBrowser(auth.user);
+    setUserInBrowserPrefs(auth.user);
     updateUser(auth.user);
   }, [auth.user]);
 

--- a/src/ui/utils/browser.js
+++ b/src/ui/utils/browser.js
@@ -1,0 +1,11 @@
+export function setUserInBrowserPrefs(user) {
+  user = user === null ? "" : user;
+  window.dispatchEvent(
+    new window.CustomEvent("WebChannelMessageToChrome", {
+      detail: JSON.stringify({
+        id: "record-replay",
+        message: { user },
+      }),
+    })
+  );
+}


### PR DESCRIPTION
Fixes #758.

We usually tell the Replay browser's prefs about the user's ID through the Avatar component. 

https://github.com/RecordReplay/devtools/blob/86a74874efcd0a739c6f1623e4467ea2cb27d7e0/src/ui/components/Avatar.js#L8-L20

The problem is that Avatar component is not rendered if the user is not logged in. So when a user logs in, logs out, then is redirected to the welcome page, the Replay browser's prefs are not updated.

This makes it so we tell the browser that the user is logged out.