### PR TITLE
Change timeline markers when user toggles between comments/transcript

### DIFF
--- a/src/devtools/client/debugger/src/reducers/event-listeners.js
+++ b/src/devtools/client/debugger/src/reducers/event-listeners.js
@@ -8,7 +8,7 @@ import { prefs } from "../utils/prefs";
 
 export function initialEventListenerState() {
   return {
-    active: [],
+    active: ["event.mouse.click"],
     categories: [],
     expanded: [],
     logEventBreakpoints: prefs.logEventBreakpoints,

--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -226,6 +226,7 @@ export class Timeline extends Component {
       hoveredLineNumberLocation,
       hoveredPoint,
       viewMode,
+      selectedPanel,
     } = this.props;
     const percent = getVisiblePosition({ time: currentTime, zoom: zoomRegion }) * 100;
     const hoverPercent = getVisiblePosition({ time: hoverTime, zoom: zoomRegion }) * 100;
@@ -245,7 +246,9 @@ export class Timeline extends Component {
             <div className="progress-line full" />
             <div className="progress-line preview" style={{ width: `${hoverPercent}%` }} />
             <div className="progress-line" style={{ width: `${percent}%` }} />
-            {viewMode == "dev" ? this.renderMessages() : this.renderEvents()}
+            {viewMode == "dev" && selectedPanel == "console"
+              ? this.renderMessages()
+              : this.renderEvents()}
             {this.renderPreviewMarkers()}
             <ScrollContainer />
           </div>


### PR DESCRIPTION
Fixes #1597.

Demo: https://share.descript.com/view/Wb3iOgxzKFY

Behavior:
1) Viewer mode: Only show timeline markers for recording click events*
2) Devtools mode (Transcript): Only show timeline markers for recording click events*
3) Devtools mode (Console): Only show timeline markers for console messages

*_Recording_ click events are different from the _Event filter_ click events. They don't correspond to a particular line of code. Instead, they only correspond to a point and a time.