### PR TITLE
Reveal sources

### DIFF
--- a/src/devtools/client/debugger/src/actions/ui.js
+++ b/src/devtools/client/debugger/src/actions/ui.js
@@ -7,7 +7,7 @@
 import {
   getActiveSearch,
   getPaneCollapse,
-  getSourcesCollapse,
+  getSourcesCollapsed,
   getQuickOpenEnabled,
   getSource,
   getSourceContent,
@@ -16,6 +16,7 @@ import {
   getSelectedLocation,
   getContext,
 } from "../selectors";
+import { getSelectedPrimaryPanel } from "ui/reducers/app";
 import { selectSource, selectLocation } from "../actions/sources/select";
 import { getEditor, getLocationsInViewport } from "../utils/editor";
 import { searchContents } from "./file-search";
@@ -24,8 +25,6 @@ import { isFulfilled } from "../utils/async-value";
 
 import { getCodeMirror } from "devtools/client/debugger/src/utils/editor";
 import { resizeBreakpointGutter } from "../utils/ui";
-import { prefs } from "../utils/prefs";
-import { getSelectedPrimaryPanel } from "../../../../../ui/reducers/app";
 
 export function setPrimaryPaneTab(tabName) {
   return { type: "SET_PRIMARY_PANE_TAB", tabName };
@@ -83,7 +82,7 @@ export function showSource(cx, sourceId) {
       return;
     }
 
-    //is the toolbar panel open?
+    // Is the toolbar panel open?
     if (getPaneCollapse(getState())) {
       dispatch({
         type: "TOGGLE_PANE",
@@ -91,7 +90,7 @@ export function showSource(cx, sourceId) {
       });
     }
 
-    //is the sources panel selected?
+    // Is the sources panel selected?
     if (getSelectedPrimaryPanel(getState()) !== "explorer") {
       dispatch({
         type: "set_selected_primary_panel",
@@ -99,8 +98,8 @@ export function showSource(cx, sourceId) {
       });
     }
 
-    //is the sources panel collapsed?
-    if (getSourcesCollapse(getState())) {
+    // Is the sources panel collapsed?
+    if (getSourcesCollapsed(getState())) {
       dispatch({
         type: "TOGGLE_SOURCES",
         sourcesCollapsed: false,
@@ -123,7 +122,7 @@ export function togglePaneCollapse() {
 
 export function toggleSourcesCollapse() {
   return ({ dispatch, getState }) => {
-    const sourcesCollapsed = getSourcesCollapse(getState());
+    const sourcesCollapsed = getSourcesCollapsed(getState());
     dispatch({ type: "TOGGLE_SOURCES", sourcesCollapsed: !sourcesCollapsed });
   };
 }

--- a/src/devtools/client/debugger/src/actions/ui.js
+++ b/src/devtools/client/debugger/src/actions/ui.js
@@ -7,6 +7,7 @@
 import {
   getActiveSearch,
   getPaneCollapse,
+  getSourcesCollapse,
   getQuickOpenEnabled,
   getSource,
   getSourceContent,
@@ -23,6 +24,7 @@ import { isFulfilled } from "../utils/async-value";
 
 import { getCodeMirror } from "devtools/client/debugger/src/utils/editor";
 import { resizeBreakpointGutter } from "../utils/ui";
+import { prefs } from "../utils/prefs";
 
 export function setPrimaryPaneTab(tabName) {
   return { type: "SET_PRIMARY_PANE_TAB", tabName };
@@ -74,6 +76,7 @@ export function toggleFrameworkGrouping(toggleValue) {
 }
 
 export function showSource(cx, sourceId) {
+
   return ({ dispatch, getState }) => {
     const source = getSource(getState(), sourceId);
     if (!source) {
@@ -83,13 +86,19 @@ export function showSource(cx, sourceId) {
     if (getPaneCollapse(getState())) {
       dispatch({
         type: "TOGGLE_PANE",
-        position: "start",
         paneCollapsed: false,
       });
     }
 
-    dispatch(setPrimaryPaneTab("sources"));
+    //is the sources panel itself open?
+    if (getSourcesCollapse(getState())) {
+      dispatch({
+        type: "TOGGLE_SOURCES",
+        sourcesCollapsed: false,
+      });
+    }
 
+    dispatch(setPrimaryPaneTab("sources"));
     dispatch({ type: "SHOW_SOURCE", source: null });
     dispatch(selectSource(cx, source.id));
     dispatch({ type: "SHOW_SOURCE", source });
@@ -100,6 +109,13 @@ export function togglePaneCollapse() {
   return ({ dispatch, getState }) => {
     const paneCollapsed = getPaneCollapse(getState());
     dispatch({ type: "TOGGLE_PANE", paneCollapsed: !paneCollapsed });
+  };
+}
+
+export function toggleSourcesCollapse() {
+  return ({ dispatch, getState }) => {
+    const sourcesCollapsed = getSourcesCollapse(getState());
+    dispatch({ type: "TOGGLE_SOURCES", sourcesCollapsed: !sourcesCollapsed });
   };
 }
 

--- a/src/devtools/client/debugger/src/actions/ui.js
+++ b/src/devtools/client/debugger/src/actions/ui.js
@@ -25,6 +25,7 @@ import { isFulfilled } from "../utils/async-value";
 import { getCodeMirror } from "devtools/client/debugger/src/utils/editor";
 import { resizeBreakpointGutter } from "../utils/ui";
 import { prefs } from "../utils/prefs";
+import { getSelectedPrimaryPanel } from "../../../../../ui/reducers/app";
 
 export function setPrimaryPaneTab(tabName) {
   return { type: "SET_PRIMARY_PANE_TAB", tabName };
@@ -76,13 +77,13 @@ export function toggleFrameworkGrouping(toggleValue) {
 }
 
 export function showSource(cx, sourceId) {
-
   return ({ dispatch, getState }) => {
     const source = getSource(getState(), sourceId);
     if (!source) {
       return;
     }
 
+    //is the toolbar panel open?
     if (getPaneCollapse(getState())) {
       dispatch({
         type: "TOGGLE_PANE",
@@ -90,7 +91,15 @@ export function showSource(cx, sourceId) {
       });
     }
 
-    //is the sources panel itself open?
+    //is the sources panel selected?
+    if (getSelectedPrimaryPanel(getState()) !== "explorer") {
+      dispatch({
+        type: "set_selected_primary_panel",
+        panel: "explorer",
+      });
+    }
+
+    //is the sources panel collapsed?
     if (getSourcesCollapse(getState())) {
       dispatch({
         type: "TOGGLE_SOURCES",

--- a/src/devtools/client/debugger/src/actions/ui.js
+++ b/src/devtools/client/debugger/src/actions/ui.js
@@ -82,7 +82,8 @@ export function showSource(cx, sourceId) {
       return;
     }
 
-    // Is the toolbar panel open?
+    // Make sure the explorer/pause information panel is open so that the user
+    // sees those panels
     if (getPaneCollapse(getState())) {
       dispatch({
         type: "TOGGLE_PANE",
@@ -90,7 +91,8 @@ export function showSource(cx, sourceId) {
       });
     }
 
-    // Is the sources panel selected?
+    // Make sure the explorer panel is selected so that the user
+    // sees the sources panel.
     if (getSelectedPrimaryPanel(getState()) !== "explorer") {
       dispatch({
         type: "set_selected_primary_panel",
@@ -98,7 +100,8 @@ export function showSource(cx, sourceId) {
       });
     }
 
-    // Is the sources panel collapsed?
+    // Make sure the sources panel is expanded so that the user
+    // sees the source.
     if (getSourcesCollapsed(getState())) {
       dispatch({
         type: "TOGGLE_SOURCES",

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/index.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/index.js
@@ -16,6 +16,7 @@ import SourcesTree from "./SourcesTree";
 import Accordion from "../shared/Accordion";
 
 import "./Sources.css";
+import { selectors } from "../../../../../../ui/reducers";
 
 class PrimaryPanes extends Component {
   state = {
@@ -50,9 +51,10 @@ class PrimaryPanes extends Component {
       header: "Sources",
       className: "sources-pane",
       component: <SourcesTree />,
-      opened: prefs.sourcesExpanded,
+      opened: !prefs.sourcesCollapsed,
       onToggle: opened => {
-        prefs.sourcesExpanded = opened;
+        // prefs.sourcesExpanded = opened;
+        this.props.toggleSourcesCollapse();
       },
     };
   }
@@ -73,6 +75,7 @@ const mapStateToProps = state => {
     cx: getContext(state),
     selectedTab: getSelectedPrimaryPaneTab(state),
     sourceSearchOn: getActiveSearch(state) === "source",
+    sourcesCollapsed: selectors.getSourcesCollapse(state),
   };
 };
 
@@ -80,6 +83,7 @@ const connector = connect(mapStateToProps, {
   setPrimaryPaneTab: actions.setPrimaryPaneTab,
   setActiveSearch: actions.setActiveSearch,
   closeActiveSearch: actions.closeActiveSearch,
+  toggleSourcesCollapse: actions.toggleSourcesCollapse,
 });
 
 export default connector(PrimaryPanes);

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/index.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/index.js
@@ -7,7 +7,7 @@
 import React, { Component } from "react";
 
 import actions from "../../actions";
-import { getActiveSearch, getSelectedPrimaryPaneTab, getContext } from "../../selectors";
+import { getActiveSearch, getSelectedPrimaryPaneTab, getContext, getSourcesCollapsed } from "../../selectors";
 import { connect } from "../../utils/connect";
 import { prefs } from "../../utils/prefs";
 
@@ -16,7 +16,6 @@ import SourcesTree from "./SourcesTree";
 import Accordion from "../shared/Accordion";
 
 import "./Sources.css";
-import { selectors } from "../../../../../../ui/reducers";
 
 class PrimaryPanes extends Component {
   state = {
@@ -53,7 +52,6 @@ class PrimaryPanes extends Component {
       component: <SourcesTree />,
       opened: !prefs.sourcesCollapsed,
       onToggle: opened => {
-        // prefs.sourcesExpanded = opened;
         this.props.toggleSourcesCollapse();
       },
     };
@@ -75,7 +73,7 @@ const mapStateToProps = state => {
     cx: getContext(state),
     selectedTab: getSelectedPrimaryPaneTab(state),
     sourceSearchOn: getActiveSearch(state) === "source",
-    sourcesCollapsed: selectors.getSourcesCollapse(state),
+    sourcesCollapsed: getSourcesCollapsed(state),
   };
 };
 

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/index.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/index.js
@@ -7,7 +7,12 @@
 import React, { Component } from "react";
 
 import actions from "../../actions";
-import { getActiveSearch, getSelectedPrimaryPaneTab, getContext, getSourcesCollapsed } from "../../selectors";
+import {
+  getActiveSearch,
+  getSelectedPrimaryPaneTab,
+  getContext,
+  getSourcesCollapsed,
+} from "../../selectors";
 import { connect } from "../../utils/connect";
 import { prefs } from "../../utils/prefs";
 

--- a/src/devtools/client/debugger/src/reducers/ui.js
+++ b/src/devtools/client/debugger/src/reducers/ui.js
@@ -119,7 +119,7 @@ export function getPaneCollapse(state) {
   return state.ui.startPanelCollapsed;
 }
 
-export function getSourcesCollapse(state) {
+export function getSourcesCollapsed(state) {
   return state.ui.sourcesCollapsed;
 }
 

--- a/src/devtools/client/debugger/src/reducers/ui.js
+++ b/src/devtools/client/debugger/src/reducers/ui.js
@@ -17,6 +17,7 @@ export const createUIState = () => ({
   shownSource: null,
   startPanelCollapsed: prefs.startPanelCollapsed,
   endPanelCollapsed: prefs.endPanelCollapsed,
+  sourcesCollapsed: prefs.sourcesCollapsed,
   frameworkGroupingOn: prefs.frameworkGroupingOn,
   highlightedLineRange: undefined,
   orientation: "horizontal",
@@ -46,6 +47,11 @@ function update(state = createUIState(), action) {
     case "TOGGLE_PANE": {
       prefs.startPanelCollapsed = action.paneCollapsed;
       return { ...state, startPanelCollapsed: action.paneCollapsed };
+    }
+
+    case "TOGGLE_SOURCES": {
+      prefs.sourcesCollapsed = action.sourcesCollapsed;
+      return { ...state, sourcesCollapsed: action.sourcesCollapsed };
     }
 
     case "HIGHLIGHT_LINES":
@@ -111,6 +117,10 @@ export function getShownSource(state) {
 
 export function getPaneCollapse(state) {
   return state.ui.startPanelCollapsed;
+}
+
+export function getSourcesCollapse(state) {
+  return state.ui.sourcesCollapsed;
 }
 
 export function getHighlightedLineRange(state) {

--- a/src/devtools/client/debugger/src/utils/prefs.js
+++ b/src/devtools/client/debugger/src/utils/prefs.js
@@ -19,7 +19,7 @@ pref("devtools.debugger.logging", false);
 pref("devtools.debugger.timing", false);
 pref("devtools.debugger.alphabetize-outline", false);
 pref("devtools.debugger.outline-expanded", false);
-pref("devtools.debugger.sources-expanded", false);
+pref("devtools.debugger.sources-collapsed", false);
 pref("devtools.source-map.client-service.enabled", true);
 pref("devtools.chrome.enabled", false);
 pref("devtools.debugger.log-exceptions", false);
@@ -83,7 +83,7 @@ export const prefs = new PrefsHelper("devtools", {
   editorWrapping: ["Bool", "debugger.ui.editor-wrapping"],
   alphabetizeOutline: ["Bool", "debugger.alphabetize-outline"],
   outlineExpanded: ["Bool", "debugger.outline-expanded"],
-  sourcesExpanded: ["Bool", "debugger.sources-expanded"],
+  sourcesCollapsed: ["Bool", "debugger.sources-collapsed"],
   clientSourceMapsEnabled: ["Bool", "source-map.client-service.enabled"],
   chromeAndExtensionsEnabled: ["Bool", "chrome.enabled"],
   logExceptions: ["Bool", "debugger.log-exceptions"],


### PR DESCRIPTION
right clicking on an open source file and selecting 'reveal in tree' now ensures that the explorer pane is open and sources panel expands to reveal the source node in the tree