### PR TITLE
display the shorthand CSS properties in the rules view

### DIFF
--- a/src/devtools/client/inspector/rules/models/rule.ts
+++ b/src/devtools/client/inspector/rules/models/rule.ts
@@ -10,6 +10,7 @@ import { StyleFront } from "protocol/thread/style";
 import { assert } from "protocol/utils";
 import { UIStore } from "ui/actions";
 import CSSProperties from "../../css-properties";
+import { parseNamedDeclarations } from "devtools/shared/css/parsing-utils";
 import { Inspector } from "../../inspector";
 import ElementStyle from "./element-style";
 const Services = require("Services");
@@ -645,7 +646,11 @@ export default class Rule {
     const store = this.elementStyle.store;
 
     assert(this.domRule.style);
-    for (const prop of this.domRule.style.properties) {
+    const properties = parseNamedDeclarations(
+      this.cssProperties.isKnown,
+      this.domRule.style.cssText
+    );
+    for (const prop of properties) {
       const name = prop.name;
       // In an inherited rule, we only show inherited properties.
       // However, we must keep all properties in order for rule
@@ -658,7 +663,7 @@ export default class Rule {
         this,
         name,
         value,
-        prop.important ? "important" : undefined,
+        prop.priority ? "important" : undefined,
         !("commentOffsets" in prop),
         invisible
       );

--- a/src/devtools/client/themes/rules.css
+++ b/src/devtools/client/themes/rules.css
@@ -476,7 +476,6 @@
 }
 
 .ruleview-overridden-items {
-  margin-inline-start: -25px;
   list-style: none;
   line-height: 1.5em;
 }

--- a/src/devtools/shared/css/parsing-utils.d.ts
+++ b/src/devtools/shared/css/parsing-utils.d.ts
@@ -1,0 +1,15 @@
+export interface ParsedCSSDeclaration {
+  name: string;
+  value: string;
+  priority: "" | "important";
+  terminator: string;
+  offsets: [start: number, end: number];
+  colonOffsets: [start: number, end: number];
+  commentOffsets?: [start: number, end: number];
+}
+
+export function parseNamedDeclarations(
+  isCssPropertyKnown: (cssProperty: string) => boolean,
+  inputString: string,
+  parseComments?: boolean
+): ParsedCSSDeclaration[];

--- a/src/protocol/thread/style.ts
+++ b/src/protocol/thread/style.ts
@@ -45,6 +45,10 @@ export class StyleFront {
   get type() {
     return ELEMENT_STYLE;
   }
+
+  get cssText() {
+    return this._style.cssText;
+  }
 }
 
 Object.setPrototypeOf(StyleFront.prototype, new Proxy({}, DisallowEverythingProxyHandler));

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -506,15 +506,31 @@ async function checkComputedStyle(style, value) {
   });
 }
 
