### PR TITLE
Fix console messages to wrap around location

### DIFF
--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -324,16 +324,14 @@
 }
 
 .webconsole-app .message-location {
-  max-width: 40vw;
-  flex-shrink: 0;
+  float: right;
   color: var(--frame-link-source);
-  margin: 0 1ch;
   /* Makes the file name truncated (and ellipsis shown) on the left side */
   direction: rtl;
+  margin-inline-end: 1ch;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: end;
 }
 
 .message-location a {
@@ -350,10 +348,6 @@
   unicode-bidi: embed;
 }
 
-.webconsole-app .message-flex-body {
-  display: flex;
-}
-
 .webconsole-app .message-body {
   white-space: pre-wrap;
   word-wrap: break-word;
@@ -362,6 +356,7 @@
 .webconsole-app .message-flex-body > .message-body {
   display: block;
   flex: 1;
+  word-break: break-all;
 }
 
 /* Network styles */

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -461,11 +461,15 @@ class Message extends Component {
           },
           // Add whitespaces for formatting when copying to the clipboard.
           timestampEl ? " " : null,
-          dom.span({ className: "message-body devtools-monospace" }, ...bodyElements, learnMore),
+          dom.span(
+            { className: "message-body devtools-monospace" },
+            location,
+            " ",
+            ...bodyElements,
+            learnMore
+          ),
           repeat ? " " : null,
-          repeat,
-          " ",
-          location
+          repeat
         ),
         attachment,
         ...notesNodes


### PR DESCRIPTION
## Issue

In narrow viewports, the message body width is limited by the location and can cause the content to be rendered vertically one character at a time.

## Analysis

The flex box layout reserves space for the location at the expense of the body. Furthermore, flex reserves all the vertical space below the location so the body can't wrap into that space either.

## Resolution

* Move the location into the body and float it right so it only consumes the vertical and horizontal space it requires.
* Add `word-break: break-all` to the content so single word content wraps mid-word rather than be forced to the next line.

![image](https://user-images.githubusercontent.com/788456/104482321-a99e6300-557b-11eb-994e-99efde2baf0a.png)

## Additional Considerations

I'm not sure how to test this with all possible message types so it's possible there are some regressions but the DOM structure is consistent for all so I expect it to be okay.

Fixes #1519