### PR TITLE
Only show one breakpoint pane when clicking on the source

### DIFF
--- a/src/devtools/client/debugger/panel.js
+++ b/src/devtools/client/debugger/panel.js
@@ -210,9 +210,6 @@ export class DebuggerPanel {
     const location = { sourceId, line, column };
 
     await this._actions.selectSource(cx, sourceId, location);
-    if (this._selectors.hasLogpoint(this._getState(), location)) {
-      this._actions.openConditionalPanel(location, true);
-    }
   }
 
   canLoadSource(sourceId) {


### PR DESCRIPTION
Fix #801. This makes sure that clicking on a logpoint's source from the console doesn't show multiple panes. 