### PR TITLE
cant edit title by clicking title in dashboard anymore

### DIFF
--- a/src/ui/components/Dashboard/RecordingItem/RecordingGridItem.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingGridItem.js
@@ -25,6 +25,7 @@ export default function RecordingGridItem({
           recordingId={data.recording_id}
           editingTitle={editingTitle}
           setEditingTitle={setEditingTitle}
+          allowEditOnTitleClick={false}
         />
         <div className="secondary">{moment(data.date).format("MMM Do, h:mm a")}</div>
         <div className="permissions" onClick={toggleIsPrivate}>

--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.js
@@ -79,6 +79,7 @@ function ItemTitle({ data, editing, editingTitle, setEditingTitle }) {
           recordingId={data.recording_id}
           editingTitle={editingTitle}
           setEditingTitle={setEditingTitle}
+          allowEditOnTitleClick={false}
         />
         {!editing ? (
           <div className="item-title-label-actions">

--- a/src/ui/components/Header/Header.js
+++ b/src/ui/components/Header/Header.js
@@ -62,7 +62,6 @@ function HeaderTitle({ recordingId, editingTitle, setEditingTitle }) {
 
   const recording = data.recordings[0];
   const { recordingTitle, title, date } = recording || {};
-
   return (
     <div className="title-container">
       <Title
@@ -70,6 +69,7 @@ function HeaderTitle({ recordingId, editingTitle, setEditingTitle }) {
         setEditingTitle={setEditingTitle}
         editingTitle={editingTitle}
         recordingId={recordingId}
+        allowEditOnTitleClick={true}
       />
       {!editingTitle && <Subtitle date={date} />}
     </div>

--- a/src/ui/components/shared/Title.js
+++ b/src/ui/components/shared/Title.js
@@ -16,7 +16,13 @@ const UPDATE_RECORDING = gql`
   }
 `;
 
-export default function Title({ defaultTitle, recordingId, setEditingTitle, editingTitle }) {
+export default function Title({
+  defaultTitle,
+  recordingId,
+  setEditingTitle,
+  editingTitle,
+  allowEditOnTitleClick,
+}) {
   const { isAuthenticated } = useAuth0();
   const [updateRecordingTitle] = useMutation(UPDATE_RECORDING);
   const [title, setTitle] = useState(defaultTitle);
@@ -57,9 +63,13 @@ export default function Title({ defaultTitle, recordingId, setEditingTitle, edit
     );
   }
 
-  return (
-    <div className="title" onClick={handleClick} title="Click to edit the title.">
-      {title}
-    </div>
-  );
+  if (allowEditOnTitleClick) {
+    return (
+      <div className="title" onClick={handleClick} title="Click to edit the title.">
+        {title}
+      </div>
+    );
+  }
+
+  return <div className="title">{title}</div>;
 }


### PR DESCRIPTION
fixes issue #1392 
previously, clicking on the title in the dashboard would cause an input box to appear that allows the user to edit, however we weren't calling stopPropogation so before the user got a chance to edit the title it'd just navigate them to the replay page. after discussing with @jonbell-lot23 the ability to edit the title by clicking on it has been removed from the dashboard.
to accomplish this i've added a new property to the Title element to determine whether or not you can edit on click, i chose to do this instead of removing the Title element from the dashboard because we still need the Title element to edit the title via the three dots on the right of the replay row.