### PR TITLE
Change markers from circle to diamond, and add a timeline scrubber

### DIFF
--- a/src/image/images/scrubber.svg
+++ b/src/image/images/scrubber.svg
@@ -1,0 +1,3 @@
+<svg width="9" height="10" viewBox="0 0 9 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0H9V6L4.5 10L0 6V0Z" fill="#9400FF"/>
+</svg>

--- a/src/ui/components/Timeline/Message.js
+++ b/src/ui/components/Timeline/Message.js
@@ -5,11 +5,10 @@ import { LocalizationHelper } from "devtools/shared/l10n";
 import { getPixelOffset, getPixelDistance, getLeftOffset } from "../../utils/timeline";
 import { connect } from "react-redux";
 import classnames from "classnames";
+import { timelineMarkerWidth } from "../../utils/timeline";
 
 const L10N = new LocalizationHelper("devtools/client/locales/toolbox.properties");
 const getFormatStr = (key, a) => L10N.getFormatStr(`toolbox.replay.${key}`, a);
-
-const markerWidth = 11;
 
 function sameLocation(m1, m2) {
   const f1 = m1.frame;
@@ -98,7 +97,7 @@ class Message extends React.Component {
         overlayWidth,
         zoom: zoomRegion,
       }) >
-      markerWidth / 2;
+      timelineMarkerWidth / 2;
 
     const isHighlighted = highlightedMessage == message.id;
 

--- a/src/ui/components/Timeline/Message.js
+++ b/src/ui/components/Timeline/Message.js
@@ -5,7 +5,7 @@ import { LocalizationHelper } from "devtools/shared/l10n";
 import { getPixelOffset, getPixelDistance, getLeftOffset } from "../../utils/timeline";
 import { connect } from "react-redux";
 import classnames from "classnames";
-import { timelineMarkerWidth } from "../../utils/timeline";
+import { timelineMarkerWidth } from "../../constants";
 
 const L10N = new LocalizationHelper("devtools/client/locales/toolbox.properties");
 const getFormatStr = (key, a) => L10N.getFormatStr(`toolbox.replay.${key}`, a);

--- a/src/ui/components/Timeline/Message.js
+++ b/src/ui/components/Timeline/Message.js
@@ -9,7 +9,7 @@ import classnames from "classnames";
 const L10N = new LocalizationHelper("devtools/client/locales/toolbox.properties");
 const getFormatStr = (key, a) => L10N.getFormatStr(`toolbox.replay.${key}`, a);
 
