### PR TITLE
Update badge background color

### DIFF
--- a/src/devtools/client/debugger/src/components/shared/Badge.css
+++ b/src/devtools/client/debugger/src/components/shared/Badge.css
@@ -8,9 +8,7 @@
   height: var(--size);
   min-width: var(--size);
   line-height: var(--size);
-  background: var(--theme-toolbar-background-hover);
   color: var(--theme-body-color);
-  border-radius: var(--radius);
-  padding: 0 4px;
+  padding: 0 16px;
   font-size: 0.9em;
 }

--- a/src/devtools/client/debugger/src/components/shared/Badge.js
+++ b/src/devtools/client/debugger/src/components/shared/Badge.js
@@ -6,6 +6,6 @@
 import React from "react";
 import "./Badge.css";
 
-const Badge = ({ children }) => <span className="badge text-white text-center">{children}</span>;
+const Badge = ({ children }) => <span className="badge text-center">{children}</span>;
 
 export default Badge;


### PR DESCRIPTION
Cat and I updated the badge stying so that it would be a little easier to read:

### Before
<img width="346" alt="Screen Shot 2020-12-04 at 2 23 51 PM" src="https://user-images.githubusercontent.com/254562/101221364-6677d880-363c-11eb-987f-83503ed88a4d.png">
<img width="311" alt="Screen Shot 2020-12-04 at 2 23 47 PM" src="https://user-images.githubusercontent.com/254562/101221368-68419c00-363c-11eb-83a5-1ed3a692bd4f.png">

###. After
<img width="344" alt="Screen Shot 2020-12-04 at 2 23 24 PM" src="https://user-images.githubusercontent.com/254562/101221369-68da3280-363c-11eb-8835-1414e317e22a.png">
<img width="318" alt="Screen Shot 2020-12-04 at 2 23 20 PM" src="https://user-images.githubusercontent.com/254562/101221370-68da3280-363c-11eb-9ad1-3edeb14dd91c.png">
