### PR TITLE
Keep the console pause line in-sync

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/commands.js
+++ b/src/devtools/client/debugger/src/actions/pause/commands.js
@@ -6,7 +6,7 @@
 
 import {
   getThreadContext,
-  getThreadExecutionPoint,
+  getExecutionPoint,
   getResumePoint,
   getFramePositions,
 } from "../../selectors";
@@ -30,7 +30,7 @@ export function command(cx, type) {
     const { dispatch, getState, client } = thunkArgs;
     log(`Debugger CommandStart ${type}`);
 
-    const point = getThreadExecutionPoint(getState());
+    const point = getExecutionPoint(getState());
 
     if (!type) {
       return;

--- a/src/devtools/client/debugger/src/actions/pause/resumed.js
+++ b/src/devtools/client/debugger/src/actions/pause/resumed.js
@@ -13,14 +13,8 @@ import { inDebuggerEval } from "../../utils/pause";
  * @memberof actions/pause
  * @static
  */
-export function resumed(thread) {
-  return async ({ dispatch, client, getState }) => {
-    const why = getPauseReason(getState(), thread);
-    const wasPausedInEval = inDebuggerEval(why);
-    const wasStepping = isStepping(getState(), thread);
-
-    dispatch({ type: "RESUME", thread, wasStepping });
-
-    const cx = getThreadContext(getState());
+export function resumed() {
+  return async ({ dispatch }) => {
+    dispatch({ type: "RESUME" });
   };
 }

--- a/src/devtools/client/debugger/src/actions/sources/select.js
+++ b/src/devtools/client/debugger/src/actions/sources/select.js
@@ -30,7 +30,7 @@ import {
   getSourceByURL,
   getActiveSearch,
   getSelectedSource,
-  getThreadExecutionPoint,
+  getExecutionPoint,
 } from "../../selectors";
 
 export const setSelectedLocation = (cx, source, location) => ({
@@ -168,7 +168,7 @@ export function showAlternateSource(oldSource, newSource) {
       ThreadFront.preferSource(oldSource.id, false);
     }
 
-    const executionPoint = getThreadExecutionPoint(getState());
+    const executionPoint = getExecutionPoint(getState());
     await dispatch(paused({ executionPoint }));
   };
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
@@ -9,7 +9,7 @@ import actions from "../../../actions";
 import { getTruncatedFileName, getSourceQueryString, getFileURL } from "../../../utils/source";
 import { getHasSiblingOfSameName, getContext } from "../../../selectors";
 import { features } from "../../../utils/prefs";
-import { getThreadExecutionPoint } from "../../../reducers/pause";
+import { getExecutionPoint } from "../../../reducers/pause";
 import { selectors } from "../../../../../../../ui/reducers";
 import { CloseButton } from "../../shared/Button";
 
@@ -72,7 +72,7 @@ class BreakpointHeading extends PureComponent {
 const mapStateToProps = (state, { source, breakpoint }) => ({
   cx: getContext(state),
   hasSiblingOfSameName: getHasSiblingOfSameName(state, source),
-  executionPoint: getThreadExecutionPoint(state),
+  executionPoint: getExecutionPoint(state),
 });
 
 export default connect(mapStateToProps, {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -1,7 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 import { compareNumericStrings } from "../../../../../../../protocol/utils";
-import { getThreadExecutionPoint } from "../../../reducers/pause";
+import { getExecutionPoint } from "../../../reducers/pause";
 import { connect } from "../../../utils/connect";
 import { selectors } from "ui/reducers";
 const { getAnalysisPointsForLocation } = selectors;
@@ -99,7 +99,7 @@ function BreakpointNavigationStatus({ executionPoint, analysisPoints }) {
 
 const mapStateToProps = (state, { breakpoint }) => ({
   analysisPoints: getAnalysisPointsForLocation(state, breakpoint.location),
-  executionPoint: getThreadExecutionPoint(state),
+  executionPoint: getExecutionPoint(state),
 });
 
 export default connect(mapStateToProps, {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.js
@@ -1,10 +1,9 @@
 import React, { useState, useEffect, useRef } from "react";
-import { actions as UIActions } from "../../../../../../../ui/actions";
-import { timelineMarkerWidth as pointWidth } from "../../../../../../../ui/constants";
-import { connect } from "../../../utils/connect";
-import { selectors } from "../../../../../../../ui/reducers";
-const { getAnalysisPointsForLocation } = selectors;
-import BreakpointTimelinePoint, { getLeftPercentOffset } from "./BreakpointTimelinePoint";
+import { actions as UIActions } from "ui/actions";
+import { selectors } from "ui/reducers";
+import { timelineMarkerWidth as pointWidth } from "ui/constants";
+import { connect } from "devtools/client/debugger/src/utils/connect";
+import BreakpointTimelinePoint from "./BreakpointTimelinePoint";
 
 function getNewZoomRegion(zoomRegion, analysisPoints) {
   let newZoomRegion = {
@@ -63,7 +62,7 @@ function BreakpointTimeline({
   currentTime,
 }) {
   const timelineNode = useRef();
-  const [mounted, setMounted] = useState(false);
+  const [, setMounted] = useState(false);
   const title = "Cmd + click to zoom into these points";
 
   // Trigger a re-render on mount so that we can pass down the correct timelineNode.
@@ -108,7 +107,7 @@ function BreakpointTimeline({
 
 export default connect(
   (state, { breakpoint }) => ({
-    analysisPoints: getAnalysisPointsForLocation(state, breakpoint.location),
+    analysisPoints: selectors.getAnalysisPointsForLocation(state, breakpoint.location),
     zoomRegion: selectors.getZoomRegion(state),
     currentTime: selectors.getCurrentTime(state),
   }),

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.js
@@ -11,7 +11,7 @@ import {
   getFramePositions,
   getSelectedFrame,
   getThreadContext,
-  getThreadExecutionPoint,
+  getExecutionPoint,
 } from "../../selectors";
 
 import { getSelectedLocation } from "../../reducers/sources";
@@ -203,7 +203,7 @@ class FrameTimeline extends Component {
 const mapStateToProps = state => {
   const thread = getThreadContext(state).thread;
   const selectedFrame = getSelectedFrame(state, thread);
-  const executionPoint = getThreadExecutionPoint(state, thread);
+  const executionPoint = getExecutionPoint(state, thread);
 
   return {
     framePositions: getFramePositions(state),

--- a/src/devtools/client/debugger/src/reducers/pause.js
+++ b/src/devtools/client/debugger/src/reducers/pause.js
@@ -183,7 +183,6 @@ function update(state = createPauseState(), action) {
       return {
         ...state,
         ...resumedPauseState,
-        wasStepping: !!action.wasStepping,
         expandedScopes: new Set(),
         lastExpandedScopes: [state.expandedScopes],
       };
@@ -272,10 +271,6 @@ export function getPauseCommand(state) {
   return state.pause.command;
 }
 
-export function wasStepping(state) {
-  return state.pause.wasStepping;
-}
-
 export function isStepping(state) {
   return ["stepIn", "stepOver", "stepOut"].includes(getPauseCommand(state));
 }
@@ -345,7 +340,7 @@ export function isTopFrame(state) {
   return topFrame == selectedFrame;
 }
 
-export function getThreadExecutionPoint(state) {
+export function getExecutionPoint(state) {
   return state.pause.executionPoint;
 }
 
@@ -363,7 +358,7 @@ export function getPausePreviewLocation(state) {
 
 export function getResumePoint(state, type) {
   const framePoints = getFramePositions(state)?.positions.map(p => p.point);
-  const executionPoint = getThreadExecutionPoint(state);
+  const executionPoint = getExecutionPoint(state);
 
   if (!framePoints || isTopFrame(state)) {
     return null;

--- a/src/devtools/client/webconsole/actions/messages.js
+++ b/src/devtools/client/webconsole/actions/messages.js
@@ -37,15 +37,6 @@ export function setupMessages(store) {
   ThreadFront.findConsoleMessages((_, msg) => store.dispatch(onConsoleMessage(msg)));
 }
 
-export function setupThreadEventListeners(store) {
-  ThreadFront.on("paused", ({ point, time }) =>
-    store.dispatch(setPauseExecutionPoint(point, time))
-  );
-  ThreadFront.on("instantWarp", ({ point, time }) =>
-    store.dispatch(setPauseExecutionPoint(point, time))
-  );
-}
-
 function convertStack(stack, { frames }) {
   if (!stack) {
     return null;

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
@@ -8,7 +8,7 @@ const dom = require("react-dom-factories");
 const { connect } = require("devtools/client/shared/redux/visibility-handler-connect");
 const actions = require("devtools/client/webconsole/actions/index");
 const ReactDOM = require("react-dom");
-const selectors = require("devtools/client/webconsole/selectors/messages");
+const { selectors } = require("ui/reducers");
 
 const PropTypes = require("prop-types");
 const {
@@ -170,7 +170,7 @@ function scrollToBottom(node) {
 
 function mapStateToProps(state, props) {
   return {
-    pausedExecutionPoint: selectors.getPausedExecutionPoint(state),
+    pausedExecutionPoint: selectors.getExecutionPoint(state),
     closestMessage: selectors.getClosestMessage(state),
     messages: selectors.getAllMessagesById(state),
     visibleMessages: selectors.getVisibleMessages(state),

--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,6 @@ const { setupMessages } = require("devtools/client/webconsole/actions/messages")
 const { LocalizationHelper } = require("devtools/shared/l10n");
 const { setupEventListeners } = require("devtools/client/debugger/src/actions/event-listeners");
 const { DevToolsToolbox } = require("ui/utils/devtools-toolbox");
-const { setupThreadEventListeners } = require("devtools/client/webconsole/actions/messages");
 const { createSession } = require("ui/actions/session");
 const {
   initOutputSyntaxHighlighting,
@@ -68,8 +67,6 @@ async function initialize() {
 (async () => {
   window.gToolbox = new DevToolsToolbox();
   store = await bootstrapStore();
-  setupThreadEventListeners(store);
-
   await bootstrapApp({}, { recordingId }, store);
 
   if (!initialized) {

--- a/src/ui/actions/index.ts
+++ b/src/ui/actions/index.ts
@@ -1,4 +1,5 @@
-import { Store } from "redux";
+import { Action, Store } from "redux";
+
 import * as appActions from "./app";
 import * as timelineActions from "./timeline";
 import * as metadataActions from "./metadata";
@@ -15,13 +16,16 @@ import { SessionAction } from "ui/actions/session";
 import UserProperties from "devtools/client/inspector/rules/models/user-properties";
 const consoleActions = require("devtools/client/webconsole/actions");
 
+type DebuggerAction = Action<"RESUME">;
+
 export type UIAction =
   | AppAction
   | MetadataAction
   | TimelineAction
   | MarkupAction
   | EventTooltipAction
-  | SessionAction;
+  | SessionAction
+  | DebuggerAction;
 
 interface ThunkExtraArgs {
   client: any;

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -273,6 +273,7 @@ function playback(startTime: number, endTime: number): UIThunkAction {
         return dispatch(setTimelineState({ currentTime: endTime, playback: null }));
       }
 
+      dispatch({ type: "RESUME" });
       dispatch(
         setTimelineState({
           currentTime,


### PR DESCRIPTION
This is a WIP

1. console closest message selector will now look at execution time
2. console will no longer keep track of pause info
3. the debugger's execution point will be cleared on play
4. small cleanups e.g. remove wasStepping, remove thread code