### PR TITLE
check if event.key is defined (#882)

### DIFF
--- a/src/devtools/client/debugger/dist/devtools-services.js
+++ b/src/devtools/client/debugger/dist/devtools-services.js
@@ -447,7 +447,7 @@ PrefBranch.prototype = {
    *        storage change
    */
   _onStorageChange: function (event) {
-    if (event.storageArea !== localStorage) {
+    if (event.storageArea !== localStorage || !event.key) {
       return;
     }
 


### PR DESCRIPTION
When `localStorage.clear()` is called, a `StorageEvent` with its `key` property set to `null` is sent.