### PR TITLE
New markup view

### DIFF
--- a/src/devtools/client/inspector/inspector.js
+++ b/src/devtools/client/inspector/inspector.js
@@ -1099,7 +1099,6 @@ class Inspector {
       this.markup = new MarkupView(this);
     } else {
       this.markup = new NewMarkupView(this);
-      ReactDOM.render(this.markup.provider, document.getElementById("markup-root"));
     }
 
     const loading = document.getElementById("markup-loading");
@@ -1110,7 +1109,8 @@ class Inspector {
       if (features.oldMarkupView) {
         this.markup.expandNode(this.selection.nodeFront);
       } else {
-        this.markup.update();
+        await this.markup.update();
+        ReactDOM.render(this.markup.provider, document.getElementById("markup-root"));
       }
     }
 

--- a/src/devtools/client/inspector/inspector.js
+++ b/src/devtools/client/inspector/inspector.js
@@ -1101,10 +1101,6 @@ class Inspector {
       this.markup = new NewMarkupView(this);
     }
 
-    const loading = document.getElementById("markup-loading");
-    loading.hidden = true;
-    //log(`Inspector HideMarkupLoading`);
-
     if (this.selection.nodeFront) {
       if (features.oldMarkupView) {
         this.markup.expandNode(this.selection.nodeFront);
@@ -1113,6 +1109,10 @@ class Inspector {
         ReactDOM.render(this.markup.provider, document.getElementById("markup-root"));
       }
     }
+
+    const loading = document.getElementById("markup-loading");
+    loading.hidden = true;
+    //log(`Inspector HideMarkupLoading`);
 
     // Restore the highlighter states prior to emitting "new-root".
     if (this._highlighters) {

--- a/src/devtools/client/inspector/markup/actions/index.js
+++ b/src/devtools/client/inspector/markup/actions/index.js
@@ -2,6 +2,12 @@ const { createEnum } = require("devtools/client/shared/enum");
 
 createEnum(
   [
+    // Adds a node to the tree.
+    "ADD_NODE",
+
+    // Updates the children of a node.
+    "UPDATE_CHILDREN",
+
     // Updates the expanded state for a given node.
     "UPDATE_NODE_EXPANDED",
 

--- a/src/devtools/client/inspector/markup/actions/markup.js
+++ b/src/devtools/client/inspector/markup/actions/markup.js
@@ -1,4 +1,6 @@
 const {
+  ADD_NODE,
+  UPDATE_CHILDREN,
   UPDATE_NODE_EXPANDED,
   UPDATE_ROOT_NODE,
   UPDATE_SELECTED_NODE,
@@ -6,6 +8,27 @@ const {
 } = require("./index");
 
 module.exports = {
+  /**
+   * Adds a node to the tree.
+   */
+  addNode(node) {
+    return {
+      type: ADD_NODE,
+      node,
+    };
+  },
+
+  /**
+   * Updates the children of a node.
+   */
+  updateChildren(parentNodeId, childNodeIds) {
+    return {
+      type: UPDATE_CHILDREN,
+      parentNodeId,
+      childNodeIds,
+    };
+  },
+
   /**
    * Updates the expanded state for a given node.
    *

--- a/src/devtools/client/inspector/markup/components/MarkupApp.js
+++ b/src/devtools/client/inspector/markup/components/MarkupApp.js
@@ -39,6 +39,8 @@ class MarkupApp extends PureComponent {
           onSelectNode: this.props.onSelectNode,
           onShowEventTooltip: this.props.onShowEventTooltip,
           onToggleNodeExpanded: this.props.onToggleNodeExpanded,
+          onMouseEnterNode: this.props.onMouseEnterNode,
+          onMouseLeaveNode: this.props.onMouseLeaveNode,
         });
       })
     );

--- a/src/devtools/client/inspector/markup/components/MarkupApp.js
+++ b/src/devtools/client/inspector/markup/components/MarkupApp.js
@@ -17,7 +17,7 @@ class MarkupApp extends PureComponent {
     };
   }
 
-  renderTreeView() {
+  render() {
     const { markup } = this.props;
     const { rootNode, tree } = markup;
 
@@ -43,19 +43,6 @@ class MarkupApp extends PureComponent {
           onMouseLeaveNode: this.props.onMouseLeaveNode,
         });
       })
-    );
-  }
-
-  render() {
-    return dom.div(
-      {
-        id: "markup-box",
-        className: "theme-body devtools-monospace",
-      },
-      dom.div(
-        { id: "markup-root-wrapper", role: "presentation" },
-        dom.div({ id: "markup-root", role: "presentation" }, this.renderTreeView())
-      )
     );
   }
 }

--- a/src/devtools/client/inspector/markup/components/Node.js
+++ b/src/devtools/client/inspector/markup/components/Node.js
@@ -30,6 +30,8 @@ class Node extends PureComponent {
 
     this.onExpanderToggle = this.onExpanderToggle.bind(this);
     this.onSelectNodeClick = this.onSelectNodeClick.bind(this);
+    this.onMouseEnter = this.onMouseEnter.bind(this);
+    this.onMouseLeave = this.onMouseLeave.bind(this);
   }
 
   onExpanderToggle(event) {
@@ -49,6 +51,14 @@ class Node extends PureComponent {
     }
 
     this.props.onSelectNode(node.id);
+  }
+
+  onMouseEnter() {
+    this.props.onMouseEnterNode(this.props.node.id);
+  }
+
+  onMouseLeave() {
+    this.props.onMouseLeaveNode(this.props.node.id);
   }
 
   /**
@@ -76,6 +86,8 @@ class Node extends PureComponent {
           onSelectNode: this.props.onSelectNode,
           onShowEventTooltip: this.props.onShowEventTooltip,
           onToggleNodeExpanded: this.props.onToggleNodeExpanded,
+          onMouseEnterNode: this.props.onMouseEnterNode,
+          onMouseLeaveNode: this.props.onMouseLeaveNode,
         });
       })
     );
@@ -148,6 +160,8 @@ class Node extends PureComponent {
           (showExpander ? " expandable" : ""),
         role: "presentation",
         onClick: this.onSelectNodeClick,
+        onMouseEnter: this.onMouseEnter,
+        onMouseLeave: this.onMouseLeave,
       },
       dom.div(
         {

--- a/src/devtools/client/inspector/markup/components/Node.js
+++ b/src/devtools/client/inspector/markup/components/Node.js
@@ -160,13 +160,13 @@ class Node extends PureComponent {
           (showExpander ? " expandable" : ""),
         role: "presentation",
         onClick: this.onSelectNodeClick,
-        onMouseEnter: this.onMouseEnter,
-        onMouseLeave: this.onMouseLeave,
       },
       dom.div(
         {
           className: "tag-line" + (isSelected ? " selected" : ""),
           role: "treeitem",
+          onMouseEnter: this.onMouseEnter,
+          onMouseLeave: this.onMouseLeave,
         },
         dom.span({
           className: "tag-state" + (isSelected ? " theme-selected" : ""),

--- a/src/devtools/client/inspector/markup/new-markup.js
+++ b/src/devtools/client/inspector/markup/new-markup.js
@@ -102,15 +102,6 @@ class MarkupView {
   }
 
   /**
-   * An object representing the markup tree. The key to the object represents the object
-   * ID of a NodeFront of a given node. The value of each item in the object contains
-   * an object representing the properties of the given node.
-   */
-  getTree() {
-    return this.store.getState().tree;
-  }
-
-  /**
    * Given the NodeFront, add a representation of the node's properties to the
    * markup tree object.
    *

--- a/src/devtools/client/inspector/markup/new-markup.js
+++ b/src/devtools/client/inspector/markup/new-markup.js
@@ -4,6 +4,7 @@ const { ThreadFront } = require("protocol/thread");
 const { DOCUMENT_TYPE_NODE } = require("devtools/shared/dom-node-constants");
 const { HTMLTooltip } = require("devtools/client/shared/widgets/tooltip/HTMLTooltip");
 const { setEventTooltip } = require("devtools/client/shared/widgets/tooltip/EventTooltipHelper");
+const Highlighter = require("highlighter/highlighter.js");
 
 const {
   updateNodeExpanded,
@@ -33,9 +34,13 @@ class MarkupView {
     // an object representing the properties of the given node.
     this.tree = {};
 
+    this.hoveredNodeId = undefined;
+
     this.onSelectNode = this.onSelectNode.bind(this);
     this.onShowEventTooltip = this.onShowEventTooltip.bind(this);
     this.onToggleNodeExpanded = this.onToggleNodeExpanded.bind(this);
+    this.onMouseEnterNode = this.onMouseEnterNode.bind(this);
+    this.onMouseLeaveNode = this.onMouseLeaveNode.bind(this);
     this.update = this.update.bind(this);
 
     this.inspector.sidebar.on("markupview-selected", this.update);
@@ -53,6 +58,8 @@ class MarkupView {
       onSelectNode: this.onSelectNode,
       onShowEventTooltip: this.onShowEventTooltip,
       onToggleNodeExpanded: this.onToggleNodeExpanded,
+      onMouseEnterNode: this.onMouseEnterNode,
+      onMouseLeaveNode: this.onMouseLeaveNode,
     });
 
     const provider = createElement(
@@ -320,6 +327,20 @@ class MarkupView {
     }
 
     this.store.dispatch(updateSelectedNode(nodeId));
+  }
+
+  onMouseEnterNode(nodeId) {
+    if (this.hoveredNodeId !== nodeId) {
+      this.hoveredNodeId = nodeId;
+      Highlighter.highlight(this.nodes.get(nodeId));
+    }
+  }
+
+  onMouseLeaveNode(nodeId) {
+    if (this.hoveredNodeId === nodeId) {
+      this.hoveredNodeId = undefined;
+      Highlighter.unhighlight();
+    }
   }
 
   /**

--- a/src/devtools/client/inspector/markup/new-markup.js
+++ b/src/devtools/client/inspector/markup/new-markup.js
@@ -14,6 +14,7 @@ const {
 
 const MarkupApp = createFactory(require("./components/MarkupApp"));
 
+const { features } = require("../prefs");
 const { LocalizationHelper } = require("devtools/shared/l10n");
 const INSPECTOR_L10N = new LocalizationHelper("devtools/client/locales/inspector.properties");
 
@@ -202,7 +203,11 @@ class MarkupView {
    * Returns true if the markup panel is visisble, and false otherwise.
    */
   isPanelVisible() {
-    return this.inspector?.sidebar?.getCurrentTabID() === "markupview";
+    if (features.oldMarkupView) {
+      return this.inspector?.sidebar?.getCurrentTabID() === "markupview";
+    } else {
+      return this.inspector?.toolbox?.currentTool === "inspector";
+    }
   }
 
   /**

--- a/src/devtools/client/inspector/markup/reducers/markup.js
+++ b/src/devtools/client/inspector/markup/reducers/markup.js
@@ -20,7 +20,9 @@ const INITIAL_MARKUP = {
   rootNode: null,
   // The selected node to display in the DOM view.
   selectedNode: null,
-  // The markup tree representation of the DOM view.
+  // An object representing the markup tree. The key to the object represents the object
+  // ID of a NodeFront of a given node. The value of each item in the object contains
+  // an object representing the properties of the given node.
   tree: {},
 };
 

--- a/src/devtools/client/inspector/markup/reducers/markup.js
+++ b/src/devtools/client/inspector/markup/reducers/markup.js
@@ -1,5 +1,7 @@
 const Services = require("Services");
 const {
+  ADD_NODE,
+  UPDATE_CHILDREN,
   UPDATE_NODE_EXPANDED,
   UPDATE_ROOT_NODE,
   UPDATE_SELECTED_NODE,
@@ -23,6 +25,33 @@ const INITIAL_MARKUP = {
 };
 
 const reducers = {
+  [ADD_NODE](markup, { node }) {
+    if (markup.tree[node.id]) return markup;
+
+    return {
+      ...markup,
+      tree: {
+        ...markup.tree,
+        [node.id]: node,
+      },
+    };
+  },
+
+  [UPDATE_CHILDREN](markup, { parentNodeId, childNodeIds }) {
+    if (!markup.tree[parentNodeId]) return markup;
+
+    return {
+      ...markup,
+      tree: {
+        ...markup.tree,
+        [parentNodeId]: {
+          ...markup.tree[parentNodeId],
+          children: childNodeIds,
+        },
+      },
+    };
+  },
+
   [UPDATE_NODE_EXPANDED](markup, { nodeId, isExpanded }) {
     return {
       ...markup,

--- a/src/devtools/client/inspector/prefs.js
+++ b/src/devtools/client/inspector/prefs.js
@@ -1,5 +1,4 @@
 import { PrefsHelper } from "devtools/client/shared/prefs";
-import { asyncStoreHelper } from "devtools-modules";
 
 import Services from "devtools-services";
 
@@ -10,6 +9,7 @@ pref("devtools.inspector.three-pane-enabled", false);
 // features
 pref("devtools.inspector.features.old-rulesview.enabled", false);
 pref("devtools.inspector.features.new-markupview.enabled", false);
+pref("devtools.inspector.features.old-markupview.enabled", true);
 
 export const prefs = new PrefsHelper("devtools.inspector", {
   threePaneEnabled: ["Bool", "three-pane-enabled"],
@@ -18,4 +18,5 @@ export const prefs = new PrefsHelper("devtools.inspector", {
 export const features = new PrefsHelper("devtools.inspector.features", {
   oldRulesView: ["Bool", "old-rulesview.enabled"],
   newMarkupView: ["Bool", "new-markupview.enabled"],
+  oldMarkupView: ["Bool", "old-markupview.enabled"],
 });


### PR DESCRIPTION
This is #830 minus the commits that are not directly related to the new markup view (and also work with the old one).

There's a new feature flag devtools.inspector.features.old-markupview.enabled for disabling the old markup view.
When this is set to false, the new markup view will be shown in its place.
When it is set to true, the old markup view will be shown and the new markup view will appear in the side panel if devtools.inspector.features.new-markupview.enabled is set to true.

There are still a couple of bugs to fix, but since this is happening behind a feature flag, I think we can merge this already.