### PR TITLE
Refresh codemirror when going in/out of breakpoint editing mode, fixes #1568

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -89,6 +89,10 @@ function Panel({ breakpoint, editor, insertAt, hoveredPoint }) {
   const [width, setWidth] = useState(getPanelWidth(editor));
   const [inputToFocus, setInputToFocus] = useState("logValue");
 
+  // Force CodeMirror to refresh when changing the size of the breakpoint
+  // panel so that code selection works properly.
+  window.dispatchEvent(new Event("resize"));
+
   const toggleEditingOn = () => setEditing(true);
   const toggleEditingOff = () => setEditing(false);
   const updateWidth = () => setWidth(getPanelWidth(editor));


### PR DESCRIPTION
It's hard to tell from the recording in #1568 why the selection doesn't refresh properly here, since the issue is in CodeMirror which I don't know well.  We've had other similar issues with CodeMirror though, and forcing it to refresh fixed those problems.  That works here as well --- we need CodeMirror to update both when going in and out of editing mode on the breakpoint in order for code selection to work as expected.  Sending a resize event to the window is the best way I've found for doing that.