### PR TITLE
Add playback autoplay

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -69,7 +69,7 @@ function onEndpoint({ point, time }: TimeStampedPoint): UIThunkAction {
 
 function onPaused({ time }: PauseEventArgs): UIThunkAction {
   return async ({ dispatch, getState }) => {
-    dispatch(setTimelineState({ currentTime: time, playback: null }));
+    dispatch(setTimelineState({ currentTime: time, playback: null, autoplay: true }));
 
     const { screen, mouse } = await getGraphicsAtTime(time);
 

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -79,6 +79,10 @@ export class Timeline extends Component {
     if (prevState.closestMessage != this.props.closestMessage) {
       this.scrollToMessage(this.props.closestMessage);
     }
+
+    if (this.props.autoplay && !prevProps.autoplay) {
+      this.startPlayback();
+    }
   }
 
   get toolbox() {
@@ -389,7 +393,7 @@ export class Timeline extends Component {
     if (this.props.playback) {
       this.seekTime(this.props.playback.time);
     }
-    this.props.setTimelineState({ playback: null });
+    this.props.setTimelineState({ playback: null, autoplay: false });
   }
 
   replayPlayback = () => {
@@ -614,6 +618,7 @@ export default connect(
     timelineDimensions: selectors.getTimelineDimensions(state),
     loaded: selectors.getTimelineLoaded(state),
     messages: selectors.getMessagesForTimeline(state),
+    autoplay: selectors.getAutoplay(state),
   }),
   {
     setTimelineToTime: actions.setTimelineToTime,

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -19,6 +19,7 @@ function initialTimelineState(): TimelineState {
     mouse: null,
     loaded: false,
     tooltip: null,
+    autoplay: false,
   };
 }
 
@@ -59,3 +60,4 @@ export const getMouse = (state: UIState) => state.timeline.mouse;
 export const getTimelineDimensions = (state: UIState) => state.timeline.timelineDimensions;
 export const getTimelineLoaded = (state: UIState) => state.timeline.loaded;
 export const getTooltip = (state: UIState) => state.timeline.tooltip;
+export const getAutoplay = (state: UIState) => state.timeline.autoplay;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -33,4 +33,5 @@ export interface TimelineState {
   shouldAnimate: boolean;
   loaded: boolean;
   tooltip: Tooltip | null;
+  autoplay: boolean;
 }


### PR DESCRIPTION
This adds an autoplay when a user opens a replay and behaves as follows:
- The autoplay playback starts immediately after the replay is loaded and ends when it hits the end
- Toggling between the player/debug view doesn't stop the autoplay playback – it continues where it left off in the previous view
- Pressing pause during the autoplay playback stops the playback
- Once the autoplay playback is stopped, toggling between player/debug view behaves as it did before