### PR TITLE
Rewrite warp tests to avoid relying on pause line location.

### DIFF
--- a/test/scripts/console_warp-02.js
+++ b/test/scripts/console_warp-02.js
@@ -25,19 +25,29 @@ Test.describe(
 
     await Test.warpToMessage("number: 2");
     await Test.checkPausedMessage("number: 2");
+
     await Test.stepOverToLine(20);
+    await Test.checkPausedMessage("number: 2");
 
     await Test.executeInConsole("1 << 5");
-    await Test.checkPausedMessage("32");
+    await Test.checkPausedMessage("number: 2");
 
     await Test.stepOverToLine(21);
+    await Test.checkPausedMessage("number: 2");
+
     await Test.executeInConsole("1 << 7");
-    await Test.checkPausedMessage("128");
+    await Test.checkPausedMessage("number: 2");
 
     await Test.reverseStepOverToLine(20);
-    await Test.checkPausedMessage("32");
+    await Test.checkPausedMessage("number: 2");
 
     await Test.executeInConsole("1 << 6");
-    await Test.checkPausedMessage("64");
+    await Test.checkPausedMessage("number: 2");
+
+    await Test.stepOverToLine(21);
+    await Test.checkPausedMessage("number: 2");
+
+    await Test.stepOverToLine(22);
+    await Test.checkPausedMessage("number: 3");
   }
 );


### PR DESCRIPTION
It looks like this test broke due to changes in https://github.com/RecordReplay/devtools/pull/1274

Fixes #1298