### PR TITLE
Force guests to sign in before leaving a comment

### DIFF
--- a/src/ui/actions/index.ts
+++ b/src/ui/actions/index.ts
@@ -2,6 +2,7 @@ import { Store } from "redux";
 import * as appActions from "./app";
 import * as timelineActions from "./timeline";
 import * as metadataActions from "./metadata";
+import * as sessionActions from "./session";
 import { ThunkAction } from "ui/utils/thunk";
 import { UIState } from "ui/state";
 import type { AppAction } from "./app";
@@ -45,4 +46,5 @@ export const actions = {
   ...eventListeners,
   ...debuggerActions,
   ...consoleActions,
+  ...sessionActions,
 };

--- a/src/ui/components/Comments/NewCommentButton.js
+++ b/src/ui/components/Comments/NewCommentButton.js
@@ -6,6 +6,7 @@ import { getMarkerLeftOffset } from "ui/utils/timeline";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
 import hooks from "ui/hooks";
+import { useAuth0 } from "@auth0/auth0-react";
 
 const markerWidth = 19;
 
@@ -18,7 +19,9 @@ function NewCommentButton({
   setFocusedCommentId,
   comments,
   hideTooltip,
+  setExpectedError,
 }) {
+  const { isAuthenticated } = useAuth0();
   const addCommentCallback = id => {
     setFocusedCommentId(id);
     hideTooltip();
@@ -35,6 +38,13 @@ function NewCommentButton({
   }
 
   const handleClick = () => {
+    if (!isAuthenticated) {
+      return setExpectedError({
+        message: "You need to sign in to leave a comment.",
+        action: "sign-in",
+      });
+    }
+
     const newComment = {
       content: "",
       recording_id: recordingId,
@@ -77,5 +87,6 @@ export default connect(
   {
     setFocusedCommentId: actions.setFocusedCommentId,
     hideTooltip: actions.hideTooltip,
+    setExpectedError: actions.setExpectedError,
   }
 )(NewCommentButton);


### PR DESCRIPTION
Fixes #1374.

This makes it so that clicking on the add a new comment button as an anonymous user shows a screen that prompts the user to sign in.

![image](https://user-images.githubusercontent.com/15959269/103391082-93a59280-4ae5-11eb-8dd8-7e65f799cca9.png)
