### PR TITLE
Fix console object inspector to sort arrays correctly

### DIFF
--- a/src/protocol/thread/value.ts
+++ b/src/protocol/thread/value.ts
@@ -270,6 +270,14 @@ export class ValueFront {
       contents,
     }));
     rv.sort((a, b) => {
+      // if both element names are numbers, sort them numerically instead of
+      // alphabetically.
+      const aN = Number.parseInt(a.name);
+      const bN = Number.parseInt(b.name);
+      if (!isNaN(aN) && !isNaN(bN)) {
+        return aN - bN;
+      }
+
       const _a = a.name?.toUpperCase();
       const _b = b.name?.toUpperCase();
       return _a < _b ? -1 : _a > _b ? 1 : 0;


### PR DESCRIPTION
When both keys are numbers, sort numerically instead of alphabetically.

![image](https://user-images.githubusercontent.com/788456/104387343-bd01ed80-54eb-11eb-9e16-d7efd3900ca6.png)

This proposed fix will sort the keys of objects too like the screenshot below.

![image](https://user-images.githubusercontent.com/788456/104387126-554ba280-54eb-11eb-8c69-332e8cddc9e7.png)

Another alternative is to typecheck the object as an array and apply a different sort for those vs objects. I can change to this approach if it is preferred but I think the proposed solution is reasonable.

Fixes #1507