### PR TITLE
Switch to panel toggling mode

### DIFF
--- a/src/devtools/client/debugger/src/actions/ui.js
+++ b/src/devtools/client/debugger/src/actions/ui.js
@@ -80,7 +80,7 @@ export function showSource(cx, sourceId) {
       return;
     }
 
-    if (getPaneCollapse(getState(), "start")) {
+    if (getPaneCollapse(getState())) {
       dispatch({
         type: "TOGGLE_PANE",
         position: "start",
@@ -96,25 +96,13 @@ export function showSource(cx, sourceId) {
   };
 }
 
-export function togglePaneCollapse(position, paneCollapsed) {
+export function togglePaneCollapse() {
   return ({ dispatch, getState }) => {
-    const prevPaneCollapse = getPaneCollapse(getState(), position);
-    if (prevPaneCollapse === paneCollapsed) {
-      return;
-    }
-
-    dispatch({
-      type: "TOGGLE_PANE",
-      position,
-      paneCollapsed,
-    });
+    const paneCollapsed = getPaneCollapse(getState());
+    dispatch({ type: "TOGGLE_PANE", paneCollapsed: !paneCollapsed });
   };
 }
 
-/**
- * @memberof actions/sources
- * @static
- */
 export function highlightLineRange(location) {
   return {
     type: "HIGHLIGHT_LINES",
@@ -129,10 +117,6 @@ export function flashLineRange(location) {
   };
 }
 
-/**
- * @memberof actions/sources
- * @static
- */
 export function clearHighlightLineRange() {
   return {
     type: "CLEAR_HIGHLIGHT_LINES",

--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -63,14 +63,10 @@ class Debugger extends Component {
   onEscape;
   onCommandSlash;
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      shortcutsModalEnabled: false,
-      startPanelSize: 0,
-      endPanelSize: 0,
-    };
-  }
+  state = {
+    shortcutsModalEnabled: false,
+    startPanelSize: 0,
+  };
 
   getChildContext = () => {
     return { shortcuts, l10n: L10N };
@@ -188,19 +184,14 @@ class Debugger extends Component {
   }
 
   renderEditorPane = () => {
-    const { startPanelCollapsed, endPanelCollapsed } = this.props;
-    const { endPanelSize, startPanelSize } = this.state;
+    const { startPanelSize } = this.state;
     const horizontal = this.isHorizontal();
 
     return (
       <div className="editor-pane">
         <div className="editor-container">
-          <EditorTabs
-            startPanelCollapsed={startPanelCollapsed}
-            endPanelCollapsed={endPanelCollapsed}
-            horizontal={horizontal}
-          />
-          <Editor startPanelSize={startPanelSize} endPanelSize={endPanelSize} />
+          <EditorTabs horizontal={horizontal} />
+          <Editor startPanelSize={startPanelSize} />
           {!this.props.selectedSource ? (
             <WelcomeBox
               horizontal={horizontal}
@@ -230,7 +221,7 @@ class Debugger extends Component {
   }
 
   renderLayout = () => {
-    const { startPanelCollapsed, endPanelCollapsed, debuggerMode } = this.props;
+    const { startPanelCollapsed, debuggerMode } = this.props;
     const horizontal = this.isHorizontal();
 
     return (
@@ -300,8 +291,7 @@ Debugger.childContextTypes = {
 
 const mapStateToProps = state => ({
   selectedSource: getSelectedSource(state),
-  startPanelCollapsed: getPaneCollapse(state, "start"),
-  endPanelCollapsed: getPaneCollapse(state, "end"),
+  startPanelCollapsed: getPaneCollapse(state),
   activeSearch: getActiveSearch(state),
   quickOpenEnabled: getQuickOpenEnabled(state),
   orientation: getOrientation(state),

--- a/src/devtools/client/debugger/src/components/Editor/Footer.js
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.js
@@ -138,22 +138,6 @@ class SourceFooter extends PureComponent {
     );
   }
 
-  renderToggleButton() {
-    if (this.props.horizontal) {
-      return;
-    }
-
-    return (
-      <PaneToggleButton
-        key="toggle"
-        collapsed={this.props.endPanelCollapsed}
-        horizontal={this.props.horizontal}
-        handleClick={this.props.togglePaneCollapse}
-        position="end"
-      />
-    );
-  }
-
   renderCommands() {
     const commands = [this.blackBoxButton(), this.prettyPrintButton()].filter(Boolean);
 
@@ -220,7 +204,6 @@ class SourceFooter extends PureComponent {
         <div className="source-footer-end">
           {this.renderSourceSummary()}
           {this.renderCursorPosition()}
-          {this.renderToggleButton()}
         </div>
       </div>
     );
@@ -237,7 +220,6 @@ const mapStateToProps = state => {
     selectedSource,
     alternateSource,
     prettySource: getPrettySource(state, selectedSource ? selectedSource.id : null),
-    endPanelCollapsed: getPaneCollapse(state, "end"),
     canPrettyPrint: selectedSource ? canPrettyPrintSource(state, selectedSource.id) : false,
   };
 };

--- a/src/devtools/client/debugger/src/components/Editor/Tabs.js
+++ b/src/devtools/client/debugger/src/components/Editor/Tabs.js
@@ -47,7 +47,6 @@ class Tabs extends PureComponent {
   renderTabs;
   renderDropDown;
   renderStartPanelToggleButton;
-  renderEndPanelToggleButton;
   onResize;
   _draggedSource;
   _draggedSourceIndex;
@@ -246,36 +245,9 @@ class Tabs extends PureComponent {
     return <CommandBar horizontal={horizontal} />;
   }
 
-  renderStartPanelToggleButton() {
-    return (
-      <PaneToggleButton
-        position="start"
-        collapsed={this.props.startPanelCollapsed}
-        handleClick={this.props.togglePaneCollapse}
-      />
-    );
-  }
-
-  renderEndPanelToggleButton() {
-    const { horizontal, endPanelCollapsed, togglePaneCollapse } = this.props;
-    if (!horizontal) {
-      return;
-    }
-
-    return (
-      <PaneToggleButton
-        position="end"
-        collapsed={endPanelCollapsed}
-        handleClick={togglePaneCollapse}
-        horizontal={horizontal}
-      />
-    );
-  }
-
   render() {
     return (
       <div className="source-header">
-        {this.renderStartPanelToggleButton()}
         {this.renderTabs()}
         {this.renderDropdown()}
       </div>
@@ -295,6 +267,5 @@ export default connect(mapStateToProps, {
   moveTab: actions.moveTab,
   moveTabBySourceId: actions.moveTabBySourceId,
   closeTab: actions.closeTab,
-  togglePaneCollapse: actions.togglePaneCollapse,
   showSource: actions.showSource,
 })(Tabs);

--- a/src/devtools/client/debugger/src/components/Editor/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/index.js
@@ -355,10 +355,7 @@ class Editor extends PureComponent {
       return;
     }
 
-    if (
-      nextProps.startPanelSize !== this.props.startPanelSize ||
-      nextProps.endPanelSize !== this.props.endPanelSize
-    ) {
+    if (nextProps.startPanelSize !== this.props.startPanelSize) {
       editor.codeMirror.setSize();
     }
   }

--- a/src/devtools/client/debugger/src/components/WelcomeBox.js
+++ b/src/devtools/client/debugger/src/components/WelcomeBox.js
@@ -2,13 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-//
 import React, { Component } from "react";
-
 import { connect } from "../utils/connect";
-
 import actions from "../actions";
-import { getPaneCollapse } from "../selectors";
 import { formatKeyShortcut } from "../utils/text";
 
 import "./WelcomeBox.css";
@@ -64,12 +60,9 @@ export class WelcomeBox extends Component {
   }
 }
 
-const mapStateToProps = state => ({
-  endPanelCollapsed: getPaneCollapse(state, "end"),
-});
+const mapStateToProps = state => ({});
 
 export default connect(mapStateToProps, {
-  togglePaneCollapse: actions.togglePaneCollapse,
   setActiveSearch: actions.setActiveSearch,
   openQuickOpen: actions.openQuickOpen,
 })(WelcomeBox);

--- a/src/devtools/client/debugger/src/reducers/ui.js
+++ b/src/devtools/client/debugger/src/reducers/ui.js
@@ -44,13 +44,8 @@ function update(state = createUIState(), action) {
     }
 
     case "TOGGLE_PANE": {
-      if (action.position == "start") {
-        prefs.startPanelCollapsed = action.paneCollapsed;
-        return { ...state, startPanelCollapsed: action.paneCollapsed };
-      }
-
-      prefs.endPanelCollapsed = action.paneCollapsed;
-      return { ...state, endPanelCollapsed: action.paneCollapsed };
+      prefs.startPanelCollapsed = action.paneCollapsed;
+      return { ...state, startPanelCollapsed: action.paneCollapsed };
     }
 
     case "HIGHLIGHT_LINES":
@@ -114,12 +109,8 @@ export function getShownSource(state) {
   return state.ui.shownSource;
 }
 
-export function getPaneCollapse(state, position) {
-  if (position == "start") {
-    return state.ui.startPanelCollapsed;
-  }
-
-  return state.ui.endPanelCollapsed;
+export function getPaneCollapse(state) {
+  return state.ui.startPanelCollapsed;
 }
 
 export function getHighlightedLineRange(state) {

--- a/src/ui/components/Toolbox.js
+++ b/src/ui/components/Toolbox.js
@@ -18,22 +18,20 @@ class Toolbox extends React.Component {
   };
 
   async componentDidMount() {
-    const selectedPanel = "debugger";
-    await gToolbox.init(selectedPanel);
-
-    shortcuts.on("Esc", this.onEscape);
+    await gToolbox.init("debugger");
   }
 
-  onEscape = e => {
-    if (e.cancelBubble) {
-      return;
+  selectPanel(panel) {
+    if (
+      this.props.panelCollapsed ||
+      (this.state.debuggerMode == panel && !this.props.panelCollapsed)
+    ) {
+      this.props.togglePaneCollapse();
     }
 
-    this.toggleSplitConsole(!this.props.splitConsoleOpen);
-  };
-
-  toggleSplitConsole(open) {
-    this.props.setSplitConsole(open);
+    if (this.state.debuggerMode != panel) {
+      this.setState({ debuggerMode: panel });
+    }
   }
 
   renderToolbar() {
@@ -42,13 +40,13 @@ class Toolbox extends React.Component {
       <div id="toolbox-toolbar">
         <div
           className={classnames("toolbar-panel-button", { active: debuggerMode == "explorer" })}
-          onClick={() => this.setState({ debuggerMode: "explorer" })}
+          onClick={() => this.selectPanel("explorer")}
         >
           <div className="img explorer-panel toolbar-panel-icon"></div>
         </div>
         <div
           className={classnames("toolbar-panel-button", { active: debuggerMode == "debug" })}
-          onClick={() => this.setState({ debuggerMode: "debug" })}
+          onClick={() => this.selectPanel("debug")}
         >
           <div className="img debugger-panel toolbar-panel-icon"></div>
         </div>
@@ -56,50 +54,17 @@ class Toolbox extends React.Component {
     );
   }
 
-  getSplitBoxDimensions() {
-    const { selectedPanel, splitConsoleOpen } = this.props;
-
-    if (selectedPanel == "console") {
-      // We intentionally don't pass in the `initialSize: "0%"` here. This is
-      // important for when the split console is open, and we switch panels from
-      // uncontrolled (console) to controlled (debugger/inspector). This way, the
-      // controlled height is not stuck at 0% until we resize the panel manually.
-      return {
-        minSize: 0,
-        maxSize: 0,
-      };
-    }
-
-    if (splitConsoleOpen) {
-      return {
-        initialSize: "50%",
-        minSize: "0%",
-        maxSize: "100%",
-      };
-    }
-
-    return {
-      initialSize: "50%",
-      minSize: "100%",
-      maxSize: "100%",
-    };
-  }
-
   render() {
     const { debuggerMode } = this.state;
-
-    const topPanels = (
-      <div className="toolbox-top-panels">
-        <div className="toolbox-panel" id="toolbox-content-debugger">
-          <DebuggerApp debuggerMode={debuggerMode} />
-        </div>
-      </div>
-    );
 
     return (
       <div id="toolbox">
         {this.renderToolbar()}
-        {topPanels}
+        <div className="toolbox-top-panels">
+          <div className="toolbox-panel" id="toolbox-content-debugger">
+            <DebuggerApp debuggerMode={debuggerMode} />
+          </div>
+        </div>
       </div>
     );
   }
@@ -108,8 +73,10 @@ export default connect(
   state => ({
     initializedPanels: selectors.getInitializedPanels(state),
     toolboxExpanded: selectors.getToolboxExpanded(state),
+    panelCollapsed: selectors.getPaneCollapse(state),
   }),
   {
     setSelectedPanel: actions.setSelectedPanel,
+    togglePaneCollapse: actions.togglePaneCollapse,
   }
 )(Toolbox);


### PR DESCRIPTION
This adopts the IDE convention of using the primary nav as a panel toggle as well

1. clicking on a button selects it and expands the panel if needed
2. clicking it again collapses it