### PR TITLE
Bring back highlight lines in editor

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/index.js
@@ -26,6 +26,8 @@ import DebugLine from "./DebugLine";
 import EmptyLines from "./EmptyLines";
 import EditorMenu from "./EditorMenu";
 import LineNumberTooltip from "./LineNumberTooltip";
+import HighlightLine from "./HighlightLine";
+import HighlightLines from "./HighlightLines";
 
 import {
   showSourceText,
@@ -414,12 +416,12 @@ class Editor extends PureComponent {
     return (
       <div>
         <DebugLine />
-        {/* <HighlightLine /> */}
+        <HighlightLine />
         <EmptyLines editor={editor} />
         <Breakpoints editor={editor} cx={cx} />
         <Preview editor={editor} editorRef={this.$editorWrapper} />
         <LineNumberTooltip editor={editor} />
-        {/* <HighlightLines editor={editor} /> */}
+        <HighlightLines editor={editor} />
         {
           <EditorMenu
             editor={editor}


### PR DESCRIPTION
Close #1505

Bring back the two components that commented out before. Clicking in outline panel and navigating in quick open will highlight the function in editor.

https://www.loom.com/share/e8c0331a94e44ddb882e771e06e8ea47