### PR TITLE
Re-enable user select

### DIFF
--- a/src/devtools/client/themes/markup.css
+++ b/src/devtools/client/themes/markup.css
@@ -32,10 +32,6 @@
   -moz-control-character-visibility: visible;
 }
 
-body {
-  user-select: none;
-}
-
 /* Force height and width (possibly overflowing) from inline elements.
  * This allows long overflows of text or input fields to still be styled with
  * the container, rather than the background disappearing when scrolling */

--- a/src/ui/components/Header/Header.css
+++ b/src/ui/components/Header/Header.css
@@ -106,7 +106,6 @@ button.login {
   align-items: center;
   cursor: pointer;
   line-height: 16px;
-  margin-bottom: 20px;
 }
 
 .loading-bar {


### PR DESCRIPTION
Selecting text in the scopes panel works on Firefox. The difference was that we're using a css file (`markup.css`) that they aren't, and there's a `user-select: none` in that file. I took it out.

Fixes #1339.