### PR TITLE
scrolling no longer jitters when adding breakpoint then scrolling in source file

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -62,12 +62,9 @@ function Widget({ location, children, editor, insertAt }) {
       return;
     }
     const editorLine = toEditorLine(location.sourceId, location.line || 0);
-    const _widget = editor.codeMirror.addLineWidget(editorLine, node, {
+    editor.codeMirror.addLineWidget(editorLine, node, {
       insertAt,
     });
-    return () => {
-      _widget.clear();
-    };
   }, [loading]);
 
   if (!node) {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -62,9 +62,16 @@ function Widget({ location, children, editor, insertAt }) {
       return;
     }
     const editorLine = toEditorLine(location.sourceId, location.line || 0);
-    editor.codeMirror.addLineWidget(editorLine, node, {
+    const _widget = editor.codeMirror.addLineWidget(editorLine, node, {
       insertAt,
     });
+
+    // We are clearing the widget here because without
+    // doing so causes breakpoints to show up on the
+    // wrong line number when clicking in the gutter.
+    return () => {
+      _widget.clear();
+    };
   }, [loading]);
 
   if (!node) {

--- a/src/devtools/client/debugger/src/utils/editor/index.js
+++ b/src/devtools/client/debugger/src/utils/editor/index.js
@@ -126,8 +126,7 @@ export function getLocationsInViewport(
   { codeMirror },
   // Offset represents an allowance of characters or lines offscreen to improve
   // perceived performance of column breakpoint rendering
-  offsetHorizontalCharacters = 100,
-  offsetVerticalLines = 20
+  offsetHorizontalCharacters = 100
 ) {
   // Get scroll position
   if (!codeMirror) {
@@ -139,9 +138,6 @@ export function getLocationsInViewport(
   const charWidth = codeMirror.defaultCharWidth();
   const scrollArea = codeMirror.getScrollInfo();
   const { scrollLeft } = codeMirror.doc;
-  const rect = codeMirror.getWrapperElement().getBoundingClientRect();
-  const topVisibleLine = codeMirror.lineAtHeight(rect.top, "window") - offsetVerticalLines;
-  const bottomVisibleLine = codeMirror.lineAtHeight(rect.bottom, "window") + offsetVerticalLines;
 
   const leftColumn = Math.floor(
     scrollLeft > 0 ? scrollLeft / charWidth - offsetHorizontalCharacters : 0
@@ -149,13 +145,20 @@ export function getLocationsInViewport(
   const rightPosition = scrollLeft + (scrollArea.clientWidth - 30);
   const rightCharacter = Math.floor(rightPosition / charWidth) + offsetHorizontalCharacters;
 
+  // This is used to tell codemirror what part of the
+  // source file is within the viewport so it knows what
+  // breakpoint widgets to render.
+  // We're setting start to zero and end to infinity because
+  // we want all breakpoint widgets to be rendered on load
+  // without removing and re-adding them as they leave the
+  // viewport while a user is scrolling through the file
   return {
     start: {
-      line: topVisibleLine || 0,
+      line: 0,
       column: leftColumn || 0,
     },
     end: {
-      line: bottomVisibleLine || 0,
+      line: Number.POSITIVE_INFINITY,
       column: rightCharacter,
     },
   };


### PR DESCRIPTION
fixes issue #1026 
there isn't much documentation on why _widget.clear() was being called so i tested different scenarios to make sure nothing would break.
- adding a breakpoint to the same line number in two different files
- giving each one different custom logs
- ff and rewinding to each
- removing and re-adding each
- refreshing page to be sure the breakpoints were still there