### PR TITLE
Use function name as logpoint expression

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/index.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/index.js
@@ -14,7 +14,9 @@ import {
   getSelectedSource,
   getBreakpointAtLocation,
   getBreakpointsForSource,
+  getSymbols,
 } from "../../selectors";
+import { findClosestEnclosedSymbol } from "../../utils/ast";
 import {
   addBreakpoint,
   removeBreakpoint,
@@ -176,6 +178,7 @@ export function addBreakpointAtLine(cx, line, shouldLog = false, disabled = fals
     if (!source) {
       return;
     }
+
     const breakpointLocation = {
       sourceId: source.id,
       sourceUrl: source.url,
@@ -185,7 +188,9 @@ export function addBreakpointAtLine(cx, line, shouldLog = false, disabled = fals
 
     const options = {};
     const file = source.url.split("/").pop();
-    options.logValue = `"${file}:${line}"`;
+    const symbols = getSymbols(state, source);
+    const closestSymbol = findClosestEnclosedSymbol(symbols, { line });
+    options.logValue = closestSymbol ? `"${closestSymbol.name}"` : `"${file}:${line}"`;
 
     return dispatch(addBreakpoint(cx, breakpointLocation, options, disabled));
   };
@@ -209,7 +214,9 @@ export function addBreakpointAtColumn(cx, location) {
 
     const options = {};
     const file = source.url.split("/").pop();
-    options.logValue = `"${file}:${line}:${column}"`;
+    const symbols = getSymbols(state, source);
+    const closestSymbol = findClosestEnclosedSymbol(symbols, location);
+    options.logValue = closestSymbol ? `"${closestSymbol.name}"` : `"${file}:${line}:${column}"`;
 
     return dispatch(addBreakpoint(cx, breakpointLocation, options));
   };

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
@@ -10,7 +10,7 @@ import { connect } from "../../utils/connect";
 import { score as fuzzaldrinScore } from "fuzzaldrin-plus";
 const classnames = require("classnames");
 
-import { containsPosition, positionAfter } from "../../utils/ast";
+import { findClosestEnclosedSymbol } from "../../utils/ast";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { findFunctionText } from "../../utils/function";
 import { getTruncatedFileName } from "../../utils/source";
@@ -86,26 +86,7 @@ export class Outline extends Component {
 
   setFocus(cursorPosition) {
     const { symbols } = this.props;
-    let classes = [];
-    let functions = [];
-
-    if (symbols && !symbols.loading) {
-      ({ classes, functions } = symbols);
-    }
-
-    // Find items that enclose the selected location
-    const enclosedItems = [...functions, ...classes].filter(
-      item => item.name != "anonymous" && containsPosition(item.location, cursorPosition)
-    );
-
-    if (enclosedItems.length == 0) {
-      return this.setState({ focusedItem: null });
-    }
-
-    // Find the closest item to the selected location to focus
-    const closestItem = enclosedItems.reduce((item, closest) =>
-      positionAfter(item.location, closest.location) ? item : closest
-    );
+    const closestItem = findClosestEnclosedSymbol(symbols, cursorPosition);
 
     this.setState({ focusedItem: closestItem });
   }

--- a/src/devtools/client/debugger/src/utils/ast.js
+++ b/src/devtools/client/debugger/src/utils/ast.js
@@ -50,6 +50,7 @@ function findClosestofSymbol(declarations, location) {
   }
 
   return declarations.reduce((found, currNode) => {
+    // Find a symbol that encloses the location
     if (
       currNode.name === "anonymous" ||
       !containsPosition(currNode.location, {
@@ -64,6 +65,7 @@ function findClosestofSymbol(declarations, location) {
       return currNode;
     }
 
+    // If two symbols enclose the location, get the closer symbol
     if (found.location.start.line > currNode.location.start.line) {
       return found;
     }
@@ -92,4 +94,15 @@ export function findClosestClass(symbols, location) {
   }
 
   return findClosestofSymbol(symbols.classes, location);
+}
+
+export function findClosestEnclosedSymbol(symbols, location) {
+  let classes = [];
+  let functions = [];
+
+  if (symbols && !symbols.loading) {
+    ({ classes, functions } = symbols);
+  }
+
+  return findClosestofSymbol([...functions, ...classes], location);
 }


### PR DESCRIPTION
Close #1009

LogValue is using function name as an expression if I add a breakpoint or a column breakpoint within a function.
<img width="614" alt="Screen Shot 2020-12-10 at 8 29 44 AM" src="https://user-images.githubusercontent.com/38041280/101706198-918e7c00-3ac3-11eb-8e81-3e460b802fa4.png">

<img width="601" alt="Screen Shot 2020-12-10 at 8 29 53 AM" src="https://user-images.githubusercontent.com/38041280/101706226-a10dc500-3ac3-11eb-97f6-f72bcaf8bd4b.png">
