### PR TITLE
guard against an empty recordings array

### DIFF
--- a/src/ui/components/Header/Header.js
+++ b/src/ui/components/Header/Header.js
@@ -64,7 +64,8 @@ function HeaderTitle({ recordingId, editingTitle, setEditingTitle }) {
     return <div className="title">Recordings</div>;
   }
 
-  const { recordingTitle, title } = data.recordings[0];
+  const recording = data.recordings[0];
+  const { recordingTitle, title } = recording || {};
 
   return (
     <Title

--- a/src/ui/components/Header/ShareDropdown.js
+++ b/src/ui/components/Header/ShareDropdown.js
@@ -110,7 +110,7 @@ function ShareDropdown({ recordingId, setSharingModal }) {
     variables: { recordingId },
   });
 
-  const isPrivate = data.recordings[0].is_private;
+  const isPrivate = data.recordings[0]?.is_private;
   const [updateIsPrivate] = useMutation(UPDATE_IS_PRIVATE, {
     variables: { recordingId, isPrivate: !isPrivate },
   });


### PR DESCRIPTION
I got some exceptions while debugging because `data.recordings[0]` was undefined. Perhaps the reason was that I used a recording that I didn't create.