### PR TITLE
Add skeleton loader screen for viewer view

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -99,7 +99,7 @@
   width: 100%;
 }
 
-.loader {
+.old-loader {
   margin: auto;
 }
 

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -78,11 +78,8 @@ export function setupApp(recordingId: RecordingId, store: UIStore) {
   ThreadFront.ensureProcessed(undefined, regions =>
     store.dispatch(onUnprocessedRegions(regions))
   ).then(() => {
-    clearInterval(loadingInterval);
     store.dispatch({ type: "loading", loading: 100 });
   });
-
-  const loadingInterval = setInterval(() => store.dispatch(bumpLoading()), 1000);
 }
 
 function setupPointHandlers(store: UIStore) {
@@ -95,15 +92,6 @@ function setupPointHandlers(store: UIStore) {
 
   PointHandlers.addPendingNotification = (location: any) => {
     store.dispatch(setPendingNotification(location));
-  };
-}
-
-function bumpLoading(): UIThunkAction {
-  return ({ dispatch, getState }) => {
-    const loading = selectors.getLoading(getState());
-    const increment = Math.random() * 4;
-
-    dispatch({ type: "loading", loading: Math.min(loading + increment, 99) });
   };
 }
 

--- a/src/ui/components/App.js
+++ b/src/ui/components/App.js
@@ -5,7 +5,6 @@ import { useAuth0 } from "@auth0/auth0-react";
 
 import DevTools from "./DevTools";
 import Account from "./Account";
-import Loader from "./shared/Loader";
 import { AppErrors, PopupBlockedError } from "./shared/Error";
 import SharingModal from "./shared/SharingModal";
 import { isDeployPreview } from "ui/utils/environment";
@@ -76,7 +75,7 @@ function App({ theme, recordingId, modal, updateNarrowMode, updateUser }) {
   }
 
   if ((!isDeployPreview() && auth.isLoading) || !apolloClient || hasLoadingParam()) {
-    return <Loader />;
+    return null;
   }
 
   return (

--- a/src/ui/components/Header/Header.css
+++ b/src/ui/components/Header/Header.css
@@ -85,7 +85,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  background: none;
   cursor: text;
   line-height: 18px;
   margin-right: 0.5em;
@@ -95,6 +94,7 @@
 #header input.title:focus {
   border: none;
   outline: none;
+  background: none;
   width: 400px;
 }
 

--- a/src/ui/components/SkeletonLoader.css
+++ b/src/ui/components/SkeletonLoader.css
@@ -1,0 +1,130 @@
+.loader {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+
+.loader main {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+}
+
+.loader main section {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--theme-splitter-color);
+}
+
+.loader main .video {
+  transition-duration: 100ms;
+  flex-grow: 1;
+}
+
+.loader main .debugger {
+  flex-grow: 1;
+}
+
+.loader main .timeline {
+  position: relative;
+  box-sizing: content-box;
+  height: 36px;
+}
+
+.loader main .timeline .loading-container {
+  width: 100%;
+  position: relative;
+  margin: 0px 24px;
+}
+
+.loader main .timeline .loading-container .tooltip {
+  position: absolute;
+  width: 80px;
+  transform: translateX(-50%);
+  text-align: center;
+  padding: 8px 12px;
+  bottom: 20px;
+  border-radius: 8px;
+  background: white;
+  box-shadow: rgba(15, 15, 15, 0.05) 0px 0px 0px 1px, rgba(15, 15, 15, 0.1) 0px 3px 6px, rgba(15, 15, 15, 0.2) 0px 9px 24px;
+}
+
+.loader main .timeline .progress-line,
+.loader main .timeline .tooltip {
+  transition-duration: 200ms;
+}
+
+.loader main .comments {
+  padding: 20px;
+  flex-grow: 1;
+}
+
+/* Loading elements */
+
+.loader .loading-placeholder {
+  border-radius: 8px;
+  background: var(--theme-splitter-color);
+  overflow: hidden;
+  position: relative;
+}
+
+.loader .loading-placeholder::before {
+  position: absolute;
+  background: linear-gradient(to right, transparent, var(--grey-10-a30), transparent);
+  display: block;
+  height: 100%;
+  width: 100px;
+  left: -100px;
+  content: "";
+  animation: skeleton-loading 1.5s cubic-bezier(0.4, 0.0, 0.2, 1) infinite;
+}
+
+.loader header .header-left,
+.loader header .links {
+  height: 24px;
+}
+
+.loader header .message {
+  color: var(--theme-comment);
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.loader .header-left > *,
+.loader .links > * {
+  height: 100%;
+}
+
+.loader header .back,
+.loader header .share,
+.loader header .avatar {
+  width: 24px;
+  margin-left: 4px;
+}
+
+.loader header .title {
+  width: 64px;
+  margin-left: 8px;
+  background: var(--new-blue-300);
+}
+
+.loader header .subtitle {
+  width: 64px;
+}
+
+.loader header .view {
+  width: 160px;
+}
+
+.loader main .comments .loading-placeholder {
+  width: 100%;
+  height: 44px;
+  margin-bottom: 20px;
+}
+
+@keyframes skeleton-loading {
+  100% {left:100%;}
+}

--- a/src/ui/components/SkeletonLoader.js
+++ b/src/ui/components/SkeletonLoader.js
@@ -1,0 +1,111 @@
+import React, { useState, useEffect, useRef } from "react";
+import { connect } from "react-redux";
+import { prefs } from "../utils/prefs";
+import { selectors } from "../reducers";
+
+import "./SkeletonLoader.css";
+
+function SkeletonLoader({ setFinishedLoading, progress = 1, content, viewMode }) {
+  const [displayedProgress, setDisplayedProgress] = useState(0);
+  const key = useRef(null);
+  const backgroundColor = `hsl(0, 0%, ${35 - displayedProgress * 0.35}%)`;
+
+  useEffect(() => {
+    if (displayedProgress == 100) {
+      // This gives the Loader component some time (300ms) to bring the progress
+      // bar to 100% before unmounting this loader and showing the application.
+      setTimeout(() => setFinishedLoading(true), 300);
+    }
+
+    // This handles the artificial progress bump. It has a randomized increment
+    // whose effect is decayed as the progress approaches 100/100. Whenever the
+    // underlying progress is higher than the artificial progress, we update to use
+    // the underlying progress. Expected behavior assuming no underlying progress is:
+    // 10s (50%) 20s (70%) 30s (85%) 45s (95%) 60s (98%)
+    useRef.current = setTimeout(() => {
+      const increment = Math.random();
+      const decayed = increment * ((100 - displayedProgress) / 40);
+      const newDisplayedProgress = Math.max(displayedProgress + decayed, progress);
+
+      setDisplayedProgress(newDisplayedProgress);
+    }, 200);
+
+    return () => clearTimeout(key.current);
+  }, [displayedProgress]);
+
+  return (
+    <div className="loader">
+      <Header content={content} progress={progress} />
+      {viewMode == "non-dev" ? (
+        <NonDevMain backgroundColor={backgroundColor} displayedProgress={displayedProgress} />
+      ) : (
+        <DevMain displayedProgress={displayedProgress} />
+      )}
+    </div>
+  );
+}
+
+function Header({ progress, content }) {
+  return (
+    <header id="header">
+      <div className="header-left">
+        <div className="loading-placeholder back" />
+        <div className="loading-placeholder title" />
+        <div className="loading-placeholder subtitle" />
+      </div>
+      <div className="message">{progress == 100 ? "Ready" : content}</div>
+      <div className="links">
+        <div className="loading-placeholder share" />
+        <div className="loading-placeholder view" />
+        <div className="loading-placeholder avatar" />
+      </div>
+    </header>
+  );
+}
+
+function NonDevMain({ backgroundColor, displayedProgress }) {
+  return (
+    <main>
+      <section style={{ width: prefs.nonDevSidePanelWidth }}>
+        <div className="video" style={{ background: backgroundColor }}></div>
+        <div className="timeline">
+          <div className="loading-container">
+            <div className="progress-line full" />
+            <div className="progress-line" style={{ width: `${displayedProgress}%` }} />
+            <div className="tooltip" style={{ left: `${displayedProgress}%` }}>
+              Loading...
+            </div>
+          </div>
+        </div>
+      </section>
+      <div className="comments">
+        <div className="loading-placeholder" />
+        <div className="loading-placeholder" />
+        <div className="loading-placeholder" />
+      </div>
+    </main>
+  );
+}
+
+function DevMain({ displayedProgress }) {
+  return (
+    <main>
+      <section style={{ width: "100%" }}>
+        <div className="debugger" />
+        <div className="timeline">
+          <div className="loading-container">
+            <div className="progress-line full" />
+            <div className="progress-line" style={{ width: `${displayedProgress}%` }} />
+            <div className="tooltip" style={{ left: `${displayedProgress}%` }}>
+              Loading...
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default connect(state => ({
+  viewMode: selectors.getViewMode(state),
+}))(SkeletonLoader);

--- a/src/ui/components/shared/Loader.js
+++ b/src/ui/components/shared/Loader.js
@@ -13,8 +13,8 @@ export default function Loader({ message }) {
   };
 
   return (
-    <div className="loader">
-      <Lottie options={defaultOptions} height={50} width={200} />
+    <div className="old-loader">
+      <Lottie options={defaultOptions} height={50} width={200} margin={"auto"} />
       <div className="loading-message">{message}</div>
     </div>
   );


### PR DESCRIPTION
Demo: https://share.descript.com/view/6BvWCJVxD0n

This replaces the old loading screen with a simple skeleton loading screen that looks similar to the Viewer. DevTools skeleton view is sparse for now, and can be done as a follow up.

#### Screenshots (Viewer and DevTools) 

![image](https://user-images.githubusercontent.com/15959269/105080722-3b680d80-5a5f-11eb-9ce2-89459d6829d6.png)
![image](https://user-images.githubusercontent.com/15959269/105080799-589cdc00-5a5f-11eb-91e5-defc3f584124.png)
