### PR TITLE
Only create logrocket sessions when logged in

### DIFF
--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -12,7 +12,6 @@ import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
 import { hasLoadingParam } from "ui/utils/environment";
 import ResizeObserverPolyfill from "resize-observer-polyfill";
-import hooks from "ui/hooks";
 import LogRocket from "ui/utils/logrocket";
 
 import "styles.css";
@@ -55,19 +54,10 @@ function App({ theme, recordingId, modal, updateNarrowMode }: AppProps) {
   }, [theme]);
 
   useEffect(() => {
-    const setUserInLogRocket = async () => {
-      if (auth.user) {
-        const userId = await hooks.fetchUserId(auth.user.sub);
-        LogRocket.identify(auth.user.sub, {
-          name: auth.user.name,
-          email: auth.user.email,
-          id: userId,
-        });
-      }
-    };
-
     setUserInBrowserPrefs(auth.user);
-    setUserInLogRocket();
+    if (auth.user) {
+      LogRocket.createSession(auth);
+    }
   }, [auth.user]);
 
   if (hasLoadingParam()) {

--- a/src/ui/utils/bootstrap/bootstrap.tsx
+++ b/src/ui/utils/bootstrap/bootstrap.tsx
@@ -10,31 +10,16 @@ import App, { AppProps } from "ui/components/App";
 const { PopupBlockedError } = require("ui/components/shared/Error");
 import tokenManager from "ui/utils/tokenManager";
 import useToken from "ui/utils/useToken";
-import LogRocket from "ui/utils/logrocket";
 import { createApolloClient } from "ui/utils/apolloClient";
 import { ApolloProvider } from "@apollo/client";
 
-import { isDevelopment, isTest } from "../environment";
+import { skipTelemetry } from "../environment";
 import { UIStore } from "ui/actions";
-const skipTelemetry = isTest() || isDevelopment();
-
-function setupLogRocket() {
-  if (skipTelemetry) {
-    return;
-  }
-
-  LogRocket.init();
-  LogRocket.getSessionURL(sessionURL => {
-    Sentry.configureScope(scope => {
-      scope.setExtra("sessionURL", sessionURL);
-    });
-  });
-}
 
 export function setupSentry(context: Record<string, any>) {
   const ignoreList = ["Current thread has paused or resumed", "Current thread has changed"];
 
-  if (skipTelemetry) {
+  if (skipTelemetry()) {
     return;
   }
 
@@ -79,7 +64,6 @@ function ApolloWrapper({ children }: { children: ReactNode }) {
 
 export function bootstrapApp(props: AppProps, context: Record<string, any>, store: UIStore) {
   setupSentry(context);
-  setupLogRocket();
 
   ReactDOM.render(
     <Router>

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -16,6 +16,10 @@ export function isTest() {
   return getTest() != null;
 }
 
+export function skipTelemetry() {
+  return isTest() || isDevelopment();
+}
+
 export function isDeployPreview() {
   return url.hostname.includes("replay-devtools.netlify.app");
 }

--- a/src/ui/utils/logrocket.ts
+++ b/src/ui/utils/logrocket.ts
@@ -1,16 +1,32 @@
 import LogRocket from "logrocket";
 import setupLogRocketReact from "logrocket-react";
+import * as Sentry from "@sentry/react";
+import { skipTelemetry } from "./environment";
 
 let setup = false;
 
 export default {
-  init: () => {
+  createSession: (auth: any) => {
+    if (skipTelemetry()) {
+      return;
+    }
+
     setup = true;
     setupLogRocketReact(LogRocket);
     LogRocket.init("4sdo4i/replay");
+    LogRocket.getSessionURL(sessionURL => {
+      Sentry.configureScope(scope => {
+        scope.setExtra("sessionURL", sessionURL);
+      });
+    });
+
+    LogRocket.identify(auth.user.sub, {
+      name: auth.user.name,
+      email: auth.user.email,
+      id: auth.user.email,
+    });
   },
-  identify: (uuid: string, attributes: Record<string, string | number | boolean>) =>
-    setup && LogRocket.identify(uuid, attributes),
+
   getSessionURL: (callback: (sessionUrl: string) => void) =>
     setup && LogRocket.getSessionURL(callback),
   reduxMiddleware: () =>


### PR DESCRIPTION
It looks like we were previously creating logrocket sessions whenever `skipTelemetry` was false... the downside is that we would not wait to see if somebody logged in. This left us exposed to runlive tests which would still be created.