### PR TITLE
Display clicks in the non-dev view transcript

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ const loadImages = require("image/image");
 const { bootstrapApp } = require("ui/utils/bootstrap/bootstrap");
 const { bootstrapStore } = require("ui/utils/bootstrap/bootstrapStore");
 const { setupTimeline, setupMetadata, setupApp } = require("ui/actions").actions;
+const { setupGraphics } = require("protocol/graphics");
 
 const { LocalizationHelper } = require("devtools/shared/l10n");
 const { setupEventListeners } = require("devtools/client/debugger/src/actions/event-listeners");
@@ -77,5 +78,6 @@ async function initialize() {
     setupTimeline(recordingId, store);
     setupMetadata(recordingId, store);
     setupEventListeners(recordingId, store);
+    setupGraphics(store);
   }
 })();

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -6,10 +6,11 @@ import {
   unprocessedRegions,
   PointDescription,
   Location,
+  MouseEvent,
 } from "@recordreplay/protocol";
 import { ThreadFront } from "protocol/thread";
 import { selectors } from "ui/reducers";
-import { Modal, PanelName, PrimaryPanelName, ViewMode } from "ui/state/app";
+import { Modal, PanelName, PrimaryPanelName, ViewMode, Event } from "ui/state/app";
 
 const { PointHandlers } = require("protocol/logpoint");
 
@@ -32,6 +33,10 @@ export type SetAnalysisPointsAction = Action<"set_analysis_points"> & {
   analysisPoints: PointDescription[] | null;
   location: Location;
 };
+export type SetEventsForType = Action<"set_events"> & {
+  events: MouseEvent[];
+  eventType: Event;
+};
 export type SetViewMode = Action<"set_view_mode"> & { viewMode: ViewMode };
 export type SetNarrowMode = Action<"set_narrow_mode"> & { narrowMode: boolean };
 export type SetHoveredLineNumberLocation = Action<"set_hovered_line_number_location"> & {
@@ -51,6 +56,7 @@ export type AppAction =
   | SetModalAction
   | SetPendingNotificationAction
   | SetAnalysisPointsAction
+  | SetEventsForType
   | SetViewMode
   | SetNarrowMode
   | SetHoveredLineNumberLocation;
@@ -166,6 +172,14 @@ export function setAnalysisPoints(
     type: "set_analysis_points",
     analysisPoints: points,
     location,
+  };
+}
+
+export function setEventsForType(events: MouseEvent[], eventType: Event): SetEventsForType {
+  return {
+    type: "set_events",
+    eventType,
+    events,
   };
 }
 

--- a/src/ui/components/SecondaryToolbox/CommentsPanel.css
+++ b/src/ui/components/SecondaryToolbox/CommentsPanel.css
@@ -9,7 +9,8 @@
   height: 100%;
 }
 
