### PR TITLE
Move breakpoints panel to the right sidebar

### DIFF
--- a/src/devtools/client/debugger/images/logpoint.svg
+++ b/src/devtools/client/debugger/images/logpoint.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" width="12" height="12">
+  <path fill="context-fill" stroke="context-fill" stroke-linejoin="round" d="M.5 9V3c0-.83.67-1.5 1.5-1.5h5.05a.5.5 0 0 1 .38.17L11.33 6l-3.9 4.33a.5.5 0 0 1-.38.17H2A1.5 1.5 0 0 1 .5 9z"/>
+</svg>

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -134,6 +134,7 @@ html .breakpoints-list .breakpoint.paused {
 
 .breakpoint-line-close {
   margin-inline-start: 4px;
+  position: relative;
 }
 
 .breakpoints-list .breakpoint .breakpoint-line {
@@ -194,14 +195,7 @@ html .breakpoints-list .breakpoint.paused {
   position: absolute;
   /* hide button outside of row until hovered or focused */
   top: -100px;
-}
-
-[dir="ltr"] .breakpoint .close-btn {
-  right: 12px;
-}
-
-[dir="rtl"] .breakpoint .close-btn {
-  left: 12px;
+  right: 0px;
 }
 
 /* Reveal the remove button on hover/focus */

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/index.js
@@ -18,7 +18,11 @@ import { createHeadlessEditor } from "../../../utils/editor/create-editor";
 
 import { makeBreakpointId, sortSelectedBreakpoints } from "../../../utils/breakpoint";
 
-import { getSelectedSource, getBreakpointSources } from "../../../selectors";
+import {
+  getSelectedSource,
+  getBreakpointSources,
+  getShouldLogExceptions,
+} from "../../../selectors";
 
 import "./Breakpoints.css";
 
@@ -66,7 +70,7 @@ class Breakpoints extends Component {
   }
 
   renderBreakpoints() {
-    const { breakpointSources, selectedSource } = this.props;
+    const { breakpointSources, selectedSource, sidebar } = this.props;
     if (!breakpointSources.length) {
       return null;
     }
@@ -96,18 +100,33 @@ class Breakpoints extends Component {
   }
 
   render() {
-    return (
+    const pane = (
       <div className="pane">
         {this.renderExceptionsOptions()}
         {this.renderBreakpoints()}
       </div>
     );
+
+    if (this.props.sidebar) {
+      return (
+        <div className="logpoints">
+          <div className="pane-header">
+            <div className="img logpoint" />
+            <div className="pane-header-content">Logpoints</div>
+          </div>
+          {pane}
+        </div>
+      );
+    }
+
+    return pane;
   }
 }
 
 const mapStateToProps = state => ({
   breakpointSources: getBreakpointSources(state),
   selectedSource: getSelectedSource(state),
+  shouldLogExceptions: getShouldLogExceptions(state),
 });
 
 export default connect(mapStateToProps, {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/index.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/index.js
@@ -16,7 +16,6 @@ import {
   getIsWaitingOnBreak,
   getPauseCommand,
   getSelectedFrame,
-  getShouldLogExceptions,
   getThreadContext,
   getSourceFromId,
   getSkipPausing,
@@ -158,15 +157,11 @@ class SecondaryPanes extends Component {
   }
 
   getBreakpointsItem() {
-    const { shouldLogExceptions, logExceptions } = this.props;
-
     return {
       header: L10N.getStr("breakpoints.header"),
       className: "breakpoints-pane",
       buttons: [this.renderBreakpointsToggle()],
-      component: (
-        <Breakpoints shouldLogExceptions={shouldLogExceptions} logExceptions={logExceptions} />
-      ),
+      component: <Breakpoints />,
       opened: prefs.breakpointsVisible,
       onToggle: opened => {
         prefs.breakpointsVisible = opened;
@@ -277,7 +272,6 @@ const mapStateToProps = state => {
     isWaitingOnBreak: getIsWaitingOnBreak(state),
     renderWhyPauseDelay: getRenderWhyPauseDelay(state),
     selectedFrame,
-    shouldLogExceptions: getShouldLogExceptions(state),
     skipPausing: getSkipPausing(state),
     source: selectedFrame && getSourceFromId(state, selectedFrame.location.sourceId),
   };
@@ -285,7 +279,6 @@ const mapStateToProps = state => {
 
 export default connect(mapStateToProps, {
   toggleAllBreakpoints: actions.toggleAllBreakpoints,
-  logExceptions: actions.logExceptions,
   breakOnNext: actions.breakOnNext,
   toggleEventLogging: actions.toggleEventLogging,
 })(SecondaryPanes);

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -128,6 +128,7 @@ const gMaskImages = {
   ".img.link": require("devtools/client/debugger/images/link.svg"),
   ".img.invite": require("devtools/client/debugger/images/invite.svg"),
   ".img.expand": require("devtools/client/debugger/images/expand.svg"),
+  ".img.logpoint": require("devtools/client/debugger/images/logpoint.svg"),
   "#toolbox-toolbar-console .toolbar-panel-icon": require("devtools/client/themes/images/tool-webconsole.svg"),
   "#toolbox-toolbar-debugger .toolbar-panel-icon": require("devtools/client/themes/images/tool-debugger.svg"),
   "#toolbox-toolbar-inspector .toolbar-panel-icon": require("devtools/client/themes/images/tool-inspector.svg"),

--- a/src/ui/components/RightSidebar/RightSidebar.css
+++ b/src/ui/components/RightSidebar/RightSidebar.css
@@ -54,3 +54,22 @@
   background: var(--theme-icon-color);
   transition: 200ms;
 }
+
+.right-sidebar .logpoints {
+  width: 300px;
+}
+
+.right-sidebar .logpoints .pane-header {
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  margin: 20px 20px 12px 20px;
+}
+
+.right-sidebar .logpoints .pane-header > *:not(:last-child) {
+  margin-right: 4px;
+}
+
+.right-sidebar .logpoints input[type="checkbox"] {
+  margin-right: 4px;
+}

--- a/src/ui/components/RightSidebar/index.js
+++ b/src/ui/components/RightSidebar/index.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import EventsTimeline from "./EventsTimeline";
 import Intercom from "./Intercom";
 import EventListeners from "devtools/client/debugger/src/components/SecondaryPanes/EventListeners";
+import Breakpoints from "devtools/client/debugger/src/components/SecondaryPanes/Breakpoints";
 import classnames from "classnames";
 import "./RightSidebar.css";
 
@@ -19,6 +20,7 @@ function Tooltip({ tooltip, drawerNode }) {
 function Buttons({ setExpanded, expanded, tooltip, setTooltip }) {
   const [commentButtonNode, setCommentButtonNode] = useState(null);
   const [eventButtonNode, setEventButtonNode] = useState(null);
+  const [breakpointsButtonNode, setBreakpointsButtonNode] = useState(null);
   const [nextAction, setNextAction] = useState(null);
 
   const handleMouseEnter = (node, name) => {
@@ -48,7 +50,7 @@ function Buttons({ setExpanded, expanded, tooltip, setTooltip }) {
         onMouseEnter={() => handleMouseEnter(commentButtonNode, "Comments")}
         onMouseLeave={handleMouseLeave}
       >
-        <div className="img comment-icon"></div>
+        <div className="img comment-icon" />
       </button>
       <button
         className={classnames({ expanded: expanded === "event-logpoints" })}
@@ -57,7 +59,16 @@ function Buttons({ setExpanded, expanded, tooltip, setTooltip }) {
         onMouseEnter={() => handleMouseEnter(eventButtonNode, "Event Logpoints")}
         onMouseLeave={handleMouseLeave}
       >
-        <div className="img lightning"></div>
+        <div className="img lightning" />
+      </button>
+      <button
+        className={classnames({ expanded: expanded === "breakpoints" })}
+        onClick={() => setExpanded(expanded === "breakpoints" ? null : "breakpoints")}
+        ref={node => setBreakpointsButtonNode(node)}
+        onMouseEnter={() => handleMouseEnter(breakpointsButtonNode, "Logpoints")}
+        onMouseLeave={handleMouseLeave}
+      >
+        <div className="img logpoint" />
       </button>
     </div>
   );
@@ -87,6 +98,7 @@ export default function RightSidebar({}) {
     <div className="right-sidebar">
       {expanded === "comments" && <EventsTimeline expanded={expanded} />}
       {expanded === "event-logpoints" && <EventListeners />}
+      {expanded === "breakpoints" && <Breakpoints sidebar />}
       <Drawer setExpanded={setExpanded} expanded={expanded} />
     </div>
   );


### PR DESCRIPTION
This patch gets the ball rolling for #891. 

It shows the breakpoints pane as a sidebar item so users can open the panel even if they don't have the debugger panel one.

This also goes a step further and changes the name from Breakpoints to Logpoints. 

### Screenshots
![image](https://user-images.githubusercontent.com/15959269/97466453-815a7d00-1919-11eb-863a-f2bb285fdb43.png)
![image](https://user-images.githubusercontent.com/15959269/97466485-89b2b800-1919-11eb-945c-6e2cb3f08e77.png)
![image](https://user-images.githubusercontent.com/15959269/97466519-933c2000-1919-11eb-8431-3df529ba930a.png)
