### PR TITLE
Use token base preview matching

### DIFF
--- a/src/devtools/client/debugger/src/actions/preview.js
+++ b/src/devtools/client/debugger/src/actions/preview.js
@@ -2,49 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-//
-
 import { isConsole } from "../utils/preview";
-import { findBestMatchExpression } from "../utils/ast";
 import { getExpressionFromCoords } from "../utils/editor/get-expression";
 import { createPrimitiveValueFront } from "protocol/thread";
 
 import {
   getPreview,
-  isLineInScope,
   isSelectedFrameVisible,
   getSelectedSource,
   getSelectedFrame,
-  getSymbols,
   getPreviewCount,
 } from "../selectors";
 
-function findExpressionMatch(state, codeMirror, tokenPos) {
-  const source = getSelectedSource(state);
-  if (!source) {
-    return;
-  }
-
-  const symbols = getSymbols(state, source);
-
-  let match;
-  if (!symbols || symbols.loading) {
-    match = getExpressionFromCoords(codeMirror, tokenPos);
-  } else {
-    match = findBestMatchExpression(symbols, tokenPos);
-  }
-  return match;
-}
-
 export function updatePreview(cx, target, tokenPos, codeMirror) {
-  return ({ dispatch, getState, client, sourceMaps }) => {
+  return ({ dispatch, getState }) => {
     const cursorPos = target.getBoundingClientRect();
 
-    if (!isSelectedFrameVisible(getState()) || !isLineInScope(getState(), tokenPos.line)) {
+    if (!isSelectedFrameVisible(getState())) {
       return;
     }
 
-    const match = findExpressionMatch(getState(), codeMirror, tokenPos);
+    const match = getExpressionFromCoords(codeMirror, tokenPos);
     if (!match) {
       return;
     }

--- a/src/devtools/client/debugger/src/utils/editor/token-events.js
+++ b/src/devtools/client/debugger/src/utils/editor/token-events.js
@@ -17,25 +17,38 @@ function isValidToken(target) {
 
   // exclude literal tokens where it does not make sense to show a preview
   const invalidType = ["cm-atom", ""].includes(target.className);
+  if (invalidType) {
+    return false;
+  }
 
   // exclude syntax where the expression would be a syntax error
   const invalidToken = tokenText === "" || tokenText.match(/^[(){}\|&%,.;=<>\+-/\*\s](?=)/);
+  if (invalidToken) {
+    return false;
+  }
 
   // exclude codemirror elements that are not tokens
   const invalidTarget =
     (target.parentElement && !target.parentElement.closest(".CodeMirror-line")) ||
     cursorPos.top == 0;
+  if (invalidTarget) {
+    return false;
+  }
 
-  const invalidClasses = ["editor-mount"];
+  const invalidClasses = ["editor-mount", "CodeMirror-line", "cm-tag"];
   if (invalidClasses.some(className => target.classList.contains(className))) {
-    return true;
+    return false;
+  }
+
+  if (target.attributes.role?.value == "presentation") {
+    return false;
   }
 
   if (target.closest(".popover")) {
-    return true;
+    return false;
   }
 
-  return invalidTarget || invalidToken || invalidType;
+  return true;
 }
 
 function dispatch(codeMirror, eventName, data) {


### PR DESCRIPTION
This uses the simpler expression matching and unfortunately updates a lot of the token location logic which was pretty unstable