### PR TITLE
Handle null location values for event breakpoints

### DIFF
--- a/src/protocol/logpoint.ts
+++ b/src/protocol/logpoint.ts
@@ -22,7 +22,7 @@ interface LogpointInfo {
   analysisWaiters: Promise<createAnalysisResult>[];
   points: PointDescription[];
   pointsWaiter?: (value: void) => void;
-  locations: Location[] | null;
+  locations: Location[];
   showInConsole: boolean;
 }
 
@@ -105,7 +105,9 @@ client.Analysis.addAnalysisPointsListener(({ analysisId, points }) => {
     info.pointsWaiter();
   }
 
-  if (PointHandlers.onPoints) {
+  // Skip saving analysis points for event breakpoint analyses. We can tell
+  // event breakpoint analyses apart because their only location is null.
+  if (PointHandlers.onPoints && info.locations[0] !== null) {
     PointHandlers.onPoints(points, info);
   }
 
@@ -134,8 +136,8 @@ async function createLogpointAnalysis(
   }
 
   // To avoid duplication, only add the location if this logGroupId's info doesn't have it yet
-  if (gLogpoints.get(logGroupId)!.locations!.every(loc => loc.sourceId != location!.sourceId)) {
-    gLogpoints.get(logGroupId)!.locations!.push(location!);
+  if (gLogpoints.get(logGroupId)!.locations.every(loc => loc.sourceId != location!.sourceId)) {
+    gLogpoints.get(logGroupId)!.locations.push(location!);
   }
 
   const waiter = client.Analysis.createAnalysis({

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -84,7 +84,9 @@ export function setupApp(recordingId: RecordingId, store: UIStore) {
 function setupPointHandlers(store: UIStore) {
   PointHandlers.onPoints = (points: PointDescription[], info: any) => {
     const { locations } = info;
-    locations.forEach((location: Location) => store.dispatch(setAnalysisPoints(points, location)));
+    locations.forEach(
+      (location: Location | null) => location && store.dispatch(setAnalysisPoints(points, location))
+    );
   };
 
   PointHandlers.addPendingNotification = (location: any) => {


### PR DESCRIPTION
This is a follow up to #1420. 

I found out that when we receive points for event listener breakpoints, they end up being added to the analysisPoints in redux as well. The problem is that these points have a `null` location. This simply guards the `onPoints` callback to check if the incoming points are for event listener breakpoints. If they are, we don't save them in redux.

http://localhost:8080/index.html?id=30c359ce-9a1d-4e77-83d5-a47f5add53fb