### PR TITLE
Handle 'This recording format is no longer supported' errors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -53,6 +53,8 @@ async function createSession() {
   } catch (e) {
     if (e.code == 9) {
       store.dispatch(setErrorMessage("Invalid recording ID"));
+    } else if (e.code == 31) {
+      store.dispatch(setErrorMessage("This recording format is no longer supported"));
     } else {
       throw e;
     }

--- a/src/ui/components/App.js
+++ b/src/ui/components/App.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import DevTools from "./DevTools";
 import Account from "./Account";
 import Loader from "./shared/Loader";
-import { SessionError, PopupBlockedError } from "./shared/Error";
+import { Error, PopupBlockedError } from "./shared/Error";
 import { selectors } from "ui/reducers";
 import { useApolloClient, ApolloProvider } from "@apollo/client";
 import { useAuth0 } from "@auth0/auth0-react";
@@ -37,7 +37,7 @@ function useGetApolloClient() {
   return { apolloClient, consentPopupBlocked };
 }
 
-function App({ theme, recordingId, sessionError }) {
+function App({ theme, recordingId, error }) {
   const { isAuthenticated, isLoading } = useAuth0();
   const { apolloClient, consentPopupBlocked } = useGetApolloClient();
 
@@ -55,8 +55,8 @@ function App({ theme, recordingId, sessionError }) {
 
   return (
     <ApolloProvider client={apolloClient}>
-      {sessionError && <SessionError error={sessionError} />}
       {recordingId ? <DevTools /> : <Account />}
+      {error && <Error error={error} />}
     </ApolloProvider>
   );
 }
@@ -65,7 +65,7 @@ export default connect(
   state => ({
     theme: selectors.getTheme(state),
     recordingId: selectors.getRecordingId(state),
-    sessionError: selectors.getErrorMessage(state),
+    error: selectors.getErrorMessage(state),
   }),
   {}
 )(App);

--- a/src/ui/components/shared/Error.js
+++ b/src/ui/components/shared/Error.js
@@ -30,7 +30,17 @@ export function PopupBlockedError() {
   );
 }
 
-export function SessionError({ error }) {
+export function Error({ error }) {
+  if (error != "Session died unexpectedly") {
+    return (
+      <Modal opaque error>
+        <h1>Whoops!</h1>
+        <p>Looks like something went wrong with this page.</p>
+        <p className="tip">Error: {error}</p>
+      </Modal>
+    );
+  }
+
   return (
     <Modal translucent error>
       <h1>Whoops!</h1>


### PR DESCRIPTION
Fix #813. 

This does the trick, though we probably need to revisit how errors are handled in the frontend. I didn't take the time to plan out z-indices in advance and they're only going to get more convoluted from here.