### PR TITLE
Occupy the widget bottom row when there are no hits

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -81,7 +81,7 @@ function Widget({ location, children, editor, insertAt }) {
   return ReactDOM.createPortal(<>{children}</>, node);
 }
 
-function Panel({ breakpoint, editor, insertAt }) {
+export default function Panel({ breakpoint, editor, insertAt }) {
   const [editing, setEditing] = useState(false);
   const [width, setWidth] = useState(getPanelWidth(editor));
   const [inputToFocus, setInputToFocus] = useState("logValue");
@@ -117,5 +117,3 @@ function Panel({ breakpoint, editor, insertAt }) {
     </Widget>
   );
 }
-
-export default Panel;

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
@@ -7,6 +7,12 @@
   align-items: center;
 }
 
+.breakpoint-navigation.empty .breakpoint-navigation-status-container,
+.breakpoint-navigation.empty .breakpoint-navigation-status {
+  width: 100%;
+  text-align: center;
+}
+
 .breakpoint-navigation-commands {
   display: flex;
   flex-direction: row;

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -1,4 +1,5 @@
 import React from "react";
+import classnames from "classnames";
 import { compareNumericStrings } from "../../../../../../../protocol/utils";
 import { getThreadExecutionPoint } from "../../../reducers/pause";
 import { connect } from "../../../utils/connect";
@@ -22,6 +23,7 @@ function BreakpointNavigation({
       seek(point.point, point.time, true);
     }
   };
+  const isEmpty = analysisPoints && !analysisPoints.length;
 
   let prev, next;
 
@@ -31,27 +33,10 @@ function BreakpointNavigation({
   }
 
   return (
-    <div className="breakpoint-navigation">
-      <div className="breakpoint-navigation-commands">
-        <button
-          className={`breakpoint-navigation-command-prev ${!prev ? " disabled" : ""}`}
-          disabled={!prev}
-          onClick={() => {
-            navigateToPoint(prev);
-          }}
-        >
-          <div className="img play-circle" style={{ transform: "rotate(180deg)" }} />
-        </button>{" "}
-        <button
-          className={`breakpoint-navigation-command-next ${!next ? " disabled" : ""}`}
-          disabled={!next}
-          onClick={() => {
-            navigateToPoint(next);
-          }}
-        >
-          <div className="img play-circle" />
-        </button>
-      </div>
+    <div className={classnames("breakpoint-navigation", { empty: isEmpty })}>
+      {!isEmpty ? (
+        <BreakpointNavigationCommands prev={prev} next={next} navigateToPoint={navigateToPoint} />
+      ) : null}
       {analysisPoints?.length ? (
         <BreakpointTimeline breakpoint={breakpoint} setZoomedBreakpoint={setZoomedBreakpoint} />
       ) : null}
@@ -65,10 +50,37 @@ function BreakpointNavigation({
   );
 }
 
+function BreakpointNavigationCommands({ prev, next, navigateToPoint }) {
+  return (
+    <div className="breakpoint-navigation-commands">
+      <button
+        className={`breakpoint-navigation-command-prev ${!prev ? " disabled" : ""}`}
+        disabled={!prev}
+        onClick={() => {
+          navigateToPoint(prev);
+        }}
+      >
+        <div className="img play-circle" style={{ transform: "rotate(180deg)" }} />
+      </button>{" "}
+      <button
+        className={`breakpoint-navigation-command-next ${!next ? " disabled" : ""}`}
+        disabled={!next}
+        onClick={() => {
+          navigateToPoint(next);
+        }}
+      >
+        <div className="img play-circle" />
+      </button>
+    </div>
+  );
+}
+
 function BreakpointNavigationStatus({ executionPoint, analysisPoints }) {
   let status = "";
 
-  if (!analysisPoints?.length) {
+  if (!analysisPoints) {
+    status = "Loading";
+  } else if (!analysisPoints.length) {
     status = "No hits";
   } else {
     const points = analysisPoints

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -23,7 +23,7 @@ function BreakpointNavigation({
       seek(point.point, point.time, true);
     }
   };
-  const isEmpty = analysisPoints && !analysisPoints.length;
+  const isEmpty = analysisPoints && analysisPoints?.length == 0;
 
   let prev, next;
 
@@ -80,7 +80,7 @@ function BreakpointNavigationStatus({ executionPoint, analysisPoints }) {
 
   if (!analysisPoints) {
     status = "Loading";
-  } else if (!analysisPoints.length) {
+  } else if (analysisPoints.length == 0) {
     status = "No hits";
   } else {
     const points = analysisPoints


### PR DESCRIPTION
Fix #1369. Let's circle back to this when we have a better idea about loading state and allowing/disallowing users to add breakpoints on lines that don't have any corresponding points.

Loaded with hits and loaded with no hits: 
![image](https://user-images.githubusercontent.com/15959269/103390556-09f4c580-4ae3-11eb-9b94-08b403b4a2fc.png)
Loading:
![image](https://user-images.githubusercontent.com/15959269/103390580-3ad4fa80-4ae3-11eb-9f87-7a10d5ee4f07.png)
