### PR TITLE
Make the console timeline navigation button more noticeable

### DIFF
--- a/src/devtools/client/debugger/images/diamond-pause.svg
+++ b/src/devtools/client/debugger/images/diamond-pause.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="14" viewBox="0 0 13 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13 7L6.5 0.5L0 7L6.5 13.5L13 7ZM6 4.5H4.5V9.5H6V4.5ZM8.5 4.5H7V9.5H8.5V4.5Z" fill="white"/>
+</svg>

--- a/src/devtools/client/debugger/images/rewind-button.svg
+++ b/src/devtools/client/debugger/images/rewind-button.svg
@@ -1,0 +1,4 @@
+<svg width="11" height="14" viewBox="0 0 11 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 11.5442V2.45576L3.70797 7L10 11.5442Z" stroke="white" stroke-width="2"/>
+<rect y="2" width="2" height="11" fill="white"/>
+</svg>

--- a/src/devtools/client/themes/images/comment-add.svg
+++ b/src/devtools/client/themes/images/comment-add.svg
@@ -1,6 +1,6 @@
 <svg width="19" height="16" viewBox="0 0 19 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M0 14C0 15.1046 0.895431 16 2 16H17C18.1046 16 19 15.1046 19 14V6C19 4.89543 18.1046 4 17 4H12.35H6.65H2C0.895432 4 0 4.89543 0 6V14Z" fill="#F9F9FA"/>
 <path d="M9.5 0L5 6L14 6L9.5 0Z" fill="#F9F9FA"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M4 15C2.89543 15 2 14.1046 2 13V8C2 6.89543 2.89543 6 4 6H7L9.5 2L12 6H15C16.1046 6 17 6.89543 17 8V13C17 14.1046 16.1046 15 15 15H4Z" fill="#5BA1F8"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4 15C2.89543 15 2 14.1046 2 13V8C2 6.89543 2.89543 6 4 6H7L9.5 2L12 6H15C16.1046 6 17 6.89543 17 8V13C17 14.1046 16.1046 15 15 15H4Z" fill="#5b41ff"/>
 <path d="M9 8H10V10H12V11H10V13H9V11H7V10H9V8Z" fill="white"/>
 </svg>

--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -959,20 +959,6 @@ a.learn-more-link.webconsole-learn-more-link {
   margin-top: calc(var(--console-output-vertical-padding) - 1px);
 }
 
