### PR TITLE
Ensure split console is closed upon opening a replay

### DIFF
--- a/src/ui/utils/prefs.js
+++ b/src/ui/utils/prefs.js
@@ -8,7 +8,7 @@ import Services from "devtools-services";
 const { pref } = Services;
 
 // app prefs.
-pref("devtools.split-console", true);
+pref("devtools.split-console", false);
 pref("devtools.selected-panel", "debugger");
 pref("devtools.user", "{}");
 pref("devtools.recording-id", "");


### PR DESCRIPTION
This makes sure that whenever a replay is opened, the splitconsole is toggled off.

Fix #729