### PR TITLE
Bring back timelime marker highlighting when the corresponding console message is hovered

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoint.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoint.js
@@ -50,14 +50,6 @@ class Breakpoint extends PureComponent {
     return bp;
   }
 
-  onMouseEnter = event => {
-    this.props.highlightLocation(this.props.breakpoint.location);
-  };
-
-  onMouseLeave = () => {
-    this.props.unhighlightLocation();
-  };
-
   onClick = event => {
     const { cx, breakpoint, removeBreakpointsAtLine } = this.props;
 
@@ -131,6 +123,4 @@ class Breakpoint extends PureComponent {
 
 export default connect(null, {
   removeBreakpointsAtLine: actions.removeBreakpointsAtLine,
-  highlightLocation: actions.highlightLocation,
-  unhighlightLocation: actions.unhighlightLocation,
 })(Breakpoint);

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -139,35 +139,10 @@ export function setTimelineToTime({
   };
 }
 
-export function setTimelineToMessage({
-  message,
-  offset,
-}: {
-  message: any;
-  offset: number;
-}): UIThunkAction {
-  return async ({ dispatch, getState }) => {
-    try {
-      dispatch(updateTooltip({ left: offset }));
-      dispatch(setTimelineState({ highlightedMessageId: message.id }));
-
-      const paintPoint = getMostRecentPaintPoint(message.executionPointTime);
-      if (!paintPoint) return;
-      const { point, paintHash } = paintPoint;
-      const screen = await screenshotCache.getScreenshotForTooltip(point, paintHash);
-
-      const currentMessageId = selectors.getHighlightedMessageId(getState());
-      if (currentMessageId === message.id) {
-        dispatch(updateTooltip({ screen, left: offset }));
-      }
-    } catch {}
-  };
-}
-
 export function hideTooltip(): UIThunkAction {
   return ({ dispatch }) => {
     dispatch(updateTooltip(null));
-    dispatch(setTimelineState({ hoverTime: null, highlightedMessageId: null }));
+    dispatch(setTimelineState({ hoverTime: null }));
   };
 }
 
@@ -200,12 +175,4 @@ export function seek(
       ThreadFront.timeWarp(point, time, hasFrames);
     }
   };
-}
-
-export function highlightLocation(location: Location) {
-  return { type: "set_timeline_state", state: { highlightedLocation: location } };
-}
-
-export function unhighlightLocation() {
-  return { type: "set_timeline_state", state: { highlightedLocation: null } };
 }

--- a/src/ui/components/Timeline/Message.js
+++ b/src/ui/components/Timeline/Message.js
@@ -39,11 +39,12 @@ export function Marker({ message, onMarkerClick, onMarkerMouseEnter, onMarkerMou
   );
 }
 
