### PR TITLE
made editing title of replay more obvious

### DIFF
--- a/src/ui/components/Header/Header.css
+++ b/src/ui/components/Header/Header.css
@@ -81,13 +81,12 @@
 
 #header .title {
   max-width: 320px;
-  color: var(--grey-90);
   font-size: 1.25rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   background: none;
-  cursor: pointer;
+  cursor: text;
   line-height: 18px;
   margin-right: 0.5em;
   color: var(--primary-accent);

--- a/src/ui/components/shared/Title.js
+++ b/src/ui/components/shared/Title.js
@@ -58,7 +58,7 @@ export default function Title({ defaultTitle, recordingId, setEditingTitle, edit
   }
 
   return (
-    <div className="title" onDoubleClick={handleClick}>
+    <div className="title" onClick={handleClick} title="Click to edit the title.">
       {title}
     </div>
   );


### PR DESCRIPTION
fixes issue #1350 
- added title property to element saying "Click to edit the title."
- changed cursor to text icon on hover
- changed from double click to single click to edit the title
- also removed extra color styling as it wasn't being used and was overridden by new color style added recently

(not pictured in the screenshots is the cursor changed from 'pointer' to 'text' on hover)
before:
![image](https://user-images.githubusercontent.com/19538307/103250655-bee38280-4929-11eb-816d-d806db0936fc.png)


after:
![image](https://user-images.githubusercontent.com/19538307/103250646-b4c18400-4929-11eb-9660-41b4d05a8531.png)
