### PR TITLE
initialize the Auth0Provider with the correct audience

### DIFF
--- a/src/ui/utils/auth0.js
+++ b/src/ui/utils/auth0.js
@@ -21,6 +21,7 @@ const Auth0ProviderWithHistory = ({ children }) => {
       onRedirectCallback={onRedirectCallback}
       cacheLocation="localstorage"
       prompt="select_account"
+      audience="hasura-api"
     >
       {children}
     </Auth0Provider>


### PR DESCRIPTION
Without this, the Auth0Provider will not fetch the Hasura access token on login. That token will be fetched later instead, sometimes requiring the user to login a second time (in a popup). This usually happens in a private/incognito window, but I've also seen it happen in a regular window, depending on the browser settings.