### PR TITLE
Show framework group badge with a grey badge text color

### DIFF
--- a/src/devtools/client/debugger/src/components/shared/Badge.js
+++ b/src/devtools/client/debugger/src/components/shared/Badge.js
@@ -6,6 +6,6 @@
 import React from "react";
 import "./Badge.css";
 
-const Badge = ({ children }) => <span className="badge text-white text-center">{children}</span>;
+const Badge = ({ children }) => <span className="badge text-center">{children}</span>;
 
 export default Badge;


### PR DESCRIPTION
<img width="232" alt="Screen Shot 2020-12-15 at 8 21 50 PM" src="https://user-images.githubusercontent.com/254562/102304858-55b84400-3f13-11eb-88a8-d1658ebeb4c2.png">
