### PR TITLE
Allow the timeline playback to continue playing without interruptions

### DIFF
--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -17,7 +17,6 @@ export interface TimelineState {
   playback: {
     startTime: number;
     startDate: number;
-    pauseTarget: PauseDescription;
     time: number;
   } | null;
   screenShot: ScreenShot | null;


### PR DESCRIPTION
As it is, we stop the ongoing playback whenever a breakpoint is hit. This PR makes playback continuous. Once a user presses play on the timeline, the timeline will continue to play until it hits the end of the recording.

This fixes #1390.