### PR TITLE
Remove breakpoint logpoint/conditional styling

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoint.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoint.js
@@ -102,18 +102,9 @@ class Breakpoint extends PureComponent {
 
     editor.codeMirror.addLineClass(line, "line", "new-breakpoint");
     editor.codeMirror.removeLineClass(line, "line", "breakpoint-disabled");
-    editor.codeMirror.removeLineClass(line, "line", "has-condition");
-    // editor.codeMirror.removeLineClass(line, "line", "has-log");
 
     if (breakpoint.disabled) {
       editor.codeMirror.addLineClass(line, "line", "breakpoint-disabled");
-    }
-
-    // if (breakpoint.options.logValue) {
-    //   editor.codeMirror.addLineClass(line, "line", "has-log");
-    // }
-    if (breakpoint.options.condition) {
-      editor.codeMirror.addLineClass(line, "line", "has-condition");
     }
   }
 
@@ -136,8 +127,6 @@ class Breakpoint extends PureComponent {
     doc.setGutterMarker(line, "breakpoints", null);
     doc.removeLineClass(line, "line", "new-breakpoint");
     doc.removeLineClass(line, "line", "breakpoint-disabled");
-    doc.removeLineClass(line, "line", "has-condition");
-    doc.removeLineClass(line, "line", "has-log");
   }
 
   render() {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoints.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoints.css
@@ -16,10 +16,6 @@
 
 .theme-light,
 .theme-dark {
-  --logpoint-fill: var(--theme-graphs-purple);
-  --logpoint-stroke: var(--purple-60);
-  --breakpoint-condition-fill: var(--theme-graphs-yellow);
-  --breakpoint-condition-stroke: var(--theme-graphs-orange);
   --breakpoint-skipped-opacity: 0.15;
   --breakpoint-inactive-opacity: 0.3;
   --breakpoint-disabled-opacity: 0.6;
@@ -75,16 +71,6 @@
   right: -16px;
 }
 
-.new-breakpoint.has-condition .CodeMirror-gutter-wrapper svg {
-  fill: var(--breakpoint-condition-fill);
-  stroke: var(--breakpoint-condition-stroke);
-}
-
-.new-breakpoint.has-log .CodeMirror-gutter-wrapper svg {
-  fill: var(--logpoint-fill);
-  stroke: var(--logpoint-stroke);
-}
-
 .editor.new-breakpoint.breakpoint-disabled svg {
   fill-opacity: var(--breakpoint-disabled-opacity);
   stroke-opacity: var(--breakpoint-disabled-opacity);
@@ -127,21 +113,6 @@
 .column-breakpoint.disabled svg {
   fill-opacity: var(--breakpoint-disabled-opacity);
   stroke-opacity: var(--breakpoint-disabled-opacity);
-}
-
-.column-breakpoint.has-log.disabled svg {
-  fill-opacity: 0.5;
-  stroke-opacity: 0.5;
-}
-
-.column-breakpoint.has-condition svg {
-  fill: var(--breakpoint-condition-fill);
-  stroke: var(--breakpoint-condition-stroke);
-}
-
-.column-breakpoint.has-log svg {
-  fill: var(--logpoint-fill);
-  stroke: var(--logpoint-stroke);
 }
 
 .editor-wrapper.skip-pausing .column-breakpoint svg {

--- a/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoint.js
+++ b/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoint.js
@@ -25,8 +25,6 @@ function makeBookmark({ breakpoint }, { onClick, onContextMenu }) {
   const logValue = breakpoint && breakpoint.options.logValue;
 
   bp.className = classnames("column-breakpoint", {
-    "has-condition": condition,
-    "has-log": logValue,
     active: isActive,
     disabled: isDisabled,
   });

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -110,8 +110,6 @@ class Breakpoint extends PureComponent {
           breakpoint,
           paused: this.isCurrentlyPausedAtBreakpoint(),
           disabled: breakpoint.disabled,
-          "is-conditional": !!breakpoint.options.condition,
-          // "is-log": !!breakpoint.options.logValue,
         })}
         onClick={this.selectBreakpoint}
         onDoubleClick={this.onDoubleClick}

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -103,24 +103,10 @@
   text-overflow: ellipsis;
 }
 
-html[dir="rtl"] .breakpoints-list .breakpoint,
-html[dir="rtl"] .breakpoints-list .breakpoint-heading,
-html[dir="rtl"] .breakpoints-exceptions {
-  border-right: 4px solid transparent;
-}
-
-html:not([dir="rtl"]) .breakpoints-list .breakpoint,
-html:not([dir="rtl"]) .breakpoints-list .breakpoint-heading,
-html:not([dir="rtl"]) .breakpoints-exceptions {
+html .breakpoints-list .breakpoint,
+html .breakpoints-list .breakpoint-heading,
+html .breakpoints-exceptions {
   border-left: 4px solid transparent;
-}
-
-html .breakpoints-list .breakpoint.is-conditional {
-  border-inline-start-color: var(--theme-graphs-yellow);
-}
-
-html .breakpoints-list .breakpoint.is-log {
-  border-inline-start-color: var(--theme-graphs-purple);
 }
 
 html .breakpoints-list .breakpoint.paused {
@@ -194,14 +180,7 @@ html .breakpoints-list .breakpoint.paused {
   position: absolute;
   /* hide button outside of row until hovered or focused */
   top: -100px;
-}
-
-[dir="ltr"] .breakpoint .close-btn {
   right: 12px;
-}
-
-[dir="rtl"] .breakpoint .close-btn {
-  left: 12px;
 }
 
 /* Reveal the remove button on hover/focus */


### PR DESCRIPTION
This removes the separate styling for breakpoints with logs/conditions as displayed in either the editor gutter or the breakpoints panel.