### PR TITLE
Revise icons on left nav

### DIFF
--- a/src/devtools/client/themes/images/tool-debugger.svg
+++ b/src/devtools/client/themes/images/tool-debugger.svg
@@ -1,6 +1,3 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="context-fill #0c0c0d">
-  <path d="M2.5 4a.5.5 0 0 0-.5.5v7c0 .28.22.5.5.5h7.55l3.6-4-3.6-4H2.5zM0 4.5A2.5 2.5 0 0 1 2.5 2h8a1 1 0 0 1 .74.33l4.5 5a1 1 0 0 1 0 1.34l-4.5 5a1 1 0 0 1-.74.33h-8A2.5 2.5 0 0 1 0 11.5v-7z"/>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.8941 7.68839C13.2424 8.06098 13.2424 8.63467 12.8941 9.00726C11.9825 9.98258 10.3151 11.6957 9.85059 11.6957C9.04594 11.6957 5.31655 11.6957 3.4999 11.6957C2.94762 11.6957 2.5 11.2479 2.5 10.6957V6C2.5 5.44772 2.94624 5 3.49853 5C5.36606 5 9.25344 5 9.85059 5C10.3151 5 11.9825 6.71307 12.8941 7.68839Z" stroke="black"/>
 </svg>

--- a/src/devtools/client/themes/images/tool-explorer.svg
+++ b/src/devtools/client/themes/images/tool-explorer.svg
@@ -1,5 +1,6 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M4 2H9.28199C9.56812 2 9.84054 2.12257 10.0303 2.33669L12.7483 5.40317L13.4967 4.73986L12.7483 5.40317C12.9105 5.58608 13 5.82205 13 6.06647V13C13 13.5523 12.5523 14 12 14H4C3.44772 14 3 13.5523 3 13V3C3 2.44772 3.44772 2 4 2Z" stroke="black" stroke-width="2"/>
-<path d="M5.5 8.5H10.5" stroke="black" stroke-linecap="round"/>
-<path d="M5.5 10.5H10.5" stroke="black" stroke-linecap="round"/>
+<rect x="2.5" y="1.5" width="10" height="13" rx="1.5" stroke="black"/>
+<rect x="5" y="4.66667" width="5.33333" height="0.666667" rx="0.333333" fill="black"/>
+<rect x="5" y="6.66666" width="5.33333" height="0.666667" rx="0.333333" fill="black"/>
+<rect x="5" y="8.66667" width="5.33333" height="0.666667" rx="0.333333" fill="black"/>
 </svg>


### PR DESCRIPTION
<img width="619" alt="image" src="https://user-images.githubusercontent.com/9154902/100393109-71ab9100-309d-11eb-95b2-0f9bfbcafde9.png">

The previous icons were quite thick, so I made them thinner. Here's how they look now:

<img width="258" alt="image" src="https://user-images.githubusercontent.com/9154902/100393155-9e5fa880-309d-11eb-987a-273c0dd6f971.png">
