### PR TITLE
Store multiple locations in the gLogpoints info

### DIFF
--- a/src/protocol/logpoint.ts
+++ b/src/protocol/logpoint.ts
@@ -22,7 +22,7 @@ interface LogpointInfo {
   analysisWaiters: Promise<createAnalysisResult>[];
   points: PointDescription[];
   pointsWaiter?: (value: void) => void;
-  location: Location | null;
+  locations: Location[] | null;
   showInConsole: boolean;
 }
 
@@ -130,7 +130,12 @@ async function createLogpointAnalysis(
   showInConsole: boolean
 ) {
   if (!gLogpoints.has(logGroupId)) {
-    gLogpoints.set(logGroupId, { analysisWaiters: [], points: [], location, showInConsole });
+    gLogpoints.set(logGroupId, { analysisWaiters: [], points: [], locations: [], showInConsole });
+  }
+
+  // To avoid duplication, only add the location if this logGroupId's info doesn't have it yet
+  if (gLogpoints.get(logGroupId)!.locations!.every(loc => loc.sourceId != location!.sourceId)) {
+    gLogpoints.get(logGroupId)!.locations!.push(location!);
   }
 
   const waiter = client.Analysis.createAnalysis({

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -83,10 +83,8 @@ export function setupApp(recordingId: RecordingId, store: UIStore) {
 
 function setupPointHandlers(store: UIStore) {
   PointHandlers.onPoints = (points: PointDescription[], info: any) => {
-    const { location } = info;
-    if (location) {
-      store.dispatch(setAnalysisPoints(points, location));
-    }
+    const { locations } = info;
+    locations.forEach((location: Location) => store.dispatch(setAnalysisPoints(points, location)));
   };
 
   PointHandlers.addPendingNotification = (location: any) => {


### PR DESCRIPTION
This stores multiple locations in each logGroupId. This makes it so that there are **separate analysisPoint** entries for each sourceId. 

This fixes #1354 and fixes #1419. The main discussion can be found [here](https://github.com/RecordReplay/devtools/issues/1419).

| | Before | After
--- | --- | --- 
Location | app.js:5:2 | app.js:5:2
Source ID  | 2 | 2
Key | 2:5:2 | 2:5:2
`app.js` IDs | [ "1", "2" ] | [ "1", "2" ]
analysisPoints | {"1:5:2": [...]} | {"1:5:2": [...], "2:5:2": [...]} 
Result | No match for key => "no hits" | Match for key => "X hits"