### PR TITLE
scrolling node into view when revealing in tree and its scrolled out of view

### DIFF
--- a/src/devtools/client/debugger/packages/devtools-components/src/tree.js
+++ b/src/devtools/client/debugger/packages/devtools-components/src/tree.js
@@ -753,17 +753,16 @@ class Tree extends Component {
           return closestScrolledParent(node.parentNode);
         };
 
-        const scrolledParentRect = treeElement?.getBoundingClientRect();
-        const isVisible =
-          !treeElement || (top >= scrolledParentRect.top && bottom <= scrolledParentRect.bottom);
+        //this is the one that contains the scrollable contents without expanding its height past what is visible
+        const parentElem = document.querySelector(".debugger .controlled");
+        const scrolledParentRect = parentElem.getBoundingClientRect();
+        const isVisible = top >= scrolledParentRect.top && bottom <= scrolledParentRect.bottom;
 
-        if (!isVisible) {
-          const { alignTo } = options;
-          const scrollToTop = alignTo
-            ? alignTo === "top"
-            : !scrolledParentRect || top < scrolledParentRect.top;
-          element.scrollIntoView(scrollToTop);
+        if (isVisible) {
+          return;
         }
+
+        element.scrollIntoView({ block: "center" });
       }
     }
   }

--- a/src/devtools/client/debugger/packages/devtools-components/src/tree.js
+++ b/src/devtools/client/debugger/packages/devtools-components/src/tree.js
@@ -753,7 +753,6 @@ class Tree extends Component {
           return closestScrolledParent(node.parentNode);
         };
 
-        //this is the one that contains the scrollable contents without expanding its height past what is visible
         const parentElem = document.querySelector(".debugger .controlled");
         const scrolledParentRect = parentElem.getBoundingClientRect();
         const isVisible = top >= scrolledParentRect.top && bottom <= scrolledParentRect.bottom;

--- a/src/devtools/client/debugger/packages/devtools-components/src/tree.js
+++ b/src/devtools/client/debugger/packages/devtools-components/src/tree.js
@@ -753,9 +753,9 @@ class Tree extends Component {
           return closestScrolledParent(node.parentNode);
         };
 
-        const parentElem = document.querySelector(".debugger .controlled");
-        const scrolledParentRect = parentElem.getBoundingClientRect();
-        const isVisible = top >= scrolledParentRect.top && bottom <= scrolledParentRect.bottom;
+        const scrolledParentRect = treeElement?.getBoundingClientRect();
+        const isVisible =
+          !treeElement || (top >= scrolledParentRect.top && bottom <= scrolledParentRect.bottom);
 
         if (isVisible) {
           return;

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.css
@@ -26,9 +26,13 @@
 }
 
 .outlines-pane {
-  flex: 1;
   display: flex;
   flex-direction: column;
+  overflow-y: hidden;
+}
+
+.outlines-pane.expanded {
+  flex: 1;
 }
 
 .outline-pane-info {

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.css
@@ -25,6 +25,12 @@
   height: 28px;
 }
 
+.outlines-pane {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
 .outline-pane-info {
   padding: 0.5em;
   width: 100%;

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
@@ -20,11 +20,15 @@
   flex-direction: column;
   overflow-x: auto;
   overflow-y: hidden;
+}
+
+div.sources-pane {
   height: 100%;
 }
 
 .sources-pane.expanded {
   flex: 1;
+  height: 100%;
 }
 
 .sources-list .img.blackBox {

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
@@ -17,9 +17,9 @@
 
 .sources-pane {
   display: flex;
-  flex: 1;
   flex-direction: column;
   overflow-x: auto;
+  flex: 1;
 }
 
 .sources-list .img.blackBox {

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
@@ -20,6 +20,7 @@
   flex-direction: column;
   overflow-x: auto;
   overflow-y: hidden;
+  height: 100%;
 }
 
 .sources-pane.expanded {
@@ -34,11 +35,14 @@
 .sources-list {
   flex: 1;
   display: flex;
+  height: 100%;
 }
 
 .sources-list .managed-tree {
   flex: 1;
   display: flex;
+  height: 100%;
+  overflow-y: auto;
 }
 
 .sources-list .managed-tree .tree {

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
@@ -19,6 +19,10 @@
   display: flex;
   flex-direction: column;
   overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.sources-pane.expanded {
   flex: 1;
 }
 

--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -10,6 +10,8 @@
   margin-top: 0px;
   display: flex;
   flex-direction: column;
+  overflow-y: hidden;
+  height: 100%;
 }
 
 .accordion ._header {
@@ -68,6 +70,8 @@
 .accordion ._content {
   border-bottom: 1px solid var(--theme-splitter-color);
   font-size: var(--theme-body-font-size);
+  overflow-y: auto;
+  height: 100%;
 }
 
 .accordion div:last-child ._content {

--- a/src/devtools/client/debugger/src/components/shared/Accordion.js
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.js
@@ -33,7 +33,7 @@ class Accordion extends Component {
     const { opened } = item;
 
     return (
-      <li className={item.className} key={i}>
+      <li className={`${item.className} ${item.opened ? "expanded" : "collapsed"}`} key={i}>
         <h2
           className="_header"
           tabIndex="0"


### PR DESCRIPTION
changed the container we were using to check if a node was within view, to the '.controlled' div as it's the only one who's height respects the scrollable space's height. also removed logic to snap the node to the top or bottom and is now scrolling happily centered.