### PR TITLE
Stop attaching the codemirror editor to the debugger panel

### DIFF
--- a/src/devtools/client/debugger/panel.js
+++ b/src/devtools/client/debugger/panel.js
@@ -6,35 +6,34 @@ import { defer, assert } from "protocol/utils";
 import { resizeBreakpointGutter } from "./src/utils/ui";
 import { openDocLink } from "devtools/client/shared/link";
 import { onConnect } from "devtools/client/debugger/src/client";
+import { getCodeMirror } from "devtools/client/debugger/src/utils/editor";
 
 export class DebuggerPanel {
   constructor(toolbox) {
     this.toolbox = toolbox;
-    this.readyWaiter = defer();
   }
 
   async open() {
-    const { actions, store, selectors, client } = await onConnect();
+    const { actions, store, selectors, client } = onConnect();
 
     this._actions = actions;
     this._store = store;
     this._selectors = selectors;
     this._client = client;
     this.isReady = true;
-    this.readyWaiter.resolve();
 
     return this;
   }
 
   refresh() {
-    if (!this.editor) {
-      return;
-    }
-
     // CodeMirror does not update properly when it is hidden. This method has
     // a few workarounds to get the editor to behave as expected when switching
     // to the debugger from another panel and the selected location has changed.
-    const { codeMirror } = this.editor.state.editor;
+    const codeMirror = getCodeMirror();
+
+    if (!codeMirror) {
+      return;
+    }
 
     // Update CodeMirror by dispatching a resize event to the window. CodeMirror
     // also has a refresh() method but it did not work as expected when testing.

--- a/src/devtools/client/debugger/src/actions/navigation.js
+++ b/src/devtools/client/debugger/src/actions/navigation.js
@@ -41,7 +41,7 @@ export function connect(url, actor, traits, isWebExtension) {
         url,
         actor,
         type: "mainThread",
-        name: L10N.getStr("mainThread"),
+        name: "Main Thread",
       },
       traits,
       isWebExtension,

--- a/src/devtools/client/debugger/src/client/index.js
+++ b/src/devtools/client/debugger/src/client/index.js
@@ -44,17 +44,7 @@ export async function loadInitialState() {
 let boundActions;
 let store;
 
-export function bootstrap(_store) {
-  store = _store;
-  boundActions = bindActionCreators(actions, store.dispatch);
-
-  verifyPrefSchema();
-  setupCommands();
-  setupEvents({ actions: boundActions });
-  store.subscribe(() => updatePrefs(store.getState()));
-}
-
-export async function onConnect() {
+function setupDebugger() {
   store.dispatch(actions.connect("", ThreadFront.actor, {}, false));
 
   ThreadFront.findSources(({ sourceId, url, sourceMapURL }) =>
@@ -67,6 +57,21 @@ export async function onConnect() {
     })
   );
 
-  await syncBreakpoints();
+  syncBreakpoints();
+}
+
+export function bootstrap(_store) {
+  store = _store;
+  boundActions = bindActionCreators(actions, store.dispatch);
+
+  setupDebugger();
+
+  verifyPrefSchema();
+  setupCommands();
+  setupEvents({ actions: boundActions });
+  store.subscribe(() => updatePrefs(store.getState()));
+}
+
+export function onConnect() {
   return { store, actions: boundActions, selectors, client: clientCommands };
 }

--- a/src/devtools/client/debugger/src/components/Editor/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/index.js
@@ -13,7 +13,6 @@ import classnames from "classnames";
 import { debounce } from "lodash";
 
 import { isFirefox } from "devtools-environment";
-import { getLineText } from "./../../utils/source";
 import { features } from "../../utils/prefs";
 import { getIndentation } from "../../utils/indentation";
 
@@ -51,7 +50,6 @@ import {
   getEditor,
   clearEditor,
   getCursorLine,
-  getCursorColumn,
   lineAtHeight,
   toSourceLine,
   getDocument,
@@ -138,7 +136,6 @@ class Editor extends PureComponent {
     this.onEditorScroll();
     this.setState({ editor });
 
-    gToolbox.getPanel("debugger").editor = this;
     return editor;
   }
 

--- a/src/devtools/client/debugger/src/utils/editor/index.js
+++ b/src/devtools/client/debugger/src/utils/editor/index.js
@@ -28,8 +28,8 @@ export function removeEditor() {
   editor = null;
 }
 
-function getCodeMirror() {
-  return editor && editor.hasCodeMirror ? editor.codeMirror : null;
+export function getCodeMirror() {
+  return editor?.codeMirror;
 }
 
 export function startOperation() {

--- a/src/devtools/client/webconsole/actions/toolbox.js
+++ b/src/devtools/client/webconsole/actions/toolbox.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 "use strict";
-const { openDocLink } = require("devtools/client/shared/link");
 
 export function highlightDomElement(grip) {
   return ({ toolbox }) => {


### PR DESCRIPTION
Fix #984 