### PR TITLE
[WIP] Re-implement the event tooltip

### DIFF
--- a/src/devtools/client/inspector/markup/actions/eventTooltip.ts
+++ b/src/devtools/client/inspector/markup/actions/eventTooltip.ts
@@ -1,0 +1,64 @@
+import { Action } from "redux";
+import { ThreadFront } from "protocol/thread";
+import { assert } from "protocol/utils";
+import { UIThunkAction } from "ui/actions";
+import { EventInfo } from "../state/eventTooltip";
+
+export type SetEventTooltipAction = Action<"set_event_tooltip"> & {
+  nodeId: string;
+  events: EventInfo[];
+};
+export type ClearEventTooltipAction = Action<"clear_event_tooltip">;
+export type EventTooltipAction = SetEventTooltipAction | ClearEventTooltipAction;
+
+export function setEventTooltip(nodeId: string, events: EventInfo[]): SetEventTooltipAction {
+  return { type: "set_event_tooltip", nodeId, events };
+}
+
+export function clearEventTooltip(): ClearEventTooltipAction {
+  return { type: "clear_event_tooltip" };
+}
+
+export function showEventTooltip(nodeId: string): UIThunkAction {
+  return async ({ dispatch }) => {
+    assert(ThreadFront.currentPause);
+    const nodeFront = ThreadFront.currentPause.getNodeFront(nodeId);
+    const listenerRaw = nodeFront.getEventListeners();
+    const frameworkListeners = await nodeFront.getFrameworkEventListeners();
+
+    const listenerInfo = [...listenerRaw, ...frameworkListeners].map(listener => {
+      const { handler, type, capture } = listener;
+      const tags = (listener as any).tags || "";
+      const location = handler.functionLocation();
+      const url = handler.functionLocationURL();
+      let origin, line, column;
+
+      if (location && url) {
+        line = location.line;
+        column = location.column;
+        origin = `${url}:${line}:${column}`;
+      } else {
+        // We end up here for DOM0 handlers...
+        origin = "[native code]";
+      }
+
+      return {
+        capturing: capture,
+        type,
+        origin,
+        url,
+        line,
+        column,
+        tags,
+        handler,
+        sourceId: url ? location?.sourceId : undefined,
+        native: !url,
+        hide: {
+          debugger: !url,
+        },
+      };
+    });
+
+    dispatch(setEventTooltip(nodeId, listenerInfo));
+  };
+}

--- a/src/devtools/client/inspector/markup/components/ElementNode.tsx
+++ b/src/devtools/client/inspector/markup/components/ElementNode.tsx
@@ -4,6 +4,7 @@ import { Attr } from "record-replay-protocol";
 
 import NodeAttribute from "./NodeAttribute";
 import TextNode from "./TextNode";
+import EventTooltip from "./EventTooltip";
 import { assert } from "protocol/utils";
 
 const { HTML_VOID_ELEMENTS } = require("../constants");
@@ -89,15 +90,7 @@ class ElementNode extends PureComponent<ElementNodeProps> {
       return null;
     }
 
-    return (
-      <div
-        className="inspector-badge interactive"
-        title={"Event listener"}
-        onClick={this.onEventBadgeClick}
-      >
-        event
-      </div>
-    );
+    return <EventTooltip nodeId={this.props.node.id} />;
   }
 
   renderDisplayBadge() {

--- a/src/devtools/client/inspector/markup/components/ElementNode.tsx
+++ b/src/devtools/client/inspector/markup/components/ElementNode.tsx
@@ -4,7 +4,6 @@ import { Attr } from "record-replay-protocol";
 
 import NodeAttribute from "./NodeAttribute";
 import TextNode from "./TextNode";
-import EventTooltip from "./EventTooltip";
 import { assert } from "protocol/utils";
 
 const { HTML_VOID_ELEMENTS } = require("../constants");
@@ -85,14 +84,6 @@ class ElementNode extends PureComponent<ElementNodeProps> {
     );
   }
 
-  renderEventBadge() {
-    if (!this.props.node.hasEventListeners) {
-      return null;
-    }
-
-    return <EventTooltip nodeId={this.props.node.id} />;
-  }
-
   renderDisplayBadge() {
     const { displayType } = this.props.node;
     assert(displayType);
@@ -155,7 +146,6 @@ class ElementNode extends PureComponent<ElementNodeProps> {
         <span className="markup-expand-badge" onClick={this.onExpandBadgeClick}></span>
         {this.renderInlineTextChild()}
         {this.renderCloseTag()}
-        {this.renderEventBadge()}
         {this.renderDisplayBadge()}
         {this.renderScrollableBadge()}
       </span>

--- a/src/devtools/client/inspector/markup/components/EventTooltip.css
+++ b/src/devtools/client/inspector/markup/components/EventTooltip.css
@@ -1,3 +1,9 @@
 #markup-root .dropdown-wrapper {
   display: inline;
 }
+
+#markup-root .dropdown-wrapper button {
+  display: inline-block;
+  padding: 0px 2px;
+  line-height: 10px;
+}

