### PR TITLE
Improve Test reporter and api

### DIFF
--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -610,4 +610,16 @@ const commands = mapValues(testCommands, (command, name) => {
   };
 });
 
-module.exports = { ...commands, dbg, dbgSelectors, app, start, finish };
+async function describe(description, cbk) {
+  console.log(`# Test ${description}`);
+  start();
+  await cbk();
+  finish();
+}
+
+async function it(description, cbk) {
+  console.log(`## ${description}`);
+  await cbk();
+}
+
+module.exports = { ...commands, dbg, dbgSelectors, app, start, finish, describe, it };

--- a/test/scripts/breakpoints-01.js
+++ b/test/scripts/breakpoints-01.js
@@ -1,6 +1,4 @@
-// Test basic breakpoint functionality.
-(async function () {
-  await Test.start();
+Test.describe(`Test basic breakpoint functionality.`, async () => {
   const { addBreakpoint, rewindToLine, resumeToLine, checkEvaluateInTopFrame } = Test;
 
   await addBreakpoint("doc_rr_basic.html", 21);
@@ -23,6 +21,4 @@
   await checkEvaluateInTopFrame("number", 9);
   await resumeToLine(21);
   await checkEvaluateInTopFrame("number", 10);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/breakpoints-02.js
+++ b/test/scripts/breakpoints-02.js
@@ -1,6 +1,4 @@
-// Test unhandled divergence while evaluating at a breakpoint.
-(async function () {
-  await Test.start();
+Test.describe(`Test unhandled divergence while evaluating at a breakpoint.`, async () => {
   await Test.addBreakpoint("doc_rr_basic.html", 21);
 
   await Test.rewindToLine(21);
@@ -10,6 +8,4 @@
   await Test.checkEvaluateInTopFrame("dump(3)", `"Error: Evaluation failed"`);
   await Test.checkEvaluateInTopFrame("number", 10);
   await Test.checkEvaluateInTopFrame("testStepping2()", undefined);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/breakpoints-03.js
+++ b/test/scripts/breakpoints-03.js
@@ -1,7 +1,5 @@
 // Test hitting breakpoints when rewinding past the point where the breakpoint
-// script was created.
-(async function () {
-  await Test.start();
+Test.describe(`script was created.`, async () => {
   await Test.rewindToLine(undefined);
 
   await Test.addBreakpoint("doc_rr_basic.html", 21);
@@ -9,6 +7,4 @@
   await Test.checkEvaluateInTopFrame("number", 1);
   await Test.resumeToLine(21);
   await Test.checkEvaluateInTopFrame("number", 2);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/breakpoints-04.js
+++ b/test/scripts/breakpoints-04.js
@@ -1,7 +1,5 @@
 // Test hitting breakpoints when using tricky control flow constructs:
-// catch, finally, generators, and async/await.
-(async function () {
-  await Test.start();
+Test.describe(`catch, finally, generators, and async/await.`, async () => {
   await rewindToBreakpoint(10);
   await resumeToBreakpoint(12);
   await resumeToBreakpoint(18);
@@ -15,8 +13,6 @@
   await resumeToBreakpoint(50);
   await resumeToBreakpoint(54);
 
-  Test.finish();
-
   async function rewindToBreakpoint(line) {
     await Test.addBreakpoint("doc_control_flow.html", line);
     await Test.rewindToLine(line);
@@ -26,4 +22,4 @@
     await Test.addBreakpoint("doc_control_flow.html", line);
     await Test.resumeToLine(line);
   }
-})();
+});

--- a/test/scripts/breakpoints-05.js
+++ b/test/scripts/breakpoints-05.js
@@ -1,6 +1,4 @@
-// Test interaction of breakpoints with debugger statements.
-(async function () {
-  await Test.start();
+Test.describe(`Test interaction of breakpoints with debugger statements.`, async () => {
   await Test.rewindToLine(9);
   await Test.addBreakpoint("doc_debugger_statements.html", 8);
   await Test.rewindToLine(8);
@@ -8,6 +6,4 @@
   await Test.removeAllBreakpoints();
   await Test.rewindToLine(7);
   await Test.resumeToLine(9);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/breakpoints-06.js
+++ b/test/scripts/breakpoints-06.js
@@ -20,6 +20,4 @@ async function checkMessageLocation(text, location) {
     logValue: "'line 17'",
   });
   await checkMessageLocation("line 17", "bundle_input.js:17");
-
-  Test.finish();
-})();
+});

--- a/test/scripts/console_eval.js
+++ b/test/scripts/console_eval.js
@@ -1,6 +1,4 @@
-// Test global console evaluation.
-(async function () {
-  await Test.start();
+Test.describe(`Test global console evaluation.`, async () => {
   await Test.selectConsole();
 
   await Test.executeInConsole("number");
@@ -8,6 +6,4 @@
 
   await Test.executeInConsole("window.updateNumber");
   await Test.waitForMessage("function updateNumber");
-
-  Test.finish();
-})();
+});

--- a/test/scripts/console_messages.js
+++ b/test/scripts/console_messages.js
@@ -1,7 +1,5 @@
 // Test expanding console objects that were logged by console messages,
-// logpoints, and evaluations when the debugger is somewhere else.
-(async function () {
-  await Test.start();
+Test.describe(`logpoints, and evaluations when the debugger is somewhere else.`, async () => {
   await Test.selectConsole();
 
   let msg;
@@ -56,6 +54,4 @@
     ["subobj: Object { subvalue: 0 }"],
     ["obj: Object { value: 0, subobj: {…} }"]
   );
-
-  Test.finish();
-})();
+});

--- a/test/scripts/console_stacks.js
+++ b/test/scripts/console_stacks.js
@@ -1,6 +1,4 @@
-// Test source mapping of logpoint errors.
-(async function () {
-  await Test.start();
+Test.describe(`Test source mapping of logpoint errors.`, async () => {
   await Test.toggleExceptionLogging();
   await Test.selectConsole();
   Test.app.actions.filterToggle("warn");
@@ -14,6 +12,4 @@
   await Test.waitForMessage("Object { number: 42 }");
   await Test.waitForMessage("Object { number: 12 }");
   await Test.waitForMessage("uncaught exception: [object Object]");
-
-  Test.finish();
-})();
+});

--- a/test/scripts/console_warp-01.js
+++ b/test/scripts/console_warp-01.js
@@ -1,6 +1,4 @@
-// Test basic console time warping functionality.
-(async function () {
-  await Test.start();
+Test.describe(`Test basic console time warping functionality.`, async () => {
   await Test.selectConsole();
   await Test.warpToMessage("Number 5");
 
@@ -19,6 +17,4 @@
 
   await Test.warpToMessage("window.foo is undefined");
   await Test.reverseStepOverToLine(7);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/console_warp-02.js
+++ b/test/scripts/console_warp-02.js
@@ -1,44 +1,43 @@
-// Test which message is the paused one after warping, stepping, and evaluating.
-(async function () {
-  await Test.start();
-  await Test.selectConsole();
+Test.describe(
+  `Test which message is the paused one after warping, stepping, and evaluating.`,
+  async () => {
+    await Test.selectConsole();
 
-  // When warping to a message, it is the paused one.
-  await Test.warpToMessage("number: 2");
-  await Test.checkPausedMessage("number: 2");
+    // When warping to a message, it is the paused one.
+    await Test.warpToMessage("number: 2");
+    await Test.checkPausedMessage("number: 2");
 
-  await Test.stepOverToLine(20);
-  await Test.checkPausedMessage("number: 2");
+    await Test.stepOverToLine(20);
+    await Test.checkPausedMessage("number: 2");
 
-  // When stepping back we end up earlier than the console call, even though we're
-  // paused at the same line. This isn't ideal.
-  await Test.reverseStepOverToLine(19);
-  await Test.checkPausedMessage("number: 1");
+    // When stepping back we end up earlier than the console call, even though we're
+    // paused at the same line. This isn't ideal.
+    await Test.reverseStepOverToLine(19);
+    await Test.checkPausedMessage("number: 1");
 
-  // When rewinding before the first message, that message is still considered
-  // the paused one so that the remaining messages can be grayed out. This also
-  // isn't ideal.
-  await Test.addBreakpoint("doc_rr_logs.html", 16);
-  await Test.rewindToLine(16);
-  await Test.removeAllBreakpoints();
-  await Test.checkPausedMessage("number: 1");
+    // When rewinding before the first message, that message is still considered
+    // the paused one so that the remaining messages can be grayed out. This also
+    // isn't ideal.
+    await Test.addBreakpoint("doc_rr_logs.html", 16);
+    await Test.rewindToLine(16);
+    await Test.removeAllBreakpoints();
+    await Test.checkPausedMessage("number: 1");
 
-  await Test.warpToMessage("number: 2");
-  await Test.checkPausedMessage("number: 2");
-  await Test.stepOverToLine(20);
+    await Test.warpToMessage("number: 2");
+    await Test.checkPausedMessage("number: 2");
+    await Test.stepOverToLine(20);
 
-  await Test.executeInConsole("1 << 5");
-  await Test.checkPausedMessage("32");
+    await Test.executeInConsole("1 << 5");
+    await Test.checkPausedMessage("32");
 
-  await Test.stepOverToLine(21);
-  await Test.executeInConsole("1 << 7");
-  await Test.checkPausedMessage("128");
+    await Test.stepOverToLine(21);
+    await Test.executeInConsole("1 << 7");
+    await Test.checkPausedMessage("128");
 
-  await Test.reverseStepOverToLine(20);
-  await Test.checkPausedMessage("32");
+    await Test.reverseStepOverToLine(20);
+    await Test.checkPausedMessage("32");
 
-  await Test.executeInConsole("1 << 6");
-  await Test.checkPausedMessage("64");
-
-  Test.finish();
-})();
+    await Test.executeInConsole("1 << 6");
+    await Test.checkPausedMessage("64");
+  }
+);

--- a/test/scripts/inspector-01.js
+++ b/test/scripts/inspector-01.js
@@ -1,7 +1,5 @@
 // Test basic inspector functionality: the inspector is able to
-// show contents when paused according to the child's current position.
-(async function () {
-  await Test.start();
+Test.describe(`show contents when paused according to the child's current position.`, async () => {
   await Test.selectInspector();
 
   let node;
@@ -22,6 +20,4 @@
 
   await Test.searchMarkup();
   await Test.waitForSelectedMarkupNode(`div id="div4" some-attribute="STUFF"`);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/inspector-02.js
+++ b/test/scripts/inspector-02.js
@@ -1,6 +1,4 @@
-// Test that the element highlighter works, and iframe behavior.
-(async function () {
-  await Test.start();
+Test.describe(`Test that the element highlighter works, and iframe behavior.`, async () => {
   // Events within the iframe should show up.
   await Test.addEventListenerLogpoints(["event.mouse.click"]);
   await Test.waitForMessage(
@@ -21,6 +19,4 @@
   const framepoint = await Test.getMarkupCanvasCoordinate("iframediv", ["myiframe"]);
   await Test.pickNode(framepoint.x, framepoint.y);
   await Test.waitForSelectedMarkupNode(`id="iframediv"`);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/inspector-03.js
+++ b/test/scripts/inspector-03.js
@@ -1,6 +1,4 @@
-// Test that styles for elements can be viewed.
-(async function () {
-  await Test.start();
+Test.describe(`Test that styles for elements can be viewed.`, async () => {
   await Test.selectInspector();
 
   let node;
@@ -19,6 +17,4 @@
   node = await Test.findMarkupNode("maindiv");
   await Test.selectMarkupNode(node);
   await Test.checkComputedStyle("background-color", "rgb(255, 0, 0)");
-
-  Test.finish();
-})();
+});

--- a/test/scripts/inspector-04.js
+++ b/test/scripts/inspector-04.js
@@ -1,132 +1,132 @@
-// Test the rule view.
-(async function () {
-  Test.start();
+Test.describe(`Test the rule view`, async () => {
   await Test.selectInspector();
 
-  let node;
+  Test.it(`Check rules for "maindiv" node`, async () => {
+    const node = await Test.findMarkupNode("maindiv");
+    await Test.selectMarkupNode(node);
+    await Test.checkAppliedRules([
+      {
+        selector: "div::first-letter",
+        source: "styles.css:26",
+        properties: [{ text: "color: teal;", overridden: false }],
+      },
+      {
+        selector: "element",
+        source: "inline",
+        properties: [{ text: "background-color: blue;", overridden: false }],
+      },
+      {
+        selector: "body div",
+        source: "styles.css:16",
+        properties: [
+          { text: "background-color: red;", overridden: true },
+          { text: "color: black !important;", overridden: false },
+        ],
+      },
+      {
+        selector: "div",
+        source: "styles.css:21",
+        properties: [
+          { text: "background-color: black;", overridden: true },
+          { text: "color: white !important;", overridden: true },
+        ],
+      },
+      {
+        selector: "body",
+        source: "styles.css:11",
+        properties: [{ text: "font-size: large;", overridden: false }],
+      },
+    ]);
+  });
 
-  node = await Test.findMarkupNode("maindiv");
-  await Test.selectMarkupNode(node);
-  await Test.checkAppliedRules([
-    {
-      selector: "div::first-letter",
-      source: "styles.css:26",
-      properties: [{ text: "color: teal;", overridden: false }],
-    },
-    {
-      selector: "element",
-      source: "inline",
-      properties: [{ text: "background-color: blue;", overridden: false }],
-    },
-    {
-      selector: "body div",
-      source: "styles.css:16",
-      properties: [
-        { text: "background-color: red;", overridden: true },
-        { text: "color: black !important;", overridden: false },
-      ],
-    },
-    {
-      selector: "div",
-      source: "styles.css:21",
-      properties: [
-        { text: "background-color: black;", overridden: true },
-        { text: "color: white !important;", overridden: true },
-      ],
-    },
-    {
-      selector: "body",
-      source: "styles.css:11",
-      properties: [{ text: "font-size: large;", overridden: false }],
-    },
-  ]);
+  Test.it(`Check rules for "conflict" node`, async () => {
+    const node = await Test.findMarkupNode("conflict");
+    await Test.selectMarkupNode(node);
+    await Test.checkAppliedRules([
+      {
+        selector: "div::first-letter",
+        source: "styles.css:26",
+        properties: [{ text: "color: teal;", overridden: false }],
+      },
+      { selector: "element", source: "inline", properties: [] },
+      {
+        selector: "#conflict",
+        source: "styles.css:6",
+        properties: [
+          { text: "background-color: gray;", overridden: false },
+          { text: "font-size: x-large;", overridden: false },
+        ],
+      },
+      {
+        selector: "#conflict",
+        source: "styles.css:2",
+        properties: [{ text: "background-color: blue;", overridden: true }],
+      },
+      {
+        selector: "body div",
+        source: "styles.css:16",
+        properties: [
+          { text: "background-color: red;", overridden: true },
+          { text: "color: black !important;", overridden: false },
+        ],
+      },
+      {
+        selector: "div",
+        source: "styles.css:21",
+        properties: [
+          { text: "background-color: black;", overridden: true },
+          { text: "color: white !important;", overridden: true },
+        ],
+      },
+      {
+        selector: "body",
+        source: "styles.css:11",
+        properties: [{ text: "font-size: large;", overridden: true }],
+      },
+    ]);
+  });
 
-  node = await Test.findMarkupNode("conflict");
-  await Test.selectMarkupNode(node);
-  await Test.checkAppliedRules([
-    {
-      selector: "div::first-letter",
-      source: "styles.css:26",
-      properties: [{ text: "color: teal;", overridden: false }],
-    },
-    { selector: "element", source: "inline", properties: [] },
-    {
-      selector: "#conflict",
-      source: "styles.css:6",
-      properties: [
-        { text: "background-color: gray;", overridden: false },
-        { text: "font-size: x-large;", overridden: false },
-      ],
-    },
-    {
-      selector: "#conflict",
-      source: "styles.css:2",
-      properties: [{ text: "background-color: blue;", overridden: true }],
-    },
-    {
-      selector: "body div",
-      source: "styles.css:16",
-      properties: [
-        { text: "background-color: red;", overridden: true },
-        { text: "color: black !important;", overridden: false },
-      ],
-    },
-    {
-      selector: "div",
-      source: "styles.css:21",
-      properties: [
-        { text: "background-color: black;", overridden: true },
-        { text: "color: white !important;", overridden: true },
-      ],
-    },
-    {
-      selector: "body",
-      source: "styles.css:11",
-      properties: [{ text: "font-size: large;", overridden: true }],
-    },
-  ]);
-
-  node = await Test.findMarkupNode("important");
-  await Test.selectMarkupNode(node);
-  await Test.checkAppliedRules([
-    {
-      selector: "div::first-letter",
-      source: "styles.css:26",
-      properties: [{ text: "color: teal;", overridden: false }],
-    },
-    { selector: "element", source: "inline", properties: [] },
-    {
-      selector: "#important",
-      source: "styles.css:34",
-      properties: [{ text: "background-color: black;", overridden: true }],
-    },
-    {
-      selector: "#important",
-      source: "styles.css:30",
-      properties: [{ text: "background-color: purple !important;", overridden: false }],
-    },
-    {
-      selector: "body div",
-      source: "styles.css:16",
-      properties: [
-        { text: "background-color: red;", overridden: true },
-        { text: "color: black !important;", overridden: false },
-      ],
-    },
-    {
-      selector: "div",
-      source: "styles.css:21",
-      properties: [
-        { text: "background-color: black;", overridden: true },
-        { text: "color: white !important;", overridden: true },
-      ],
-    },
-    {
-      selector: "body",
-      source: "styles.css:11",
-      properties: [{ text: "font-size: large;", overridden: false }],
-    },
-  ]);
-
-  Test.finish();
-})();
+  Test.it(`Check rules for "important" node`, async () => {
+    const node = await Test.findMarkupNode("important");
+    await Test.selectMarkupNode(node);
+    await Test.checkAppliedRules([
+      {
+        selector: "div::first-letter",
+        source: "styles.css:26",
+        properties: [{ text: "color: teal;", overridden: false }],
+      },
+      { selector: "element", source: "inline", properties: [] },
+      {
+        selector: "#important",
+        source: "styles.css:34",
+        properties: [{ text: "background-color: black;", overridden: true }],
+      },
+      {
+        selector: "#important",
+        source: "styles.css:30",
+        properties: [{ text: "background-color: purple !important;", overridden: false }],
+      },
+      {
+        selector: "body div",
+        source: "styles.css:16",
+        properties: [
+          { text: "background-color: red;", overridden: true },
+          { text: "color: black !important;", overridden: false },
+        ],
+      },
+      {
+        selector: "div",
+        source: "styles.css:21",
+        properties: [
+          { text: "background-color: black;", overridden: true },
+          { text: "color: white !important;", overridden: true },
+        ],
+      },
+      {
+        selector: "body",
+        source: "styles.css:11",
+        properties: [{ text: "font-size: large;", overridden: false }],
+      },
+    ]);
+  });
+});

--- a/test/scripts/inspector-05.js
+++ b/test/scripts/inspector-05.js
@@ -1,6 +1,4 @@
-// Test showing rules in source mapped style sheets.
-(async function () {
-  await Test.start();
+Test.describe(`Test showing rules in source mapped style sheets.`, async () => {
   await Test.selectInspector();
 
   const node = await Test.findMarkupNode("maindiv");
@@ -14,6 +12,4 @@
       properties: [{ text: "background-color: blue;", overridden: false }],
     },
   ]);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/logpoint-01.js
+++ b/test/scripts/logpoint-01.js
@@ -1,39 +1,38 @@
 // Test basic logpoint functionality. When logpoints are added,
-// new messages should appear in the correct order and allow time warping.
-(async function () {
-  await Test.start();
-  const { assert } = Test;
+Test.describe(
+  `new messages should appear in the correct order and allow time warping.`,
+  async () => {
+    const { assert } = Test;
 
-  await Test.selectSource("doc_rr_basic.html");
-  await Test.addBreakpoint("doc_rr_basic.html", 20);
-  await Test.setBreakpointOptions("doc_rr_basic.html", 20, undefined, {
-    logValue: `"Logpoint Number " + number`,
-  });
-  await Test.addBreakpoint("doc_rr_basic.html", 9, undefined, {
-    logValue: `"Logpoint Beginning"`,
-  });
-  await Test.addBreakpoint("doc_rr_basic.html", 7, undefined, {
-    logValue: `"Logpoint Ending"`,
-  });
+    await Test.selectSource("doc_rr_basic.html");
+    await Test.addBreakpoint("doc_rr_basic.html", 20);
+    await Test.setBreakpointOptions("doc_rr_basic.html", 20, undefined, {
+      logValue: `"Logpoint Number " + number`,
+    });
+    await Test.addBreakpoint("doc_rr_basic.html", 9, undefined, {
+      logValue: `"Logpoint Beginning"`,
+    });
+    await Test.addBreakpoint("doc_rr_basic.html", 7, undefined, {
+      logValue: `"Logpoint Ending"`,
+    });
 
-  await Test.selectConsole();
+    await Test.selectConsole();
 
-  const messages = await Test.waitForMessageCount("Logpoint", 12);
-  assert(!Test.findMessages("Loading").length);
+    const messages = await Test.waitForMessageCount("Logpoint", 12);
+    assert(!Test.findMessages("Loading").length);
 
-  assert(messages[0].textContent.includes("Beginning"));
-  for (let i = 1; i <= 10; i++) {
-    assert(messages[i].textContent.includes("Number " + i));
+    assert(messages[0].textContent.includes("Beginning"));
+    for (let i = 1; i <= 10; i++) {
+      assert(messages[i].textContent.includes("Number " + i));
+    }
+    assert(messages[11].textContent.includes("Ending"));
+
+    await Test.warpToMessage("Number 5");
+
+    await Test.checkEvaluateInTopFrame("number", 5);
+    await Test.reverseStepOverToLine(19);
+
+    // The logpoint acts like a breakpoint when resuming.
+    await Test.resumeToLine(20);
   }
-  assert(messages[11].textContent.includes("Ending"));
-
-  await Test.warpToMessage("Number 5");
-
-  await Test.checkEvaluateInTopFrame("number", 5);
-  await Test.reverseStepOverToLine(19);
-
-  // The logpoint acts like a breakpoint when resuming.
-  await Test.resumeToLine(20);
-
-  Test.finish();
-})();
+);

--- a/test/scripts/logpoint-02.js
+++ b/test/scripts/logpoint-02.js
@@ -1,7 +1,5 @@
 // Test that logpoints appear and disappear as expected as breakpoints are
-// modified. Also test that conditional logpoints work.
-(async function () {
-  await Test.start();
+Test.describe(`modified. Also test that conditional logpoints work.`, async () => {
   const { assert } = Test;
 
   await Test.selectSource("doc_rr_basic.html");
@@ -28,6 +26,4 @@
     condition: `number % 2 == 0`,
   });
   await Test.waitForMessageCount("Logpoint", 6);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/logpoint-03.js
+++ b/test/scripts/logpoint-03.js
@@ -1,6 +1,4 @@
-// Test event logpoints when replaying.
-(async function () {
-  await Test.start();
+Test.describe(`Test event logpoints when replaying.`, async () => {
   await Test.selectConsole();
   await Test.addEventListenerLogpoints(["event.mouse.click"]);
 
@@ -20,6 +18,4 @@
 
   // When expanded, other properties should be visible.
   await Test.checkMessageObjectContents(msg, ["altKey: false", "bubbles: true"]);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/logpoint-04.js
+++ b/test/scripts/logpoint-04.js
@@ -1,6 +1,4 @@
-// Test exception logpoints.
-(async function () {
-  await Test.start();
+Test.describe(`Test exception logpoints.`, async () => {
   await Test.toggleExceptionLogging();
   await Test.selectConsole();
 
@@ -12,6 +10,4 @@
 
   await Test.reverseStepOverToLine(15);
   await Test.waitForFrameTimeline("0%");
-
-  Test.finish();
-})();
+});

--- a/test/scripts/object_preview-01.js
+++ b/test/scripts/object_preview-01.js
@@ -1,7 +1,5 @@
 // Test the objects produced by console.log() calls and by evaluating various
-// expressions in the console after time warping.
-(async function () {
-  await Test.start();
+Test.describe(`expressions in the console after time warping.`, async () => {
   await Test.selectConsole();
 
   await Test.waitForMessage("Array(20) [ 0, 1, 2, 3, 4, 5,");
@@ -77,6 +75,4 @@ f();
   await Test.executeInConsole("baz");
   msg = await Test.waitForMessage("function baz()");
   Test.checkJumpIcon(msg);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/object_preview-02.js
+++ b/test/scripts/object_preview-02.js
@@ -1,12 +1,8 @@
-// Test that objects show up correctly in the scope pane.
-(async function () {
-  await Test.start();
+Test.describe(`Test that objects show up correctly in the scope pane.`, async () => {
   await Test.warpToMessage("Done");
 
   // We should be able to expand the window and see its properties.
   await Test.toggleScopeNode("<this>");
   await Test.findScopeNode("bar()");
   await Test.findScopeNode("baz()");
-
-  Test.finish();
-})();
+});

--- a/test/scripts/object_preview-03.js
+++ b/test/scripts/object_preview-03.js
@@ -1,6 +1,4 @@
-// Test previews when switching between frames and stepping.
-(async function () {
-  await Test.start();
+Test.describe(`Test previews when switching between frames and stepping.`, async () => {
   await Test.addBreakpoint("doc_rr_preview.html", 17);
   await Test.rewindToLine(17);
 
@@ -52,6 +50,4 @@
 
   await Test.selectFrame(2);
   await Test.waitForFrameTimeline("66%");
-
-  Test.finish();
-})();
+});

--- a/test/scripts/object_preview-05.js
+++ b/test/scripts/object_preview-05.js
@@ -1,6 +1,4 @@
-// Test scope mapping and switching between generated/original sources.
-(async function () {
-  await Test.start();
+Test.describe(`Test scope mapping and switching between generated/original sources.`, async () => {
   await Test.addBreakpoint("bundle_input.js", 15, undefined, {
     logValue: "barobj.barprop1 * 10",
   });
@@ -17,6 +15,4 @@
   await Test.waitForPausedLine(57);
   await Test.waitForScopeValue("n", "Array(3) […]");
   await Test.waitForScopeValue("e", "{…}");
-
-  Test.finish();
-})();
+});

--- a/test/scripts/stepping-01.js
+++ b/test/scripts/stepping-01.js
@@ -1,6 +1,4 @@
-// Test basic step-over/back functionality.
-(async function () {
-  await Test.start();
+Test.describe(`Test basic step-over/back functionality.`, async () => {
   await Test.addBreakpoint("doc_rr_basic.html", 20);
 
   await Test.rewindToLine(20);
@@ -10,6 +8,4 @@
   await Test.checkEvaluateInTopFrame("dump(3)", `"Error: Evaluation failed"`);
   await Test.stepOverToLine(20);
   await Test.checkEvaluateInTopFrame("number", 10);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/stepping-02.js
+++ b/test/scripts/stepping-02.js
@@ -1,6 +1,4 @@
-// Test fixes for some simple stepping bugs.
-(async function () {
-  await Test.start();
+Test.describe(`Test fixes for some simple stepping bugs.`, async () => {
   await Test.addBreakpoint("doc_rr_basic.html", 21);
 
   await Test.rewindToLine(21);
@@ -20,6 +18,4 @@
   await Test.stepOutToLine(26);
   await Test.reverseStepOverToLine(25);
   await Test.reverseStepOverToLine(24);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/stepping-03.js
+++ b/test/scripts/stepping-03.js
@@ -1,27 +1,26 @@
-// Stepping past the beginning or end of a frame should act like a step-out.
-(async function () {
-  await Test.start();
-  await Test.addBreakpoint("doc_rr_basic.html", 20);
-  await Test.rewindToLine(20);
-  await Test.checkEvaluateInTopFrame("number", 10);
-  await Test.reverseStepOverToLine(19);
-  await Test.reverseStepOverToLine(11);
+Test.describe(
+  `Stepping past the beginning or end of a frame should act like a step-out.`,
+  async () => {
+    await Test.addBreakpoint("doc_rr_basic.html", 20);
+    await Test.rewindToLine(20);
+    await Test.checkEvaluateInTopFrame("number", 10);
+    await Test.reverseStepOverToLine(19);
+    await Test.reverseStepOverToLine(11);
 
-  // After reverse-stepping out of the topmost frame we should rewind to the
-  // last breakpoint hit.
-  await Test.reverseStepOverToLine(20);
-  await Test.checkEvaluateInTopFrame("number", 9);
+    // After reverse-stepping out of the topmost frame we should rewind to the
+    // last breakpoint hit.
+    await Test.reverseStepOverToLine(20);
+    await Test.checkEvaluateInTopFrame("number", 9);
 
-  await Test.stepOverToLine(21);
-  await Test.stepOverToLine(22);
-  await Test.stepOverToLine(12);
-  await Test.stepOverToLine(16);
-  await Test.stepOverToLine(17);
+    await Test.stepOverToLine(21);
+    await Test.stepOverToLine(22);
+    await Test.stepOverToLine(12);
+    await Test.stepOverToLine(16);
+    await Test.stepOverToLine(17);
 
-  // After forward-stepping out of the topmost frame we should run forward to
-  // the next breakpoint hit.
-  await Test.stepOverToLine(20);
-  await Test.checkEvaluateInTopFrame("number", 10);
-
-  Test.finish();
-})();
+    // After forward-stepping out of the topmost frame we should run forward to
+    // the next breakpoint hit.
+    await Test.stepOverToLine(20);
+    await Test.checkEvaluateInTopFrame("number", 10);
+  }
+);

--- a/test/scripts/stepping-04.js
+++ b/test/scripts/stepping-04.js
@@ -1,6 +1,4 @@
-// Test stepping in blackboxed sources.
-(async function () {
-  await Test.start();
+Test.describe(`Test stepping in blackboxed sources.`, async () => {
   // Stepping forward while in a blackboxed source should act like a step out.
   await Test.addBreakpoint("blackbox.js", 3);
   await Test.rewindToLine(3);
@@ -27,6 +25,4 @@
   // to the non-blackboxed caller.
   await Test.rewindToLine(17);
   await Test.reverseStepOverToLine(15);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/stepping-05.js
+++ b/test/scripts/stepping-05.js
@@ -1,6 +1,4 @@
-// Test stepping in pretty-printed code.
-(async function () {
-  await Test.start();
+Test.describe(`Test stepping in pretty-printed code.`, async () => {
   await Test.addBreakpoint("bundle_input.js", 4);
   await Test.rewindToLine(4);
   await Test.stepInToLine(1);
@@ -22,6 +20,4 @@
   await Test.stepOutToLine(15);
   await Test.stepInToLine(5);
   await Test.stepOutToLine(15);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/stepping-06.js
+++ b/test/scripts/stepping-06.js
@@ -1,6 +1,4 @@
-// Test stepping in async frames and async call stacks.
-(async function () {
-  await Test.start();
+Test.describe(`Test stepping in async frames and async call stacks.`, async () => {
   await Test.warpToMessage("baz 2");
 
   await Test.checkFrames(5);
@@ -35,6 +33,4 @@
   await Test.checkEvaluateInTopFrame("n", 4);
   await Test.stepOutToLine(13);
   await Test.reverseStepOverToLine(12);
-
-  Test.finish();
-})();
+});

--- a/test/scripts/worker-01.js
+++ b/test/scripts/worker-01.js
@@ -1,9 +1,5 @@
 // Test that workers function when recording/replaying. For now workers can't
-// be inspected, so we're making sure that nothing crashes.
-(async function () {
-  await Test.start();
+Test.describe(`be inspected, so we're making sure that nothing crashes.`, async () => {
   await Test.addBreakpoint("doc_rr_worker.html", 15);
   await Test.rewindToLine(15);
-
-  Test.finish();
-})();
+});


### PR DESCRIPTION
Yesterday, @karina-y and I were discussing our tests and how it would be nice if they were more self-documenting. Also, @loganfsmyth and I were pairing on a fix to the harness where we had to add a `Test.start()` to every test. This got me thinking that the test suite might benefit from a bit more abstraction:

```js
Test.describe(`Test breakpoint hits`, async () => {
   // some setup
  Test.it("check adding a breakpoint on an empty line", async () => {
    // do some stuff
  })

  Test.it("check adding a breakpoint on a line with two breakable positions", async () => {
    // do some stuff
  })
});
```

under the hood, describe and it are very simple wrappers, so this shouldn't add too much misdirection