### PR TITLE
Don't enlarge timeline markers when hovering on the timeline

### DIFF
--- a/src/ui/components/Timeline/Message.css
+++ b/src/ui/components/Timeline/Message.css
@@ -43,11 +43,6 @@
   outline: none;
 }
 
-/* Enlarge all timeline markers when hovering on the timeline */
-.timeline:hover .message {
-  transform: scale(1.2);
-}
-
 /* Dimmed styles */
 
 .timeline.dimmed .message .fill {


### PR DESCRIPTION
Fix #1537.