### PR TITLE
Prevent the timeline height from collapsing

### DIFF
--- a/src/ui/components/Toolbox.css
+++ b/src/ui/components/Toolbox.css
@@ -10,7 +10,7 @@
 }
 
 #toolbox-timeline {
-  height: 58px;
+  min-height: 58px;
   background: var(--theme-toolbar-background);
   border-top: 1px solid var(--theme-splitter-color);
   border-bottom: 1px solid var(--theme-splitter-color);


### PR DESCRIPTION
This fixes a bug in Firefox where the timeline container is too short and overlaps with the comments.

Before:
![image](https://user-images.githubusercontent.com/15959269/95105230-d7fedd80-0704-11eb-9d84-ea7a0f908715.png)

After:
![image](https://user-images.githubusercontent.com/15959269/95105272-ea791700-0704-11eb-8cf6-40d868d904b7.png)
