### PR TITLE
Ensure that the selected tab is visible and not hidden

### DIFF
--- a/src/devtools/client/debugger/src/utils/tabs.js
+++ b/src/devtools/client/debugger/src/utils/tabs.js
@@ -14,8 +14,31 @@
  * @returns Array
  */
 
+export function getLastVisibleTab(sourceTabEls) {
+  sourceTabEls = [...sourceTabEls];
+
+  const topOffsets = sourceTabEls.map(el => el.getBoundingClientRect().top);
+  const visibleTabsTopOffset = Math.min(...topOffsets);
+
+  const visibleTabs = sourceTabEls.filter(
+    el => el.getBoundingClientRect().top < visibleTabsTopOffset + 10
+  );
+
+  return visibleTabs.pop();
+}
+
+export function getSelectedSourceIsVisible(sourceTabEls) {
+  sourceTabEls = [...sourceTabEls];
+
+  const selectedSourceTab = sourceTabEls.find(elem => elem.classList.contains("active"));
+  const topOffsets = sourceTabEls.map(el => el.getBoundingClientRect().top);
+  const visibleTabsTopOffset = Math.min(...topOffsets);
+
+  return selectedSourceTab.getBoundingClientRect().top < visibleTabsTopOffset + 10;
+}
+
 export function getHiddenTabs(sourceTabs, sourceTabEls) {
-  sourceTabEls = [].slice.call(sourceTabEls);
+  sourceTabEls = [...sourceTabEls];
   function getTopOffset() {
     const topOffsets = sourceTabEls.map(t => t.getBoundingClientRect().top);
     return Math.min(...topOffsets);


### PR DESCRIPTION
Fix #1182. Fix #1164.

This makes sure that a newly selected source (opened through SourcesTree/clicking on a console message source/etc) is always visible in the editor tabs. Otherwise, they might be hidden in the hidden tabs dropdown.

In cases where a newly-selected source ends up being hidden, and we pluck it from its original tab order and place it just before the last visible tab in the editor tabs. 