### PR TITLE
Console eval

### DIFF
--- a/src/devtools/client/webconsole/actions/input.js
+++ b/src/devtools/client/webconsole/actions/input.js
@@ -100,6 +100,7 @@ function onExpressionEvaluated(response) {
     }
 
     dispatch(messagesActions.messagesAdd([response]));
+
     return;
   };
 }

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -5,6 +5,7 @@
 "use strict";
 
 const { Component, createFactory, createElement } = require("react");
+const React  = require("react");
 const dom = require("react-dom-factories");
 const { l10n } = require("devtools/client/webconsole/utils/messages");
 const actions = require("devtools/client/webconsole/actions/index");

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -5,7 +5,6 @@
 "use strict";
 
 const { Component, createFactory, createElement } = require("react");
-const React  = require("react");
 const dom = require("react-dom-factories");
 const { l10n } = require("devtools/client/webconsole/utils/messages");
 const actions = require("devtools/client/webconsole/actions/index");

--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -1068,14 +1068,8 @@ function getDefaultFiltersCounter() {
 
 //get the point for the corresponding command, regardless of where we're currently paused
 function getPausePoint(newMessage, state) {
-  if (
-    newMessage.type === constants.MESSAGE_TYPE.RESULT &&
-    newMessage.parameters &&
-    newMessage.parameters.length > 0 &&
-    newMessage.parameters[0]._pause &&
-    newMessage.parameters[0]._pause.point
-  ) {
-    return newMessage.parameters[0]._pause.point;
+  if (newMessage.type === constants.MESSAGE_TYPE.RESULT && newMessage.parameters[0]) {
+    return newMessage.parameters[0].getExecutionPoint();
   } else {
     return state.pausedExecutionPoint;
   }

--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -1099,7 +1099,6 @@ function ensureExecutionPoint(state, newMessage) {
     const lastMessage = getLastMessageWithPoint(state, point);
     if (lastMessage.lastExecutionPoint) {
       messageCount = lastMessage.lastExecutionPoint.messageCount + 1;
-      console.log("messageCount", messageCount)
     }
   } else if (state.visibleMessages.length) {
     const lastId = state.visibleMessages[state.visibleMessages.length - 1];

--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -1069,7 +1069,7 @@ function getDefaultFiltersCounter() {
 //get the point for the corresponding command, regardless of where we're currently paused
 function getPausePoint(newMessage, state) {
   if (newMessage.type === constants.MESSAGE_TYPE.RESULT && newMessage.parameters[0]) {
-    return newMessage.parameters[0].getExecutionPoint();
+    return newMessage.parameters[0].getExecutionPoint() || state.pausedExecutionPoint;
   } else {
     return state.pausedExecutionPoint;
   }
@@ -1121,7 +1121,11 @@ function getLastMessageWithPoint(state, point) {
   // value as the given point.
   const filteredMessageId = state.visibleMessages.filter(function (p) {
     const currentMessage = state.messagesById.get(p);
-    if (currentMessage.executionPoint) {
+
+    if (!point) {
+      console.log("khjlkh", point)
+    }
+    if (currentMessage.executionPoint || !point) {
       return false;
     }
 

--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -1066,6 +1066,19 @@ function getDefaultFiltersCounter() {
   return count;
 }
 
+//get the point for the corresponding command, regardless of where we're currently paused
+function getPausePoint(newMessage, state) {
+  if (
+    newMessage.type === constants.MESSAGE_TYPE.RESULT &&
+    newMessage.parameters &&
+    newMessage.parameters.length > 0
+  ) {
+    return newMessage.parameters[0]._pause.point;
+  } else {
+    return state.pausedExecutionPoint;
+  }
+}
+
 // Make sure that message has an execution point which can be used for sorting
 // if other messages with real execution points appear later.
 function ensureExecutionPoint(state, newMessage) {
@@ -1081,11 +1094,12 @@ function ensureExecutionPoint(state, newMessage) {
     time = 0,
     messageCount = 1;
   if (state.pausedExecutionPoint) {
-    point = state.pausedExecutionPoint;
+    point = getPausePoint(newMessage, state);
     time = state.pausedExecutionPointTime;
     const lastMessage = getLastMessageWithPoint(state, point);
     if (lastMessage.lastExecutionPoint) {
       messageCount = lastMessage.lastExecutionPoint.messageCount + 1;
+      console.log("messageCount", messageCount)
     }
   } else if (state.visibleMessages.length) {
     const lastId = state.visibleMessages[state.visibleMessages.length - 1];
@@ -1144,7 +1158,7 @@ function messageCountSinceLastExecutionPoint(state, id) {
  * @param {Boolean} timeStampSort: set to true to sort messages by their timestamps.
  */
 function maybeSortVisibleMessages(state, sortWarningGroupMessage = false, timeStampSort = false) {
-  // When using log points while replaying, messages can be added out of order
+  // When using log points while replaying, messages can be added out of order˜
   // with respect to how they originally executed. Use the execution point
   // information in the messages to sort visible messages according to how
   // they originally executed. This isn't necessary if we haven't seen any

--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -1122,10 +1122,7 @@ function getLastMessageWithPoint(state, point) {
   const filteredMessageId = state.visibleMessages.filter(function (p) {
     const currentMessage = state.messagesById.get(p);
 
-    if (!point) {
-      console.log("khjlkh", point)
-    }
-    if (currentMessage.executionPoint || !point) {
+    if (currentMessage.executionPoint) {
       return false;
     }
 

--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -1071,7 +1071,9 @@ function getPausePoint(newMessage, state) {
   if (
     newMessage.type === constants.MESSAGE_TYPE.RESULT &&
     newMessage.parameters &&
-    newMessage.parameters.length > 0
+    newMessage.parameters.length > 0 &&
+    newMessage.parameters[0]._pause &&
+    newMessage.parameters[0]._pause.point
   ) {
     return newMessage.parameters[0]._pause.point;
   } else {

--- a/src/protocol/thread/value.ts
+++ b/src/protocol/thread/value.ts
@@ -61,6 +61,10 @@ export class ValueFront {
     }
   }
 
+  getExecutionPoint() {
+    return this._pause?.point;
+  }
+
   getPause() {
     return this._pause;
   }


### PR DESCRIPTION
fixes issue #1143 
instead of placing the evaluation results at the last pause point, we check if the type is of 'result' and if so it gets placed under its command