### PR TITLE
Fix continue to here

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoint.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoint.js
@@ -60,7 +60,7 @@ class Breakpoint extends PureComponent {
 
     const selectedLocation = breakpoint.location;
     if (event.metaKey) {
-      return editorActions.continueToHere(cx, selectedLocation.line);
+      return editorActions.continueToHere(cx, selectedLocation);
     }
 
     if (event.shiftKey) {


### PR DESCRIPTION
This fixes the continue to here functionality when clicking on a line in the gutter with cmd+click.