### PR TITLE
fix node scroll bug in tree component

### DIFF
--- a/src/devtools/client/debugger/packages/devtools-components/src/tree.js
+++ b/src/devtools/client/debugger/packages/devtools-components/src/tree.js
@@ -753,7 +753,7 @@ class Tree extends Component {
           return closestScrolledParent(node.parentNode);
         };
 
-        const scrolledParentRect = treeElement ? treeElement.getBoundingClientRect() : null;
+        const scrolledParentRect = treeElement?.getBoundingClientRect();
         const isVisible =
           !treeElement || (top >= scrolledParentRect.top && bottom <= scrolledParentRect.bottom);
 

--- a/src/devtools/client/debugger/packages/devtools-components/src/tree.js
+++ b/src/devtools/client/debugger/packages/devtools-components/src/tree.js
@@ -752,10 +752,10 @@ class Tree extends Component {
           }
           return closestScrolledParent(node.parentNode);
         };
-        const scrolledParent = closestScrolledParent(treeElement);
-        const scrolledParentRect = scrolledParent ? scrolledParent.getBoundingClientRect() : null;
+
+        const scrolledParentRect = treeElement ? treeElement.getBoundingClientRect() : null;
         const isVisible =
-          !scrolledParent || (top >= scrolledParentRect.top && bottom <= scrolledParentRect.bottom);
+          !treeElement || (top >= scrolledParentRect.top && bottom <= scrolledParentRect.bottom);
 
         if (!isVisible) {
           const { alignTo } = options;


### PR DESCRIPTION
fixes #1173 bug
we were checking if the parent of the source node was in view, now checking if the source node is in view of the tree pane