### PR TITLE
update the protocol dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7630,15 +7630,8 @@
       }
     },
     "record-replay-protocol": {
-      "version": "git://github.com/RecordReplay/protocol.git#81d7fdd99c5a216674594e861a6a7713a51a09a9",
-      "from": "git://github.com/RecordReplay/protocol.git",
-      "dependencies": {
-        "ws": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
-        }
-      }
+      "version": "git://github.com/RecordReplay/protocol.git#6e0d83de45f5b72c54bf4b27d6daa3f394284d25",
+      "from": "git://github.com/RecordReplay/protocol.git"
     },
     "redux": {
       "version": "4.0.5",


### PR DESCRIPTION
This is necessary for the recent protocol changes to be automatically installed by `npm install`.
Note that this update was done manually as running `npm update record-replay-protocol` had an issue due to inconsistent package names (see RecordReplay/protocol#11).