### PR TITLE
Add header titles to the recordings and recording viewer

### DIFF
--- a/src/ui/components/App.js
+++ b/src/ui/components/App.js
@@ -50,7 +50,7 @@ function App({ theme, recordingId, sessionError }) {
     return <PopupBlockedError />;
   }
 
-  if (isLoading || (isAuthenticated && !apolloClient)) {
+  if (isLoading || !apolloClient) {
     return <Loader />;
   }
 

--- a/src/ui/components/Header.css
+++ b/src/ui/components/Header.css
@@ -85,3 +85,43 @@
   background: linear-gradient(138.3deg, #236eff 7.98%, #71e5ff 93.53%);
   transition-duration: 300ms;
 }
+
+#header .title {
+  position: absolute;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
+  max-width: 320px;
+  color: var(--grey-90);
+  font-size: 1.25rem;
+  line-height: 26px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background: none;
+  cursor: text;
+}
+
+#header .title:not(input):hover {
+  color: #2D7EFF;
+}
+
+#header input.title:focus {
+  border: none;
+  outline: none;
+  width: 400px;
+}
+
+@media (max-width: 760px) {
+  #header .title {
+    width: 140px;
+  }
+}
+
+@media (max-width: 600px) {
+  #header .title {
+    display: none;
+  }
+}

--- a/src/ui/components/Header.js
+++ b/src/ui/components/Header.js
@@ -67,15 +67,16 @@ function useGetTitle(recordingId) {
     return null;
   }
 
