### PR TITLE
Fix "Not Allowed" messages triggered by LogRocket

### DIFF
--- a/src/devtools/client/inspector/rules/actions/rules.js
+++ b/src/devtools/client/inspector/rules/actions/rules.js
@@ -47,7 +47,7 @@ module.exports = {
   updateRules(rules) {
     return {
       type: UPDATE_RULES,
-      rules,
+      rules: rules.map(rule => getRuleState(rule)),
     };
   },
 
@@ -67,3 +67,80 @@ module.exports = {
     };
   },
 };
+
+/**
+ * Given a rule's TextProperty, returns the properties that are needed to render a
+ * CSS declaration.
+ *
+ * @param  {TextProperty} declaration
+ *         A TextProperty of a rule.
+ * @param  {String} ruleId
+ *         The rule id that is associated with the given CSS declaration.
+ * @return {Object} containing the properties needed to render a CSS declaration.
+ */
+function getDeclarationState(declaration, ruleId) {
+  return {
+    // Array of the computed properties for a CSS declaration.
+    computedProperties: declaration.computedProperties,
+    // An unique CSS declaration id.
+    id: declaration.id,
+    // Whether or not the declaration is valid. (Does it make sense for this value
+    // to be assigned to this property name?)
+    isDeclarationValid: declaration.isValid(),
+    // Whether or not the declaration is enabled.
+    isEnabled: declaration.enabled,
+    // Whether or not the declaration is invisible. In an inherited rule, only the
+    // inherited declarations are shown and the rest are considered invisible.
+    isInvisible: declaration.invisible,
+    // Whether or not the declaration's property name is known.
+    isKnownProperty: declaration.isKnownProperty,
+    // Whether or not the property name is valid.
+    isNameValid: declaration.isNameValid(),
+    // Whether or not the the declaration is overridden.
+    isOverridden: !!declaration.overridden,
+    // Whether or not the declaration is changed by the user.
+    isPropertyChanged: declaration.isPropertyChanged,
+    // The declaration's property name.
+    name: declaration.name,
+    // The declaration's priority (either "important" or an empty string).
+    priority: declaration.priority,
+    // The CSS rule id that is associated with this CSS declaration.
+    ruleId,
+    // The declaration's property value.
+    value: declaration.value,
+  };
+}
+
+/**
+ * Given a Rule, returns the properties that are needed to render a CSS rule.
+ *
+ * @param  {Rule} rule
+ *         A Rule object containing information about a CSS rule.
+ * @return {Object} containing the properties needed to render a CSS rule.
+ */
+function getRuleState(rule) {
+  return {
+    // Array of CSS declarations.
+    declarations: rule.declarations.map(declaration =>
+      getDeclarationState(declaration, rule.domRule.objectId())
+    ),
+    // An unique CSS rule id.
+    id: rule.domRule.objectId(),
+    // An object containing information about the CSS rule's inheritance.
+    inheritance: rule.inheritance,
+    // Whether or not the rule does not match the current selected element.
+    isUnmatched: rule.isUnmatched,
+    // Whether or not the rule is an user agent style.
+    isUserAgentStyle: rule.domRule.isSystem,
+    // An object containing information about the CSS keyframes rules.
+    // keyframesRule: rule.keyframesRule,
+    // The pseudo-element keyword used in the rule.
+    pseudoElement: rule.pseudoElement,
+    // An object containing information about the CSS rule's selector.
+    selector: rule.selector,
+    // An object containing information about the CSS rule's stylesheet source.
+    sourceLink: rule.sourceLink,
+    // The type of CSS rule.
+    type: rule.domRule.type,
+  };
+}

--- a/src/devtools/client/inspector/rules/reducers/rules.js
+++ b/src/devtools/client/inspector/rules/reducers/rules.js
@@ -20,83 +20,6 @@ const INITIAL_RULES = {
   rules: [],
 };
 
