### PR TITLE
changed classname for created from page-url to more applicable name, …

### DIFF
--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.js
@@ -86,7 +86,7 @@ function ItemTitle({ data, editing, editingTitle, setEditingTitle }) {
           </div>
         ) : null}
       </div>
-      <div className="page-url">Created {moment(data.date).fromNow()}</div>
+      <div className="replay-created-at">Created {moment(data.date).fromNow()}</div>
     </div>
   );
 }

--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.js
@@ -86,7 +86,7 @@ function ItemTitle({ data, editing, editingTitle, setEditingTitle }) {
           </div>
         ) : null}
       </div>
-      <div className="replay-created-at">Created {moment(data.date).fromNow()}</div>
+      <div>Created {moment(data.date).fromNow()}</div>
     </div>
   );
 }


### PR DESCRIPTION
…fixes the created date from turning blue and underlined on hover
fixes issue #1357 

before:
![image](https://user-images.githubusercontent.com/19538307/103249001-11b93c00-4922-11eb-9c12-75bd0876ea08.png)

after:
![image](https://user-images.githubusercontent.com/19538307/103249010-18e04a00-4922-11eb-9948-fb3c048f2ec9.png)
