### PR TITLE
Toggle privacy

### DIFF
--- a/src/ui/components/Comments/index.js
+++ b/src/ui/components/Comments/index.js
@@ -5,7 +5,6 @@ import { connect } from "react-redux";
 import Comment from "./Comment";
 import CommentMarker from "./CommentMarker";
 import { selectors } from "../../reducers";
-import { features } from "../../utils/prefs";
 
 import "./Comments.css";
 

--- a/src/ui/components/DevTools.js
+++ b/src/ui/components/DevTools.js
@@ -69,7 +69,7 @@ function getUploadingMessage(uploading) {
 function getIsAuthorized({ data, error, isAuthenticated }) {
   // We let Hasura decide whether or not the user can view a recording. The response to our query
   // will have a recording if they're authorized to view the recording, and will be empty if not.
-  return data.recordings.length > 0 ? true : false;
+  return data.recordings.length;
 }
 
 function DevTools({

--- a/src/ui/components/DevTools.js
+++ b/src/ui/components/DevTools.js
@@ -26,9 +26,6 @@ const GET_RECORDING = gql`
       title
       recordingTitle
       is_private
-      user {
-        auth_id
-      }
     }
   }
 `;
@@ -67,6 +64,16 @@ function getUploadingMessage(uploading) {
 }
 
 function getIsAuthorized({ data, error, isAuthenticated }) {
+  const test = new URL(window.location.href).searchParams.get("test");
+
+  // Ideally, test recordings should be inserted into Hasura. However, test recordings are currently
+  // not being inserted as a Hasura recordings row, so the GET_RECORDING query will respond with an
+  // empty recordings array. To temporarily work around this for now, we return `true` here so
+  // the test can proceed.
+  if (test) {
+    return true;
+  }
+
   // We let Hasura decide whether or not the user can view a recording. The response to our query
   // will have a recording if they're authorized to view the recording, and will be empty if not.
   return data.recordings.length;

--- a/src/ui/components/DevTools.js
+++ b/src/ui/components/DevTools.js
@@ -17,7 +17,6 @@ import { screenshotCache, nextPaintEvent, getClosestPaintPoint } from "protocol/
 import { gql, useQuery } from "@apollo/client";
 import { useAuth0 } from "@auth0/auth0-react";
 import { data } from "react-dom-factories";
-import { features } from "ui/utils/prefs";
 import { setExpectedError } from "../actions/app";
 
 const GET_RECORDING = gql`
@@ -27,6 +26,9 @@ const GET_RECORDING = gql`
       title
       recordingTitle
       is_private
+      user {
+        auth_id
+      }
     }
   }
 `;
@@ -65,15 +67,8 @@ function getUploadingMessage(uploading) {
 }
 
 function getIsAuthorized({ data, error, isAuthenticated }) {
-  if (!features.private) {
-    return true;
-  }
-
   // We let Hasura decide whether or not the user can view a recording. The response to our query
   // will have a recording if they're authorized to view the recording, and will be empty if not.
-  // What this doesn't explicitly tell us is *why* that user is allowed to view the recording: is the
-  // recording public, or is the user the original creator for that recording? You can check that
-  // by checking the recording's user field, which will be null for non-creator users.
   return data.recordings.length > 0 ? true : false;
 }
 

--- a/src/ui/components/Header/Header.js
+++ b/src/ui/components/Header/Header.js
@@ -9,7 +9,6 @@ import Title from "ui/components/shared/Title";
 import ShareDropdown from "ui/components/Header/ShareDropdown";
 import "./Header.css";
 
-import { features } from "ui/utils/prefs";
 import { gql, useQuery, useMutation } from "@apollo/client";
 
 const GET_RECORDING_TITLE = gql`
@@ -46,11 +45,9 @@ function Links({ user, getActiveUsers, recordingId, setSharingModal }) {
       <a id="headway" onClick={() => Headway.toggle()}>
         What&apos;s new
       </a>
-      {recordingId ? (
-        <ShareDropdown recordingId={recordingId} setSharingModal={setSharingModal} />
-      ) : null}
+      {recordingId ? <ShareDropdown /> : null}
       <Avatars user={user} getActiveUsers={getActiveUsers} />
-      {features.auth0 ? <LoginButton /> : null}
+      <LoginButton />
     </div>
   );
 }

--- a/src/ui/components/Header/ShareDropdown.js
+++ b/src/ui/components/Header/ShareDropdown.js
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from "react";
+import { connect } from "react-redux";
+import { selectors } from "ui/reducers";
+import { actions } from "ui/actions";
 import { gql, useQuery, useMutation } from "@apollo/client";
 import Dropdown from "ui/components/shared/Dropdown";
+import { useAuth0 } from "@auth0/auth0-react";
 import "./ShareDropdown.css";
-import { features } from "../../utils/prefs";
 
 const UPDATE_IS_PRIVATE = gql`
   mutation SetRecordingIsPrivate($recordingId: String, $isPrivate: Boolean) {
@@ -26,6 +29,25 @@ const GET_RECORDING_PRIVACY = gql`
     }
   }
 `;
+
+const GET_OWNER_AUTH_ID = gql`
+  query GetOwnerAuthId($recordingId: String) {
+    recordings(where: { recording_id: { _eq: $recordingId } }) {
+      user {
+        auth_id
+      }
+    }
+  }
+`;
+
+function getIsOwner(recordingId) {
+  const { user } = useAuth0();
+  const { data } = useQuery(GET_OWNER_AUTH_ID, {
+    variables: { recordingId },
+  });
+
+  return user.sub === data.recordings[0]?.user.auth_id;
+}
 
 function CopyUrl({ recordingId }) {
   const [copyClicked, setCopyClicked] = useState(false);
@@ -104,22 +126,34 @@ function Collaborators({ recordingId, setExpanded, setSharingModal }) {
   );
 }
 
-function ShareDropdown({ recordingId, setSharingModal }) {
-  const [expanded, setExpanded] = useState(false);
-  const { data, refetch } = useQuery(GET_RECORDING_PRIVACY, {
+function OwnerSettings({ recordingId, setSharingModal, setExpanded }) {
+  const { data } = useQuery(GET_RECORDING_PRIVACY, {
     variables: { recordingId },
   });
 
   const isPrivate = data.recordings[0]?.is_private;
   const [updateIsPrivate] = useMutation(UPDATE_IS_PRIVATE, {
     variables: { recordingId, isPrivate: !isPrivate },
+    refetchQueries: ["GetRecordingPrivacy"],
   });
 
-  const toggleIsPrivate = () => {
-    updateIsPrivate();
-    refetch();
-  };
+  return (
+    <>
+      <Privacy isPrivate={isPrivate} toggleIsPrivate={updateIsPrivate} />
+      {isPrivate ? (
+        <Collaborators
+          recordingId={recordingId}
+          setExpanded={setExpanded}
+          setSharingModal={setSharingModal}
+        />
+      ) : null}
+    </>
+  );
+}
 
+function ShareDropdown({ recordingId, setSharingModal }) {
+  const [expanded, setExpanded] = useState(false);
+  const isOwner = getIsOwner(recordingId);
   const buttonContent = (
     <>
       <div className="img share" />
@@ -127,23 +161,12 @@ function ShareDropdown({ recordingId, setSharingModal }) {
     </>
   );
 
-  if (!features.private) {
-    return (
-      <div className="share">
-        <Dropdown buttonContent={buttonContent} setExpanded={setExpanded} expanded={expanded}>
-          <CopyUrl recordingId={recordingId} />
-        </Dropdown>
-      </div>
-    );
-  }
-
   return (
     <div className="share">
       <Dropdown buttonContent={buttonContent} setExpanded={setExpanded} expanded={expanded}>
         <CopyUrl recordingId={recordingId} />
-        <Privacy isPrivate={isPrivate} toggleIsPrivate={toggleIsPrivate} />
-        {isPrivate ? (
-          <Collaborators
+        {isOwner ? (
+          <OwnerSettings
             recordingId={recordingId}
             setExpanded={setExpanded}
             setSharingModal={setSharingModal}
@@ -154,4 +177,11 @@ function ShareDropdown({ recordingId, setSharingModal }) {
   );
 }
 
-export default ShareDropdown;
+export default connect(
+  state => ({
+    recordingId: selectors.getRecordingId(state),
+  }),
+  {
+    setSharingModal: actions.setSharingModal,
+  }
+)(ShareDropdown);

--- a/src/ui/components/Header/ShareDropdown.js
+++ b/src/ui/components/Header/ShareDropdown.js
@@ -40,11 +40,15 @@ const GET_OWNER_AUTH_ID = gql`
   }
 `;
 
-function getIsOwner(recordingId) {
-  const { user } = useAuth0();
-  const { data } = useQuery(GET_OWNER_AUTH_ID, {
+function useIsOwner(recordingId) {
+  const { user, isAuthenticated } = useAuth0();
+  const { data, loading } = useQuery(GET_OWNER_AUTH_ID, {
     variables: { recordingId },
   });
+
+  if (!isAuthenticated || loading) {
+    return false;
+  }
 
   return user.sub === data.recordings[0]?.user.auth_id;
 }
@@ -153,7 +157,7 @@ function OwnerSettings({ recordingId, setSharingModal, setExpanded }) {
 
 function ShareDropdown({ recordingId, setSharingModal }) {
   const [expanded, setExpanded] = useState(false);
-  const isOwner = getIsOwner(recordingId);
+  const isOwner = useIsOwner(recordingId);
   const buttonContent = (
     <>
       <div className="img share" />

--- a/src/ui/components/Recordings/Recording.js
+++ b/src/ui/components/Recordings/Recording.js
@@ -4,7 +4,6 @@ import Title from "../shared/Title";
 import Dropdown from "devtools/client/debugger/src/components/shared/Dropdown";
 import moment from "moment";
 import { gql, useMutation } from "@apollo/client";
-import { features } from "ui/utils/prefs";
 import { actions } from "ui/actions";
 import { selectors } from "ui/reducers";
 
@@ -45,7 +44,7 @@ const DropdownPanel = ({
       <div className="menu-item" onClick={() => onDeleteRecording(recordingId)}>
         Delete Recording
       </div>
-      {!features.private ? null : isPrivate ? (
+      {isPrivate ? (
         <div className="menu-item" onClick={toggleIsPrivate}>
           Make public
         </div>
@@ -105,11 +104,9 @@ const Recording = ({ data, onDeleteRecording, setSharingModal }) => {
           setEditingTitle={setEditingTitle}
         />
         <div className="secondary">{formatDate(data.date)}</div>
-        {features.private ? (
-          <div className="permissions" onClick={toggleIsPrivate}>
-            {data.is_private ? "Private" : "Public"}
-          </div>
-        ) : null}
+        <div className="permissions" onClick={toggleIsPrivate}>
+          {data.is_private ? "Private" : "Public"}
+        </div>
       </div>
     </div>
   );

--- a/src/ui/components/shared/Title.js
+++ b/src/ui/components/shared/Title.js
@@ -20,9 +20,10 @@ export default function Title({ defaultTitle, recordingId, setEditingTitle, edit
   const { isAuthenticated } = useAuth0();
   const [updateRecordingTitle] = useMutation(UPDATE_RECORDING);
   const [title, setTitle] = useState(defaultTitle);
+  const test = new URL(window.location.href).searchParams.get("test");
 
   useEffect(() => {
-    setTitle(defaultTitle);
+    setTitle(test ? `Test: ${test}` : defaultTitle);
   }, [defaultTitle]);
 
   const saveTitle = () => {

--- a/src/ui/utils/prefs.js
+++ b/src/ui/utils/prefs.js
@@ -20,7 +20,6 @@ pref("devtools.toolbox-opened", true);
 pref("devtools.features.comments", true);
 pref("devtools.features.users", true);
 pref("devtools.features.auth0", true);
-pref("devtools.features.private", true);
 
 export const prefs = new PrefsHelper("devtools", {
   isToolboxOpen: ["Bool", "toolbox-opened"],

--- a/src/ui/utils/prefs.js
+++ b/src/ui/utils/prefs.js
@@ -20,7 +20,7 @@ pref("devtools.toolbox-opened", true);
 pref("devtools.features.comments", true);
 pref("devtools.features.users", true);
 pref("devtools.features.auth0", true);
-pref("devtools.features.private", false);
+pref("devtools.features.private", true);
 
 export const prefs = new PrefsHelper("devtools", {
   isToolboxOpen: ["Bool", "toolbox-opened"],


### PR DESCRIPTION
Re-do of #829.

The old patch broke the tests because it blocked the test runner from opening the test recording.

The main problem it that new test recordings are not being inserted as new rows in the Hasura recordings table. When the viewer tries to fetch the test recording from Hasura for authorization purposes, Hasura responds with an empty array. We then infer from the empty array that the user does not have permission to view the recording, and we display a "You need to sign in to view this recording" error instead.

This patch works around this problem by skipping the authorization step if we're in a test.