### PR TITLE
Make sure only one console message has the paused marker on it

### DIFF
--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
@@ -117,6 +117,23 @@ class ConsoleOutput extends Component {
     (previous || resultNode).scrollIntoView();
   }
 
+  getIsFirstMessageForPoint(index, visibleMessages) {
+    const { messages } = this.props;
+
+    if (index == 0) {
+      return true;
+    }
+
+    let previousMessage = messages.get(visibleMessages[index - 1]);
+    let currentMessage = messages.get(visibleMessages[index]);
+
+    if (!previousMessage || !currentMessage) {
+      return false;
+    }
+
+    return previousMessage.executionPoint !== currentMessage.executionPoint;
+  }
+
   render() {
     let {
       dispatch,
@@ -138,7 +155,7 @@ class ConsoleOutput extends Component {
     });
 
     const pausedMessage = getClosestMessage(visibleMessages, messages, pausedExecutionPoint);
-    const messageNodes = visibleMessages.map(messageId =>
+    const messageNodes = visibleMessages.map((messageId, i) =>
       createElement(MessageContainer, {
         dispatch,
         key: messageId,
@@ -154,6 +171,7 @@ class ConsoleOutput extends Component {
         pausedExecutionPoint,
         getMessage: () => messages.get(messageId),
         isPaused: !!pausedMessage && pausedMessage.id == messageId,
+        isFirstMessageForPoint: this.getIsFirstMessageForPoint(i, visibleMessages),
       })
     );
 

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -145,6 +145,7 @@ class Message extends Component {
       type,
       frame,
       message,
+      isFirstMessageForPoint,
     } = this.props;
 
     if (inWarningGroup || !pausedExecutionPoint || !executionPoint || !frame) {
@@ -171,6 +172,11 @@ class Message extends Component {
       overlayType = "rewind";
       label = "Rewind";
       onClick = onRewindClick;
+    }
+
+    // Handle cases where executionPoint is the same as pauseExecutionPoint.
+    if (!isFirstMessageForPoint) {
+      return;
     } else if (!["command", "result"].includes(type)) {
       overlayType = "debug";
       label = "Debug";

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
@@ -41,6 +41,7 @@ function ConsoleApiCall(props) {
     pausedExecutionPoint,
     isPaused,
     maybeScrollToBottom,
+    isFirstMessageForPoint,
   } = props;
   const {
     id: messageId,
@@ -154,6 +155,7 @@ function ConsoleApiCall(props) {
     parameters,
     message,
     maybeScrollToBottom,
+    isFirstMessageForPoint,
   });
 }
 


### PR DESCRIPTION
Fix #1217.

This makes sure that even if there are multiple logs (e.g. breakpoint + event breakpoint) that is associated with a particular execution point, we only show one pause marker in the console message. This is different from what we have now, where we would show a pause marker for each of those console messages if we were paused at that point.

This gets the job done but it's a half measure. Ideally, if a user is paused at a point where there are multiple messages, it should still be obvious that there are multiple messages associated with that pause. 

```
Scenario: Paused on Pause group 1

Before:
⏸ Event breakpoint message (Pause group 1)
⏸ Breakpoint message (Pause group 1)
   Breakpoint message (Pause group 2)
   Breakpoint message (Pause group 3)

After:
⏸ Event breakpoint message (Pause group 1)
   Breakpoint message (Pause group 1)
   Breakpoint message (Pause group 2)
   Breakpoint message (Pause group 3)
```

In the `After` case, the breakpoint message in pause group 1 is no longer visually associated with the current pause. This makes it easy to mistake it for being in a different pause group altogether.

![image](https://user-images.githubusercontent.com/15959269/102303435-26143680-3f29-11eb-9670-0fd3012bce84.png)
