### PR TITLE
don't try to load graphics for an undefined paintHash

### DIFF
--- a/src/protocol/screenshot-cache.ts
+++ b/src/protocol/screenshot-cache.ts
@@ -35,7 +35,10 @@ export class ScreenshotCache {
    * Returns a promise for the requested screenshot. The promise may be rejected
    * if another tooltip screenshot is requested before this download was started.
    */
-  async getScreenshotForTooltip(point: string, paintHash: string): Promise<ScreenShot> {
+  async getScreenshotForTooltip(point: string, paintHash: string): Promise<ScreenShot | undefined> {
+    if (!paintHash) {
+      return undefined;
+    }
     if (this.resizedCache.has(paintHash)) {
       return this.resizedCache.get(paintHash)!;
     }
@@ -63,7 +66,10 @@ export class ScreenshotCache {
    * Returns a promise for the requested screenshot. The download will be started
    * immediately and will only be rejected if sendMessage() throws.
    */
-  async getScreenshotForPlayback(point: string, paintHash: string): Promise<ScreenShot> {
+  async getScreenshotForPlayback(point: string, paintHash: string): Promise<ScreenShot | undefined> {
+    if (!paintHash) {
+      return undefined;
+    }
     if (this.fullsizeCache.has(paintHash)) {
       return this.fullsizeCache.get(paintHash)!;
     }


### PR DESCRIPTION
This will remove the "Not a valid paint point" error messages.