### PR TITLE
Make sure that the test harness only listens to the current tab.

### DIFF
--- a/test/header.js
+++ b/test/header.js
@@ -143,7 +143,17 @@ function waitForMessage(msg) {
   log(`WaitingForMessage ${msg}`);
   const { resolve, promise } = defer();
   const listener = {
-    receiveMessage() {
+    receiveMessage(evt) {
+      const { remoteTab } = window.gBrowser.selectedBrowser.frameLoader;
+
+      // Test fixtures load into a process before the record button is
+      // pressed, so we need to make sure that the message we are listening
+      // for actually came from the current tab, and not the initial page-load
+      // process that is not being recorded.
+      if (!remoteTab || evt.target.osPid != remoteTab.osPid) {
+        return;
+      }
+
       resolve();
       Services.ppmm.removeMessageListener(msg, listener);
     },


### PR DESCRIPTION
I think this is the source of the issue. Otherwise we end up with the following issue:

1. Parent process loads test harness
2. Test URL loads with code that triggers an async message
3. Test harness presses the record button
4. The message from the non-recording page arrives, causing the test harness to think the test finished
5. Test harness stops recording

So because the message from the non-recorded tab would come first, we'd end up with a race between the recording stopping and the recording page finishing loading. So we weren't even guaranteed to record the test that succeeded!