-.comments-panel .comment {
+.comments-panel .comment,
+.comments-panel .event {
   padding: 20px 16px 20px;
   line-height: 1.25rem;
   font-size: 1rem;
@@ -114,10 +115,16 @@
   mask-position: center;
 }
 
-.comments-panel .item-label {
+.comments-panel .comment .item-label {
   font-size: 1.25rem;
   color: var(--theme-body-color);
   margin-bottom: 4px;
+}
+
+.comments-panel .event .item-label {
+  font-size: 1.25rem;
+  color: var(--theme-body-color);
+  align-self: center;
 }
 
 .comments-panel .item-content {

--- a/src/ui/components/SecondaryToolbox/CommentsPanel.js
+++ b/src/ui/components/SecondaryToolbox/CommentsPanel.js
@@ -1,14 +1,14 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 
 import { connect } from "react-redux";
 import { selectors } from "ui/reducers";
 import hooks from "ui/hooks";
 import { sortBy } from "lodash";
 
-import Comment from "ui/components/SecondaryToolbox/Comment";
+import TranscriptEntry from "./TranscriptEntry/index";
 import "./CommentsPanel.css";
 
-function CommentsPanel({ recordingId }) {
+function CommentsPanel({ recordingId, clickEvents, showClicks }) {
   const { comments, loading, error } = hooks.useGetComments(recordingId);
 
   // Don't render anything if the comments are loading. For now, we fail silently
@@ -19,7 +19,7 @@ function CommentsPanel({ recordingId }) {
     return null;
   }
 
-  if (!comments.length) {
+  if (!comments.length && !clickEvents.length) {
     return (
       <div className="comments-panel">
         <p>There is nothing here yet. Try adding a comment in the timeline below.</p>
@@ -27,10 +27,15 @@ function CommentsPanel({ recordingId }) {
     );
   }
 
+  let entries = comments;
+  if (showClicks) {
+    entries = [...comments, ...clickEvents];
+  }
+
   return (
     <div className="comments-panel">
-      {sortBy(comments, comment => comment.time).map(comment => (
-        <Comment comment={comment} key={comment.id} />
+      {sortBy(entries, entry => entry.time).map((entry, i) => (
+        <TranscriptEntry entry={entry} key={i} />
       ))}
     </div>
   );
@@ -38,4 +43,5 @@ function CommentsPanel({ recordingId }) {
 
 export default connect(state => ({
   recordingId: selectors.getRecordingId(state),
+  clickEvents: selectors.getEventsForType(state, "mousedown"),
 }))(CommentsPanel);

--- a/src/ui/components/SecondaryToolbox/TranscriptEntry/CommentEntry.js
+++ b/src/ui/components/SecondaryToolbox/TranscriptEntry/CommentEntry.js
@@ -8,7 +8,7 @@ import Dropdown from "devtools/client/debugger/src/components/shared/Dropdown";
 import CommentEditor from "ui/components/Comments/CommentEditor";
 import CommentDropdownPanel from "ui/components/Comments/CommentDropdownPanel";
 
-function Comment({ comment, currentTime, seek }) {
+function CommentEntry({ comment, currentTime, seek }) {
   const [editing, setEditing] = useState(false);
   const seekToComment = () => {
     const { point, time, has_frames } = comment;
@@ -59,4 +59,4 @@ function CommentBody({ comment, startEditing }) {
 
 export default connect(state => ({ currentTime: selectors.getCurrentTime(state) }), {
   seek: actions.seek,
-})(Comment);
+})(CommentEntry);

--- a/src/ui/components/SecondaryToolbox/TranscriptEntry/EventEntry.js
+++ b/src/ui/components/SecondaryToolbox/TranscriptEntry/EventEntry.js
@@ -1,0 +1,33 @@
+import React from "react";
+import classnames from "classnames";
+
+import { connect } from "react-redux";
+import { selectors } from "ui/reducers";
+import { actions } from "ui/actions";
+
+function EventEntry({ entry, currentTime, index, seek }) {
+  const seekToEvent = () => {
+    const { point, time } = entry;
+    seek(point, time, false);
+  };
+
+  return (
+    <div
+      onClick={seekToEvent}
+      className={classnames("event", {
+        selected: currentTime === entry.time,
+      })}
+      key={index}
+    >
+      <div className="img event-click" />
+      <div className="item-label">Mouse Click</div>
+    </div>
+  );
+}
+
+export default connect(
+  state => ({
+    currentTime: selectors.getCurrentTime(state),
+  }),
+  { seek: actions.seek }
+)(EventEntry);

--- a/src/ui/components/SecondaryToolbox/TranscriptEntry/TranscriptEntry.js
+++ b/src/ui/components/SecondaryToolbox/TranscriptEntry/TranscriptEntry.js
@@ -1,0 +1,11 @@
+import React from "react";
+import CommentEntry from "./CommentEntry";
+import EventEntry from "./EventEntry";
+
+export default function TranscriptEntry({ entry }) {
+  if (entry.__typename === "comments") {
+    return <CommentEntry comment={entry} />;
+  } else {
+    return <EventEntry entry={entry} />;
+  }
+}

--- a/src/ui/components/SecondaryToolbox/TranscriptEntry/index.js
+++ b/src/ui/components/SecondaryToolbox/TranscriptEntry/index.js
@@ -1,0 +1,3 @@
+import TranscriptEntry from "./TranscriptEntry";
+
+export default TranscriptEntry;

--- a/src/ui/components/Views/NonDevView.css
+++ b/src/ui/components/Views/NonDevView.css
@@ -55,3 +55,21 @@
 .right-sidebar .comments-panel {
   flex-grow: 1;
 }
+
+.right-sidebar .toolbar-options {
+  display: flex;
+  flex-direction: row;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.right-sidebar .toolbar-options > :first-child {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.right-sidebar .toolbar-options label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/ui/components/Views/NonDevView.js
+++ b/src/ui/components/Views/NonDevView.js
@@ -15,7 +15,7 @@ import { selectors } from "../../reducers";
 import "./NonDevView.css";
 
 export function EventsFilter() {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(TextTrackCueList);
 
   const buttonContent = <div className="img settings" />;
 
@@ -33,7 +33,28 @@ export function EventsFilter() {
   );
 }
 
-function NonDevView({ updateTimelineDimensions, narrowMode }) {
+export function TranscriptOptions({ showClicks, setShowClicks, clickEvents }) {
+  const count = clickEvents.length;
+
+  return (
+    <div className="toolbar-options">
+      <label htmlFor="show-clicks">
+        <span>Show clicks</span>
+        {!showClicks ? <span>{` (${count})`}</span> : null}
+      </label>
+      <input
+        type="checkbox"
+        id="show-clicks"
+        checked={showClicks}
+        onChange={() => setShowClicks(!showClicks)}
+      />
+    </div>
+  );
+}
+
+function NonDevView({ updateTimelineDimensions, narrowMode, clickEvents }) {
+  const [showClicks, setShowClicks] = useState(true);
+
   useEffect(() => {
     installObserver();
   }, []);
@@ -54,9 +75,13 @@ function NonDevView({ updateTimelineDimensions, narrowMode }) {
     <div className="right-sidebar">
       <div className="right-sidebar-toolbar">
         <div className="right-sidebar-toolbar-item">Transcript and Comments</div>
-        <EventsFilter />
+        <TranscriptOptions
+          showClicks={showClicks}
+          setShowClicks={setShowClicks}
+          clickEvents={clickEvents}
+        />
       </div>
-      <CommentsPanel />
+      <CommentsPanel showClicks={showClicks} />
     </div>
   );
 
@@ -114,6 +139,7 @@ function NonDevView({ updateTimelineDimensions, narrowMode }) {
 export default connect(
   state => ({
     narrowMode: selectors.getNarrowMode(state),
+    clickEvents: selectors.getEventsForType(state, "mousedown"),
   }),
   {
     updateTimelineDimensions,

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -21,6 +21,7 @@ function initialAppState(): AppState {
     modal: null,
     pendingNotification: null,
     analysisPoints: {},
+    events: {},
     viewMode: prefs.viewMode,
     narrowMode: false,
     hoveredLineNumberLocation: null,
@@ -89,6 +90,16 @@ export default function update(state = initialAppState(), action: AppAction | Se
       };
     }
 
+    case "set_events": {
+      return {
+        ...state,
+        events: {
+          ...state.events,
+          [action.eventType]: action.events,
+        },
+      };
+    }
+
     case "set_pending_notification": {
       return { ...state, pendingNotification: action.location };
     }
@@ -140,3 +151,4 @@ export const getPointsForHoveredLineNumber = (state: UIState) => {
   const location = getHoveredLineNumberLocation(state);
   return getAnalysisPointsForLocation(state, location);
 };
+export const getEventsForType = (state: UIState, type: string) => state.app.events[type] || [];

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -4,6 +4,7 @@ import {
   SessionId,
   PointDescription,
   Location,
+  MouseEvent,
 } from "@recordreplay/protocol";
 
 export type PanelName = "console" | "debugger" | "inspector";
@@ -44,8 +45,15 @@ export interface AppState {
   viewMode: ViewMode;
   narrowMode: boolean;
   hoveredLineNumberLocation: Location | null;
+  events: Events;
 }
 
 export interface AnalysisPoints {
   [key: string]: PointDescription;
 }
+
+interface Events {
+  [key: string]: MouseEvent[];
+}
+
+export type Event = "mousedown";


### PR DESCRIPTION
This adds a "Show clicks" checkbox for Play mode, in place of the old event listener breakpoint dropdown. Toggling the checkbox toggles the visibility of click events as entries in the transcript.



![image](https://user-images.githubusercontent.com/15959269/102924523-bf7aa580-445f-11eb-9f0f-d555fd4efd5f.png)
![image](https://user-images.githubusercontent.com/15959269/102924538-c6091d00-445f-11eb-8206-b3fbaaeb5ac3.png)
