### PR TITLE
Workaround for duplicate applied rules

### DIFF
--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -215,7 +215,14 @@ export class NodeFront {
       this._pause
         .sendMessage(client.CSS.getAppliedRules, { node: this._object.objectId })
         .then(({ rules, data }) => {
-          this._rules = rules;
+          this._rules = [];
+          for (const rule of rules) {
+            if (
+              !this._rules.some(r => rule.rule === r.rule && rule.pseudoElement === r.pseudoElement)
+            ) {
+              this._rules.push(rule);
+            }
+          }
           this._pause.addData(data);
         }),
       this._pause

--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -10,6 +10,7 @@ import { Pause, WiredObject } from "./pause";
 import { defer, assert, DisallowEverythingProxyHandler, Deferred } from "../utils";
 const { getFrameworkEventListeners } = require("../event-listeners");
 import { ValueFront } from "./value";
+const { uniqBy } = require("lodash");
 const HTML_NS = "http://www.w3.org/1999/xhtml";
 
 export interface WiredEventListener {
@@ -215,14 +216,7 @@ export class NodeFront {
       this._pause
         .sendMessage(client.CSS.getAppliedRules, { node: this._object.objectId })
         .then(({ rules, data }) => {
-          this._rules = [];
-          for (const rule of rules) {
-            if (
-              !this._rules.some(r => rule.rule === r.rule && rule.pseudoElement === r.pseudoElement)
-            ) {
-              this._rules.push(rule);
-            }
-          }
+          this._rules = uniqBy(rules, (rule: AppliedRule) => `${rule.rule}|${rule.pseudoElement}`);
           this._pause.addData(data);
         }),
       this._pause


### PR DESCRIPTION
We sometimes receive duplicate rules from `CSS.getAppliedRules`, as a result React writes a lot of error messages to the console warning about duplicate keys in `RulesApp`.
This patch works around the issue by removing duplicate rules from the result of `CSS.getAppliedRules`. It can be reverted when RecordReplay/backend#384 is resolved.