-/**
- * Given a rule's TextProperty, returns the properties that are needed to render a
- * CSS declaration.
- *
- * @param  {TextProperty} declaration
- *         A TextProperty of a rule.
- * @param  {String} ruleId
- *         The rule id that is associated with the given CSS declaration.
- * @return {Object} containing the properties needed to render a CSS declaration.
- */
-function getDeclarationState(declaration, ruleId) {
-  return {
-    // Array of the computed properties for a CSS declaration.
-    computedProperties: declaration.computedProperties,
-    // An unique CSS declaration id.
-    id: declaration.id,
-    // Whether or not the declaration is valid. (Does it make sense for this value
-    // to be assigned to this property name?)
-    isDeclarationValid: declaration.isValid(),
-    // Whether or not the declaration is enabled.
-    isEnabled: declaration.enabled,
-    // Whether or not the declaration is invisible. In an inherited rule, only the
-    // inherited declarations are shown and the rest are considered invisible.
-    isInvisible: declaration.invisible,
-    // Whether or not the declaration's property name is known.
-    isKnownProperty: declaration.isKnownProperty,
-    // Whether or not the property name is valid.
-    isNameValid: declaration.isNameValid(),
-    // Whether or not the the declaration is overridden.
-    isOverridden: !!declaration.overridden,
-    // Whether or not the declaration is changed by the user.
-    isPropertyChanged: declaration.isPropertyChanged,
-    // The declaration's property name.
-    name: declaration.name,
-    // The declaration's priority (either "important" or an empty string).
-    priority: declaration.priority,
-    // The CSS rule id that is associated with this CSS declaration.
-    ruleId,
-    // The declaration's property value.
-    value: declaration.value,
-  };
-}
-
-/**
- * Given a Rule, returns the properties that are needed to render a CSS rule.
- *
- * @param  {Rule} rule
- *         A Rule object containing information about a CSS rule.
- * @return {Object} containing the properties needed to render a CSS rule.
- */
-function getRuleState(rule) {
-  return {
-    // Array of CSS declarations.
-    declarations: rule.declarations.map(declaration =>
-      getDeclarationState(declaration, rule.domRule.objectId())
-    ),
-    // An unique CSS rule id.
-    id: rule.domRule.objectId(),
-    // An object containing information about the CSS rule's inheritance.
-    inheritance: rule.inheritance,
-    // Whether or not the rule does not match the current selected element.
-    isUnmatched: rule.isUnmatched,
-    // Whether or not the rule is an user agent style.
-    isUserAgentStyle: rule.domRule.isSystem,
-    // An object containing information about the CSS keyframes rules.
-    // keyframesRule: rule.keyframesRule,
-    // The pseudo-element keyword used in the rule.
-    pseudoElement: rule.pseudoElement,
-    // An object containing information about the CSS rule's selector.
-    selector: rule.selector,
-    // An object containing information about the CSS rule's stylesheet source.
-    sourceLink: rule.sourceLink,
-    // The type of CSS rule.
-    type: rule.domRule.type,
-  };
-}
-
 const reducers = {
   [UPDATE_ADD_RULE_ENABLED](rules, { enabled }) {
     return {
@@ -114,9 +37,8 @@ const reducers = {
 
   [UPDATE_RULES](rules, { rules: newRules }) {
     return {
-      highlightedSelector: rules.highlightedSelector,
-      isAddRuleEnabled: rules.isAddRuleEnabled,
-      rules: newRules.map(rule => getRuleState(rule)),
+      ...rules,
+      rules: newRules,
     };
   },
 

--- a/src/protocol/utils.ts
+++ b/src/protocol/utils.ts
@@ -72,10 +72,10 @@ function NotAllowed() {
 }
 
 export const DisallowEverythingProxyHandler: ProxyHandler<object> = {
-  getPrototypeOf() {
-    NotAllowed();
-    return null;
-  },
+  // getPrototypeOf() {
+  //   NotAllowed();
+  //   return null;
+  // },
   //has() {
   //  NotAllowed();
   //  return false;

--- a/src/ui/utils/bootstrap/bootstrapStore.js
+++ b/src/ui/utils/bootstrap/bootstrapStore.js
@@ -10,6 +10,7 @@ import { clientCommands } from "devtools/client/debugger/src/client/commands";
 import LogRocket from "ui/utils/logrocket";
 import * as dbgClient from "devtools/client/debugger/src/client";
 import { bootstrapWorkers } from "devtools/client/debugger/src/utils/bootstrap";
+import { sanityCheckMiddleware } from "../sanitize";
 
 import { isDevelopment, isTest } from "../environment";
 const skipTelemetry = isTest() || isDevelopment();
@@ -75,7 +76,11 @@ export const bootstrapStore = async function bootstrapStore() {
   });
 
   const initialState = await getInitialState();
-  const middleware = skipTelemetry ? undefined : applyMiddleware(LogRocket.reduxMiddleware());
+  const middleware = skipTelemetry
+    ? isDevelopment()
+      ? applyMiddleware(sanityCheckMiddleware)
+      : undefined
+    : applyMiddleware(LogRocket.reduxMiddleware());
 
   const store = createStore(combineReducers(reducers), initialState, middleware);
 

--- a/src/ui/utils/logrocket.js
+++ b/src/ui/utils/logrocket.js
@@ -1,5 +1,6 @@
 import LogRocket from "logrocket";
 import setupLogRocketReact from "logrocket-react";
+import { sanitize } from "./sanitize";
 
 let setup = false;
 
@@ -11,5 +12,9 @@ export default {
   },
   identify: (uuid, attributes) => setup && LogRocket.identify(uuid, attributes),
   getSessionURL: callback => setup && LogRocket.getSessionURL(callback),
-  reduxMiddleware: () => LogRocket.reduxMiddleware(),
+  reduxMiddleware: () =>
+    LogRocket.reduxMiddleware({
+      actionSanitizer: action => sanitize(action, "", `action[type=${action.type}]`, false),
+      stateSanitizer: state => sanitize(state, "", "state", false),
+    }),
 };

--- a/src/ui/utils/sanitize.ts
+++ b/src/ui/utils/sanitize.ts
@@ -1,0 +1,54 @@
+import { Pause, ValueFront } from "protocol/thread";
+import { NodeFront } from "protocol/thread/node";
+import { StyleSheetFront } from "protocol/thread/styleSheet";
+import { StyleFront } from "protocol/thread/style";
+import { RuleFront } from "protocol/thread/rule";
+import { NodeBoundsFront } from "protocol/thread/bounds";
+import { Dispatch, Middleware } from "redux";
+import { UIState } from "ui/state";
+import { UIAction } from "ui/actions";
+
+const forbiddenClasses: Record<string, any> = {
+  Pause,
+  ValueFront,
+  NodeFront,
+  StyleSheetFront,
+  StyleFront,
+  RuleFront,
+  NodeBoundsFront,
+};
+
+const loggedCategories = new Set<string>();
+
+export function sanitize(obj: any, path: string, category: string, logSanitized: boolean): any {
+  for (const name in forbiddenClasses) {
+    if (obj instanceof forbiddenClasses[name]) {
+      if (logSanitized && !loggedCategories.has(category)) {
+        console.warn(`${category}${path} is of type ${name}`);
+        loggedCategories.add(category);
+      }
+      return undefined;
+    }
+  }
+  if (Array.isArray(obj)) {
+    return obj.map((item, i) => sanitize(item, `${path}[${i}]`, category, logSanitized));
+  }
+  if (typeof obj === "object") {
+    const sanitized: Record<string, any> = {};
+    for (const key in obj) {
+      sanitized[key] = sanitize(obj[key], `${path}.${key}`, category, logSanitized);
+    }
+    return sanitized;
+  }
+  return obj;
+}
+
+export const sanityCheckMiddleware: Middleware<
+  {},
+  UIState,
+  Dispatch<UIAction>
+> = store => next => action => {
+  sanitize(store.getState(), "", "state", true);
+  sanitize(action, "", `action[type=${action.type}]`, true);
+  return next(action);
+};


### PR DESCRIPTION
- Removes the `RuleFront`s from the actions for the Rules view
- Adds sanitizers to the LogRocket middleware that remove all `*Front` objects from state and actions before they are inspected by LogRocket
- Adds a sanity checking middleware in development mode which logs `*Front` objects found in state and actions (without flooding the console with log messages)