-  const { data, loading, error } = useQuery(RECORDING_TITLE, {
+  const { data } = useQuery(RECORDING_TITLE, {
     variables: { recordingId },
   });
 
-  if (!data || !data.recordings[0]) {
+  const firstRecording = data?.recordings[0];
+  if (!firstRecording) {
     return null;
   }
 
-  return data.recordings[0].recordingTitle || data.recordings[0].title;
+  return firstRecording.recordingTitle || firstRecording.title;
 }
 
 function Header({ user, getActiveUsers, recordingId }) {

--- a/src/ui/components/Recordings/Recording.js
+++ b/src/ui/components/Recordings/Recording.js
@@ -1,61 +1,13 @@
 import React, { useState } from "react";
+import Title from "../shared/Title";
 import Dropdown from "devtools/client/debugger/src/components/shared/Dropdown";
 import moment from "moment";
-import { gql, useMutation } from "@apollo/client";
 
 function formatDate(date) {
   return moment(date).format("MMM Do, h:mm a");
 }
 
-const UPDATE_RECORDING = gql`
-  mutation MyMutation($id: uuid, $title: String) {
-    update_recordings(_set: { recordingTitle: $title }, where: { id: { _eq: $id } }) {
-      returning {
-        id
-        recordingTitle
-      }
-    }
-  }
-`;
-
-const Title = ({ defaultTitle, id, setEditingTitle, editingTitle }) => {
-  const [updateRecordingTitle] = useMutation(UPDATE_RECORDING);
-  const [title, setTitle] = useState(defaultTitle);
-
-  const saveTitle = () => {
-    updateRecordingTitle({ variables: { id, title } });
-    setEditingTitle(false);
-  };
-  const handleKeyDown = event => {
-    if (event.key == "Enter") {
-      saveTitle();
-    } else if (event.key == "Escape") {
-      setEditingTitle(false);
-    }
-  };
-
-  if (editingTitle) {
-    return (
-      <input
-        type="text"
-        className="title"
-        value={title}
-        onChange={e => setTitle(e.target.value)}
-        onKeyDown={handleKeyDown}
-        onBlur={saveTitle}
-        autoFocus
-      />
-    );
-  }
-
-  return (
-    <div className="title" onClick={() => setEditingTitle(true)}>
-      {title}
-    </div>
-  );
-};
-
-const DropdownPanel = ({ editingTitle, setEditingTitle, onDeleteRecording, id }) => {
+const DropdownPanel = ({ editingTitle, setEditingTitle, onDeleteRecording, recordingId }) => {
   return (
     <div className="dropdown-panel">
       {!editingTitle ? (
@@ -76,7 +28,7 @@ export const Recording = ({ data, onDeleteRecording }) => {
     <DropdownPanel
       editingTitle={editingTitle}
       setEditingTitle={setEditingTitle}
-      id={data.id}
+      recordingId={data.recording_id}
       onDeleteRecording={onDeleteRecording}
     />
   );
@@ -98,7 +50,7 @@ export const Recording = ({ data, onDeleteRecording }) => {
       </div>
       <Title
         defaultTitle={data.recordingTitle || data.title || "Untitled"}
-        id={data.id}
+        recordingId={data.recording_id}
         editingTitle={editingTitle}
         setEditingTitle={setEditingTitle}
       />

--- a/src/ui/components/Recordings/Recordings.css
+++ b/src/ui/components/Recordings/Recordings.css
@@ -54,7 +54,6 @@
 }
 
 .recordings .recording .screenshot img {
-  height: 100%;
   object-fit: contain;
   width: 100%;
 }

--- a/src/ui/components/shared/Title.js
+++ b/src/ui/components/shared/Title.js
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from "react";
+import { gql, useMutation } from "@apollo/client";
+import { useAuth0 } from "@auth0/auth0-react";
+
+const UPDATE_RECORDING = gql`
+  mutation MyMutation($recordingId: String, $title: String) {
+    update_recordings(
+      _set: { recordingTitle: $title }
+      where: { recording_id: { _eq: $recordingId } }
+    ) {
+      returning {
+        id
+        recordingTitle
+      }
+    }
+  }
+`;
+
+export default function Title({ defaultTitle, recordingId, setEditingTitle, editingTitle }) {
+  const { isAuthenticated } = useAuth0();
+  const [updateRecordingTitle] = useMutation(UPDATE_RECORDING);
+  const [title, setTitle] = useState(defaultTitle);
+
+  useEffect(() => {
+    setTitle(defaultTitle);
+  }, [defaultTitle]);
+
+  const saveTitle = () => {
+    updateRecordingTitle({ variables: { recordingId, title } });
+    setEditingTitle(false);
+  };
+  const handleKeyDown = event => {
+    if (event.key == "Enter") {
+      saveTitle();
+    } else if (event.key == "Escape") {
+      setEditingTitle(false);
+    }
+  };
+  const handleClick = () => {
+    if (!isAuthenticated) {
+      return;
+    }
+    setEditingTitle(true);
+  };
+
+  if (editingTitle) {
+    return (
+      <input
+        type="text"
+        className="title"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={saveTitle}
+        autoFocus
+      />
+    );
+  }
+
+  return (
+    <div className="title" onClick={handleClick}>
+      {title}
+    </div>
+  );
+}

--- a/src/ui/components/shared/Title.js
+++ b/src/ui/components/shared/Title.js
@@ -3,7 +3,7 @@ import { gql, useMutation } from "@apollo/client";
 import { useAuth0 } from "@auth0/auth0-react";
 
 const UPDATE_RECORDING = gql`
-  mutation MyMutation($recordingId: String, $title: String) {
+  mutation UpdateRecordingTitle($recordingId: String, $title: String) {
     update_recordings(
       _set: { recordingTitle: $title }
       where: { recording_id: { _eq: $recordingId } }
@@ -29,6 +29,7 @@ export default function Title({ defaultTitle, recordingId, setEditingTitle, edit
     updateRecordingTitle({ variables: { recordingId, title } });
     setEditingTitle(false);
   };
+
   const handleKeyDown = event => {
     if (event.key == "Enter") {
       saveTitle();
@@ -36,11 +37,11 @@ export default function Title({ defaultTitle, recordingId, setEditingTitle, edit
       setEditingTitle(false);
     }
   };
+
   const handleClick = () => {
-    if (!isAuthenticated) {
-      return;
+    if (isAuthenticated) {
+      setEditingTitle(true);
     }
-    setEditingTitle(true);
   };
 
   if (editingTitle) {
@@ -58,7 +59,7 @@ export default function Title({ defaultTitle, recordingId, setEditingTitle, edit
   }
 
   return (
-    <div className="title" onClick={handleClick}>
+    <div className="title" onDoubleClick={handleClick}>
       {title}
     </div>
   );

--- a/src/ui/utils/apolloClient.js
+++ b/src/ui/utils/apolloClient.js
@@ -1,4 +1,4 @@
-import { gql, ApolloClient, InMemoryCache } from "@apollo/client";
+import { ApolloClient, InMemoryCache } from "@apollo/client";
 import { HttpLink } from "apollo-link-http";
 
 export const createApolloClient = async auth0Client => {
@@ -11,21 +11,19 @@ export const createApolloClient = async auth0Client => {
   if (!auth0Client.isAuthenticated) {
     options = { ...options, uri: "https://graphql.replay.io/v1/graphql" };
   } else {
-    console.log("created apolloclient with token");
-    const link = await createHttpLink({}, auth0Client);
+    const link = await createHttpLink(auth0Client);
     options = { ...options, link };
   }
 
   return new ApolloClient(options);
 };
 
-async function createHttpLink(headers, auth0Client) {
+async function createHttpLink(auth0Client) {
   let hasuraToken = await getToken(auth0Client);
 
   return new HttpLink({
     uri: "https://graphql.replay.io/v1/graphql",
     headers: {
-      ...headers,
       Authorization: `Bearer ${hasuraToken}`,
     },
     fetch,

--- a/src/ui/utils/apolloClient.js
+++ b/src/ui/utils/apolloClient.js
@@ -2,31 +2,35 @@ import { gql, ApolloClient, InMemoryCache } from "@apollo/client";
 import { HttpLink } from "apollo-link-http";
 
 export const createApolloClient = async auth0Client => {
-  if (auth0Client.isLoading === true || !auth0Client.isAuthenticated) {
+  if (auth0Client.isLoading === true) {
     return;
   }
-  const createHttpLink = async headers => {
-    let hasuraToken = await getToken(auth0Client);
 
-    return new HttpLink({
-      uri: "https://graphql.replay.io/v1/graphql",
-      headers: {
-        ...headers,
-        Authorization: `Bearer ${hasuraToken}`,
-      },
-      fetch,
-    });
-  };
+  let options = { cache: new InMemoryCache() };
 
-  const link = await createHttpLink({});
+  if (!auth0Client.isAuthenticated) {
+    options = { ...options, uri: "https://graphql.replay.io/v1/graphql" };
+  } else {
+    console.log("created apolloclient with token");
+    const link = await createHttpLink({}, auth0Client);
+    options = { ...options, link };
+  }
 
-  const client = new ApolloClient({
-    link,
-    cache: new InMemoryCache(),
-  });
-
-  return client;
+  return new ApolloClient(options);
 };
+
+async function createHttpLink(headers, auth0Client) {
+  let hasuraToken = await getToken(auth0Client);
+
+  return new HttpLink({
+    uri: "https://graphql.replay.io/v1/graphql",
+    headers: {
+      ...headers,
+      Authorization: `Bearer ${hasuraToken}`,
+    },
+    fetch,
+  });
+}
 
 async function getToken(auth0Client) {
   try {


### PR DESCRIPTION
Fix #783, Fix #782

This patch adds a header title. When the user is in a recording, they can edit the header title the same way the would edit the title from the recordings page.

Demo: https://www.loom.com/share/cd67ea901ae544be998e59ba92fed010

Recordings: `/viewer`
![image](https://user-images.githubusercontent.com/15959269/94859627-d41c4400-0402-11eb-8014-ac1232ca8d17.png)
Recording: `/viewer?id=`
![image](https://user-images.githubusercontent.com/15959269/94859668-e26a6000-0402-11eb-94dd-55b87dcc2a25.png)
