### PR TITLE
Make sure the paused message and pause line are visible during playback

### DIFF
--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
@@ -6,7 +6,7 @@
 const { Component, createElement } = require("react");
 const dom = require("react-dom-factories");
 const { connect } = require("devtools/client/shared/redux/visibility-handler-connect");
-const actions = require("devtools/client/webconsole/actions/index");
+const { actions } = require("ui/actions");
 const ReactDOM = require("react-dom");
 const { selectors } = require("ui/reducers");
 
@@ -178,6 +178,7 @@ function mapStateToProps(state, props) {
     messagesPayload: selectors.getAllMessagesPayloadById(state),
     warningGroups: selectors.getAllWarningGroupsById(state),
     timestampsVisible: state.consoleUI.timestampsVisible,
+    playback: selectors.getPlayback(state),
   };
 }
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
Fixes #1449. 

This scrolls the console during playback such that the pause line and the closest console message to the pause line are always visible.

Demo: https://share.descript.com/view/M497crdzcDg