### PR TITLE
fix for Typescript 4.1

### DIFF
--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -321,7 +321,7 @@ export class NodeFront {
 
   getBoundingClientRect() {
     assert(this._loaded);
-    const [left, top, right, bottom] = this._bounds;
+    const [left, top, right, bottom] = this._bounds!;
     return new DOMRect(left, top, right - left, bottom - top);
   }
 


### PR DESCRIPTION
Typescript 4.1 became a little stricter, so the latest version of VS Code (which ships with Typescript 4.1) complained about this line.