### PR TITLE
displaying message now when there are no breakpoints to show in the breakpoint panel

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -6,6 +6,11 @@
   overflow-x: auto;
 }
 
+.no-breakpoints {
+  padding: 8px;
+  white-space: pre-wrap;
+}
+
 .breakpoints-list *:focus:not(:focus-visible) {
   outline: none;
   background: inherit;

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -6,7 +6,7 @@
   overflow-x: auto;
 }
 
-.no-breakpoints {
+.empty-state-content {
   padding: 8px;
   white-space: pre-wrap;
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/index.js
@@ -46,7 +46,7 @@ class Breakpoints extends Component {
 
     if (!breakpointSources.length) {
       return (
-        <div className="no-breakpoints">
+        <div className="empty-state-content">
           There is nothing here yet. Try adding a breakpoint in a source file.
         </div>
       );

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/index.js
@@ -45,7 +45,11 @@ class Breakpoints extends Component {
     const { breakpointSources } = this.props;
 
     if (!breakpointSources.length) {
-      return null;
+      return (
+        <div className="no-breakpoints">
+          There is nothing here yet. Try adding a breakpoint in a source file.
+        </div>
+      );
     }
 
     const sources = [...breakpointSources.map(({ source }) => source)];


### PR DESCRIPTION
fixes issue #1077 
i followed the same format message in the comments panel for the empty breakpoints panel. the text will also wrap to fit the width of the panel and hide when the breakpoint panel is collapsed.

before:
![image](https://user-images.githubusercontent.com/19538307/103248954-d0c12780-4921-11eb-89f7-5e5dfb99f85f.png)

after:
![image](https://user-images.githubusercontent.com/19538307/103248961-d6b70880-4921-11eb-9b83-ff8b7b34e2b4.png)
