### PR TITLE
Set Session errors in hasura

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -19,59 +19,16 @@ if (test) {
 // be good if this was less fragile...
 //
 
-const { initSocket, sendMessage, setStatus, addEventListener } = require("protocol/socket");
-const { ThreadFront } = require("protocol/thread");
+const { initSocket } = require("protocol/socket");
 const loadImages = require("image/image");
 const { bootstrapApp } = require("ui/utils/bootstrap/bootstrap");
 const { bootstrapStore } = require("ui/utils/bootstrap/bootstrapStore");
-const {
-  setupTimeline,
-  setupMetadata,
-  setUploading,
-  setupApp,
-  setUnexpectedError,
-  setExpectedError,
-} = require("ui/actions").actions;
+const { setupTimeline, setupMetadata, setupApp } = require("ui/actions").actions;
 
 const { LocalizationHelper } = require("devtools/shared/l10n");
 const { setupEventListeners } = require("devtools/client/debugger/src/actions/event-listeners");
 const { DevToolsToolbox } = require("ui/utils/devtools-toolbox");
-const { prefs } = require("ui/utils/prefs");
 const { setupThreadEventListeners } = require("devtools/client/webconsole/actions/messages");
-
-// Create a session to use while debugging.
-async function createSession() {
-  addEventListener("Recording.uploadedData", onUploadedData);
-  addEventListener("Recording.sessionError", onSessionError);
-
-  try {
-    ThreadFront.setTest(test);
-    ThreadFront.recordingId = recordingId;
-    const { sessionId } = await sendMessage("Recording.createSession", {
-      recordingId,
-    });
-    window.sessionId = sessionId;
-    ThreadFront.setSessionId(sessionId);
-    store.dispatch(setUploading(null));
-    prefs.recordingId = recordingId;
-  } catch (e) {
-    if (e.code == 9 || e.code == 31) {
-      store.dispatch(setExpectedError(e));
-    } else {
-      throw e;
-    }
-  }
-}
-
-function onUploadedData({ uploaded, length }) {
-  const uploadedMB = (uploaded / (1024 * 1024)).toFixed(2);
-  const lengthMB = length ? (length / (1024 * 1024)).toFixed(2) : undefined;
-  store.dispatch(setUploading({ total: lengthMB, amount: uploadedMB }));
-}
-
-function onSessionError(error) {
-  store.dispatch(setUnexpectedError(error));
-}
 
 let initialized = false;
 async function initialize() {

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -2,7 +2,6 @@ import { Action } from "redux";
 import { UIStore, UIThunkAction } from ".";
 import {
   RecordingId,
-  sessionError,
   SessionId,
   unprocessedRegions,
   PointDescription,
@@ -10,7 +9,8 @@ import {
 } from "@recordreplay/protocol";
 import { ThreadFront } from "protocol/thread";
 import { selectors } from "ui/reducers";
-import { ExpectedError, Modal, PanelName, PrimaryPanelName, ViewMode } from "ui/state/app";
+import { Modal, PanelName, PrimaryPanelName, ViewMode } from "ui/state/app";
+
 const { PointHandlers } = require("protocol/logpoint");
 
 export type SetupAppAction = Action<"setup_app"> & { recordingId: RecordingId };
@@ -23,8 +23,6 @@ export type SetSelectedPrimaryPanelAction = Action<"set_selected_primary_panel">
   panel: PrimaryPanelName;
 };
 export type SetInitializedPanelsAction = Action<"set_initialized_panels"> & { panel: PanelName };
-export type SetExpectedErrorAction = Action<"set_expected_error"> & { error: ExpectedError };
-export type SetUnexpectedErrorAction = Action<"set_unexpected_error"> & { error: sessionError };
 export type SetUploadingAction = Action<"set_uploading"> & { uploading: boolean };
 export type SetModalAction = Action<"set_modal"> & { modal: Modal | null };
 export type SetPendingNotificationAction = Action<"set_pending_notification"> & {
@@ -49,8 +47,6 @@ export type AppAction =
   | SetSelectedPanelAction
   | SetSelectedPrimaryPanelAction
   | SetInitializedPanelsAction
-  | SetExpectedErrorAction
-  | SetUnexpectedErrorAction
   | SetUploadingAction
   | SetModalAction
   | SetPendingNotificationAction
@@ -138,14 +134,6 @@ export function setSelectedPrimaryPanel(panel: PrimaryPanelName): SetSelectedPri
 
 export function setInitializedPanels(panel: PanelName): SetInitializedPanelsAction {
   return { type: "set_initialized_panels", panel };
-}
-
-export function setExpectedError(error: ExpectedError): SetExpectedErrorAction {
-  return { type: "set_expected_error", error };
-}
-
-export function setUnexpectedError(error: sessionError): SetUnexpectedErrorAction {
-  return { type: "set_unexpected_error", error };
 }
 
 export function setUploading(uploading: boolean): SetUploadingAction {

--- a/src/ui/actions/index.ts
+++ b/src/ui/actions/index.ts
@@ -11,6 +11,7 @@ import * as eventListeners from "devtools/client/debugger/src/actions/event-list
 import debuggerActions from "devtools/client/debugger/src/actions";
 import { MarkupAction } from "devtools/client/inspector/markup/actions/markup";
 import { EventTooltipAction } from "devtools/client/inspector/markup/actions/eventTooltip";
+import { SessionAction } from "ui/actions/session";
 import UserProperties from "devtools/client/inspector/rules/models/user-properties";
 const consoleActions = require("devtools/client/webconsole/actions");
 
@@ -19,7 +20,8 @@ export type UIAction =
   | MetadataAction
   | TimelineAction
   | MarkupAction
-  | EventTooltipAction;
+  | EventTooltipAction
+  | SessionAction;
 
 interface ThunkExtraArgs {
   client: any;

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -1,0 +1,85 @@
+const { sendMessage, addEventListener } = require("protocol/socket");
+import { sessionError, uploadedData } from "@recordreplay/protocol";
+import { Action } from "redux";
+import { mutate } from "ui/utils/apolloClient";
+import { gql } from "@apollo/client";
+
+import { UIStore, actions, UIThunkAction } from "ui/actions";
+const { ThreadFront } = require("protocol/thread");
+const { prefs } = require("ui/utils/prefs");
+const { getTest } = require("ui/utils/environment");
+
+import { ExpectedError } from "ui/state/app";
+
+export type SetUnexpectedErrorAction = Action<"set_unexpected_error"> & { error: sessionError };
+export type SetExpectedErrorAction = Action<"set_expected_error"> & { error: ExpectedError };
+export type SessionAction = SetExpectedErrorAction | SetUnexpectedErrorAction;
+
+declare global {
+  interface Window {
+    sessionId: string;
+  }
+}
+
+// Create a session to use while debugging.
+export async function createSession(store: UIStore, recordingId: string) {
+  addEventListener("Recording.uploadedData", onUploadedData);
+  addEventListener("Recording.sessionError", onSessionError);
+  try {
+    ThreadFront.setTest(getTest());
+    ThreadFront.recordingId = recordingId;
+    const { sessionId } = await sendMessage("Recording.createSession", {
+      recordingId,
+    });
+
+    window.sessionId = sessionId;
+    ThreadFront.setSessionId(sessionId);
+    store.dispatch(actions.setUploading(null));
+    prefs.recordingId = recordingId;
+  } catch (e) {
+    if (e.code == 9 || e.code == 31) {
+      store.dispatch(setExpectedError(e));
+    } else {
+      throw e;
+    }
+  }
+}
+
+function onUploadedData({ uploaded, length }: uploadedData): UIThunkAction {
+  return ({ dispatch }) => {
+    const uploadedMB = (uploaded / (1024 * 1024)).toFixed(2);
+    const lengthMB = length ? (length / (1024 * 1024)).toFixed(2) : undefined;
+    dispatch(actions.setUploading({ total: lengthMB, amount: uploadedMB }));
+  };
+}
+
+function onSessionError(error: sessionError): UIThunkAction {
+  return ({ dispatch }) => {
+    setSessionError(error);
+    dispatch(setUnexpectedError(error));
+  };
+}
+
+export function setExpectedError(error: ExpectedError): SetExpectedErrorAction {
+  return { type: "set_expected_error", error };
+}
+
+export function setUnexpectedError(error: sessionError): SetUnexpectedErrorAction {
+  return { type: "set_unexpected_error", error };
+}
+
+function setSessionError({ sessionId, code }: { sessionId: string; code: number }) {
+  return mutate({
+    mutation: gql`
+      mutation AddSessionError($sessionId: String, $error: String) {
+        update_sessions(where: { id: { _eq: $sessionId } }, _set: { error: $error }) {
+          returning {
+            id
+            error
+          }
+        }
+      }
+    `,
+    variables: { sessionId, error: `${code}` },
+  });
+}

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -1,6 +1,7 @@
 import { AppState } from "ui/state/app";
 import { AppAction } from "ui/actions/app";
 import { UIState } from "ui/state";
+import { SessionAction } from "ui/actions/session";
 const { prefs } = require("../utils/prefs");
 const { getLocationKey } = require("../../devtools/client/debugger/src/utils/breakpoint");
 
@@ -26,7 +27,7 @@ function initialAppState(): AppState {
   };
 }
 
-export default function update(state = initialAppState(), action: AppAction) {
+export default function update(state = initialAppState(), action: AppAction | SessionAction) {
   switch (action.type) {
     case "setup_app": {
       return { ...state, recordingId: action.recordingId };

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -8,8 +8,12 @@ export function isFirefox() {
   return /firefox/i.test(navigator.userAgent);
 }
 
+export function getTest() {
+  return url.searchParams.get("test");
+}
+
 export function isTest() {
-  return url.searchParams.get("test") != null;
+  return getTest() != null;
 }
 
 export function isDeployPreview() {


### PR DESCRIPTION
started off as a PR that added a saveSessionError function. Then it grew into:

1. move createSession to its own file
2. simplify the console panel because of legacy garbage...
3. typescript session stuff