### PR TITLE
Fix regression and bring back timeline hover preview

### DIFF
--- a/src/ui/components/Timeline/index.js
+++ b/src/ui/components/Timeline/index.js
@@ -90,6 +90,7 @@ export class Timeline extends Component {
     const mouseTime = this.getMouseTime(e);
 
     if (hoverTime != mouseTime) {
+      paintGraphicsAtTime(mouseTime);
       let offset = getVisiblePosition({ time: mouseTime, zoom: zoomRegion }) * this.overlayWidth;
       setTimelineToTime({ time: mouseTime, offset });
     }


### PR DESCRIPTION
Timeline hover was regressed by #1619. This fixes it.

This addresses issue #1632 but stops short of adding tests. Let's keep the issue open and do that as a follow up.