### PR TITLE
Rename Inspector to Elements, Debugger to Sources

### DIFF
--- a/src/ui/components/Toolbox.js
+++ b/src/ui/components/Toolbox.js
@@ -353,7 +353,7 @@ class Toolbox extends React.Component {
           onClick={() => this.selectTool("inspector")}
         >
           <div className="toolbar-panel-icon"></div>
-          Inspector
+          Elements
         </div>
         <div
           className={classnames("toolbar-panel-button", {
@@ -363,7 +363,7 @@ class Toolbox extends React.Component {
           onClick={() => this.selectTool("debugger")}
         >
           <div className="toolbar-panel-icon"></div>
-          Debugger
+          Sources
         </div>
         <div
           className={classnames("toolbar-panel-button", {


### PR DESCRIPTION
Fix #923.

![image](https://user-images.githubusercontent.com/15959269/98269066-4ed50380-1f5b-11eb-9044-115ea10f0904.png)
