### PR TITLE
Update the created at contextual timestamp for a replay without refre…

### DIFF
--- a/src/ui/components/Header/Header.js
+++ b/src/ui/components/Header/Header.js
@@ -71,9 +71,23 @@ function HeaderTitle({ recordingId, editingTitle, setEditingTitle }) {
         editingTitle={editingTitle}
         recordingId={recordingId}
       />
-      {!editingTitle && <div className="subtitle">{moment(date).fromNow()}</div>}
+      {!editingTitle && <Subtitle date={date} />}
     </div>
   );
+}
+
+function Subtitle({ date }) {
+  const [time, setTime] = useState(Date.now());
+
+  // Update the "Created at" time every 30s.
+  useEffect(() => {
+    const interval = setInterval(() => setTime(Date.now()), 10000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  return <div className="subtitle">Created {moment(date).fromNow()}</div>;
 }
 
 function Header({ user, getActiveUsers, recordingId }) {


### PR DESCRIPTION
Fix #1341

This updates the "created" time every 30s so it's doesn't become stale.

That said, it doesn't solve the problem where somebody might look at this time and not be sure what it's referring to. Last saved? Last activity? Last comment? For that, we probably should add "Created ...." right at the beginning of that sentence