### PR TITLE
Opening a source link from a console message should be reflected in the source tree

### DIFF
--- a/src/devtools/client/debugger/panel.js
+++ b/src/devtools/client/debugger/panel.js
@@ -117,6 +117,7 @@ export class DebuggerPanel {
     const cx = this._selectors.getContext(this._getState());
     const location = { sourceId, line, column };
 
+    this._actions.showSource(cx, sourceId);
     await this._actions.selectSource(cx, sourceId, location);
   }
 

--- a/src/devtools/client/debugger/src/actions/sources/select.js
+++ b/src/devtools/client/debugger/src/actions/sources/select.js
@@ -122,6 +122,11 @@ export function selectLocation(cx, location, { keepContext = true } = {}) {
     await dispatch(loadSourceText({ source }));
     await dispatch(setBreakableLines(cx, source.id));
 
+    // Set shownSource to null first, then the actual source to trigger
+    // a proper re-render in the SourcesTree component
+    dispatch({ type: "SHOW_SOURCE", source: null });
+    dispatch({ type: "SHOW_SOURCE", source });
+
     const loadedSource = getSource(getState(), source.id);
 
     if (!loadedSource) {

--- a/src/devtools/client/debugger/src/actions/ui.js
+++ b/src/devtools/client/debugger/src/actions/ui.js
@@ -110,9 +110,7 @@ export function showSource(cx, sourceId) {
     }
 
     dispatch(setPrimaryPaneTab("sources"));
-    dispatch({ type: "SHOW_SOURCE", source: null });
     dispatch(selectSource(cx, source.id));
-    dispatch({ type: "SHOW_SOURCE", source });
   };
 }
 


### PR DESCRIPTION
Fix #1181.

This updates the store, specifically the `shownSource` value, so that the SourceTree component is responsive to the user opening a new source.