### PR TITLE
Lazy load draft-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.2",
     "typescript": "^4.0.3",
-    "webpack-dev-server": "^3.11.0"
+    "webpack-dev-server": "^3.11.0",
+    "webpack-visualizer-plugin": "^0.1.11"
   },
   "browserslist": [
     "defaults"

--- a/src/devtools/client/debugger/dist/immutable.js
+++ b/src/devtools/client/debugger/dist/immutable.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/src/ui/components/Comments/CommentEditor.js
+++ b/src/ui/components/Comments/CommentEditor.js
@@ -6,8 +6,6 @@ import { selectors } from "ui/reducers";
 import hooks from "ui/hooks";
 import { actions } from "ui/actions";
 import CommentTool from "ui/components/shared/CommentTool";
-import { Editor, EditorState, getDefaultKeyBinding } from "draft-js";
-
 import "draft-js/dist/Draft.css";
 
 function CommentEditor({
@@ -19,8 +17,23 @@ function CommentEditor({
   currentTime,
 }) {
   const { user } = useAuth0();
-  const [editorState, setEditorState] = useState(EditorState.createEmpty());
+  const [editorState, setEditorState] = useState(null);
+  const [DraftJS, setDraftJS] = useState();
+
   const addComment = hooks.useAddComment(clearPendingComment);
+
+  useEffect(() => {
+    import("draft-js").then(DraftJS => {
+      setEditorState(DraftJS.EditorState.createEmpty());
+      setDraftJS(DraftJS);
+    });
+  }, []);
+
+  if (!DraftJS) {
+    return null;
+  }
+
+  const { Editor, EditorState, getDefaultKeyBinding } = DraftJS;
 
   const isNewComment = comment.content === "";
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const Visualizer = require("webpack-visualizer-plugin");
 
 module.exports = {
   entry: {
@@ -26,7 +27,10 @@ module.exports = {
     liveReload: false,
     disableHostCheck: true,
   },
-  plugins: [new MiniCssExtractPlugin()],
+  plugins: [
+    new MiniCssExtractPlugin(),
+    process.env.REPLAY_BUILD_VISUALIZE && new Visualizer(),
+  ].filter(Boolean),
   resolve: {
     extensions: [".js", ".jsx", ".ts", ".tsx"],
     modules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   devtool: "source-map",
   output: {
-    publicPath: "dist",
+    publicPath: "dist/",
   },
   devServer: {
     before: app => {


### PR DESCRIPTION
* Removes `immutable.js` from `debugger/dist` which was breaking draft.js which also had a dependency on that module
* Fixes the `publicPath` config in webpack to load the chunks
* Adds `webpack-visualizer-plugin` and support for `REPLAY_BUILD_VISUALIZER` environment variable to trigger visualization `stats.html` build
* Lazy loads `draft-js`!