### PR TITLE
Fix scopes width to fit content

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Scopes.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Scopes.css
@@ -97,4 +97,5 @@ html[dir="rtl"] .scopes-content .object-node {
 
 .scopes-list .tree {
   line-height: 15px;
+  min-width: fit-content;
 }


### PR DESCRIPTION
Fixes #1340

Before:
![image](https://user-images.githubusercontent.com/15959269/103393311-061b7000-4af0-11eb-81e2-f52bbf974341.png)

After:
![image](https://user-images.githubusercontent.com/15959269/103393327-1a5f6d00-4af0-11eb-8078-24cbb40d93c2.png)
