### PR TITLE
Don't show framework icon for sources/tabs

### DIFF
--- a/src/devtools/client/debugger/src/components/shared/SourceIcon.js
+++ b/src/devtools/client/debugger/src/components/shared/SourceIcon.js
@@ -16,10 +16,10 @@ import { getSymbols, getTabs } from "../../selectors";
 
 import "./SourceIcon.css";
 
-class SourceIcon extends PureComponent {
+export default class SourceIcon extends PureComponent {
   render() {
-    const { shouldHide, source, symbols, framework } = this.props;
-    const iconClass = framework ? framework.toLowerCase() : getSourceClassnames(source, symbols);
+    const { shouldHide, source } = this.props;
+    const iconClass = getSourceClassnames(source);
 
     if (shouldHide && shouldHide(iconClass)) {
       return null;
@@ -28,8 +28,3 @@ class SourceIcon extends PureComponent {
     return <AccessibleImage className={`source-icon ${iconClass}`} />;
   }
 }
-
-export default connect((state, props) => ({
-  symbols: getSymbols(state, props.source),
-  framework: getFramework(getTabs(state), props.source.url),
-}))(SourceIcon);

--- a/src/devtools/client/debugger/src/utils/source.js
+++ b/src/devtools/client/debugger/src/utils/source.js
@@ -384,7 +384,7 @@ export function getTextAtPosition(sourceId, asyncContent, location) {
   return lineText.slice(column, column + 100).trim();
 }
 
-export function getSourceClassnames(source, symbols) {
+export function getSourceClassnames(source) {
   // Conditionals should be ordered by priority of icon!
   const defaultClassName = "file";
 
@@ -398,10 +398,6 @@ export function getSourceClassnames(source, symbols) {
 
   if (source.isBlackBoxed) {
     return "blackBox";
-  }
-
-  if (symbols && !symbols.loading && symbols.framework) {
-    return symbols.framework.toLowerCase();
   }
 
   if (isUrlExtension(source.url)) {


### PR DESCRIPTION
Fixes #1378.

This makes it so that we don't treat framework sources any differently from regular sources. This means we don't override their icons with the corresponding framework icon.

This is best tested with [this replay](http://localhost:8080/index.html?id=b83997d3-c207-409c-a326-c3cf55c76ec0). Just go into sources and open `static/js/components/App.js`.

![image](https://user-images.githubusercontent.com/15959269/103314087-fae11b00-49ef-11eb-89da-0b973068782d.png)
