### PR TITLE
Keep gutter breakpoint markers from collapsing

### DIFF
--- a/src/devtools/client/shared/sourceeditor/codemirror/lib/codemirror.js
+++ b/src/devtools/client/shared/sourceeditor/codemirror/lib/codemirror.js
@@ -2184,7 +2184,7 @@
         var id = cm.display.gutterSpecs[k].className, found = markers.hasOwnProperty(id) && markers[id];
         if (found)
           { gutterWrap.appendChild(elt("div", [found], "CodeMirror-gutter-elt",
-                                     ("left: " + (dims.gutterLeft[id]) + "px; width: " + (dims.gutterWidth[id]) + "px"))); }
+                                     ("left: " + (dims.gutterLeft[id]) + "px; width: " + (cm.display.lineNumWidth) + "px"))); }
       } }
     }
   }


### PR DESCRIPTION
Fix #889. Demo: https://share.descript.com/view/Meb61S6bJBu

This fix makes the breakpoints behave pretty much the same–I tested it up to [6 digit line numbers](https://share.descript.com/view/VlHP44pM81p). 

At 8 or 9 digits it starts going wonky, but that's unrelated. The breakpoint SVG is 60px wide and we can't keep pushing it to the right.

---

Update: It works for code lines up to 7 digits. It definitely won't for 8 digits–then again, if somebody's loading a file that big we've got other problems...
![image](https://user-images.githubusercontent.com/15959269/98308890-31258f80-1f97-11eb-8a97-9513dae02d0f.png)
