### PR TITLE
Pause line

### DIFF
--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
@@ -52,6 +52,8 @@ function getClosestMessage(visibleMessages, messages, executionPoint) {
     const point = messageExecutionPoint(msg);
     if (point && pointPrecedes(executionPoint, point)) {
       break;
+    } else if (point === executionPoint && msg.type === MESSAGE_TYPE.LOG_POINT) {
+      last = msg;
     }
     last = msg;
   }

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
@@ -55,7 +55,6 @@ function getClosestMessage(visibleMessages, messages, executionPoint) {
     } else if (point === executionPoint && msg.type === MESSAGE_TYPE.LOG_POINT) {
       last = msg;
     }
-    last = msg;
   }
 
   return last;

--- a/src/devtools/client/webconsole/constants.js
+++ b/src/devtools/client/webconsole/constants.js
@@ -159,6 +159,7 @@ const chromeRDPEnums = {
     // output anything (e.g. `console.time()` calls).
     NULL_MESSAGE: "nullMessage",
     NAVIGATION_MARKER: "navigationMarker",
+    LOG_POINT: "logPoint",
   },
   MESSAGE_LEVEL: {
     LOG: "log",


### PR DESCRIPTION
fixes issue #1175 
purple pause line in the console panel now sticks with the breakpoints, not evaluations