### PR TITLE
WIP: Feature/display selector

### DIFF
--- a/src/ui/components/NodePicker.js
+++ b/src/ui/components/NodePicker.js
@@ -91,7 +91,15 @@ export default class NodePicker extends React.Component {
   };
 
   nodePickerMouseClick = e => {
-    this.nodePickerMouseClickInCanvas(this.mouseEventCanvasPosition(e));
+    const canvasPosition = this.mouseEventCanvasPosition(e);
+    
+    // If the click is outside of the canvas,
+    // there is no need for any other action
+    if (!canvasPosition) {
+      return
+    }
+
+    this.nodePickerMouseClickInCanvas(canvasPosition);
     gToolbox.selectTool("inspector");
   };
 

--- a/src/ui/components/NodePicker.js
+++ b/src/ui/components/NodePicker.js
@@ -92,11 +92,11 @@ export default class NodePicker extends React.Component {
 
   nodePickerMouseClick = e => {
     const canvasPosition = this.mouseEventCanvasPosition(e);
-    
+
     // If the click is outside of the canvas,
     // there is no need for any other action
     if (!canvasPosition) {
-      return
+      return;
     }
 
     this.nodePickerMouseClickInCanvas(canvasPosition);

--- a/src/ui/components/SecondaryToolbox/index.js
+++ b/src/ui/components/SecondaryToolbox/index.js
@@ -14,13 +14,7 @@ import { installObserver } from "../../../protocol/graphics";
 
 function PanelButtons({ selectedPanel, setSelectedPanel, narrowMode }) {
   const onClick = panel => {
-    setSelectedPanel(panel);
-
-    // The comments panel doesn't have to be initialized by the toolbox,
-    // only the console and the inspector.
-    if (panel !== "comments") {
-      gToolbox.selectTool(panel);
-    }
+    gToolbox.selectTool(panel);
   };
 
   return (

--- a/src/ui/components/Views/NonDevView.css
+++ b/src/ui/components/Views/NonDevView.css
@@ -1,3 +1,11 @@
+/* TODO: make more flexible without depending on outside defined id */
+#outer-viewer .viewer-toolbar {
+  flex: 0;
+  background: var(--theme-toolbar-background);
+  height: 40px;
+  border-bottom: solid var(--theme-splitter-color);
+}
+
 .right-sidebar {
   background: var(--theme-body-background);
   display: flex;
@@ -48,8 +56,8 @@
 }
 
 .right-sidebar .event-listeners .event-listeners-content {
-    height: 300px;
-    overflow-y: auto;
+  height: 300px;
+  overflow-y: auto;
 }
 
 .right-sidebar .comments-panel {

--- a/src/ui/components/Views/NonDevView.js
+++ b/src/ui/components/Views/NonDevView.js
@@ -7,6 +7,7 @@ import SplitBox from "devtools/client/shared/components/splitter/SplitBox";
 import CommentsPanel from "ui/components/SecondaryToolbox/CommentsPanel";
 import EventListeners from "devtools/client/debugger/src/components/SecondaryPanes/EventListeners";
 import Dropdown from "ui/components/shared/Dropdown";
+import NodePicker from "ui/components/NodePicker.js";
 
 import { installObserver } from "../../../protocol/graphics";
 import { updateTimelineDimensions } from "../../actions/timeline";
@@ -40,6 +41,9 @@ function NonDevView({ updateTimelineDimensions, narrowMode }) {
 
   const viewer = (
     <div id="outer-viewer">
+      <nav className="viewer-toolbar">
+        <NodePicker />
+      </nav>
       <div id="viewer">
         <canvas id="graphics"></canvas>
         <div id="highlighter-root"></div>

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -50,7 +50,7 @@ export default function update(state = initialAppState(), action: AppAction | Se
     }
 
     case "set_selected_panel": {
-      return { ...state, selectedPanel: action.panel };
+      return { ...state, viewMode: 'dev', selectedPanel: action.panel };
     }
 
     case "set_selected_primary_panel": {

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -50,7 +50,7 @@ export default function update(state = initialAppState(), action: AppAction | Se
     }
 
     case "set_selected_panel": {
-      return { ...state, viewMode: 'dev', selectedPanel: action.panel };
+      return { ...state, viewMode: "dev", selectedPanel: action.panel };
     }
 
     case "set_selected_primary_panel": {

--- a/src/ui/utils/devtools-toolbox.js
+++ b/src/ui/utils/devtools-toolbox.js
@@ -74,7 +74,16 @@ export class DevToolsToolbox {
   };
 
   async selectTool(name) {
+    store.dispatch(actions.setSelectedPanel(name));
+
+    // The comments panel doesn't have to be initialized by the toolbox,
+    // only the console and the inspector.
+    if (name === 'comments') {
+      return 
+    }
+    
     let panel = await this.getOrStartPanel(name);
+    
     this.emit("select", name);
 
     this.currentTool = name;

--- a/src/ui/utils/devtools-toolbox.js
+++ b/src/ui/utils/devtools-toolbox.js
@@ -78,12 +78,12 @@ export class DevToolsToolbox {
 
     // The comments panel doesn't have to be initialized by the toolbox,
     // only the console and the inspector.
-    if (name === 'comments') {
-      return 
+    if (name === "comments") {
+      return;
     }
-    
+
     let panel = await this.getOrStartPanel(name);
-    
+
     this.emit("select", name);
 
     this.currentTool = name;


### PR DESCRIPTION
This PR adds a new toolbar with an inspector to the non-dev view.

The majority of the work completed so far is around a refactor to how the `NodePicker` works. Originally, setting a tool and setting a panel were two separate calls. For the functionality of the new dev-view `NodePicker`, we wanted the view to change when a node is clicked, and we wanted the active panel to be the inspector panel.

To create this effect, we moved the assumption that `gTool.selectTool` would dispatch a Redux action that would result in both the `panel` and `viewMode` values in the store being set at the same time.

Todo:
- [ ] get the selected node from the non-dev view to be selected in the dev view
- [ ] properly handle the behavior of using the non-dev view `NodePicker` twice (events seem to not be fired)
- [ ] cleanup CSS/styling
- [ ] tests (and test fixes)