### PR TITLE
Change the logpoint default message to filename + line number

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/index.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/index.js
@@ -212,7 +212,8 @@ export function addBreakpointAtLine(cx, line, shouldLog = false, disabled = fals
     };
 
     const options = {};
-    options.logValue = "displayName";
+    const file = source.url.split("/").pop();
+    options.logValue = `"${file}:${line}"`;
 
     return dispatch(addBreakpoint(cx, breakpointLocation, options, disabled));
   };

--- a/src/devtools/client/debugger/src/components/Editor/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Panel.js
@@ -263,6 +263,7 @@ export class Panel extends PureComponent {
 
   renderLogSummary() {
     const { logValue } = this.state;
+
     return (
       <button className="log" type="button" onClick={this.toggleEditingOn}>
         console.log(<span className="expression">{logValue}</span>);
@@ -272,6 +273,7 @@ export class Panel extends PureComponent {
 
   renderConditionSummary() {
     const { conditionValue } = this.state;
+
     return (
       <button className="condition" type="button" onClick={this.editCondition}>
         if (<span className="expression">{conditionValue}</span>)


### PR DESCRIPTION
This changes the default logpoint message from `displayName` to `file:line`, e.g., `app.js:21`