### PR TITLE
Apply new console message hover interactions

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -15,7 +15,12 @@
   line-height: 16px;
   color: var(--theme-toolbar-color);
   max-width: 500px;
-  min-width: 300px
+  min-width: 300px;
+  overflow: hidden;
+}
+
+.breakpoint-panel.focused {
+  border: 1px solid var(--primary-accent);
 }
 
 .breakpoint-panel.editing {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -9,6 +9,7 @@ import classnames from "classnames";
 import PanelEditor from "./PanelEditor";
 import { toEditorLine } from "devtools/client/debugger/src/utils/editor";
 import BreakpointNavigation from "devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation";
+import { getLocationKey } from "devtools/client/debugger/src/utils/breakpoint";
 
 import "./Panel.css";
 
@@ -81,10 +82,14 @@ function Widget({ location, children, editor, insertAt }) {
   return ReactDOM.createPortal(<>{children}</>, node);
 }
 
-export default function Panel({ breakpoint, editor, insertAt }) {
+export default function Panel({ breakpoint, editor, insertAt, hoveredMessage }) {
   const [editing, setEditing] = useState(false);
   const [width, setWidth] = useState(getPanelWidth(editor));
   const [inputToFocus, setInputToFocus] = useState("logValue");
+  const focused =
+    hoveredMessage?.location &&
+    breakpoint?.location &&
+    getLocationKey(hoveredMessage.location) == getLocationKey(breakpoint.location);
 
   const toggleEditingOn = () => setEditing(true);
   const toggleEditingOff = () => setEditing(false);
@@ -97,7 +102,10 @@ export default function Panel({ breakpoint, editor, insertAt }) {
 
   return (
     <Widget location={breakpoint.location} editor={editor} insertAt={insertAt}>
-      <div style={{ width: `${width}px` }} className={classnames("breakpoint-panel", { editing })}>
+      <div
+        style={{ width: `${width}px` }}
+        className={classnames("breakpoint-panel", { editing, focused })}
+      >
         {editing ? (
           <PanelEditor
             breakpoint={breakpoint}

--- a/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoint.js
+++ b/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoint.js
@@ -7,6 +7,7 @@ import React, { Component } from "react";
 import classnames from "classnames";
 import { connect } from "../../utils/connect";
 import actions from "../../actions";
+import { selectors } from "ui/reducers";
 
 import { getDocument } from "../../utils/editor";
 // import Panel from "../Breakpoints/Panel/index";
@@ -102,21 +103,31 @@ class ColumnBreakpoint extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return this.props.columnBreakpoint.breakpoint != nextProps.columnBreakpoint.breakpoint;
+    return (
+      this.props.columnBreakpoint.breakpoint != nextProps.columnBreakpoint.breakpoint ||
+      this.props.hoveredMessage != nextProps.hoveredMessage
+    );
   }
 
   render() {
-    const { editor, columnBreakpoint, insertAt } = this.props;
+    const { editor, columnBreakpoint, insertAt, hoveredMessage } = this.props;
 
     if (!columnBreakpoint.breakpoint) {
       return null;
     }
 
-    return <Panel breakpoint={columnBreakpoint.breakpoint} editor={editor} insertAt={insertAt} />;
+    return (
+      <Panel
+        breakpoint={columnBreakpoint.breakpoint}
+        editor={editor}
+        insertAt={insertAt}
+        hoveredMessage={hoveredMessage}
+      />
+    );
   }
 }
 
-export default connect(null, {
+export default connect(state => ({ hoveredMessage: selectors.getHoveredMessage(state) }), {
   addBreakpointAtColumn: actions.addBreakpointAtColumn,
   removeBreakpoint: actions.removeBreakpoint,
 })(ColumnBreakpoint);

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
@@ -67,7 +67,6 @@
 }
 
 .breakpoint-navigation-timeline-point {
-  transition: 200ms;
   cursor: pointer;
   position: absolute;
 }
@@ -76,16 +75,8 @@
   fill: var(--replaying-marker-fill);
 }
 
-.breakpoint-navigation-timeline-point .stroke {
-  stroke: var(--replaying-marker-stroke);
-}
-
 .breakpoint-navigation-timeline-point.future .fill {
   fill: var(--replaying-marker-future-fill);
-}
-
-.breakpoint-navigation-timeline-point.future .stroke {
-  stroke: var(--replaying-marker-future-stroke);
 }
 
 .breakpoint-navigation-timeline-point.pause {
@@ -94,10 +85,6 @@
 
 .breakpoint-navigation-timeline-point.pause .fill {
   fill: var(--replaying-paused-marker-fill);
-}
-
-.breakpoint-navigation-timeline-point.pause .stroke {
-  stroke: var(--replaying-paused-marker-stroke);
 }
 
 .breakpoint-navigation-timeline-pause-marker {
@@ -124,4 +111,30 @@
 .breakpoint-navigation-timeline .progress-line.full {
   width: 100%;
   background: var(--grey-30);
+}
+
+/* Dimmed styles */
+.breakpoint-navigation-timeline.dimmed .breakpoint-navigation-timeline-point .fill {
+  fill: var(--primary-accent-light);
+}
+
+.breakpoint-navigation-timeline.dimmed .progress-line {
+  background: var(--primary-accent-light);
+}
+
+.breakpoint-navigation-timeline.dimmed .breakpoint-navigation-timeline-point.secondary-highlight {
+  transform: scale(1.3);
+}
+
+.breakpoint-navigation-timeline.dimmed .breakpoint-navigation-timeline-point.secondary-highlight .fill {
+  fill: var(--primary-accent);
+}
+
+.breakpoint-navigation-timeline.dimmed .breakpoint-navigation-timeline-point.primary-highlight {
+  z-index: var(--z-index-1--paused-message);
+  transform: scale(1.3);
+}
+
+.breakpoint-navigation-timeline.dimmed .breakpoint-navigation-timeline-point.primary-highlight .fill {
+  fill: var(--primary-accent-dark);
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.js
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
+import classnames from "classnames";
+
 import { actions as UIActions } from "ui/actions";
 import { selectors } from "ui/reducers";
 import { timelineMarkerWidth as pointWidth } from "ui/constants";
@@ -60,10 +62,12 @@ function BreakpointTimeline({
   setZoomRegion,
   setZoomedBreakpoint,
   currentTime,
+  hoveredMessage,
 }) {
   const timelineNode = useRef();
   const [, setMounted] = useState(false);
   const title = "Cmd + click to zoom into these points";
+  const shouldDim = hoveredMessage;
 
   // Trigger a re-render on mount so that we can pass down the correct timelineNode.
   useEffect(() => setMounted(true), []);
@@ -81,7 +85,7 @@ function BreakpointTimeline({
   return (
     <div className="breakpoint-navigation-timeline-container">
       <div
-        className="breakpoint-navigation-timeline"
+        className={classnames("breakpoint-navigation-timeline", { dimmed: shouldDim })}
         ref={timelineNode}
         onClick={handleClick}
         title={title}
@@ -97,6 +101,7 @@ function BreakpointTimeline({
                 key={i}
                 index={i}
                 timelineNode={timelineNode.current}
+                hoveredMessage={hoveredMessage}
               />
             ))
           : null}
@@ -110,6 +115,7 @@ export default connect(
     analysisPoints: selectors.getAnalysisPointsForLocation(state, breakpoint.location),
     zoomRegion: selectors.getZoomRegion(state),
     currentTime: selectors.getCurrentTime(state),
+    hoveredMessage: selectors.getHoveredMessage(state),
   }),
   {
     setZoomRegion: UIActions.setZoomRegion,

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimelinePoint.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimelinePoint.js
@@ -7,9 +7,20 @@ const { getAnalysisPointsForLocation } = selectors;
 import { actions } from "ui/actions";
 import { Marker } from "ui/components/Timeline/Message";
 import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
+import { getLocationKey } from "devtools/client/debugger/src/utils/breakpoint";
 
 function toBigInt(num) {
   return num ? BigInt(num) : undefined;
+}
+
+function getIsSecondaryHighlighted(hoveredMessage, message) {
+  if (!message?.frame?.[0] || !hoveredMessage?.location) {
+    return false;
+  }
+
+  const keyOne = getLocationKey(hoveredMessage.location);
+  const keyTwo = getLocationKey(message.frame[0]);
+  return keyOne == keyTwo;
 }
 
 export function getLeftPercentOffset({ point, timelineNode, zoomRegion, markerWidth }) {
@@ -34,8 +45,11 @@ function BreakpointTimelinePoint({
   executionPoint,
   zoomRegion,
   seek,
+  hoveredMessage,
 }) {
   const [leftPercentOffset, setLeftPercentOffset] = useState(0);
+  const isPrimaryHighlighted = hoveredMessage?.point === point.point;
+  const isSecondaryHighlighted = getIsSecondaryHighlighted(hoveredMessage, point);
 
   useEffect(() => {
     setLeftPercentOffset(
@@ -54,6 +68,8 @@ function BreakpointTimelinePoint({
         past: toBigInt(point.point) < toBigInt(executionPoint),
         future: toBigInt(point.point) > toBigInt(executionPoint),
         pause: toBigInt(point.point) == toBigInt(executionPoint),
+        "primary-highlight": isPrimaryHighlighted,
+        "secondary-highlight": isSecondaryHighlighted,
       })}
       title={`${index + 1}/${analysisPoints.length}`}
       onClick={() => seek(point.point, point.time, true)}

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -45,6 +45,7 @@
   
   --primary-accent: #1B7FE3;
   --primary-accent-light: #86BFF9;
+  --primary-accent-dark: #1B5998;
   --secondary-accent: #8330F4;
   --secondary-accent-stroke: #F9F5FF;
 

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -45,6 +45,7 @@
   
   --primary-accent: #1B7FE3;
   --primary-accent-light: #86BFF9;
+  --primary-accent-very-light: #EFF7FF;
   --primary-accent-dark: #1B5998;
   --secondary-accent: #8330F4;
   --secondary-accent-stroke: #F9F5FF;

--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -146,6 +146,10 @@
   overflow: hidden;
 }
 
+.webconsole-app .message.secondary-highlight {
+  background: var(--primary-accent-very-light);
+}
+
 .webconsole-app .message.error {
   z-index: 2;
   color: var(--console-error-color);

--- a/src/devtools/client/webconsole/actions/toolbox.js
+++ b/src/devtools/client/webconsole/actions/toolbox.js
@@ -5,9 +5,9 @@
 "use strict";
 
 import { ThreadFront } from "protocol/thread";
-import { setTimelineState } from "ui/actions/timeline";
 import { paintGraphicsAtTime } from "protocol/graphics";
 import { selectors } from "ui/reducers";
+import { actions } from "ui/actions";
 
 export function highlightDomElement(grip) {
   return ({ toolbox }) => {
@@ -48,11 +48,18 @@ export function openNodeInInspector(valueFront) {
 export function onMessageHover(type, message) {
   return ({ dispatch, getState }) => {
     if (type == "mouseenter") {
-      dispatch(setTimelineState({ hoveredMessageId: message.id }));
+      const hoveredMessage = {
+        point: message.executionPoint,
+        time: message.executionPointTime,
+        location: message.frame,
+      };
+
+      dispatch(actions.setHoveredMessage(hoveredMessage));
       paintGraphicsAtTime(message.executionPointTime);
     }
+
     if (type == "mouseleave") {
-      dispatch(setTimelineState({ hoveredMessageId: null }));
+      dispatch(actions.setHoveredMessage(null));
       paintGraphicsAtTime(selectors.getCurrentTime(getState()));
     }
   };

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
@@ -127,10 +127,12 @@ class ConsoleOutput extends Component {
       timestampsVisible,
       pausedExecutionPoint,
       closestMessage,
+      hoveredMessage,
     } = this.props;
 
     const messageNodes = visibleMessages.map((messageId, i) =>
       createElement(MessageContainer, {
+        hoveredMessage,
         dispatch,
         key: messageId,
         messageId,
@@ -177,6 +179,7 @@ function mapStateToProps(state, props) {
     messagesUi: selectors.getAllMessagesUiById(state),
     messagesPayload: selectors.getAllMessagesPayloadById(state),
     warningGroups: selectors.getAllWarningGroupsById(state),
+    hoveredMessage: selectors.getHoveredMessage(state),
     timestampsVisible: state.consoleUI.timestampsVisible,
   };
 }

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -11,7 +11,6 @@ const { actions } = require("ui/actions/index");
 const { MESSAGE_TYPE } = require("devtools/client/webconsole/constants");
 const { MessageIndent } = require("devtools/client/webconsole/components/Output/MessageIndent");
 const MessageIcon = require("devtools/client/webconsole/components/Output/MessageIcon");
-const { CloseButton } = require("devtools/client/debugger/src/components/shared/Button");
 const FrameView = createFactory(require("devtools/client/shared/components/Frame"));
 
 const CollapseButton = require("devtools/client/webconsole/components/Output/CollapseButton");

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -17,6 +17,7 @@ const CollapseButton = require("devtools/client/webconsole/components/Output/Col
 const MessageRepeat = require("devtools/client/webconsole/components/Output/MessageRepeat");
 const PropTypes = require("prop-types");
 const SmartTrace = require("devtools/client/shared/components/SmartTrace");
+const { getLocationKey } = require("devtools/client/debugger/src/utils/breakpoint");
 
 class Message extends Component {
   static get propTypes() {
@@ -284,6 +285,7 @@ class Message extends Component {
       executionPoint,
       messageId,
       notes,
+      hoveredMessage,
     } = this.props;
 
     topLevelClasses.push("message", source, type, level);
@@ -293,6 +295,15 @@ class Message extends Component {
 
     if (isPaused) {
       topLevelClasses.push("paused");
+    }
+
+    const isSecondaryHighlighted =
+      hoveredMessage?.location &&
+      frame &&
+      getLocationKey(hoveredMessage.location) == getLocationKey(frame);
+
+    if (isSecondaryHighlighted) {
+      topLevelClasses.push("secondary-highlight");
     }
 
     const timestampEl = this.renderTimestamp();

--- a/src/devtools/client/webconsole/components/Output/MessageContainer.js
+++ b/src/devtools/client/webconsole/components/Output/MessageContainer.js
@@ -68,6 +68,7 @@ class MessageContainer extends Component {
       "pausedExecutionPoint",
       "badge",
       "inWarningGroup",
+      "hoveredMessage",
     ];
 
     return triggeringUpdateProps.some(prop => this.props[prop] !== nextProps[prop]);

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
@@ -42,6 +42,7 @@ function ConsoleApiCall(props) {
     isPaused,
     maybeScrollToBottom,
     isFirstMessageForPoint,
+    hoveredMessage,
   } = props;
   const {
     id: messageId,
@@ -156,6 +157,7 @@ function ConsoleApiCall(props) {
     message,
     maybeScrollToBottom,
     isFirstMessageForPoint,
+    hoveredMessage,
   });
 }
 

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -17,14 +17,20 @@ import { selectors } from "ui/reducers";
 import { UIStore, UIThunkAction } from ".";
 import { Action } from "redux";
 import { PauseEventArgs, RecordingDescription } from "protocol/thread/thread";
-import { TimelineState, Tooltip, ZoomRegion } from "ui/state/timeline";
+import { TimelineState, Tooltip, ZoomRegion, HoveredPoint } from "ui/state/timeline";
 
 export type SetTimelineStateAction = Action<"set_timeline_state"> & {
   state: Partial<TimelineState>;
 };
 export type UpdateTooltipAction = Action<"update_tooltip"> & { tooltip: Tooltip | null };
 export type SetZoomRegionAction = Action<"set_zoom"> & { region: ZoomRegion };
-export type TimelineAction = SetTimelineStateAction | UpdateTooltipAction | SetZoomRegionAction;
+export type SetHoveredMessage = Action<"set_hovered_message"> & { message: HoveredPoint };
+
+export type TimelineAction =
+  | SetTimelineStateAction
+  | UpdateTooltipAction
+  | SetZoomRegionAction
+  | SetHoveredMessage;
 
 export async function setupTimeline(recordingId: RecordingId, store: UIStore) {
   const { dispatch } = store;
@@ -362,5 +368,11 @@ export function goToPrevPaint(): UIThunkAction {
     }
 
     dispatch(seekToTime(Math.min(next.time, endTime)));
+  };
+}
+
+export function setHoveredMessage(message: HoveredPoint): UIThunkAction {
+  return ({ dispatch }) => {
+    dispatch({ type: "set_hovered_message", message });
   };
 }

--- a/src/ui/components/Timeline/Message.css
+++ b/src/ui/components/Timeline/Message.css
@@ -1,0 +1,72 @@
+.timeline .message {
+  height: 11px;
+  width: 11px;
+  position: absolute;
+  margin-top: auto;
+  margin-bottom: auto;
+  top: 0;
+  bottom: 0;
+  pointer-events: all;
+}
+
+.timeline .message-preview {
+  z-index: var(--z-index-2--hovered-message);
+}
+
+.timeline .message:hover {
+  cursor: pointer;
+}
+
+.timeline .message .fill {
+  fill: var(--replaying-marker-fill);
+}
+
+.timeline .message .stroke {
+  stroke: var(--theme-body-background);
+  pointer-events: none;
+}
+
+.timeline .message.paused {
+  z-index: var(--z-index-1--paused-message);
+}
+
+.timeline .message.paused .fill {
+  fill: var(--replaying-paused-marker-fill);
+}
+
+.timeline .message.paused .stroke {
+  stroke: var(--replaying-paused-marker-stroke);
+  stroke: var(--theme-body-background);
+}
+
+.timeline .message:focus {
+  outline: none;
+}
+
+/* Dimmed styles */
+
+.timeline.dimmed .message .fill {
+  fill: var(--primary-accent-light);
+}
+
+.timeline.dimmed .message-preview .fill {
+  fill: var(--replaying-marker-fill);
+}
+
+.timeline.dimmed .message.secondary-highlight {
+  transform: scale(1.3);
+  z-index: var(--z-index-2--hovered-message);
+}
+
+.timeline.dimmed .message.secondary-highlight .fill {
+  fill: var(--replaying-marker-fill);
+}
+
+.timeline.dimmed .message.primary-highlight {
+  transform: scale(1.3);
+  z-index: var(--z-index-2--hovered-message);
+}
+
+.timeline.dimmed .message.primary-highlight .fill {
+  fill: var(--primary-accent-dark);
+}

--- a/src/ui/components/Timeline/Message.js
+++ b/src/ui/components/Timeline/Message.js
@@ -2,9 +2,9 @@ import React from "react";
 
 import { LocalizationHelper } from "devtools/shared/l10n";
 import { getPixelOffset, getLeftOffset } from "../../utils/timeline";
-import { connect } from "react-redux";
 import classnames from "classnames";
-import { selectors } from "ui/reducers";
+import { getLocationKey } from "devtools/client/debugger/src/utils/breakpoint";
+import "./Message.css";
 
 const L10N = new LocalizationHelper("devtools/client/locales/toolbox.properties");
 const getFormatStr = (key, a) => L10N.getFormatStr(`toolbox.replay.${key}`, a);
@@ -39,12 +39,22 @@ export function Marker({ message, onMarkerClick, onMarkerMouseEnter, onMarkerMou
   );
 }
 
+function getIsSecondaryHighlighted(hoveredMessage, message) {
+  if (!message?.frame || !hoveredMessage?.location) {
+    return false;
+  }
+
+  const keyOne = getLocationKey(hoveredMessage.location);
+  const keyTwo = getLocationKey(message.frame);
+  return keyOne == keyTwo;
+}
+
 export default class Message extends React.Component {
   render() {
     const {
       message,
       currentTime,
-      hoveredMessageId,
+      hoveredMessage,
       zoomRegion,
       overlayWidth,
       onMarkerClick,
@@ -62,9 +72,8 @@ export default class Message extends React.Component {
       return null;
     }
 
-    // A marker is highlighted if its corresponding message is hovered on
-    // in the console
-    const isHighlighted = hoveredMessageId == message.id;
+    const isPrimaryHighlighted = hoveredMessage?.point === message.executionPoint;
+    const isSecondaryHighlighted = getIsSecondaryHighlighted(hoveredMessage, message);
     const isPauseLocation = message.executionPointTime === currentTime;
 
     let frameLocation = "";
@@ -81,7 +90,8 @@ export default class Message extends React.Component {
       <a
         tabIndex={0}
         className={classnames("message", {
-          highlighted: isHighlighted,
+          "primary-highlight": isPrimaryHighlighted,
+          "secondary-highlight": isSecondaryHighlighted,
           paused: isPauseLocation,
         })}
         style={{

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -67,64 +67,6 @@
   pointer-events: none;
 }
 
-.timeline .message {
-  height: 11px;
-  width: 11px;
-  position: absolute;
-  margin-top: auto;
-  margin-bottom: auto;
-  top: 0;
-  bottom: 0;
-  pointer-events: all;
-}
-
-.timeline .message-preview {
-  z-index: var(--z-index-2--hovered-message);
-}
-
-.timeline .message:hover {
-  cursor: pointer;
-}
-
-.timeline .message .fill {
-  fill: var(--replaying-marker-fill);
-}
-
-.timeline.dimmed .message .fill {
-  fill: var(--primary-accent-light);
-}
-
-.timeline .message .stroke {
-  stroke: var(--theme-body-background);
-  pointer-events: none;
-}
-
-.timeline .message.paused {
-  z-index: var(--z-index-1--paused-message);
-}
-
-.timeline .message.paused .fill {
-  fill: var(--replaying-paused-marker-fill);
-}
-
-.timeline .message.paused .stroke {
-  stroke: var(--replaying-paused-marker-stroke);
-  stroke: var(--theme-body-background);
-}
-
-.timeline.dimmed .message-preview .fill {
-  fill: var(--replaying-marker-fill);
-}
-
-.timeline .message:focus {
-  outline: none;
-}
-
-.timeline .message.highlighted {
-  transform: scale(1.3);
-  z-index: var(--z-index-2--hovered-message);
-}
-
 .timeline .commands {
   display: flex;
   flex-direction: row;

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -186,7 +186,7 @@ export class Timeline extends Component {
   }
 
   renderMessages() {
-    const { messages, currentTime, hoveredMessageId, zoomRegion } = this.props;
+    const { messages, currentTime, hoveredMessage, zoomRegion } = this.props;
 
     return (
       <div className="message-container">
@@ -197,7 +197,7 @@ export class Timeline extends Component {
             key={index}
             messages={messages}
             currentTime={currentTime}
-            hoveredMessageId={hoveredMessageId}
+            hoveredMessage={hoveredMessage}
             zoomRegion={zoomRegion}
             overlayWidth={this.overlayWidth}
             onMarkerClick={this.onMarkerClick}
@@ -239,12 +239,20 @@ export class Timeline extends Component {
   }
 
   render() {
-    const { loaded, zoomRegion, currentTime, hoverTime, hoveredLineNumberLocation } = this.props;
+    const {
+      loaded,
+      zoomRegion,
+      currentTime,
+      hoverTime,
+      hoveredLineNumberLocation,
+      hoveredMessage,
+    } = this.props;
     const percent = getVisiblePosition({ time: currentTime, zoom: zoomRegion }) * 100;
     const hoverPercent = getVisiblePosition({ time: hoverTime, zoom: zoomRegion }) * 100;
+    const shouldDim = hoveredLineNumberLocation || hoveredMessage;
 
     return (
-      <div className={classnames("timeline", { dimmed: !!hoveredLineNumberLocation })}>
+      <div className={classnames("timeline", { dimmed: shouldDim })}>
         {this.renderCommands()}
         <div className={classnames("progress-bar-container", { paused: true })}>
           <div
@@ -274,7 +282,7 @@ export default connect(
     currentTime: selectors.getCurrentTime(state),
     hoverTime: selectors.getHoverTime(state),
     playback: selectors.getPlayback(state),
-    hoveredMessageId: selectors.getHoveredMessageId(state),
+    hoveredMessage: selectors.getHoveredMessage(state),
     recordingDuration: selectors.getRecordingDuration(state),
     timelineDimensions: selectors.getTimelineDimensions(state),
     messages: selectors.getMessagesForTimeline(state),
@@ -282,6 +290,7 @@ export default connect(
     selectedPanel: selectors.getSelectedPanel(state),
     hoveredLineNumberLocation: selectors.getHoveredLineNumberLocation(state),
     pointsForHoveredLineNumber: selectors.getPointsForHoveredLineNumber(state),
+    hoveredMessage: selectors.getHoveredMessage(state),
   }),
   {
     setTimelineToTime: actions.setTimelineToTime,

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -8,7 +8,7 @@ function initialTimelineState(): TimelineState {
     currentTime: 0,
     hoverTime: null,
     playback: null,
-    hoveredMessageId: null,
+    hoveredMessage: null,
     unprocessedRegions: [],
     shouldAnimate: true,
     recordingDuration: null,
@@ -36,6 +36,10 @@ export default function update(
       return { ...state, tooltip: action.tooltip };
     }
 
+    case "set_hovered_message": {
+      return { ...state, hoveredMessage: action.message };
+    }
+
     default: {
       return state;
     }
@@ -46,10 +50,10 @@ export const getZoomRegion = (state: UIState) => state.timeline.zoomRegion;
 export const getCurrentTime = (state: UIState) => state.timeline.currentTime;
 export const getHoverTime = (state: UIState) => state.timeline.hoverTime;
 export const getPlayback = (state: UIState) => state.timeline.playback;
-export const getHoveredMessageId = (state: UIState) => state.timeline.hoveredMessageId;
 export const getUnprocessedRegions = (state: UIState) => state.timeline.unprocessedRegions;
 export const getRecordingDuration = (state: UIState) => state.timeline.recordingDuration;
 export const getScreenShot = (state: UIState) => state.timeline.screenShot;
 export const getMouse = (state: UIState) => state.timeline.mouse;
 export const getTimelineDimensions = (state: UIState) => state.timeline.timelineDimensions;
 export const getTooltip = (state: UIState) => state.timeline.tooltip;
+export const getHoveredMessage = (state: UIState) => state.timeline.hoveredMessage;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -1,4 +1,4 @@
-import { PauseDescription, ScreenShot, TimeRange, Location } from "@recordreplay/protocol";
+import { ScreenShot, TimeRange, Location } from "@recordreplay/protocol";
 import { MouseAndClickPosition } from "../../protocol/graphics";
 
 export interface Tooltip {
@@ -25,8 +25,19 @@ export interface TimelineState {
   zoomRegion: ZoomRegion;
   timelineDimensions: { width: number; left: number; top: number };
   hoverTime: number | null;
-  hoveredMessageId: string | null;
+  hoveredMessage: HoveredPoint | null;
   unprocessedRegions: TimeRange[];
   shouldAnimate: boolean;
   tooltip: Tooltip | null;
+}
+
+export interface HoveredPoint {
+  point: string;
+  time: number;
+  location: HoveredLocation;
+}
+
+interface HoveredLocation extends Location {
+  line: number;
+  column: number;
 }


### PR DESCRIPTION
This adds the following console message hover interactions:
- Dim the timeline while hovered on a console message.
- Dim the widget timeline while hovered on a console message.
- Highlight the hovered console message's timeline marker.
- Highlight the hovered console message's timeline sibling markers.
- Highlight the hovered console message's breakpoint's widget.
- Highlight the hovered console message's breakpoint's marker in the widget.
- Highlight the hovered console message's breakpoint's sibling markers in the widget.
- Highlight the hovered console message's console message siblings.

See #1463 for discussion.