### PR TITLE
Revert "Fix logrocket import"

### DIFF
--- a/src/ui/actions/metadata.ts
+++ b/src/ui/actions/metadata.ts
@@ -3,10 +3,10 @@ import { Action } from "redux";
 import { selectors } from "ui/reducers";
 import { UIStore, UIThunkAction } from ".";
 import { Comment } from "ui/state/metadata";
-import { prefs, features } from "ui/utils/prefs";
+const { prefs, features } = require("ui/utils/prefs");
 import { seek } from "./timeline";
 import { User } from "ui/state/metadata";
-import LogRocket from "ui/utils/logrocket";
+const LogRocket = require("ui/utils/logrocket");
 
 export type SetCommentsAction = Action<"set_comments"> & { comments: Comment[] };
 export type SetFocusedCommentAction = Action<"set_focused_comment_id"> & { id: number | null };

--- a/src/ui/actions/metadata.ts
+++ b/src/ui/actions/metadata.ts
@@ -6,7 +6,7 @@ import { Comment } from "ui/state/metadata";
 const { prefs, features } = require("ui/utils/prefs");
 import { seek } from "./timeline";
 import { User } from "ui/state/metadata";
-const LogRocket = require("ui/utils/logrocket");
+const LogRocket = require("ui/utils/logrocket").default;
 
 export type SetCommentsAction = Action<"set_comments"> & { comments: Comment[] };
 export type SetFocusedCommentAction = Action<"set_focused_comment_id"> & { id: number | null };


### PR DESCRIPTION
These imports were written using `require()` on purpose: the imported files have no typings and typescript won't accept that (because it is set to "strict" typechecking), unless you use `require()` which implies that the import has type `any`.
I wonder, however, how it is possible that this wasn't noticed: when I change the imports from `require()` to `import` in VS Code, I immediately get error markers for them. The typescript watcher (which is automatically started when you start the webpack-dev-server task in VS Code) also complains and when you include this in a PR, the typecheck workflow also complains. Yet all these checks were apparently ignored, which begs the question if we need to make them "louder"?
![Screenshot_2020-11-06_10-35-14](https://user-images.githubusercontent.com/16060807/98350848-30830c80-201c-11eb-8ec5-1fd4f964a68e.png)