--- a/src/devtools/client/inspector/markup/components/EventTooltip.css
+++ b/src/devtools/client/inspector/markup/components/EventTooltip.css
@@ -1,0 +1,3 @@
+#markup-root .dropdown-wrapper {
+  display: inline;
+}

--- a/src/devtools/client/inspector/markup/components/EventTooltip.tsx
+++ b/src/devtools/client/inspector/markup/components/EventTooltip.tsx
@@ -6,6 +6,8 @@ import { clearEventTooltip, showEventTooltip } from "../actions/eventTooltip";
 import { getEventTooltipContent, getEventTooltipNodeId } from "../reducers/eventTooltip";
 import { EventInfo } from "../state/eventTooltip";
 
+import "./EventTooltip.css";
+
 interface EventTooltipProps {
   nodeId: string;
 }
@@ -60,11 +62,12 @@ class EventTooltip extends PureComponent<EventTooltipProps & PropsFromRedux> {
     return (
       <Dropdown
         buttonContent="event"
+        buttonStyle="inspector-badge interactive"
+        position="bottom-right"
         expanded={!!events}
         setExpanded={this.setExpanded}
-        buttonStyle="inspector-badge interactive"
       >
-        {this.renderEvents(events)}
+        <div className="devtools-tooltip-events-container">{this.renderEvents(events)}</div>
       </Dropdown>
     );
   }

--- a/src/devtools/client/inspector/markup/components/EventTooltip.tsx
+++ b/src/devtools/client/inspector/markup/components/EventTooltip.tsx
@@ -1,0 +1,79 @@
+import React, { PureComponent } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import Dropdown from "ui/components/shared/Dropdown";
+import { UIState } from "ui/state";
+import { clearEventTooltip, showEventTooltip } from "../actions/eventTooltip";
+import { getEventTooltipContent, getEventTooltipNodeId } from "../reducers/eventTooltip";
+import { EventInfo } from "../state/eventTooltip";
+
+interface EventTooltipProps {
+  nodeId: string;
+}
+
+class EventTooltip extends PureComponent<EventTooltipProps & PropsFromRedux> {
+  constructor(props: EventTooltipProps & PropsFromRedux) {
+    super(props);
+
+    this.setExpanded = this.setExpanded.bind(this);
+  }
+
+  setExpanded(expanded: boolean) {
+    const { clearEventTooltip, showEventTooltip } = this.props;
+
+    if (expanded) {
+      showEventTooltip(this.props.nodeId);
+    } else {
+      clearEventTooltip();
+    }
+  }
+
+  renderEvents(events: EventInfo[] | null) {
+    if (!events) return null;
+
+    return events.map((event, index) => {
+      const phase = event.capturing ? "Capturing" : "Bubbling";
+
+      return (
+        <div key={index} className="event-header">
+          <span className="event-tooltip-event-type" title={event.type}>
+            {event.type}
+          </span>
+          <span className="event-tooltip-filename devtools-monospace" title={event.origin}>
+            {event.origin}
+          </span>
+          <div className="event-tooltip-debugger-icon" title="Open in Debugger"></div>
+          <div className="event-tooltip-attributes-container">
+            <div className="event-tooltip-attributes-box">
+              <span className="event-tooltip-attributes" title={phase}>
+                {phase}
+              </span>
+            </div>
+          </div>
+        </div>
+      );
+    });
+  }
+
+  render() {
+    const { events } = this.props;
+
+    return (
+      <Dropdown
+        buttonContent="event"
+        expanded={!!events}
+        setExpanded={this.setExpanded}
+        buttonStyle="inspector-badge interactive"
+      >
+        {this.renderEvents(events)}
+      </Dropdown>
+    );
+  }
+}
+
+const mapStateToProps = (state: UIState, { nodeId }: EventTooltipProps) => ({
+  events: getEventTooltipNodeId(state) === nodeId ? getEventTooltipContent(state) : null,
+});
+const connector = connect(mapStateToProps, { showEventTooltip, clearEventTooltip });
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default connector(EventTooltip);

--- a/src/devtools/client/inspector/markup/components/Node.tsx
+++ b/src/devtools/client/inspector/markup/components/Node.tsx
@@ -18,6 +18,7 @@ import { UIState } from "ui/state";
 import ElementNode from "./ElementNode";
 import ReadOnlyNode from "./ReadOnlyNode";
 import TextNode from "./TextNode";
