### PR TITLE
render doctype nodes correctly

### DIFF
--- a/src/devtools/client/inspector/markup/components/ReadOnlyNode.js
+++ b/src/devtools/client/inspector/markup/components/ReadOnlyNode.js
@@ -21,7 +21,7 @@ class ReadOnlyNode extends PureComponent {
           className: "tag" + (pseudoType ? " theme-fg-color3" : ""),
           tabIndex: isDocType ? -1 : "",
         },
-        isDocType ? `<!DOCTYPE ${displayName}>` : pseudoType ? `::${pseudoType}` : displayName
+        pseudoType ? `::${pseudoType}` : displayName
       )
     );
   }

--- a/src/devtools/client/inspector/markup/components/ReadOnlyNode.js
+++ b/src/devtools/client/inspector/markup/components/ReadOnlyNode.js
@@ -21,7 +21,7 @@ class ReadOnlyNode extends PureComponent {
           className: "tag" + (pseudoType ? " theme-fg-color3" : ""),
           tabIndex: isDocType ? -1 : "",
         },
-        pseudoType ? `::${pseudoType}` : displayName
+        isDocType ? `<!DOCTYPE ${displayName}>` : pseudoType ? `::${pseudoType}` : displayName
       )
     );
   }

--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -106,7 +106,7 @@ export class NodeFront {
   }
 
   get doctypeString() {
-    return `<!DOCTYPE ${this.nodeName}>`
+    return `<!DOCTYPE ${this.nodeName}>`;
   }
 
   // A list of the node's attributes.

--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -106,8 +106,7 @@ export class NodeFront {
   }
 
   get doctypeString() {
-    // NYI
-    return "unknown";
+    return this.nodeName;
   }
 
   // A list of the node's attributes.

--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -106,7 +106,7 @@ export class NodeFront {
   }
 
   get doctypeString() {
-    return this.nodeName;
+    return `<!DOCTYPE ${this.nodeName}>`
   }
 
   // A list of the node's attributes.


### PR DESCRIPTION
The "unknown" node often shown at the top of the markup view was a doctype node that wasn't rendered correctly (and not the document node as I had guessed previously).