-.webconsole-app .message:hover > .icon.rewindable {
-  cursor: pointer;
-  transform: rotate(180deg);
-}
-
-/*
- * we flip the next.svg icon by default because when we're
- * not paused, we would jump back. We remove the transform here
- * because we want to jump forward.
- */
-.webconsole-app .message.paused ~ .message:hover .icon.rewindable {
-  transform: none;
-}
-
 .webconsole-output .paused ~ .message:last-of-type,
 .webconsole-output .paused:last-of-type {
   border-bottom-width: 0;
@@ -993,4 +979,113 @@ a.learn-more-link.webconsole-learn-more-link {
   left: -9999px;
   width: 0;
   height: 0;
+}
+
+/* Overlay buttons */
+.overlay-container {
+  cursor: pointer;
+}
+
+.overlay-container > * {
+  display: flex;
+  position: absolute;
+  height: 22px;
+  align-items: center;
+  z-index: 1;
+  border-top-right-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+  transition-duration: var(--slide-in-duration);
+  --rewind-button-width: 28px;
+  --message-left-padding: 4px;
+  --slide-in-duration: 200ms;
+  --border-radius: 8px;
+  --rewind-left-padding: 5px;
+  --rewind-info-button-width: 64px;
+  --fast-forward-info-button-width: 92px;
+  --debug-info-button-width: 60px;
+}
+
+.overlay-container .button {
+  width: var(--rewind-button-width);
+  padding-left: var(--rewind-left-padding);
+  margin-left: calc(0px - var(--message-left-padding) - var(--rewind-button-width));
+  background: linear-gradient(0deg, #2D7EFF 0%, #2D7EFF 100%);
+  /* for debugging the final position when hovered */
+  /* margin-left: calc(0px - var(--message-left-padding)) !important; */
+}
+
+.overlay-container.debug .button {
+  margin-left: calc(0px - var(--message-left-padding));
+  background: linear-gradient(0deg, #5B41FF 0%, #5B41FF 100%);
+}
+
+.overlay-container .info {
+  background-color: #2D7EFF;
+  /* for debugging the final position when hovered */
+  /* margin-left: calc(var(--rewind-button-width) - var(--message-left-padding) - var(--border-radius)) !important; */
+}
+
+.overlay-container.rewind .info {
+  width: var(--rewind-info-button-width);
+  margin-left: calc(0px - var(--message-left-padding) - var(--rewind-info-button-width) );
+}
+
+.overlay-container.fast-forward .info {
+  width: var(--fast-forward-info-button-width);
+  margin-left: calc(0px - var(--message-left-padding) - var(--fast-forward-info-button-width) );
+}
+
+.overlay-container.debug .info {
+  width: var(--debug-info-button-width);
+  margin-left: calc(0px - var(--message-left-padding) - var(--debug-info-button-width) );
+  background-color: #5B41FF;
+}
+
+.overlay-container .info .label {
+  color: white;
+  opacity: 0%;
+  transition-duration: 100ms;
+  transition-delay: 150ms;
+}
+
+.overlay-container .img {
+  opacity: 100%;
+  background-color: white;
+  background-position: center;
+  height: 14px;
+  transition-property: opacity;
+  transition-duration: 100ms;
+  transition-delay: 150ms;
+}
+
+.overlay-container.fast-forward .img {
+  transform: scaleX(-1);
+}
+
+/* Hovered Overlay buttons */
+
+.message:hover .button {
+  margin-left: calc(0px - var(--message-left-padding));
+}
+
+.message:hover .button .img {
+  opacity: 100%;
+}
+
+.overlay-container:hover .button {
+  background: linear-gradient(152.2deg, #67DAFF 6.75%, #4382FF 93.14%);
+  box-shadow: 1px 0px 3px rgb(0,0,0,0.3);
+}
+
+.overlay-container.debug:hover .button {
+  background: linear-gradient(152.2deg, #5B41FF 6.75%, #B043FF 93.14%);
+}
+
+.overlay-container:hover .info {
+  padding-left: 16px;
+  margin-left: calc(var(--rewind-button-width) - var(--message-left-padding) - var(--border-radius));
+}
+
+.overlay-container:hover .info .label {
+  opacity: 100%;
 }

--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -206,9 +206,7 @@
 }
 
 /* Center first level indent within the left gutter */
-.webconsole-app
-  .message:not(.startGroup):not(.startGroupCollapsed)
-  > .indent[data-indent="1"] {
+.webconsole-app .message:not(.startGroup):not(.startGroupCollapsed) > .indent[data-indent="1"] {
   margin-inline-start: calc(1px + var(--console-icon-horizontal-offset));
   margin-inline-end: calc(11px - var(--console-icon-horizontal-offset));
 }
@@ -880,14 +878,8 @@ a.learn-more-link.webconsole-learn-more-link {
 
 /* Center the collapse button in the left gutter (first-level only) */
 .webconsole-app .message.network > .collapse-button,
-.webconsole-app
-  .message.startGroup
-  > .indent[data-indent="0"]
-  ~ .collapse-button,
-.webconsole-app
-  .message.startGroupCollapsed
-  > .indent[data-indent="0"]
-  ~ .collapse-button {
+.webconsole-app .message.startGroup > .indent[data-indent="0"] ~ .collapse-button,
+.webconsole-app .message.startGroupCollapsed > .indent[data-indent="0"] ~ .collapse-button {
   width: 24px;
   margin-inline-start: var(--console-icon-horizontal-offset);
   margin-inline-end: calc(4px - var(--console-icon-horizontal-offset));
@@ -895,14 +887,8 @@ a.learn-more-link.webconsole-learn-more-link {
 
 /* Use a bigger arrow that is visually similar to other icons (10px) */
 .webconsole-app .message.network > .collapse-button::before,
-.webconsole-app
-  .message.startGroup
-  > .indent[data-indent="0"]
-  ~ .collapse-button::before,
-.webconsole-app
-  .message.startGroupCollapsed
-  > .indent[data-indent="0"]
-  ~ .collapse-button::before {
+.webconsole-app .message.startGroup > .indent[data-indent="0"] ~ .collapse-button::before,
+.webconsole-app .message.startGroupCollapsed > .indent[data-indent="0"] ~ .collapse-button::before {
   width: 100%;
   fill: var(--theme-icon-dimmed-color);
 }
@@ -944,9 +930,9 @@ a.learn-more-link.webconsole-learn-more-link {
 }
 
 .webconsole-app .message.paused:not(.paused-before) {
-  border-top-color: var(--purple-50);
+  border-top-color: #5b41ff;
   /* always show the border, even for the last child */
-  border-top-width: 1px;
+  border-top-width: 2px;
 }
 
 .webconsole-app .message.paused ~ .message .message-body-wrapper,
@@ -1009,36 +995,40 @@ a.learn-more-link.webconsole-learn-more-link {
   width: var(--rewind-button-width);
   padding-left: var(--rewind-left-padding);
   margin-left: calc(0px - var(--message-left-padding) - var(--rewind-button-width));
-  background: linear-gradient(0deg, #2D7EFF 0%, #2D7EFF 100%);
+  background: linear-gradient(0deg, #2d7eff 0%, #2d7eff 100%);
   /* for debugging the final position when hovered */
   /* margin-left: calc(0px - var(--message-left-padding)) !important; */
 }
 
 .overlay-container.debug .button {
   margin-left: calc(0px - var(--message-left-padding));
-  background: linear-gradient(0deg, #5B41FF 0%, #5B41FF 100%);
+  background: linear-gradient(
+    0deg,
+    var(--paused-background-color) 0%,
+    var(--paused-background-color) 100%
+  );
 }
 
 .overlay-container .info {
-  background-color: #2D7EFF;
+  background-color: #2d7eff;
   /* for debugging the final position when hovered */
   /* margin-left: calc(var(--rewind-button-width) - var(--message-left-padding) - var(--border-radius)) !important; */
 }
 
 .overlay-container.rewind .info {
   width: var(--rewind-info-button-width);
-  margin-left: calc(0px - var(--message-left-padding) - var(--rewind-info-button-width) );
+  margin-left: calc(0px - var(--message-left-padding) - var(--rewind-info-button-width));
 }
 
 .overlay-container.fast-forward .info {
   width: var(--fast-forward-info-button-width);
-  margin-left: calc(0px - var(--message-left-padding) - var(--fast-forward-info-button-width) );
+  margin-left: calc(0px - var(--message-left-padding) - var(--fast-forward-info-button-width));
 }
 
 .overlay-container.debug .info {
   width: var(--debug-info-button-width);
-  margin-left: calc(0px - var(--message-left-padding) - var(--debug-info-button-width) );
-  background-color: #5B41FF;
+  margin-left: calc(0px - var(--message-left-padding) - var(--debug-info-button-width));
+  background-color: var(--paused-background-color);
 }
 
 .overlay-container .info .label {
@@ -1046,6 +1036,7 @@ a.learn-more-link.webconsole-learn-more-link {
   opacity: 0%;
   transition-duration: 100ms;
   transition-delay: 150ms;
+  transition-timing-function: ease-in-out;
 }
 
 .overlay-container .img {
@@ -1056,6 +1047,7 @@ a.learn-more-link.webconsole-learn-more-link {
   transition-property: opacity;
   transition-duration: 100ms;
   transition-delay: 150ms;
+  transition-timing-function: ease-in-out;
 }
 
 .overlay-container.fast-forward .img {
@@ -1073,17 +1065,19 @@ a.learn-more-link.webconsole-learn-more-link {
 }
 
 .overlay-container:hover .button {
-  background: linear-gradient(152.2deg, #67DAFF 6.75%, #4382FF 93.14%);
-  box-shadow: 1px 0px 3px rgb(0,0,0,0.3);
+  background: linear-gradient(152.2deg, #67daff 6.75%, #4382ff 93.14%);
+  box-shadow: 1px 0px 3px rgb(0, 0, 0, 0.3);
 }
 
 .overlay-container.debug:hover .button {
-  background: linear-gradient(152.2deg, #5B41FF 6.75%, #B043FF 93.14%);
+  background: linear-gradient(152.2deg, #5b41ff 6.75%, #b043ff 93.14%);
 }
 
 .overlay-container:hover .info {
   padding-left: 16px;
-  margin-left: calc(var(--rewind-button-width) - var(--message-left-padding) - var(--border-radius));
+  margin-left: calc(
+    var(--rewind-button-width) - var(--message-left-padding) - var(--border-radius)
+  );
 }
 
 .overlay-container:hover .info .label {

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
@@ -14,6 +14,7 @@ const {
   getAllMessagesPayloadById,
   getVisibleMessages,
   getPausedExecutionPoint,
+  getPausedExecutionPointTime,
   getAllWarningGroupsById,
   isMessageInWarningGroup,
 } = require("devtools/client/webconsole/selectors/messages");
@@ -76,7 +77,8 @@ class ConsoleOutput extends Component {
       warningGroups: PropTypes.object.isRequired,
       visibleMessages: PropTypes.array.isRequired,
       onFirstMeaningfulPaint: PropTypes.func.isRequired,
-      pausedExecutionPoint: PropTypes.any,
+      pausedExecutionPoint: PropTypes.string,
+      pausedExecutionPointTime: PropTypes.number,
     };
   }
 
@@ -185,6 +187,7 @@ class ConsoleOutput extends Component {
       timestampsVisible,
       initialized,
       pausedExecutionPoint,
+      pausedExecutionPointTime,
       zoomStartTime,
       zoomEndTime,
     } = this.props;
@@ -219,6 +222,7 @@ class ConsoleOutput extends Component {
             ? isMessageInWarningGroup(messages.get(messageId), visibleMessages)
             : false,
         pausedExecutionPoint,
+        pausedExecutionPointTime,
         getMessage: () => messages.get(messageId),
         isPaused: !!pausedMessage && pausedMessage.id == messageId,
       })
@@ -254,6 +258,7 @@ function mapStateToProps(state, props) {
   return {
     initialized: state.ui.initialized,
     pausedExecutionPoint: getPausedExecutionPoint(state),
+    pausedExecutionPointTime: getPausedExecutionPointTime(state),
     messages: getAllMessagesById(state),
     visibleMessages: getVisibleMessages(state),
     messagesUi: getAllMessagesUiById(state),

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -151,7 +151,7 @@ class Message extends Component {
     let onRewindClick = null;
     let overlayType, label, onClick;
 
-    if (inWarningGroup) {
+    if (!pausedExecutionPointTime || inWarningGroup) {
       return undefined;
     }
 

--- a/src/devtools/client/webconsole/components/Output/MessageContainer.js
+++ b/src/devtools/client/webconsole/components/Output/MessageContainer.js
@@ -48,7 +48,8 @@ class MessageContainer extends Component {
       indent: PropTypes.number,
       getMessage: PropTypes.func.isRequired,
       isPaused: PropTypes.bool.isRequired,
-      pausedExecutionPoint: PropTypes.any,
+      pausedExecutionPoint: PropTypes.string,
+      pausedExecutionPointTime: PropTypes.number,
       inWarningGroup: PropTypes.bool,
     };
   }

--- a/src/devtools/client/webconsole/components/Output/MessageIcon.js
+++ b/src/devtools/client/webconsole/components/Output/MessageIcon.js
@@ -27,11 +27,6 @@ function getIconElement(level, onRewindClick, type) {
   let title = l10n.getStr(l10nLevels[level] || level);
   const classnames = ["icon"];
 
-  if (onRewindClick) {
-    title = l10n.getFormatStr("webconsole.jumpButton.tooltip", [title]);
-    classnames.push("rewindable");
-  }
-
   if (type === "logPoint") {
     classnames.push("logpoint");
   }
@@ -39,7 +34,6 @@ function getIconElement(level, onRewindClick, type) {
   {
     return dom.span({
       className: classnames.join(" "),
-      onClick: onRewindClick,
       title,
       "aria-live": "off",
     });

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
@@ -41,6 +41,7 @@ function ConsoleApiCall(props) {
     timestampsVisible,
     repeat,
     pausedExecutionPoint,
+    pausedExecutionPointTime,
     isPaused,
     maybeScrollToBottom,
   } = props;
@@ -140,6 +141,7 @@ function ConsoleApiCall(props) {
     executionPointTime,
     executionPointHasFrames,
     pausedExecutionPoint,
+    pausedExecutionPointTime,
     isPaused,
     open,
     collapsible,

--- a/src/devtools/client/webconsole/selectors/messages.js
+++ b/src/devtools/client/webconsole/selectors/messages.js
@@ -49,6 +49,10 @@ function getPausedExecutionPoint(state) {
   return state.messages.pausedExecutionPoint;
 }
 
+function getPausedExecutionPointTime(state) {
+  return state.messages.pausedExecutionPointTime;
+}
+
 function getAllWarningGroupsById(state) {
   return state.messages.warningGroupsById;
 }
@@ -74,5 +78,6 @@ module.exports = {
   getMessage,
   getVisibleMessages,
   getPausedExecutionPoint,
+  getPausedExecutionPointTime,
   isMessageInWarningGroup,
 };

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -53,7 +53,6 @@ const gBackgroundImages = {
   "#split-console-close-button::before": require("devtools/client/themes/images/close.svg"),
   '.menuitem > .command[aria-checked="true"]': require("devtools/client/themes/images/check.svg"),
   ".message.network > .collapse-button::before, .message.startGroup > .indent[data-indent='0'] ~ .collapse-button::before, .message.startGroupCollapsed > .indent[data-indent='0'] ~ .collapse-button::before": require("devtools/client/themes/images/arrow-big.svg"),
-  ".message:hover > .icon.rewindable": require("devtools/client/debugger/images/next-circle.svg"),
   "button.jump-definition": require("devtools/client/shared/components/reps/images/jump-definition-dark.svg"),
   ".img.column-marker": require("devtools/client/debugger/images/column-marker.svg"),
   ".event-tooltip-debugger-icon": require("devtools/client/shared/components/reps/images/jump-definition-dark.svg"),
@@ -129,6 +128,9 @@ const gMaskImages = {
   "button.open-inspector": require("devtools/client/themes/images/open-inspector.svg"),
   ".img.comment-icon": require("devtools/client/themes/images/comment.svg"),
   ".img.lightning": require("image/images/lightning.svg"),
+  ".overlay-container.rewind .img": require("devtools/client/debugger/images/rewind-button.svg"),
+  ".overlay-container.fast-forward .img": require("devtools/client/debugger/images/rewind-button.svg"),
+  ".overlay-container.debug .img": require("devtools/client/debugger/images/diamond-pause.svg"),
 };
 
 const gContentImages = {

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -73,17 +73,9 @@
   height: 100%;
   background: var(--progress-playing-background);
   pointer-events: none;
-}
-
-.replay-player .progress::after {
-  background: var(--replay-head-background);
-  width: 1px;
-  height: 100%;
-  right: -0.5px;
-  opacity: 0.4;
-  display: block;
-  content: "";
-  position: absolute;
+  border-right-color: var(--replay-head-background);
+  border-right-width: 2px;
+  border-right-style: solid;
 }
 
 .replay-player .message-container {
@@ -99,6 +91,10 @@
   border: 0.5px solid var(--progress-playing-background);
   height: 7.5px;
   width: 7.5px;
+}
+
+.replay-player .message:focus {
+  outline: none;
 }
 
 .replay-player .message.future {
@@ -118,6 +114,7 @@
 .replay-player .message:hover {
   background: var(--replaying-marker-background-hover);
   cursor: pointer;
+  transform: scale(1.25);
 }
 
 .replay-player .message:hover::before {

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -255,7 +255,8 @@ export class Timeline extends Component {
   };
 
   onPlayerMouseUp = e => {
-    const { hoverTime, hoveringOverMarker } = this.props;
+    const { hoverTime } = this.props;
+    const { hoveringOverMarker } = this.state;
     const mouseTime = this.getMouseTime(e);
 
     if (hoverTime != null && !hoveringOverMarker) {
@@ -624,8 +625,6 @@ export class Timeline extends Component {
             ref: a => (this.$progressBar = a),
             onMouseEnter: this.onPlayerMouseEnter,
             onMouseMove: this.onPlayerMouseMove,
-            onMouseLeave: this.onPlayerMouseLeave,
-            onMouseDown: this.onPlayerMouseDown,
             onMouseUp: this.onPlayerMouseUp,
           },
           div({

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -75,17 +75,14 @@ export class Timeline extends Component {
     };
   }
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      comments: [],
-      numResizes: 0,
-    };
-
-    gToolbox.timeline = this;
-  }
+  state = {
+    comments: [],
+    numResizes: 0,
+    hoveringOverMarker: false,
+  };
 
   async componentDidMount() {
+    gToolbox.timeline = this;
     this.props.updateTimelineDimensions();
 
     const consoleFrame = this.console.hud.ui;

--- a/src/ui/components/Toolbox.css
+++ b/src/ui/components/Toolbox.css
@@ -4,8 +4,9 @@
   font-family: sans-serif;
   display: flex;
   flex-direction: column;
-  --toolbox-background: #f9f9fa;
   z-index: 1; /* Draw toolbox in front of the highlighter overlay. */
+  --toolbox-background: #f9f9fa;
+  --paused-background-color: #5b41ff;
 }
 
 #toolbox-timeline {


### PR DESCRIPTION
This patch does a few things:
1) It makes the previously subtle seek button in the timeline more prominent by replacing it with a big blue button that pops up from the left when a user hovers on a message. It's now very hard to miss.
2) It adds a label to the seek button when the user hovers on the button (e.g. rewind, fast-forward).
3) Once a user seeks to a message, we leave a purple paused button displayed next to the message they're paused on. This indicates that the user is paused there, and more importantly, is clickable to look at that source line in the debugger.

Demo: https://www.loom.com/share/4a5601aadeee4a46913b8789e6b557b0

Screenshot:
![image](https://user-images.githubusercontent.com/15959269/94753345-fad36f80-035b-11eb-9b9b-91ebd3dbb6f3.png)
