### PR TITLE
Add check for a recording that is missing a user

### DIFF
--- a/src/ui/components/Header/ShareDropdown.js
+++ b/src/ui/components/Header/ShareDropdown.js
@@ -47,7 +47,12 @@ function useIsOwner(recordingId) {
     return false;
   }
 
-  return user.sub === data.recordings[0]?.user.auth_id;
+  const recording = data.recordings[0];
+  if (!recording?.user) {
+    return false;
+  }
+
+  return user.sub === recording.user?.auth_id;
 }
 
 function CopyUrl({ recordingId }) {


### PR DESCRIPTION
Note, it is very surprising a recording could be created without an associated user