### PR TITLE
protocol: if websocket connection errors show correct error message

### DIFF
--- a/src/protocol/socket.ts
+++ b/src/protocol/socket.ts
@@ -135,6 +135,8 @@ function onSocketClose() {
 
 function onSocketError(evt: Event) {
   console.error("Socket Error", evt);
+  // If the socket has errored, the connection will close. So let's set `willClose`
+  // so that we show _this_ error message, and not the `onSocketClose` error message
   willClose = true;
   return ({ dispatch }: { dispatch: Dispatch<Action> }) => {
     log("Socket Error");

--- a/src/protocol/socket.ts
+++ b/src/protocol/socket.ts
@@ -41,7 +41,7 @@ export function initSocket(store: UIStore, address?: string) {
 
   socket.onopen = makeInfallible(onSocketOpen);
   socket.onclose = makeInfallible(() => store.dispatch(onSocketClose()));
-  socket.onerror = makeInfallible(() => store.dispatch(onSocketError()));
+  socket.onerror = makeInfallible((evt: Event) => store.dispatch(onSocketError(evt)));
   socket.onmessage = makeInfallible(onSocketMessage);
 }
 
@@ -133,7 +133,9 @@ function onSocketClose() {
   };
 }
 
-function onSocketError() {
+function onSocketError(evt: Event) {
+  console.error("Socket Error", evt);
+  willClose = true;
   return ({ dispatch }: { dispatch: Dispatch<Action> }) => {
     log("Socket Error");
     dispatch(


### PR DESCRIPTION
Fixes #1465

I think a lot of stuff has changed since the initial report. Now devtools does show an error when it can't connect to the backend, but it shows the `onSocketClose` error not the `onSocketError` error.

I made `onSocketError` also set `willClose` so that `onSocketClose` will not fire after it, overwriting the error message in the UI.

I also added a `console.error` that dumps the event, which I found helpful while debugging.

I tried to write a test but I had a really hard time mocking out `UIStore` 