### PR TITLE
Test runner: support multiple patterns

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -175,11 +175,14 @@ let failures = [];
 
 async function runTest(path, local, timeout = 60, env = {}) {
   const testURL = env.RECORD_REPLAY_TEST_URL || "";
-  for (const pattern of patterns) {
-    if (!path.includes(pattern) && !testURL.includes(pattern) && !local.includes(pattern)) {
-      console.log(`Skipping test ${path} ${testURL} ${local}`);
-      return;
-    }
+  if (
+    patterns.length &&
+    patterns.every(
+      pattern => !path.includes(pattern) && !testURL.includes(pattern) && !local.includes(pattern)
+    )
+  ) {
+    console.log(`Skipping test ${path} ${testURL} ${local}`);
+    return;
   }
 
   console.log(`[${elapsedTime()}] Starting test ${path} ${testURL} ${local}`);


### PR DESCRIPTION
The test runner accepts multiple `--pattern` arguments, but tests had to match all of the given patterns to be run.
With this patch, tests only need to match one of the given patterns to be run (my guess is that this was the intention all along). 