### PR TITLE
Fix seeking in the tests

### DIFF
--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -151,7 +151,7 @@ class Message extends Component {
     let onRewindClick = null;
     let overlayType, label, onClick;
 
-    if (!pausedExecutionPointTime || inWarningGroup) {
+    if (inWarningGroup) {
       return undefined;
     }
 
@@ -165,13 +165,13 @@ class Message extends Component {
       };
     }
 
-    if (executionPointTime > pausedExecutionPointTime) {
-      overlayType = "fast-forward";
-      label = "Fast Forward";
-      onClick = onRewindClick;
-    } else if (executionPointTime < pausedExecutionPointTime) {
+    if (!pausedExecutionPointTime || executionPointTime < pausedExecutionPointTime) {
       overlayType = "rewind";
       label = "Rewind";
+      onClick = onRewindClick;
+    } else if (executionPointTime > pausedExecutionPointTime) {
+      overlayType = "fast-forward";
+      label = "Fast Forward";
       onClick = onRewindClick;
     } else {
       overlayType = "debug";
@@ -187,7 +187,7 @@ class Message extends Component {
     }
 
     return dom.div(
-      { className: `overlay-container ${overlayType}`, onClick },
+      { className: `overlay-container rewindable ${overlayType}`, onClick },
       dom.div({ className: "info" }, dom.div({ className: "label" }, label)),
       dom.div({ className: "button" }, dom.div({ className: "img" }))
     );

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -338,6 +338,7 @@ async function toggleObjectInspectorNode(node) {
 
 async function checkMessageObjectContents(msg, expected, expandList = []) {
   const oi = await findMessageExpandableObjectInspector(msg);
+
   await toggleObjectInspectorNode(oi);
 
   for (const label of expandList) {
@@ -546,7 +547,7 @@ async function ensurePseudoElementRulesExpanded() {
   }
 }
 
-module.exports = {
+const testCommands = {
   selectConsole,
   selectDebugger,
   selectInspector,
@@ -587,6 +588,7 @@ module.exports = {
   checkJumpIcon,
   checkMessageObjectContents,
   toggleObjectInspectorNode,
+  findMessageExpandableObjectInspector,
   findScopeNode,
   toggleScopeNode,
   executeInConsole,
@@ -610,3 +612,11 @@ module.exports = {
   getAppliedRulesJSON,
   checkAppliedRules,
 };
+
+module.exports = Object.entries(testCommands).reduce((exports, [name, func]) => {
+  exports[name] = (...args) => {
+    console.log(name, ...args);
+    return func(...args);
+  };
+  return exports;
+}, {});

--- a/test/scripts/logpoint-03.js
+++ b/test/scripts/logpoint-03.js
@@ -1,5 +1,5 @@
 // Test event logpoints when replaying.
-(async function() {
+(async function () {
   await Test.selectConsole();
   await Test.addEventListenerLogpoints(["event.mouse.click"]);
 


### PR DESCRIPTION
Makes the seek button in the console discoverable. 

Also improves the logging for test commands so it's easier to see which commands ran
<img width="1207" alt="Screen Shot 2020-10-08 at 6 20 59 PM" src="https://user-images.githubusercontent.com/254562/95530587-1ad5e500-0993-11eb-9756-75baaddb341a.png">
