### PR TITLE
Improve markup view performance

### DIFF
--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -280,7 +280,7 @@ const connector = connect(
   (state: UIState) => ({
     is3PaneModeEnabled: state.inspector.is3PaneModeEnabled,
     activeTab: state.inspector.activeTab,
-    markupRootNode: state.markup.tree[state.markup.rootNode],
+    markupRootNode: state.markup.tree[state.markup.rootNode!],
   }),
   InspectorActions
 );

--- a/src/devtools/client/inspector/markup/components/MarkupApp.js
+++ b/src/devtools/client/inspector/markup/components/MarkupApp.js
@@ -3,6 +3,8 @@ const dom = require("react-dom-factories");
 const PropTypes = require("prop-types");
 const { connect } = require("react-redux");
 
+const { getNode, getRootNodeId } = require("../reducers/markup");
+
 const Node = createFactory(require("./Node"));
 
 const Types = require("../types");
@@ -10,18 +12,19 @@ const Types = require("../types");
 class MarkupApp extends PureComponent {
   static get propTypes() {
     return {
-      markup: PropTypes.shape(Types.markup).isRequired,
+      node: PropTypes.shape(Types.node).isRequired,
       onSelectNode: PropTypes.func.isRequired,
       onShowEventTooltip: PropTypes.func.isRequired,
       onToggleNodeExpanded: PropTypes.func.isRequired,
+      onMouseEnterNode: PropTypes.func.isRequired,
+      onMouseLeaveNode: PropTypes.func.isRequired,
     };
   }
 
   render() {
-    const { markup } = this.props;
-    const { rootNode, tree } = markup;
+    const { node } = this.props;
 
-    if (!rootNode || !tree[rootNode]) {
+    if (!node) {
       return null;
     }
 
@@ -31,11 +34,10 @@ class MarkupApp extends PureComponent {
         role: "tree",
         tabIndex: 0,
       },
-      tree[rootNode].children.map(nodeId => {
+      node.children.map(nodeId => {
         return Node({
           key: nodeId,
-          markup,
-          node: tree[nodeId],
+          nodeId,
           onSelectNode: this.props.onSelectNode,
           onShowEventTooltip: this.props.onShowEventTooltip,
           onToggleNodeExpanded: this.props.onToggleNodeExpanded,
@@ -47,4 +49,8 @@ class MarkupApp extends PureComponent {
   }
 }
 
-module.exports = connect(state => state)(MarkupApp);
+const mapStateToProps = state => ({
+  node: getNode(state, getRootNodeId(state)),
+});
+
+module.exports = connect(mapStateToProps)(MarkupApp);

--- a/src/devtools/client/inspector/markup/reducers/markup.ts
+++ b/src/devtools/client/inspector/markup/reducers/markup.ts
@@ -1,4 +1,5 @@
 import { assert } from "protocol/utils";
+import { UIState } from "ui/state";
 import { createReducer, ReducerObject } from "../../shared/reducer-object";
 import { MarkupAction } from "../actions/markup";
 import { MarkupState, MarkupTree } from "../state/markup";
@@ -91,3 +92,8 @@ const reducers: ReducerObject<MarkupState, MarkupAction> = {
 };
 
 export default createReducer(INITIAL_MARKUP, reducers);
+
+export const getNode = (state: UIState, nodeId: string) => state.markup.tree[nodeId];
+export const getRootNodeId = (state: UIState) => state.markup.rootNode;
+export const getSelectedNodeId = (state: UIState) => state.markup.selectedNode;
+export const getScrollIntoViewNodeId = (state: UIState) => state.markup.scrollIntoViewNode;

--- a/src/ui/state/index.ts
+++ b/src/ui/state/index.ts
@@ -2,11 +2,12 @@ import { TimelineState } from "./timeline";
 import { MetadataState } from "./metadata";
 import { AppState } from "./app";
 import { InspectorState } from "devtools/client/inspector/state";
+import { MarkupState } from "devtools/client/inspector/markup/state/markup";
 
 export interface UIState {
   timeline: TimelineState;
   metadata: MetadataState;
   app: AppState;
   inspector: InspectorState;
-  markup: any;
+  markup: MarkupState;
 }


### PR DESCRIPTION
The markup view used to render the entire tree whenever anything in the markup state changed.
With this patch, every markup component receives only the information it needs from the markup state, so that only the nodes that have actually changed are rendered.
Furthermore, when a new node is selected, its ancestors are only scrolled into view when their children still need to be downloaded and added to the tree.