### PR TITLE
remove unused imports from Sharing.js

### DIFF
--- a/src/ui/components/shared/Sharing.js
+++ b/src/ui/components/shared/Sharing.js
@@ -1,15 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
-import classnames from "classnames";
 import { gql, useQuery, useMutation } from "@apollo/client";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
 import Modal from "./Modal";
 import Loader from "./Loader";
-import { features } from "ui/utils/prefs";
 
 import "./Sharing.css";
-import { setConstantValue } from "typescript";
 
 const GET_OWNER_AND_COLLABORATORS = gql`
   query MyQuery($recordingId: uuid) {


### PR DESCRIPTION
One of the imports resulted in typescript being added to the webpack bundle, almost doubling its size (and showing some webpack warnings).