### PR TITLE
move the location check from mapStateToProps() to the appropriate render function (#826)

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/ConditionalPanel.js
+++ b/src/devtools/client/debugger/src/components/Editor/ConditionalPanel.js
@@ -120,6 +120,10 @@ export class ConditionalPanel extends PureComponent {
     }
     const { location, editor } = props;
 
+    if (!location) {
+      throw new Error("Conditional panel location needed.");
+    }
+
     const editorLine = toEditorLine(location.sourceId, location.line || 0);
     this.cbPanel = editor.codeMirror.addLineWidget(editorLine, this.renderConditionalPanel(props), {
       coverGutter: true,
@@ -211,15 +215,9 @@ export class ConditionalPanel extends PureComponent {
 const mapStateToProps = state => {
   const location = getConditionalPanelLocation(state);
 
-  if (!location) {
-    throw new Error("Conditional panel location needed.");
-  }
-
-  const breakpoint = getClosestBreakpoint(state, location);
-
   return {
     cx: getContext(state),
-    breakpoint,
+    breakpoint: getClosestBreakpoint(state, location),
     location,
     log: getLogPointStatus(state),
   };


### PR DESCRIPTION
This is a weird issue: the `ConditionalPanel` component is only used after checking that `conditionalPanelLocation` is defined (see [here](https://github.com/RecordReplay/devtools/blob/1cb548ba48f840874e33687a582a6b49b9391bb0/src/devtools/client/debugger/src/components/Editor/index.js#L529)). So how is it possible that it then throws an error because the location is undefined? My guess is that this happens because the check occurs in `mapStateToProps()`, which may be called more often than expected. So I moved the check to the `renderToWidget()` method, where the location is needed.