### PR TITLE
Extract console functionality out of the timeline

### DIFF
--- a/src/devtools/client/webconsole/actions/toolbox.js
+++ b/src/devtools/client/webconsole/actions/toolbox.js
@@ -4,7 +4,9 @@
 
 "use strict";
 
-import { ThreadFront, Pause } from "protocol/thread";
+import { ThreadFront } from "protocol/thread";
+import { setTimelineState } from "ui/actions/timeline";
+import { paintGraphicsAtTime } from "protocol/graphics";
 
 export function highlightDomElement(grip) {
   return ({ toolbox }) => {
@@ -43,8 +45,15 @@ export function openNodeInInspector(valueFront) {
 }
 
 export function onMessageHover(type, message) {
-  return ({ toolbox }) => {
-    toolbox.emit("message-hover", type, message);
+  return ({ dispatch }) => {
+    if (type == "mouseenter") {
+      dispatch(setTimelineState({ hoveredMessageId: message.id }));
+      paintGraphicsAtTime(message.executionPointTime);
+    }
+    if (type == "mouseleave") {
+      dispatch(setTimelineState({ hoveredMessageId: null }));
+      paintGraphicsAtTime(message.executionPointTime);
+    }
   };
 }
 

--- a/src/devtools/client/webconsole/selectors/messages.js
+++ b/src/devtools/client/webconsole/selectors/messages.js
@@ -8,11 +8,44 @@ const {
   getParentWarningGroupMessageId,
   isError,
 } = require("devtools/client/webconsole/utils/messages");
+const { pointPrecedes } = require("protocol/execution-point-utils");
+const { MESSAGE_TYPE } = require("devtools/client/webconsole/constants");
+
 import { createSelector } from "reselect";
+
+export const getAllMessagesUiById = state => state.messages.messagesUiById;
+export const getAllMessagesPayloadById = state => state.messages.messagesPayloadById;
+export const getAllGroupsById = state => state.messages.groupsById;
+export const getCurrentGroup = state => state.messages.currentGroup;
+export const getFilteredMessagesCount = state => state.messages.filteredMessagesCount;
+export const getAllRepeatById = state => state.messages.repeatById;
+export const getGroupsById = state => state.messages.groupsById;
+export const getPausedExecutionPoint = state => state.messages.pausedExecutionPoint;
+export const getPausedExecutionPointTime = state => state.messages.pausedExecutionPointTime;
+export const getAllWarningGroupsById = state => state.messages.warningGroupsById;
+
+function messageTime(msg) {
+  const { executionPointTime, lastExecutionPoint } = msg;
+  return executionPointTime || (lastExecutionPoint && lastExecutionPoint.time) || 0;
+}
 
 export function getAllMessagesById(state) {
   return state.messages.messagesById;
 }
+
+export const getVisibleMessages = createSelector(
+  getAllMessagesById,
+  state => state.messages.visibleMessages,
+  state => state.consoleUI.zoomStartTime,
+  state => state.consoleUI.zoomEndTime,
+  (messages, visibleMessages, zoomStartTime, zoomEndTime) => {
+    return visibleMessages.filter(id => {
+      const msg = messages.get(id);
+      const time = messageTime(msg);
+      return time >= zoomStartTime && time <= zoomEndTime;
+    });
+  }
+);
 
 export const getMessages = createSelector(
   getAllMessagesById,
@@ -24,51 +57,48 @@ export const getMessagesForTimeline = createSelector(getMessages, messages =>
   messages.filter(message => message.source == "console-api" || isError(message))
 );
 
+function messageExecutionPoint(msg) {
+  const { executionPoint, lastExecutionPoint } = msg;
+  return executionPoint || (lastExecutionPoint && lastExecutionPoint.point);
+}
+
+export const getClosestMessage = createSelector(
+  getVisibleMessages,
+  getAllMessagesById,
+  getPausedExecutionPoint,
+  (visibleMessages, messages, executionPoint) => {
+    if (!executionPoint || !visibleMessages || !visibleMessages.length) {
+      return null;
+    }
+
+    // If the pause location is before the first message, the first message is
+    // marked as the paused one. This allows later messages to be grayed out but
+    // isn't consistent with behavior for those other messages.
+    let last = messages.get(visibleMessages[0]);
+
+    for (const id of visibleMessages) {
+      const msg = messages.get(id);
+
+      // Skip evaluations, which will always occur at the same evaluation point as
+      // a logpoint or log
+      if (msg.type == MESSAGE_TYPE.COMMAND || msg.type == MESSAGE_TYPE.RESULT) {
+        continue;
+      }
+
+      const point = messageExecutionPoint(msg);
+      if (point && pointPrecedes(executionPoint, point)) {
+        break;
+      }
+
+      last = msg;
+    }
+
+    return last;
+  }
+);
+
 export function getMessage(state, id) {
   return getAllMessagesById(state).get(id);
-}
-
-export function getAllMessagesUiById(state) {
-  return state.messages.messagesUiById;
-}
-export function getAllMessagesPayloadById(state) {
-  return state.messages.messagesPayloadById;
-}
-
-export function getAllGroupsById(state) {
-  return state.messages.groupsById;
-}
-
-export function getCurrentGroup(state) {
-  return state.messages.currentGroup;
-}
-
-export function getVisibleMessages(state) {
-  return state.messages.visibleMessages;
-}
-
-export function getFilteredMessagesCount(state) {
-  return state.messages.filteredMessagesCount;
-}
-
-export function getAllRepeatById(state) {
-  return state.messages.repeatById;
-}
-
-export function getGroupsById(state) {
-  return state.messages.groupsById;
-}
-
-export function getPausedExecutionPoint(state) {
-  return state.messages.pausedExecutionPoint;
-}
-
-export function getPausedExecutionPointTime(state) {
-  return state.messages.pausedExecutionPointTime;
-}
-
-export function getAllWarningGroupsById(state) {
-  return state.messages.warningGroupsById;
 }
 
 export function isMessageInWarningGroup(message, visibleMessages = []) {

--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -4,13 +4,7 @@ import { ThreadFront } from "./thread";
 import { assert, binarySearch } from "./utils";
 import { ScreenshotCache } from "./screenshot-cache";
 import ResizeObserverPolyfill from "resize-observer-polyfill";
-import {
-  TimeStampedPoint,
-  MouseEvent,
-  paintPoints,
-  mouseEvents,
-  ScreenShot,
-} from "@recordreplay/protocol";
+import { TimeStampedPoint, MouseEvent, paintPoints, ScreenShot } from "@recordreplay/protocol";
 import { client } from "./socket";
 import { actions, UIStore } from "ui/actions";
 
@@ -265,6 +259,11 @@ export function paintGraphics(screenShot?: ScreenShot, mouse?: MouseAndClickPosi
   gDrawImage.src = `data:${screenShot.mimeType};base64,${screenShot.data}`;
   gDrawMouse = mouse || null;
   refreshGraphics();
+}
+
+export async function paintGraphicsAtTime(time: number) {
+  const { screen, mouse } = await getGraphicsAtTime(time);
+  paintGraphics(screen, mouse);
 }
 
 function clearGraphics() {

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -44,8 +44,6 @@ export class Timeline extends Component {
     gToolbox.timeline = this;
 
     this.props.updateTimelineDimensions();
-
-    this.toolbox.on("message-hover", this.onConsoleMessageHover);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -87,50 +85,6 @@ export class Timeline extends Component {
     return Math.ceil(this.zoomStartTime + (this.zoomEndTime - this.zoomStartTime) * clickPosition);
   }
 
-  // Called when hovering over a message in the console.
-  onConsoleMessageHover = async (type, message) => {
-    const { setTimelineState, currentTime } = this.props;
-
-    if (type == "mouseenter") {
-      setTimelineState({ hoveredMessageId: message.id });
-      const { screen, mouse } = await getGraphicsAtTime(message.executionPointTime);
-      paintGraphics(screen, mouse);
-    }
-    if (type == "mouseleave") {
-      setTimelineState({ hoveredMessageId: null });
-      const { screen, mouse } = await getGraphicsAtTime(currentTime);
-      paintGraphics(screen, mouse);
-    }
-  };
-
-  findMessage(message) {
-    const outputNode = document.getElementById("toolbox-content-console");
-    return outputNode?.querySelector(`.message[data-message-id="${message.id}"]`);
-  }
-
-  scrollToMessage(message) {
-    if (!message) {
-      return;
-    }
-
-    const element = this.findMessage(message);
-
-    if (!element) {
-      return;
-    }
-
-    const outputNode = document.getElementById("toolbox-content-console");
-    const consoleHeight = outputNode.getBoundingClientRect().height;
-    const elementTop = element.getBoundingClientRect().top;
-    if (elementTop < 30 || elementTop + 50 > consoleHeight) {
-      element.scrollIntoView({ block: "center", behavior: "smooth" });
-    }
-  }
-
-  showMessage(message) {
-    this.scrollToMessage(message);
-  }
-
   onMarkerClick = (e, message) => {
     const { selectedPanel, viewMode, seek } = this.props;
 
@@ -138,10 +92,6 @@ export class Timeline extends Component {
     e.stopPropagation();
     const { executionPoint, executionPointTime, executionPointHasFrames, pauseId } = message;
     seek(executionPoint, executionPointTime, executionPointHasFrames, pauseId);
-
-    if (viewMode == "dev" && selectedPanel == "console") {
-      this.showMessage(message);
-    }
   };
 
   onMarkerMouseEnter = () => {


### PR DESCRIPTION
This was motivated by Jaril's incredible work pulling logic out of the timeline component.

I notice we still had two console things in the timeline

1. on a console message hover, we would update the timeline state. 
2. on a marker selection, we would scroll the console

**Now**:

1. when console message is hovered, the console action dispatches a timeline state action. In the future, we would just have a hovered message in the console store...
2. when the paused execution point changes, the console selector `closestMessage` computes the closest message and the console output component scrolls there.

**unintended benefit**

having the scrolling logic in the timeline component, meant that the console would only scroll if the user selected a marker in the timeline. Now the console scrolls if the user clicks a marker in a breakpoint timeline. It also scrolls everytime we pause, which is great because we want to always see the paused line in the console to keep everything in sync.