### PR TITLE
Don't use cx in setBreakpointPositions

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/breakpointPositions.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/breakpointPositions.js
@@ -59,7 +59,7 @@ function groupByLine(results, sourceId, line) {
   return positions;
 }
 
-async function _setBreakpointPositions(cx, sourceId, line, thunkArgs) {
+async function _setBreakpointPositions(sourceId, line, thunkArgs) {
   const { client, dispatch, getState, sourceMaps } = thunkArgs;
   let generatedSource = getSource(getState(), sourceId);
   if (!generatedSource) {
@@ -72,7 +72,7 @@ async function _setBreakpointPositions(cx, sourceId, line, thunkArgs) {
 
   const actorColumns = await Promise.all(
     getSourceActorsForSource(getState(), generatedSource.id).map(actor =>
-      dispatch(loadSourceActorBreakpointColumns({ id: actor.id, line, cx }))
+      dispatch(loadSourceActorBreakpointColumns({ id: actor.id, line }))
     )
   );
 
@@ -93,7 +93,6 @@ async function _setBreakpointPositions(cx, sourceId, line, thunkArgs) {
 
   dispatch({
     type: "ADD_BREAKPOINT_POSITIONS",
-    cx,
     source,
     positions,
   });
@@ -124,6 +123,6 @@ export const setBreakpointPositions = memoizeableAction("setBreakpointPositions"
     const key = generatedSourceActorKey(getState(), sourceId);
     return line ? `${key}-${line}` : key;
   },
-  action: async ({ cx, sourceId, line }, thunkArgs) =>
-    _setBreakpointPositions(cx, sourceId, line, thunkArgs),
+  action: async ({ sourceId, line }, thunkArgs) =>
+    _setBreakpointPositions(sourceId, line, thunkArgs),
 });

--- a/src/devtools/client/debugger/src/actions/breakpoints/index.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/index.js
@@ -190,7 +190,7 @@ export function updateHoveredLineNumber(cx, line) {
     // Set the initial location here as a placeholder to be checked after any async activity.
     dispatch(actions.setHoveredLineNumberLocation(initialLocation));
 
-    await dispatch(setBreakpointPositions({ cx, sourceId: source.id, line }));
+    await dispatch(setBreakpointPositions({ sourceId: source.id, line }));
     const location = getFirstBreakpointPosition(getState(), initialLocation);
 
     // It's possible that after the `await` above the user is either 1) hovered off of the

--- a/src/devtools/client/debugger/src/actions/breakpoints/modify.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/modify.js
@@ -91,7 +91,7 @@ export function addBreakpoint(
 
     const { sourceId, column, line } = initialLocation;
 
-    await dispatch(setBreakpointPositions({ cx, sourceId, line }));
+    await dispatch(setBreakpointPositions({ sourceId, line }));
 
     const location = column
       ? getBreakpointPositionsForLocation(getState(), initialLocation)
@@ -160,7 +160,7 @@ export function runAnalysis(cx, initialLocation, options) {
     recordEvent("run_analysis");
 
     const { sourceId, line } = initialLocation;
-    await dispatch(setBreakpointPositions({ cx, sourceId, line }));
+    await dispatch(setBreakpointPositions({ sourceId, line }));
     const location = getFirstBreakpointPosition(getState(), initialLocation);
 
     if (!location) {


### PR DESCRIPTION
Fixes #1567

From the recording in that bug it's pretty easy to see that we threw an exception inside updateHoveredLineNumber and execution didn't get far enough along to actually call actions.setHoveredLineNumberLocation.

Debugger action contexts are a little tricky to use.  I added these to the firefox devtools back in 2019 to fix a raft of problems with stale async actions updating debugger state after the user resumed, paused, or navigated.  The replay devtools don't need the context as much, however, because they can't navigate and change the set of loaded sources.  They're still needed when the action is updating state related to the current pause, but that isn't needed when setting breakpoint positions.  There's a lot more cx removal that can be done here and in related code, but this is enough to get the hits to load as expected.