### PR TITLE
Show timeline hover preview on playback for Play mode

### DIFF
--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.css
@@ -2,6 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+.outlines-pane {
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 25px;
+}
+
 .outline {
   overflow-y: hidden;
 }

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
@@ -17,9 +17,9 @@
 
 .sources-pane {
   display: flex;
-  flex: 1;
   flex-direction: column;
-  overflow-x: auto;
+  overflow: auto;
+  min-height: 25px;
 }
 
 .sources-list .img.blackBox {

--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -10,6 +10,7 @@
   margin-top: 0px;
   display: flex;
   flex-direction: column;
+  height: 100%;
 }
 
 .accordion ._header {
@@ -68,8 +69,13 @@
 .accordion ._content {
   border-bottom: 1px solid var(--theme-splitter-color);
   font-size: var(--theme-body-font-size);
+  overflow: auto;
 }
 
 .accordion div:last-child ._content {
   border-bottom: none;
+}
+
+.accordion.opened > * {
+  max-height: 50%;
 }

--- a/src/devtools/client/debugger/src/components/shared/Accordion.js
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.js
@@ -55,7 +55,13 @@ class Accordion extends Component {
     );
   };
   render() {
-    return <ul className="accordion">{this.props.items.map(this.renderContainer)}</ul>;
+    const isOpened = this.props.items.some(item => item.opened);
+
+    return (
+      <ul className={`accordion${isOpened ? " opened" : ""}`}>
+        {this.props.items.map(this.renderContainer)}
+      </ul>
+    );
   }
 }
 

--- a/src/devtools/client/shared/components/Accordion.js
+++ b/src/devtools/client/shared/components/Accordion.js
@@ -189,9 +189,14 @@ class Accordion extends Component {
   }
 
   render() {
+    const { opened } = this.state;
+    console.log(">>");
+    console.log(">>", opened);
+    const somethingIsOpened = Object.keys(opened).filter(id => opened[id]);
+
     return ul(
       {
-        className: "accordion",
+        className: `accordion${somethingIsOpened[2] ? " opened" : ""}`,
         tabIndex: -1,
       },
       this.props.items.map(item => this.renderItem(item))

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -189,8 +189,35 @@ export class Timeline extends Component {
     }
   };
 
+  onPlayerMouseLeave = async e => {
+    const { currentTime } = this.props;
+    const { screen, mouse } = await getGraphicsAtTime(currentTime);
+
+    if (!screen) {
+      return;
+    }
+
+    paintGraphics(screen, mouse);
+  };
+
+  showPlaybackPreview = async time => {
+    const { screen, mouse } = await getGraphicsAtTime(time);
+
+    if (!screen) {
+      return;
+    }
+
+    paintGraphics(screen, mouse);
+  };
+
   onPlayerMouseMove = async e => {
-    const { hoverTime, recordingDuration, setTimelineToTime, timelineDimensions } = this.props;
+    const {
+      hoverTime,
+      recordingDuration,
+      setTimelineToTime,
+      timelineDimensions,
+      viewMode,
+    } = this.props;
     if (!recordingDuration) {
       return;
     }
@@ -210,6 +237,10 @@ export class Timeline extends Component {
           : offset;
 
       setTimelineToTime({ time: mouseTime, offset });
+    }
+
+    if (viewMode == "non-dev") {
+      this.showPlaybackPreview(mouseTime);
     }
   };
 
@@ -582,6 +613,7 @@ export class Timeline extends Component {
             ref: a => (this.$progressBar = a),
             onMouseEnter: this.onPlayerMouseEnter,
             onMouseMove: this.onPlayerMouseMove,
+            onMouseLeave: this.onPlayerMouseLeave,
             onMouseUp: this.onPlayerMouseUp,
           },
           div({
@@ -614,6 +646,7 @@ export default connect(
     timelineDimensions: selectors.getTimelineDimensions(state),
     loaded: selectors.getTimelineLoaded(state),
     messages: selectors.getMessagesForTimeline(state),
+    viewMode: selectors.getViewMode(state),
   }),
   {
     setTimelineToTime: actions.setTimelineToTime,

--- a/src/ui/components/Views/NonDevView.js
+++ b/src/ui/components/Views/NonDevView.js
@@ -46,7 +46,6 @@ function NonDevView({ updateTimelineDimensions, narrowMode }) {
       </div>
       <div id="toolbox-timeline">
         <Timeline />
-        <Tooltip />
       </div>
     </div>
   );
@@ -89,7 +88,6 @@ function NonDevView({ updateTimelineDimensions, narrowMode }) {
         />
         <div id="toolbox-timeline">
           <Timeline />
-          <Tooltip />
         </div>
       </>
     );


### PR DESCRIPTION
This PR changes the way we show video previews while hovering on the timeline in Play mode. 

Instead of showing the preview within a tooltip just above the timeline, this now shows the preview on the actual playback screen itself. As soon as the user moves their cursor away from the timeline, the playback screen resets to whatever the current paused point is.

I immediately noticed a few things that we haven't thought through:
1. This sucks for "long hover" cases, where the user might start at 0% and hover slowly all the way through to 100%. With the preview being shown on the playback screen, the user now has to look away from the timeline to see what changes are happening in the preview. This makes it much harder to hover in a straight line from 0% -> 100%. In my experience, my cursor kept going too far up/down.
2. It's not obvious when the screen being shown in the playback is the a) current paused screen or b) the preview screen. This makes item no.1 even worse, because there's no immediate feedback that you've stopped hovering if your mouse drifts away from the timeline. It might obvious if the current paused screen is very different from the preview screen, but apart from that, it becomes confusing very quickly.

We can dismiss 1 as a concern if we are confident that people won't do the "long hover" cases. This isn't that unreasonable of an assumption given that people can just press the play button to do the same thing. But if we think or we presume that people will still do long hovers, then we should rethink whether we want to add this preview feature.

I'd balance that decision with this feature's obvious benefit for "short hover" cases, where you're trying to pinpoint where a specific happened. For those cases, having the preview screen much larger than the tooltip is a very noticeable improvement.

If we do proceed with it, we should definitely do something about 2 and visually indicate that what they're looking at is a preview. Perhaps something like a small popup at the top+center of the screen that says "Showing preview at 6s" that remains there while the user is hovering on the timeline.