### PR TITLE
Deploy4

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -24,7 +24,6 @@ jobs:
   deploy:
     name: Deploy to S3
     runs-on: ubuntu-latest
-    needs: [build]
     timeout-minutes: 15
     steps:
       - name: Checkout


### PR DESCRIPTION
turns out deploy does its own webpack build so the two can be independent.
the build step is just for historical purposes.