### PR TITLE
Don't render console jump buttons if message doesn't have a frame

### DIFF
--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -146,7 +146,7 @@ class Message extends Component {
       frame,
     } = this.props;
 
-    if (inWarningGroup || !pausedExecutionPoint || !executionPoint) {
+    if (inWarningGroup || !pausedExecutionPoint || !executionPoint || !frame) {
       return undefined;
     }
 


### PR DESCRIPTION
Fix #987.