+import EventTooltip from "./EventTooltip";
 
 interface NodeProps {
   nodeId: string;
@@ -150,6 +151,14 @@ class _Node extends PureComponent<NodeProps & PropsFromRedux> {
     return component;
   }
 
+  renderEventBadge() {
+    if (!this.props.node.hasEventListeners) {
+      return null;
+    }
+
+    return <EventTooltip nodeId={this.props.node.id} />;
+  }
+
   render() {
     const { node, rootNodeId, isSelectedNode, isScrollIntoViewNode } = this.props;
 
@@ -194,6 +203,7 @@ class _Node extends PureComponent<NodeProps & PropsFromRedux> {
             ></span>
           ) : null}
           {this.renderComponent()}
+          {this.renderEventBadge()}
         </div>
         {this.renderChildren()}
         {this.renderClosingTag()}

--- a/src/devtools/client/inspector/markup/reducers/eventTooltip.ts
+++ b/src/devtools/client/inspector/markup/reducers/eventTooltip.ts
@@ -1,0 +1,21 @@
+import { UIState } from "ui/state";
+import { createReducer, ReducerObject } from "../../shared/reducer-object";
+import { EventTooltipAction } from "../actions/eventTooltip";
+import { EventTooltipState } from "../state/eventTooltip";
+
+const INITIAL_STATE: EventTooltipState = { nodeId: null, events: null };
+
+const reducers: ReducerObject<EventTooltipState, EventTooltipAction> = {
+  ["set_event_tooltip"](state, { nodeId, events }) {
+    return { nodeId, events };
+  },
+
+  ["clear_event_tooltip"]() {
+    return { nodeId: null, events: null };
+  },
+};
+
+export default createReducer(INITIAL_STATE, reducers);
+
+export const getEventTooltipNodeId = (state: UIState) => state.eventTooltip.nodeId;
+export const getEventTooltipContent = (state: UIState) => state.eventTooltip.events;

--- a/src/devtools/client/inspector/markup/state/eventTooltip.ts
+++ b/src/devtools/client/inspector/markup/state/eventTooltip.ts
@@ -1,0 +1,22 @@
+import { ValueFront } from "protocol/thread";
+
+export interface EventInfo {
+  capturing: boolean;
+  type: string;
+  origin: string;
+  url?: string;
+  line?: number;
+  column?: number;
+  tags: string;
+  handler: ValueFront;
+  sourceId?: string;
+  native: boolean;
+  hide: {
+    debugger: boolean;
+  };
+}
+
+export interface EventTooltipState {
+  nodeId: string | null;
+  events: EventInfo[] | null;
+}

--- a/src/devtools/client/inspector/reducers/index.ts
+++ b/src/devtools/client/inspector/reducers/index.ts
@@ -13,6 +13,8 @@ export const changes = require("devtools/client/inspector/changes/reducers/chang
 export const classList = require("devtools/client/inspector/rules/reducers/class-list");
 import _markup from "devtools/client/inspector/markup/reducers/markup";
 export const markup = _markup;
+import _eventTooltip from "devtools/client/inspector/markup/reducers/eventTooltip";
+export const eventTooltip = _eventTooltip;
 export const pseudoClasses = require("devtools/client/inspector/rules/reducers/pseudo-classes");
 export const rules = require("devtools/client/inspector/rules/reducers/rules");
 

--- a/src/devtools/client/themes/tooltips.css
+++ b/src/devtools/client/themes/tooltips.css
@@ -516,6 +516,7 @@ strong {
 
 .devtools-tooltip-events-container {
   border-radius: var(--theme-arrowpanel-border-radius);
+  width: 400px;
   height: 100%;
   overflow-y: auto;
 }

--- a/src/protocol/event-listeners.ts
+++ b/src/protocol/event-listeners.ts
@@ -1,6 +1,16 @@
 // Routines for finding framework-specific event listeners within a pause.
 
-async function getFrameworkEventListeners(node) {
+import { ValueFront } from "./thread";
+import { NodeFront } from "./thread/node";
+
+export interface FrameworkEventListener {
+  handler: ValueFront;
+  type: string;
+  capture: boolean;
+  tags: string;
+}
+
+export async function getFrameworkEventListeners(node: NodeFront) {
   const obj = node.getObjectFront();
   const props = await obj.loadChildren();
   const reactProp = props.find(v => v.name.startsWith("__reactEventHandlers$"));
@@ -18,7 +28,7 @@ async function getFrameworkEventListeners(node) {
     });
 }
 
-function logpointGetFrameworkEventListeners(frameId, frameworkListeners) {
+export function logpointGetFrameworkEventListeners(frameId: string, frameworkListeners: string) {
   const evalText = `
 (array => {
   const rv = [];
@@ -55,8 +65,3 @@ addPauseData(frameworkResult.data);
 ${frameworkListeners} = frameworkResult.returned;
 `;
 }
-
-module.exports = {
-  getFrameworkEventListeners,
-  logpointGetFrameworkEventListeners,
-};

--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -8,7 +8,7 @@ import {
 import { client } from "../socket";
 import { Pause, WiredObject } from "./pause";
 import { defer, assert, DisallowEverythingProxyHandler, Deferred } from "../utils";
-const { getFrameworkEventListeners } = require("../event-listeners");
+import { FrameworkEventListener, getFrameworkEventListeners } from "../event-listeners";
 import { ValueFront } from "./value";
 const { uniqBy } = require("lodash");
 const HTML_NS = "http://www.w3.org/1999/xhtml";
@@ -31,7 +31,7 @@ export class NodeFront {
   private _computedStyle: Map<string, string> | null;
   private _rules: AppliedRule[] | null;
   private _listeners: WiredEventListener[] | null;
-  private _frameworkListenersWaiter: Deferred<void> | null;
+  private _frameworkListenersWaiter: Deferred<FrameworkEventListener[]> | null;
   private _quads: BoxModel | null;
   private _bounds: Rect | null;
 
@@ -288,8 +288,8 @@ export class NodeFront {
     if (this._frameworkListenersWaiter) {
       return this._frameworkListenersWaiter.promise;
     }
-    this._frameworkListenersWaiter = defer<void>();
-    const listeners = getFrameworkEventListeners(this);
+    this._frameworkListenersWaiter = defer<FrameworkEventListener[]>();
+    const listeners = await getFrameworkEventListeners(this);
     this._frameworkListenersWaiter.resolve(listeners);
     return listeners;
   }

--- a/src/ui/actions/index.ts
+++ b/src/ui/actions/index.ts
@@ -10,9 +10,15 @@ import type { TimelineAction } from "./timeline";
 import * as eventListeners from "devtools/client/debugger/src/actions/event-listeners";
 import debuggerActions from "devtools/client/debugger/src/actions";
 import { MarkupAction } from "devtools/client/inspector/markup/actions/markup";
+import { EventTooltipAction } from "devtools/client/inspector/markup/actions/eventTooltip";
 const consoleActions = require("devtools/client/webconsole/actions");
 
-export type UIAction = AppAction | MetadataAction | TimelineAction | MarkupAction;
+export type UIAction =
+  | AppAction
+  | MetadataAction
+  | TimelineAction
+  | MarkupAction
+  | EventTooltipAction;
 
 interface ThunkExtraArgs {
   client: any;

--- a/src/ui/components/shared/Dropdown.tsx
+++ b/src/ui/components/shared/Dropdown.tsx
@@ -1,8 +1,17 @@
-import React from "react";
-import classnames from "classnames";
+import React, { CSSProperties, ReactNode } from "react";
 import "./Dropdown.css";
 
-function Dropdown({
+export interface DropdownProps {
+  buttonContent: string;
+  children: ReactNode;
+  setExpanded: (expanded: boolean) => void;
+  expanded: boolean;
+  position?: string;
+  buttonStyle?: string;
+  style?: CSSProperties;
+}
+
+export default function Dropdown({
   buttonContent,
   children,
   setExpanded,
@@ -10,7 +19,7 @@ function Dropdown({
   position = "bottom-left",
   buttonStyle = "primary",
   style,
-}) {
+}: DropdownProps) {
   return (
     <div className="dropdown-wrapper">
       <button className={`expand-dropdown ${buttonStyle}`} onClick={() => setExpanded(true)}>
@@ -27,5 +36,3 @@ function Dropdown({
     </div>
   );
 }
-
-export default Dropdown;

--- a/src/ui/state/index.ts
+++ b/src/ui/state/index.ts
@@ -3,6 +3,7 @@ import { MetadataState } from "./metadata";
 import { AppState } from "./app";
 import { InspectorState } from "devtools/client/inspector/state";
 import { MarkupState } from "devtools/client/inspector/markup/state/markup";
+import { EventTooltipState } from "devtools/client/inspector/markup/state/eventTooltip";
 
 export interface UIState {
   timeline: TimelineState;
@@ -10,4 +11,5 @@ export interface UIState {
   app: AppState;
   inspector: InspectorState;
   markup: MarkupState;
+  eventTooltip: EventTooltipState;
 }


### PR DESCRIPTION
This currently lacks the necessary CSS. One issue is that I can't get the Dropdown component to mask the content behind it when I use it in the markup view. The reason could be a Firefox bug:

Firefox / Replay browser:
![Screenshot_2020-11-24_20-00-41](https://user-images.githubusercontent.com/16060807/100139517-e610e500-2e8f-11eb-846b-f71236dd7ddd.png)

Chrome:
![Screenshot_2020-11-24_20-01-05](https://user-images.githubusercontent.com/16060807/100139529-eb6e2f80-2e8f-11eb-95ce-8d86a659e5e7.png)
