### PR TITLE
Fix object inspector stuck in loading state, fixes #1033

### DIFF
--- a/src/devtools/client/debugger/packages/devtools-reps/src/object-inspector/components/ObjectInspector.js
+++ b/src/devtools/client/debugger/packages/devtools-reps/src/object-inspector/components/ObjectInspector.js
@@ -103,8 +103,9 @@ class ObjectInspector extends Component {
       return;
     }
 
-    for (const [path, properties] of nextProps.loadedProperties) {
-      if (properties !== this.props.loadedProperties.get(path)) {
+    for (const path of this.cachedNodes.keys()) {
+      const existing = this.props.loadedProperties.get(path);
+      if (!existing || existing !== nextProps.loadedProperties.get(path)) {
         this.cachedNodes.delete(path);
       }
     }

--- a/src/devtools/client/debugger/packages/devtools-reps/src/object-inspector/reducer.js
+++ b/src/devtools/client/debugger/packages/devtools-reps/src/object-inspector/reducer.js
@@ -83,10 +83,8 @@ function reducer(state = initialState(), action = {}) {
     });
   }
 
-  // NOTE: we clear the state on resume because otherwise the scopes pane
-  // would be out of date. Bug 1514760
-  if (type === "RESUME" || type == "NAVIGATE") {
-    return initialState({ watchpoints: state.watchpoints });
+  if (type == "PAUSED") {
+    return cloneState({ loadedProperties: new Map() });
   }
 
   return state;

--- a/test/scripts/object_preview-03.js
+++ b/test/scripts/object_preview-03.js
@@ -24,14 +24,13 @@ Test.describe(`Test previews when switching between frames and stepping.`, async
   await Test.waitForFrameTimeline("71%");
 
   // barobj is already expanded.
-  await Test.toggleScopeNode("barobj");
   await Test.findScopeNode("barprop1");
   await Test.waitForScopeValue("barprop1", `"updated"`);
 
   //await Test.waitForInstantStep("reverseStepOver");
   await Test.reverseStepOverToLine(17);
 
-  await Test.toggleScopeNode("barobj");
+  // barobj is already expanded.
   await Test.findScopeNode("barprop1");
   await Test.waitForScopeValue("barprop1", "2");
 


### PR DESCRIPTION
I tried to write a test for this but unfortunately it doesn't repro on our simpler test cases.  There are several different maps used for caching in the object inspector and I feel this could be simplified greatly.  The protocol values do their own caching.