-class Message extends React.Component {
+export default class Message extends React.Component {
   render() {
     const {
       message,
       currentTime,
+      hoveredMessageId,
       zoomRegion,
       overlayWidth,
       onMarkerClick,
@@ -61,6 +62,9 @@ class Message extends React.Component {
       return null;
     }
 
+    // A marker is highlighted if its corresponding message is hovered on
+    // in the console
+    const isHighlighted = hoveredMessageId == message.id;
     const isPauseLocation = message.executionPointTime === currentTime;
 
     let frameLocation = "";
@@ -77,6 +81,7 @@ class Message extends React.Component {
       <a
         tabIndex={0}
         className={classnames("message", {
+          highlighted: isHighlighted,
           paused: isPauseLocation,
         })}
         style={{
@@ -116,7 +121,3 @@ export function MessagePreview({ message, overlayWidth, zoomRegion }) {
     </a>
   );
 }
-export default connect(state => ({
-  highlightedLocation: selectors.getHighlightedLocation(state),
-  hoveredLineNumberLocation: selectors.getHoveredLineNumberLocation(state),
-}))(Message);

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -120,6 +120,11 @@
   outline: none;
 }
 
+.timeline .message.highlighted {
+  transform: scale(1.3);
+  z-index: var(--z-index-2--hovered-message);
+}
+
 .timeline .commands {
   display: flex;
   flex-direction: row;

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -118,10 +118,11 @@ export class Timeline extends Component {
     const { setTimelineState } = this.props;
 
     if (type == "mouseenter") {
-      setTimelineState({ highlightedMessage: message.id });
+      setTimelineState({ hoveredMessageId: message.id });
     }
-
-    return null;
+    if (type == "mouseleave") {
+      setTimelineState({ hoveredMessageId: null });
+    }
   };
 
   findMessage(message) {
@@ -145,12 +146,6 @@ export class Timeline extends Component {
     const elementTop = element.getBoundingClientRect().top;
     if (elementTop < 30 || elementTop + 50 > consoleHeight) {
       element.scrollIntoView({ block: "center", behavior: "smooth" });
-    }
-  }
-
-  unhighlightConsoleMessage() {
-    if (this.props.highlightedMessageId) {
-      this.props.setTimelineState({ highlightedMessageId: null });
     }
   }
 
@@ -467,7 +462,7 @@ export class Timeline extends Component {
   }
 
   renderMessages() {
-    const { messages, currentTime, highlightedMessageId, zoomRegion } = this.props;
+    const { messages, currentTime, hoveredMessageId, zoomRegion } = this.props;
 
     return messages.map((message, index) => {
       const messageEl = (
@@ -476,7 +471,7 @@ export class Timeline extends Component {
           index={index}
           messages={messages}
           currentTime={currentTime}
-          highlightedMessageId={highlightedMessageId}
+          hoveredMessageId={hoveredMessageId}
           zoomRegion={zoomRegion}
           overlayWidth={this.overlayWidth}
           onMarkerClick={this.onMarkerClick}
@@ -606,8 +601,7 @@ export default connect(
     currentTime: selectors.getCurrentTime(state),
     hoverTime: selectors.getHoverTime(state),
     playback: selectors.getPlayback(state),
-    highlightedMessageId: selectors.getHighlightedMessageId(state),
-    hoveredMessage: selectors.getHoveredMessage(state),
+    hoveredMessageId: selectors.getHoveredMessageId(state),
     unprocessedRegions: selectors.getUnprocessedRegions(state),
     recordingDuration: selectors.getRecordingDuration(state),
     timelineDimensions: selectors.getTimelineDimensions(state),

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -8,9 +8,7 @@ function initialTimelineState(): TimelineState {
     currentTime: 0,
     hoverTime: null,
     playback: null,
-    highlightedMessageId: null,
-    highlightedLocation: null,
-    hoveredMessage: null,
+    hoveredMessageId: null,
     unprocessedRegions: [],
     shouldAnimate: true,
     recordingDuration: null,
@@ -49,9 +47,7 @@ export const getZoomRegion = (state: UIState) => state.timeline.zoomRegion;
 export const getCurrentTime = (state: UIState) => state.timeline.currentTime;
 export const getHoverTime = (state: UIState) => state.timeline.hoverTime;
 export const getPlayback = (state: UIState) => state.timeline.playback;
-export const getHighlightedMessageId = (state: UIState) => state.timeline.highlightedMessageId;
-export const getHighlightedLocation = (state: UIState) => state.timeline.highlightedLocation;
-export const getHoveredMessage = (state: UIState) => state.timeline.hoveredMessage;
+export const getHoveredMessageId = (state: UIState) => state.timeline.hoveredMessageId;
 export const getUnprocessedRegions = (state: UIState) => state.timeline.unprocessedRegions;
 export const getRecordingDuration = (state: UIState) => state.timeline.recordingDuration;
 export const getScreenShot = (state: UIState) => state.timeline.screenShot;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -26,9 +26,7 @@ export interface TimelineState {
   zoomRegion: ZoomRegion;
   timelineDimensions: { width: number; left: number; top: number };
   hoverTime: number | null;
-  highlightedMessageId: string | null;
-  highlightedLocation: Location | null;
-  hoveredMessage: number | null;
+  hoveredMessageId: string | null;
   unprocessedRegions: TimeRange[];
   shouldAnimate: boolean;
   loaded: boolean;


### PR DESCRIPTION
This fixes the connection between the console and the timeline, so that hovering on a console message makes the corresponding timeline marker for that message react.

> Wait for #1382 to land before this one.