-const markerWidth = 7;
+const markerWidth = 11;
 
 function sameLocation(m1, m2) {
   const f1 = m1.frame;
@@ -18,13 +18,44 @@ function sameLocation(m1, m2) {
   return f1.source === f2.source && f1.line === f2.line && f1.column === f2.column;
 }
 
+// Don't change this haphazardly. This marker is intentionally 11px x 11px, so that it
+// can be center aligned perfectly with a 1px timeline scrubber line. This means that
+// it can also center aligned with other elements so long as those other elements have
+// an odd px measurement on the relevant dimension (height/width).
+
+// If you do modify this, make sure you change EVERY single reference to this 11px width in
+// the codebase. This includes, but is not limited to, the Timeline component, Message component,
+// the timeline utilities, and the timeline styling.
+function Marker({ message, onMarkerClick, onMarkerMouseEnter, onMarkerMouseLeave }) {
+  // The stroke path element here has `pointer-events: none` enabled, so that it defers the event
+  // handling to the fill path element. Without that property, we'd have to set the event handlers
+  // on the stroke path element as well.
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 11 11" fill="none">
+      <path
+        className="fill"
+        d="M11 5.5L5.5 0 0 5.5 5.5 11 11 5.5Z"
+        fill="black"
+        onClick={e => onMarkerClick(e, message)}
+        onMouseEnter={onMarkerMouseEnter}
+        onMouseLeave={onMarkerMouseLeave}
+      />
+      {/* <path
+        className="inner-stroke"
+        d="M1.4 5.5L5.5 1.4 9.6 5.5 5.5 9.6 1.4 5.5Z"
+        style="stroke-width:2;stroke:black"
+      /> */}
+      <path className="stroke" d="M0.7 5.5L5.5 0.7 10.3 5.5 5.5 10.3 0.7 5.5Z" stroke="black" />
+    </svg>
+  );
+}
+
 class Message extends React.Component {
   render() {
     const {
       message,
       messages,
       currentTime,
-      pausedMessage,
       highlightedMessage,
       zoomRegion,
       overlayWidth,
@@ -71,7 +102,7 @@ class Message extends React.Component {
 
     const isHighlighted = highlightedMessage == message.id;
 
-    const atPausedLocation = pausedMessage && sameLocation(pausedMessage, message);
+    const isPauseLocation = message.executionPointTime === currentTime;
 
     let frameLocation = "";
     if (message.frame) {
@@ -89,7 +120,7 @@ class Message extends React.Component {
         className={classnames("message", {
           future: isFuture,
           highlighted: isHighlighted,
-          location: atPausedLocation,
+          paused: isPauseLocation,
         })}
         style={{
           left: `${getLeftOffset({
@@ -100,10 +131,14 @@ class Message extends React.Component {
           zIndex: `${index + 100}`,
         }}
         title={getFormatStr("jumpMessage2", frameLocation)}
-        onFocus={e => onMarkerClick(e, message)}
-        onMouseEnter={onMarkerMouseEnter}
-        onMouseLeave={onMarkerMouseLeave}
-      />
+      >
+        <Marker
+          message={message}
+          onMarkerClick={onMarkerClick}
+          onMarkerMouseEnter={onMarkerMouseEnter}
+          onMarkerMouseLeave={onMarkerMouseLeave}
+        />
+      </a>
     );
   }
 }

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -16,8 +16,8 @@
   --progress-recording-background: hsl(0, 100%, 97%);
   --progress-playing-background: #d4ebff;
   --recording-marker-background: hsl(14.9, 100%, 67%);
-  --replaying-marker-fill: var(--blue-40);
-  --replaying-marker-stroke: var(--blue-40);
+  --replaying-marker-fill: #3a8edb;
+  --replaying-marker-stroke: #266fb1;
   --replaying-paused-marker-fill: #5b41ff;
   --replaying-paused-marker-stroke: #3d23e2;
   --replaying-marker-highlighted-background: var(--blue-60);
@@ -41,8 +41,8 @@
   --progress-recording-line: #ff2038;
   --recording-marker-background: #9b3131;
   --recording-marker-background-hover: #a82323;
-  --replaying-marker-fill: #266fb1;
-  --replaying-marker-stroke: #3a8edb;
+  --replaying-marker-fill: var(--blue-40);
+  --replaying-marker-stroke: var(--blue-40);
   --replaying-paused-marker-fill: #5b41ff;
   --replaying-paused-marker-stroke: #1a72dc;
   --replaying-marker-highlighted-background: #3084d0;

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -7,19 +7,23 @@
   min-height: 29px;
   --progressbar-transition: 200ms;
   display: flex;
+  height: 100%;
+  padding-right: 10px;
 }
 
 .theme-light .replay-player {
   --commandbar-button-hover-background: #efefef;
   --progress-recording-background: hsl(0, 100%, 97%);
-  --progress-playing-background: hsl(207, 100%, 97%);
+  --progress-playing-background: #d4ebff;
   --recording-marker-background: hsl(14.9, 100%, 67%);
-  --replaying-marker-background: var(--blue-40);
+  --replaying-marker-fill: var(--blue-40);
+  --replaying-marker-stroke: var(--blue-40);
+  --replaying-paused-marker-fill: #5b41ff;
+  --replaying-paused-marker-stroke: #3d23e2;
   --replaying-marker-highlighted-background: var(--blue-60);
-  --replaying-marker-location-background: var(--blue-50);
   --recording-marker-background-hover: hsl(14.9, 100%, 47%);
-  --replaying-marker-background-hover: var(--blue-60);
-  --hover-point: var(--blue-50);
+  --replaying-marker-fill-hover: var(--blue-60);
+  --hover-scrubber-line-background: var(--blue-50);
   --progress-recording-line: #d0021b;
   --progressbar-background: #fff;
   --progressbar-line-color: var(--blue-40);
@@ -37,11 +41,13 @@
   --progress-recording-line: #ff2038;
   --recording-marker-background: #9b3131;
   --recording-marker-background-hover: #a82323;
-  --replaying-marker-background: #266fb1;
+  --replaying-marker-fill: #266fb1;
+  --replaying-marker-stroke: #3a8edb;
+  --replaying-paused-marker-fill: #5b41ff;
+  --replaying-paused-marker-stroke: #1a72dc;
   --replaying-marker-highlighted-background: #3084d0;
-  --replaying-marker-location-background: #3084d0;
-  --replaying-marker-background-hover: #3a8edb;
-  --hover-point: var(--blue-50);
+  --replaying-marker-fill-hover: #3a8edb;
+  --hover-scrubber-line-background: var(--blue-50);
   --progressbar-background: #0c0c0d;
   --proggressbar-border-color: var(--theme-splitter-color);
   --progressbar-line-color: #0a4786;
@@ -61,7 +67,7 @@
   position: relative;
   width: 100%;
   height: 25px;
-  background: var(--progressbar-background);
+  background: #d4ebff;
   border: 1px solid var(--proggressbar-border-color);
   overflow: hidden;
   margin: 6px 5px 2px 0;
@@ -71,62 +77,83 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  background: var(--progress-playing-background);
+  background: #c0e2ff;
   pointer-events: none;
   border-right-color: var(--replay-head-background);
-  border-right-width: 2px;
+  border-right-width: 1px;
   border-right-style: solid;
 }
 
 .replay-player .message-container {
-  top: calc(50% - 2.75px);
   position: absolute;
   width: 100%;
+  height: 100%;
 }
 
 .replay-player .message {
   position: absolute;
-  border-radius: 4.5px;
-  background: var(--replaying-marker-background);
-  border: 0.5px solid var(--progress-playing-background);
-  height: 7.5px;
-  width: 7.5px;
+  height: 11px;
+  width: 11px;
+  position: absolute;
+  margin-top: auto;
+  margin-bottom: auto;
+  top: 0;
+  bottom: 0;
+}
+
+.replay-player .message:hover {
+  cursor: pointer;
+}
+
+.replay-player .message.highlighted .fill {
+  fill: var(--replaying-marker-stroke);
+  transition-duration: 100ms;
+}
+
+.replay-player .message.highlighted  {
+  transform: scale(1.2);
+  transition-duration: 100ms;
+}
+
+.replay-player .message .fill {
+  fill: var(--replaying-marker-fill);
+}
+
+.replay-player .message .stroke {
+  stroke: var(--replaying-marker-stroke);
+  pointer-events: none;
+}
+
+.replay-player .message.paused .fill {
+  fill: var(--replaying-paused-marker-fill);
+}
+
+.replay-player .message.paused .stroke {
+  stroke: var(--replaying-paused-marker-stroke);
 }
 
 .replay-player .message:focus {
   outline: none;
 }
 
-.replay-player .message.future {
-  border-color: var(--progressbar-background);
-}
-
-.replay-player .message.highlighted {
-  background-color: var(--replaying-marker-highlighted-background);
-  transform: scale(1.25);
-  transition-duration: 100ms;
-}
-
-.replay-player .message.location {
-  background: var(--replaying-marker-location-background);
-}
-
-.replay-player .message:hover {
-  background: var(--replaying-marker-background-hover);
-  cursor: pointer;
-  transform: scale(1.25);
-}
-
-.replay-player .message:hover::before {
-  transform: scale(0.1);
-}
-
-.replay-player .hoverPoint {
+.replay-player .scrubber {
   position: absolute;
   height: 100%;
   width: 1px;
-  background: var(--hover-point);
   pointer-events: none;
+  background: transparent;
+  z-index: 1000;
+}
+
+.replay-player .scrubber.hovered {
+  background: var(--hover-scrubber-line-background);
+}
+
+/* The scrubber is 9px wide, so shifting it 4px to the left
+gets the scrubber's center position (5px) right on top of the
+pause line or the hover preview line */
+.replay-player .scrubber img {
+  margin-left: -4px;
 }
 
 .replay-player .commands {
@@ -188,9 +215,11 @@
   height: 1px;
   background: var(--progressbar-line-color);
   position: absolute;
-  left: 0;
-  top: 50%;
   pointer-events: none;
+  margin-top: auto;
+  margin-bottom: auto;
+  top: 0;
+  bottom: 0;
 }
 
 .replay-player .progress-line.end {
@@ -260,126 +289,4 @@
 .replay-player .zoomboundary {
   padding-top: 7px;
   padding-right: 4px;
-}
-
-/*. replay */
-
-.replay-player {
-  -moz-appearance: none;
-  background: var(--theme-tab-toolbar-background);
-  box-sizing: border-box;
-  min-height: 29px;
-  --progressbar-transition: 200ms;
-  display: flex;
-  height: 100%;
-  padding-right: 10px;
-}
-
-.theme-light .replay-player {
-  --commandbar-button-hover-background: #efefef;
-  --progress-recording-background: hsl(0, 100%, 97%);
-  --progress-playing-background: linear-gradient(100.04deg, #d4ebff 50%, #c0e2ff 90%);
-  --recording-marker-background: hsl(14.9, 100%, 67%);
-  --replaying-marker-background: var(--blue-40);
-  --replaying-marker-highlighted-background: var(--blue-60);
-  --replaying-marker-location-background: var(--blue-50);
-  --recording-marker-background-hover: hsl(14.9, 100%, 47%);
-  --replaying-marker-background-hover: var(--blue-60);
-  --progress-recording-line: #d0021b;
-  --progressbar-background: #fff;
-  --progressbar-line-color: var(--blue-40);
-  --proggressbar-border-color: var(--theme-splitter-color);
-  --tick-future-background: #bfc9d2;
-  --tick-background: var(--blue-50);
-  --tick-recording-background: #d0021b;
-  --replay-head-background: var(--purple-50);
-}
-
-.theme-dark .replay-player {
-  --commandbar-button-hover-background: #1a1a1a;
-  --progress-recording-background: #310707;
-  --progress-playing-background: #071a2b;
-  --progress-recording-line: #ff2038;
-  --recording-marker-background: #9b3131;
-  --recording-marker-background-hover: #a82323;
-  --replaying-marker-background: #266fb1;
-  --replaying-marker-highlighted-background: #3084d0;
-  --replaying-marker-location-background: #3084d0;
-  --replaying-marker-background-hover: #3a8edb;
-  --progressbar-background: #0c0c0d;
-  --proggressbar-border-color: var(--theme-splitter-color);
-  --progressbar-line-color: #0a4786;
-  --tick-future-background: #bfc9d2;
-  --tick-background: var(--blue-50);
-  --tick-recording-background: #e77884;
-  --replay-head-background: var(--theme-highlight-purple);
-}
-
-.replay-player .overlay-container {
-  display: flex;
-  position: relative;
-  flex-grow: 1;
-}
-
-.comment-box {
-  background-color: white;
-  border-radius: 10px;
-  border: 2px solid;
-  width: 200px;
-  height: 80px;
-}
-
-.comment-write {
-  width: 20px;
-  height: 20px;
-  float: right;
-  transform: scale(0.7);
-}
-
-.comment-confirm {
-  width: 16px;
-  height: 16px;
-  margin-top: 1px;
-  float: right;
-}
-
-.comment-close {
-  width: 16px;
-  height: 16px;
-  margin-top: 2px;
-  margin-right: 2px;
-  float: right;
-}
-
-.comment-input {
-  resize: none;
-  border: none;
-  width: calc(100% - 8px);
-  height: calc(100% - 22px);
-  margin-left: 4px;
-  font-family: ui-rounded;
-}
-
-.comment-contents {
-  width: calc(100% - 8px);
-  height: calc(100% - 22px);
-  margin-top: 18px;
-  margin-left: 4px;
-  font-family: ui-rounded;
-  font-size: medium;
-  overflow: scroll;
-}
-
-.replay-player .comment-marker {
-  position: absolute;
-  height: 100%;
-  width: 7px;
-  height: 7px;
-  border-radius: 4.5px;
-  top: calc(50% - 3.5px);
-  background-color: red;
-}
-
-.replay-player .comment-marker:hover {
-  cursor: pointer;
 }

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -31,12 +31,11 @@ const { assert } = require("protocol/utils");
 import { actions } from "../../actions";
 import { selectors } from "../../reducers";
 import Message from "./Message";
+import { timelineMarkerWidth } from "../../utils/timeline";
 
 const { div } = dom;
 
 import "./Timeline.css";
-
-const markerWidth = 11;
 
 function classname(name, bools) {
   for (const key in bools) {
@@ -485,7 +484,7 @@ export class Timeline extends Component {
   // Get the percent value for the left offset of a message.
   getLeftOffset(message) {
     const messagePosition = this.getVisiblePosition(message.executionPointTime) * 100;
-    const messageWidth = (markerWidth / this.overlayWidth) * 100;
+    const messageWidth = (timelineMarkerWidth / this.overlayWidth) * 100;
 
     return Math.max(messagePosition - messageWidth / 2, 0);
   }
@@ -532,7 +531,7 @@ export class Timeline extends Component {
     }
 
     const middlePercent = this.getVisiblePosition(comment.time) * 100;
-    const widthPercent = (markerWidth / this.overlayWidth) * 100;
+    const widthPercent = (timelineMarkerWidth / this.overlayWidth) * 100;
     const percent = Math.max(middlePercent - widthPercent / 2, 0);
 
     return dom.a({

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -229,12 +229,15 @@ export class Timeline extends Component {
     const isHovered = window.elementIsHovered(this.$progressBar);
     if (!isHovered) {
       clearInterval(this.hoverInterval);
+      this.hoverInterval = null;
       hideTooltip();
     }
   };
 
   onPlayerMouseEnter = async e => {
-    this.hoverInterval = setInterval(this.hoverTimer, 100);
+    if (!this.hoverInterval) {
+      this.hoverInterval = setInterval(this.hoverTimer, 100);
+    }
   };
 
   onPlayerMouseMove = async e => {

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -36,7 +36,7 @@ const { div } = dom;
 
 import "./Timeline.css";
 
-const markerWidth = 7;
+const markerWidth = 11;
 
 function classname(name, bools) {
   for (const key in bools) {
@@ -488,7 +488,7 @@ export class Timeline extends Component {
   }
 
   renderMessages() {
-    const { messages, currentTime, pausedMessage, highlightedMessage, zoomRegion } = this.props;
+    const { messages, currentTime, highlightedMessage, zoomRegion } = this.props;
     let visibleIndex;
 
     return messages.map((message, index) => {
@@ -499,7 +499,6 @@ export class Timeline extends Component {
           index={index}
           messages={messages}
           currentTime={currentTime}
-          pausedMessage={pausedMessage}
           highlightedMessage={highlightedMessage}
           zoomRegion={zoomRegion}
           overlayWidth={this.overlayWidth}
@@ -556,21 +555,43 @@ export class Timeline extends Component {
     return comments.map(comment => this.renderCommentMarker(comment));
   }
 
-  renderHoverPoint() {
-    const { hoverTime, hoveredMessage } = this.props;
+  renderHoverScrubber() {
+    const { hoverTime, hoveredMessage, currentTime } = this.props;
+
     if (hoverTime == null || hoveredMessage) {
       return [];
     }
-    const offset = this.getPixelOffset(hoverTime);
-    return [
-      dom.span({
-        className: "hoverPoint",
+
+    let offset = this.getPixelOffset(hoverTime);
+
+    return dom.span(
+      {
+        className: "scrubber hovered",
         style: {
           left: `${Math.max(offset, 0)}px`,
-          zIndex: 1000,
         },
-      }),
-    ];
+      },
+      dom.img({
+        src: "images/scrubber.svg",
+      })
+    );
+  }
+
+  renderPausedScrubber() {
+    const { hoverTime, hoveredMessage, currentTime } = this.props;
+    let offset = this.getPixelOffset(currentTime);
+
+    return dom.span(
+      {
+        className: "scrubber",
+        style: {
+          left: `${Math.max(offset, 0)}px`,
+        },
+      },
+      dom.img({
+        src: "images/scrubber.svg",
+      })
+    );
   }
 
   renderUnprocessedRegions() {
@@ -640,7 +661,8 @@ export class Timeline extends Component {
           ...this.renderUnprocessedRegions(),
           <ScrollContainer />
         ),
-        ...this.renderHoverPoint()
+        this.renderHoverScrubber(),
+        this.renderPausedScrubber()
       )
     );
   }

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -31,7 +31,7 @@ const { assert } = require("protocol/utils");
 import { actions } from "../../actions";
 import { selectors } from "../../reducers";
 import Message from "./Message";
-import { timelineMarkerWidth } from "../../utils/timeline";
+import { timelineMarkerWidth } from "../../constants";
 
 const { div } = dom;
 

--- a/src/ui/constants.js
+++ b/src/ui/constants.js
@@ -1,0 +1,1 @@
+export const timelineMarkerWidth = 11;

--- a/src/ui/utils/timeline.js
+++ b/src/ui/utils/timeline.js
@@ -1,4 +1,4 @@
-export const timelineMarkerWidth = 11;
+import { timelineMarkerWidth } from "../constants";
 
 // calculate pixel distance from two times
 export function getPixelDistance({ to, from, zoom, overlayWidth }) {

--- a/src/ui/utils/timeline.js
+++ b/src/ui/utils/timeline.js
@@ -1,4 +1,4 @@
-const timelineMarkerWidth = 11;
+export const timelineMarkerWidth = 11;
 
 // calculate pixel distance from two times
 export function getPixelDistance({ to, from, zoom, overlayWidth }) {

--- a/src/ui/utils/timeline.js
+++ b/src/ui/utils/timeline.js
@@ -1,4 +1,4 @@
-const timelineMarkerWidth = 7;
+const timelineMarkerWidth = 11;
 
 // calculate pixel distance from two times
 export function getPixelDistance({ to, from, zoom, overlayWidth }) {


### PR DESCRIPTION
This patch is mainly concerned with changing the timeline message markers from circles to diamonds. The main reasons for this change are:
- **Diamonds are more visually precise**: Instead of visually estimating the middle position of a circle to figure out the position of a message, a diamond has a pointy end that tells you exactly that (_Example 4_). As seen in the example, with the diamond, you can get to 1px precision, lining up the diamond tip with the paused line.
- **Diamonds are more distinct for overlapping markers**: Take for example two timeline markers that are 2px away from each other (_Example 2_). Diamond markers with their pointy ends makes each marker distinct - the circle markers just blend together into a blob.

![image](https://user-images.githubusercontent.com/15959269/94928657-0628b700-0492-11eb-8d85-580ce0d83c4b.png)
![image](https://user-images.githubusercontent.com/15959269/94929409-0ecdbd00-0493-11eb-8656-4858b812af2a.png)

Other things this patch handles:
- **Removed the hover animation for timeline message markers**: Before, it would scale 125% upon hovering on the marker. The reason is that the marker hover state is already indicated by the cursor changing from an arrow to a pointer. The scaling on hover is redundant, and more importantly, has the negative side effect of covering up other markers that are close to the hovered marker. 
- **Changed the color of timeline areas after a pause point to blue**: Before, timeline areas after the pause point would be white. This meant that if a user was paused at 50% progress, the timeline would look half blue and half white. By making it all blue, the timeline is stronger visually even if the pause point is modified. We distinguish between the pre-pause areas and post-pause areas by making the post-pause areas lighter. This can be seen in _Example 4_ where both the background and the progress line is lighter after the purple pause line.
- **Highlights the message that the user is hovering in the console**: We already did this before, but I've changed it to be more subtle. The main objective for this effect was for the user to draw the conclusion that the console messages correspond to timeline markers. The way we do it is by applying a highlighted state to the marker, and showing the screenshot as a tooltip over that marker. The tooltip was already noisy and attention grabbing, so I've made the highlighted message state identifiable, but "pop" less.
- **Added a timeline scrubber**: Before, to indicate the pause point we would simply have a purple line within the progress bar. To make the timeline look even more like a timeline, we've added a scrubber visual to that line (_Example 5_). Scrubbers, which usually look like this one or just a triangle pointing down, are a given in most editor timeline UIs. For us, it's nice to have because it makes pause point more prominent and easier for the user to find. What I like most about it is when it's combined with diamond markers, it becomes VERY obvious to users that you're paused on a marker. This is something that users would always point out in live onboarding - that it's not obvious from the timeline that they're paused on a console message. With this, the scrubber points at the diamond, the diamond points at the marker, and the paused line lines both of them up. If you have the console open, you'll even see the overlay button to the left of the message. 

![image](https://user-images.githubusercontent.com/15959269/94932274-da5c0000-0496-11eb-87d0-d988e6c52ebb.png)

Things this patch doesn't do, and that we should discuss before filing feature requests for:
- **We should get the horizontal positioning precision for the markers/scrubber/paused line down to the exact 1px**: Right now there's a 1px tolerance. The message marker width is an intentionally an odd number (11px) so that theoretically, any horizontal marker can be center aligned to 1px at its middle (6px). Right now it shifts between the 5px/6px position. Even if we get this right, the alignment logic is fragile since it depends on so many variables defined in multiple places, so we should centralize it and define the width of the marker/message/scrubber width in one place. And to keep it from shifting, ideally we would write unit tests that makes sure everything is in its right place. This might sound tedious for some shifty pixel values, but Replay is in the timeline business, and we don't have an excuse for the timeline being anything but perfect.
- **We should rethink how we implement the timeline tooltip**: The timeline tooltip is good at its current job - showing the user a preview of that hover point in time. The preview feature is a must have, but it's almost _too_ good at its job and has its pitfalls. It's too big: on a 1080p screen the viewer is 460px high and the viewer takes up 180px(40%) of that. It has a noticeable lag. And the one that pains me the most, it activates when a user hovers on a console message - while well-intentioned, what ends up happening is that as the user hovers **up and down** in the console, their eyes are moves from **left to right** at an area _above_ the console. This steals focus from console message actions, like the rewind button which is to the left of a message. It's made even worse if for example, the user hovers on a message that activates a tooltip all the way to the right of the timeline. Good luck making them notice any UI on the left - they'll go cross-eyed.
- **We should add some way for users to notice a newly added marker**: This is a small step towards differentiation of markers in the timeline. At the very least, when the user performs an action that might modify the timeline (e.g. adding a logpoint), it should be obvious to a user that the timeline has been modified and it should be easy to point to that new modification. Right now, when a user adds a logpoint that adds 1 marker to a timeline with 0 markers, it's fairly easy for them to tell that it's been modified (it went from 0 to 1 markers), and to point to the new modification (literally the only one marker on the timeline). This gets more difficult as the number of markers in the timeline increase, and it becomes downright impossible very quickly. We can easily fix this by making any new message marker to have a newly added state, where we could distinguish it by any number of effects for ~2-3 seconds. The more subtle options that are easy to implement include changing its color and making it bigger. The more explicit options, and ones I particularly would enjoy, is if we started exploring popups. It comes in two forms. One can be a tooltip just above each marker with information (e.g. Logpoint script.js:50:1). The other one can be a small popup modal that tells the user about an action they just performed (e.g. Added 10 timeline markers from Logpoint in script.js:50:1).
- **We should make it easier for users to zoom in/out**: We can already zoom in the timeline by hovering on the scrollbar and scrolling up/down. However, this UI is not discoverable - I have yet to see a user find out about the zoom feature by themselves. It also doesn't make it obvious to a user if they're zoomed in/out. Scroll to zoom is nice for power users, but we should also have a foolproof zoom UI that's discoverable. An effective UI would be something similar to video editors like Adobe Premiere/AfterEffects where there is a timeline summary above the timeline with a start pointer and end pointer. Those start/end pointers are draggable, and affects the zoom in the timeline. [Vue devtools](https://headwayapp.co/vue-js-devtools-changelog/timeline-and-api-166716) recently implemented a stripped down version of this and it looks really good. With this, we also won't have to indicate zoom level (100%/150%/200%) somewhere because it the user's zoom status would be easily inferred from the start/end pointers. Another option is to add a zoom slider outside of the actual timeline, that increases the zoom relative to the current pause point, similar to [Sonuum](https://sonuum.com/) where they have a slider that goes from a minus magnifying glass to a plus magnifying glasses.
- **We should handle overlapping markers better**: Right now, we simply check each marker as we render them. If we find that there's already a rendered marker within 2.5px of our new marker, we don't render the new marker. This isn't great since we're hiding markers. Ideally all the marker should be on the timeline, and we deal with overlapped markers in a different way. This is an interesting problem because there's no obvious prior art. Video editor keyframes don't get nearly as crowded as Replay's, and their solution to crowding is to display everything and let them overlap. A simple solution might be to group markers that are close together and present them as a "blobbed" selection for the user to click on and zoom into. We could also communicate how many markers are in the blob.

Things we should discuss but are not urgent and should not be prioritized:
- **We should add some way for users to differentiate between different markers**: I don't feel like this should be prioritized, because it will require adding more complexity in the timeline before we nail down the basics. But at some point, it should be easy for users to tell different types of markers apart from each other. There are a lot of ways we can do this as markers can be differentiated based on how it was added (inline console.log, warning, error, logpoint, event logpoint, etc), their source (foo.js vs bar.js), the function they're in (Foo() vs Bar()). This is a long discussion as it also shoehorns into a multiple timeline feature, but again, this should be done later.
- **We should add time indicators to the timeline**: A few months ago we had tick marks in the timeline that was a good way of indicating _some_ measure of time, although it didn't actually tell you which minute/second each tick corresponded to. It would be nice to have ticks and timestamps - it's an expected visual element in editor timelines. But I'm not sure that we need it, and even if we did, that we need to do it now. For one, users I've talked to have never once referred to a time while using debugging a recording (e.g. "I wish I could see what happened at the 43 second mark"). My sample is limited, but my theory is that in a recording, a user's proxy for time passing is either the viewer screenshot or the code execution itself. They don't think in minutes and seconds, rather they think in terms of what events have happened. I found this interesting and it makes sense. For example, when somebody is editing a podcast together, a lot of their actions (splicing audio) is based on the words being said at that time. They don't think "I should extract the audio from this clip starting at 2.2s and end at 10.1s", instead they think "I should extract the audio from this clip starting when the person starts talking, and end when they stop talking". In fact, [businesses like Descript](https://www.descript.com/) are built around navigating a timeline by words, rather than timestamps. This is hardly uncommon - the same pattern is seen in almost every video player (Youtube, Netflix) where they don't have tick marks in the timeline. I think we have the same phenomenon in Replay. It would be _nice_ to have ticks and timestamps, but it's hardly important. I think there might be value in displaying the current paused time and total recording time, but that's outside of ticks and timestamps.