### PR TITLE
Tighten events in the transcripts panel

### DIFF
--- a/src/ui/components/SecondaryToolbox/CommentsPanel.css
+++ b/src/ui/components/SecondaryToolbox/CommentsPanel.css
@@ -7,11 +7,12 @@
   align-items: center;
   background: white;
   height: 100%;
+  padding-top: 10px;
 }
 
 .comments-panel .comment,
 .comments-panel .event {
-  padding: 20px 16px 20px;
+  padding: 10px 16px 10px;
   line-height: 1.25rem;
   font-size: 1rem;
   display: flex;


### PR DESCRIPTION
### New 
<img width="1230" alt="Screen Shot 2021-01-29 at 6 01 08 PM" src="https://user-images.githubusercontent.com/254562/106343797-05473c80-625c-11eb-98af-d315d4045fdc.png">

<img width="1024" alt="Screen Shot 2021-01-29 at 5 56 51 PM" src="https://user-images.githubusercontent.com/254562/106343755-d29d4400-625b-11eb-8f6a-ff61f77d1856.png">

---
### Old

<img width="1154" alt="Screen Shot 2021-01-29 at 6 00 32 PM" src="https://user-images.githubusercontent.com/254562/106343801-07a99680-625c-11eb-9346-23bd33d0a703.png">
<img width="1148" alt="Screen Shot 2021-01-29 at 6 00 26 PM" src="https://user-images.githubusercontent.com/254562/106343802-08dac380-625c-11eb-822b-022e9b281c5d.png">