+function setLonghandsExpanded(expanded) {
+  document.querySelectorAll(".ruleview-expander").forEach(expander => {
+    if (expander.style.display !== "none" && expander.classList.contains("open") !== expanded) {
+      expander.click();
+    }
+  });
+}
+
 function getAppliedRulesJSON() {
   const rules = document.querySelectorAll(".ruleview-rule");
   return [...rules].map(rule => {
     const selector = rule.querySelector(".ruleview-selectorcontainer").innerText.trim();
     const source = rule.querySelector(".ruleview-rule-source").innerText.trim();
-    const properties = [...rule.querySelectorAll(".ruleview-property")].map(prop => {
+    const properties = [...rule.querySelectorAll(".ruleview-propertycontainer")].map(prop => {
+      let longhandProps;
+      if (prop.nextSibling) {
+        longhandProps = [...prop.nextSibling.querySelectorAll("li")].map(longhand => ({
+          text: longhand.innerText,
+          overridden: longhand.classList.contains("ruleview-overridden"),
+        }));
+      }
       return {
         text: prop.innerText.trim(),
-        overridden: prop.className.includes("overridden"),
+        overridden: prop.parentNode.className.includes("overridden"),
+        longhandProps,
       };
     });
     return { selector, source, properties };
@@ -595,6 +611,7 @@ const testCommands = {
   pickNode,
   selectMarkupNode,
   checkComputedStyle,
+  setLonghandsExpanded,
   getAppliedRulesJSON,
   checkAppliedRules,
 };

--- a/test/examples/doc_inspector_shorthand.html
+++ b/test/examples/doc_inspector_shorthand.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+  <link rel="stylesheet" href="shorthand_styles.css">
+</head>
+<body>
+  <div id="first" class="parent">
+    Foo
+    <div class="child">
+      Bar
+    </div>
+  </div>
+  <div class="parent" style="font-family: serif; font-variant: normal; margin: unset;">
+    Foo
+    <div class="child" style="font-size: inherit; font-family: unset; font-weight: initial;">
+      Bar
+    </div>
+  </div>
+</body>
+<script>
+  function recordingFinished() {
+    dump(`RecReplaySendAsyncMessage Example__Finished`);
+  }
+  window.setTimeout(recordingFinished);
+</script>
+</html>

--- a/test/examples/shorthand_styles.css
+++ b/test/examples/shorthand_styles.css
@@ -1,0 +1,9 @@
+.parent {
+  margin-left: 10px;
+  font: italic small-caps bold 24px courier;
+}
+
+.child {
+  font-size: 20px;
+  font-family: sans-serif;
+}

--- a/test/manifest.json
+++ b/test/manifest.json
@@ -29,5 +29,6 @@
   ["inspector-02.js", "doc_inspector_basic.html"],
   ["inspector-03.js", "doc_inspector_styles.html"],
   ["inspector-04.js", "doc_inspector_styles.html"],
-  ["inspector-05.js", "doc_inspector_sourcemapped.html"]
+  ["inspector-05.js", "doc_inspector_sourcemapped.html"],
+  ["inspector-06.js", "doc_inspector_shorthand.html"]
 ]

--- a/test/scripts/inspector-06.js
+++ b/test/scripts/inspector-06.js
@@ -1,0 +1,55 @@
+Test.describe(`Test showing both longhand and shorthand properties in rules.`, async () => {
+  await Test.selectInspector();
+
+  const node = await Test.findMarkupNode('<div id="first" class="parent">');
+  await Test.selectMarkupNode(node);
+
+  await Test.checkAppliedRules([
+    { selector: "element", source: "inline", properties: [] },
+    {
+      selector: ".parent",
+      source: "shorthand_styles.css:1",
+      properties: [
+        { text: "margin-left: 10px;", overridden: false },
+        { text: "font: italic small-caps bold 24px courier;", overridden: false },
+      ],
+    },
+  ]);
+
+  Test.setLonghandsExpanded(true);
+
+  await Test.checkAppliedRules([
+    { selector: "element", source: "inline", properties: [] },
+    {
+      selector: ".parent",
+      source: "shorthand_styles.css:1",
+      properties: [
+        { text: "margin-left: 10px;", overridden: false },
+        {
+          text: "font: italic small-caps bold 24px courier;",
+          overridden: false,
+          longhandProps: [
+            { text: "font-style: italic;", overridden: false },
+            { text: "font-variant-caps: small-caps;", overridden: false },
+            { text: "font-weight: bold;", overridden: false },
+            { text: "font-stretch: normal;", overridden: false },
+            { text: "font-size: 24px;", overridden: false },
+            { text: "line-height: normal;", overridden: false },
+            { text: "font-family: courier;", overridden: false },
+            { text: "font-size-adjust: none;", overridden: false },
+            { text: "font-kerning: auto;", overridden: false },
+            { text: "font-optical-sizing: auto;", overridden: false },
+            { text: "font-variant-alternates: normal;", overridden: false },
+            { text: "font-variant-east-asian: normal;", overridden: false },
+            { text: "font-variant-ligatures: normal;", overridden: false },
+            { text: "font-variant-numeric: normal;", overridden: false },
+            { text: "font-variant-position: normal;", overridden: false },
+            { text: "font-language-override: normal;", overridden: false },
+            { text: "font-feature-settings: normal;", overridden: false },
+            { text: "font-variation-settings: normal;", overridden: false },
+          ],
+        },
+      ],
+    },
+  ]);
+});


### PR DESCRIPTION
This was a lot easier than expected because all the necessary functionality was already there, we just need to use it.