### PR TITLE
checking messages exist

### DIFF
--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -370,7 +370,7 @@ function messages(state = MessageState(), action) {
       const currMessage = messagesById.get(action.id);
 
       // If the message is a console.group/groupCollapsed or a warning group.
-      if (isGroupType(currMessage.type) || isWarningGroup(currMessage)) {
+      if (currMessage && (isGroupType(currMessage.type) || isWarningGroup(currMessage))) {
         // We want to make its children visible
         const messagesToShow = [...messagesById].reduce((res, [id, message]) => {
           if (


### PR DESCRIPTION
fixes issue #1129 
when removing all console messages we'd get an error that none exist, now checking they exist before running code related to messages