### PR TITLE
Fix last broken test.

### DIFF
--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -197,11 +197,7 @@ function getVisibleSelectedFrameLine() {
 }
 
 async function waitForPausedLine(line) {
-  const pauseLine = await waitUntil(() => {
-    const pauseLine = getVisibleSelectedFrameLine();
-    return pauseLine == line ? line : false;
-  });
-  assert(pauseLine == line, `Expected line ${line} got ${pauseLine}`);
+  await waitUntil(() => line == getVisibleSelectedFrameLine());
 }
 
 function resumeThenPauseAtLineFunctionFactory(method) {

--- a/test/harness.js
+++ b/test/harness.js
@@ -21,7 +21,7 @@ const recordViewer = env.get("RECORD_REPLAY_DONT_RECORD_VIEWER") == "false";
     clickRecordingButton();
     dump(`TestHarnessExampleRecordingTabFinished\n`);
   } else {
-    dump(`TestHarnessRetrievingExampleFromRecordings`);
+    dump(`TestHarnessRetrievingExampleFromRecordings\n`);
   }
 
   await waitForDevtools();


### PR DESCRIPTION
This was broken in #1158

The function as it stands now will never resolve if `line === undefined`, which it is in `breakpoints-03.js`.

I deleted the assertion as well because it can never fail with the function written as-is, because `waitUntil` throws if the function never returns true, and the only time it returns truthy is when it returns `line`, so the assertion is guaranteed to pass.