### PR TITLE
Persist the selected tab when switching between view modes

### DIFF
--- a/src/ui/components/Header/ViewToggle.js
+++ b/src/ui/components/Header/ViewToggle.js
@@ -9,7 +9,7 @@ import { getViewMode } from "../../reducers/app";
 
 function ViewToggle({ viewMode, setViewMode, clearSelectedLocation, cx }) {
   const handleClick = () => {
-    clearSelectedLocation(cx);
+    // clearSelectedLocation(cx);
     setViewMode(viewMode == "dev" ? "non-dev" : "dev");
   };
 


### PR DESCRIPTION
This PR makes it so that when the user switches between the dev view and non-dev view, their selected editor tab is maintained in the dev view.