### PR TITLE
Use seeking for "continue to here" feature

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/index.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/index.js
@@ -28,12 +28,6 @@ export * from "./breakpointPositions";
 export * from "./modify";
 export * from "./syncBreakpoint";
 
-export function addHiddenBreakpoint(cx, location) {
-  return ({ dispatch }) => {
-    return dispatch(addBreakpoint(cx, location, { hidden: true }));
-  };
-}
-
 /**
  * Disable all breakpoints in a source
  *

--- a/src/devtools/client/debugger/src/actions/pause/paused.js
+++ b/src/devtools/client/debugger/src/actions/pause/paused.js
@@ -3,12 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 //
-import {
-  getHiddenBreakpoint,
-  isEvaluatingExpression,
-  getSelectedFrame,
-  getThreadContext,
-} from "../../selectors";
+import { getSelectedFrame, getThreadContext } from "../../selectors";
 
 import { fetchFrames } from ".";
 import { removeBreakpoint } from "../breakpoints";
@@ -40,11 +35,6 @@ export function paused({ executionPoint }) {
     const frame = getSelectedFrame(getState());
     if (frame) {
       dispatch(selectLocation(cx, frame.location, { remap: true }));
-    }
-
-    const hiddenBreakpoint = getHiddenBreakpoint(getState());
-    if (hiddenBreakpoint) {
-      dispatch(removeBreakpoint(cx, hiddenBreakpoint));
     }
 
     const promises = [];

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoint.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoint.js
@@ -95,11 +95,6 @@ class Breakpoint extends PureComponent {
     const { breakpoint, editor, selectedSource } = props;
     const selectedLocation = breakpoint.location;
 
-    // Hidden Breakpoints are never rendered on the client
-    if (breakpoint.options.hidden) {
-      return;
-    }
-
     if (!selectedSource) {
       return;
     }

--- a/src/devtools/client/debugger/src/components/Editor/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/index.js
@@ -33,6 +33,7 @@ import {
   getSkipPausing,
   getInlinePreview,
   getSelectedFrame,
+  getFramePositions,
 } from "../../selectors";
 
 // Redux actions
@@ -118,7 +119,7 @@ class Editor extends PureComponent {
 
     // disables the default search shortcuts
     // $FlowIgnore
-    editor._initShortcuts = () => {};
+    editor._initShortcuts = () => { };
 
     const node = ReactDOM.findDOMNode(this);
     if (node instanceof HTMLElement) {
@@ -297,6 +298,7 @@ class Editor extends PureComponent {
       isPaused,
       conditionalPanelLocation,
       closeConditionalPanel,
+      framePositions,
     } = this.props;
     const { editor } = this.state;
     if (!selectedSource || !editor) {
@@ -320,11 +322,12 @@ class Editor extends PureComponent {
 
     if (target.classList.contains("CodeMirror-linenumber")) {
       const lineText = getLineText(sourceId, selectedSource.content, line).trim();
+      const disabled = !isPaused || !framePositions;
 
       return showMenu(event, [
         ...createBreakpointItems(cx, location, breakpointActions, lineText),
         { type: "separator" },
-        continueToHereItem(cx, location, isPaused, editorActions),
+        continueToHereItem(cx, location, disabled, editorActions),
       ]);
     }
 
@@ -370,7 +373,7 @@ class Editor extends PureComponent {
     }
 
     if (ev.metaKey) {
-      return continueToHere(cx, sourceLine);
+      return continueToHere(cx, { line: sourceLine });
     }
 
     return addBreakpointAtLine(cx, sourceLine, ev.altKey, ev.shiftKey);
@@ -591,6 +594,7 @@ const mapStateToProps = state => {
     skipPausing: getSkipPausing(state),
     inlinePreviewEnabled: getInlinePreview(state),
     selectedFrame: getSelectedFrame(state),
+    framePositions: getFramePositions(state),
   };
 };
 

--- a/src/devtools/client/debugger/src/components/Editor/menus/editor.js
+++ b/src/devtools/client/debugger/src/components/Editor/menus/editor.js
@@ -15,9 +15,9 @@ import { features } from "../../../utils/prefs";
 import { isFulfilled } from "../../../utils/async-value";
 import actions from "../../../actions";
 
-export const continueToHereItem = (cx, location, isPaused, editorActions) => ({
+export const continueToHereItem = (cx, location, disabled, editorActions) => ({
   accesskey: L10N.getStr("editor.continueToHere.accesskey"),
-  disabled: !isPaused,
+  disabled,
   click: () => editorActions.continueToHere(cx, location),
   id: "node-menu-continue-to-here",
   label: L10N.getStr("editor.continueToHere.label"),

--- a/src/devtools/client/debugger/src/reducers/breakpoints.js
+++ b/src/devtools/client/debugger/src/reducers/breakpoints.js
@@ -186,11 +186,6 @@ export function getBreakpointForLocation(state, location) {
   });
 }
 
-export function getHiddenBreakpoint(state) {
-  const breakpoints = getBreakpointsList(state);
-  return breakpoints.find(bp => bp.options.hidden);
-}
-
 export function hasLogpoint(state, location) {
   const breakpoint = getBreakpoint(state, location);
   return breakpoint && breakpoint.options.logValue;

--- a/src/devtools/client/debugger/src/reducers/pending-breakpoints.js
+++ b/src/devtools/client/debugger/src/reducers/pending-breakpoints.js
@@ -31,10 +31,6 @@ function update(state = {}, action) {
 }
 
 function setBreakpoint(state, { breakpoint }) {
-  if (breakpoint.options.hidden) {
-    return state;
-  }
-
   const locationId = makePendingLocationId(breakpoint.location);
   const pendingBreakpoint = createPendingBreakpoint(breakpoint);
 

--- a/src/devtools/client/debugger/src/selectors/visibleColumnBreakpoints.js
+++ b/src/devtools/client/debugger/src/selectors/visibleColumnBreakpoints.js
@@ -32,10 +32,7 @@ function groupBreakpoints(breakpoints, selectedSource) {
     return {};
   }
 
-  const map = groupBy(
-    breakpoints.filter(breakpoint => !breakpoint.options.hidden),
-    breakpoint => breakpoint.location.line
-  );
+  const map = groupBy(breakpoint => breakpoint.location.line);
 
   for (const line in map) {
     map[line] = groupBy(map[line], breakpoint => breakpoint.location.column);


### PR DESCRIPTION
This changes the implementation for `continueToHere`.

Instead of adding a hidden breakpoint on the line that the user selects and using rewind/resume to hit it, we seek to the first point on that line instead. This way, it doesn't end up pausing on other breakpoints on the way to the target line.

https://www.loom.com/share/8dbbb4f616d94656ad28bcb803f86527