### PR TITLE
Store inspector panel state

### DIFF
--- a/src/devtools/client/inspector/prefs.js
+++ b/src/devtools/client/inspector/prefs.js
@@ -4,7 +4,7 @@ import Services from "devtools-services";
 
 const { pref } = Services;
 
-pref("devtools.inspector.is-three-pane-mode-enabled", false);
+pref("devtools.inspector.is-three-pane-mode-enabled", true);
 pref("devtools.inspector.sidebar-size", 700);
 pref("devtools.inspector.split-sidebar-size", 350);
 pref("devtools.inspector.active-tab", "layoutview");

--- a/src/devtools/client/inspector/prefs.js
+++ b/src/devtools/client/inspector/prefs.js
@@ -4,14 +4,20 @@ import Services from "devtools-services";
 
 const { pref } = Services;
 
-pref("devtools.inspector.three-pane-enabled", false);
+pref("devtools.inspector.is-three-pane-mode-enabled", false);
+pref("devtools.inspector.sidebar-size", 700);
+pref("devtools.inspector.split-sidebar-size", 350);
+pref("devtools.inspector.active-tab", "layoutview");
 
 // features
 pref("devtools.inspector.features.old-rulesview.enabled", false);
 pref("devtools.inspector.features.show-whitespace-nodes", true);
 
 export const prefs = new PrefsHelper("devtools.inspector", {
-  threePaneEnabled: ["Bool", "three-pane-enabled"],
+  is3PaneModeEnabled: ["Bool", "is-three-pane-mode-enabled"],
+  sidebarSize: ["Int", "sidebar-size"],
+  splitSidebarSize: ["Int", "split-sidebar-size"],
+  activeTab: ["String", "active-tab"],
 });
 
 export const features = new PrefsHelper("devtools.inspector.features", {

--- a/src/devtools/client/inspector/reducers/index.ts
+++ b/src/devtools/client/inspector/reducers/index.ts
@@ -6,6 +6,7 @@
 
 import { InspectorAction } from "../actions";
 import { initialInspectorState, InspectorState } from "../state";
+const { prefs } = require("devtools/client/inspector/prefs");
 
 export const boxModel = require("devtools/client/inspector/boxmodel/reducers/box-model");
 export const changes = require("devtools/client/inspector/changes/reducers/changes");
@@ -27,9 +28,12 @@ export function inspector(
 ): InspectorState {
   switch (action.type) {
     case "set_inspector_3_pane_mode":
+      prefs.is3PaneModeEnabled = action.is3PaneModeEnabled;
       let activeTab = state.activeTab === "ruleview" ? "layoutview" : state.activeTab;
+      prefs.activeTab = activeTab;
       return { ...state, is3PaneModeEnabled: action.is3PaneModeEnabled, activeTab };
     case "set_active_inspector_tab":
+      prefs.activeTab = action.activeTab;
       return { ...state, activeTab: action.activeTab };
     default:
       return state;

--- a/src/devtools/client/inspector/state/index.ts
+++ b/src/devtools/client/inspector/state/index.ts
@@ -1,3 +1,5 @@
+const { prefs } = require("devtools/client/inspector/prefs");
+
 export interface InspectorState {
   is3PaneModeEnabled: boolean;
   activeTab: string;
@@ -5,7 +7,7 @@ export interface InspectorState {
 
 export function initialInspectorState(): InspectorState {
   return {
-    is3PaneModeEnabled: true,
-    activeTab: "layoutview",
+    is3PaneModeEnabled: prefs.is3PaneModeEnabled,
+    activeTab: prefs.activeTab,
   };
 }


### PR DESCRIPTION
This will store the sidebar panel widths, `is3PaneModeEnabled` and the active sidebar tab in `prefs`.
I decided not to reflect the panel widths in the redux state because I don't want to trigger lots of renders while the user drags the splitter.
For `is3PaneModeEnabled` and `activeTab` I didn't use the mechanism we have in `ui/utils/bootstrap/bootstrapStore` because that uses a different `PrefsHelper` than the one used in the Inspector. I set the prefs directly in the reducers instead.
Depends on #1041.