### PR TITLE
Add error handling for Apollo queries/mutations

### DIFF
--- a/src/ui/hooks/comments.ts
+++ b/src/ui/hooks/comments.ts
@@ -92,8 +92,6 @@ export function useGetComments(
     pollInterval: 5000,
   });
 
-  // This gives us some basic logging for when there's a problem
-  // while fetching the comments.
   if (error) {
     console.error("Apollo error while fetching comments:", error);
   }
@@ -102,7 +100,7 @@ export function useGetComments(
 }
 
 export function useAddComment(callback: Function = () => {}) {
-  const [addComment] = useMutation(ADD_COMMENT, {
+  const [addComment, { error }] = useMutation(ADD_COMMENT, {
     onCompleted: data => {
       const { id } = data.insert_comments_one;
       callback(id);
@@ -110,29 +108,45 @@ export function useAddComment(callback: Function = () => {}) {
     refetchQueries: ["GetComments"],
   });
 
+  if (error) {
+    console.error("Apollo error while adding a comment:", error);
+  }
+
   return addComment;
 }
 
 export function useUpdateComment(callback: Function) {
-  const [updateCommentContent] = useMutation(UPDATE_COMMENT_CONTENT, {
+  const [updateCommentContent, { error }] = useMutation(UPDATE_COMMENT_CONTENT, {
     onCompleted: () => callback(),
   });
+
+  if (error) {
+    console.error("Apollo error while updating a comment:", error);
+  }
 
   return updateCommentContent;
 }
 
 export function useDeleteComment(callback: Function) {
-  const [deleteComment] = useMutation(DELETE_COMMENT, {
+  const [deleteComment, { error }] = useMutation(DELETE_COMMENT, {
     refetchQueries: ["GetComments"],
   });
+
+  if (error) {
+    console.error("Apollo error while deleting a comment:", error);
+  }
 
   return deleteComment;
 }
 
 export function useDeleteCommentReplies(callback: Function) {
-  const [deleteCommentReplies] = useMutation(DELETE_COMMENT_REPLIES, {
+  const [deleteCommentReplies, { error }] = useMutation(DELETE_COMMENT_REPLIES, {
     refetchQueries: ["GetComments"],
   });
+
+  if (error) {
+    console.error("Apollo error while deleting a comment's replies:", error);
+  }
 
   return deleteCommentReplies;
 }

--- a/src/ui/hooks/sessions.ts
+++ b/src/ui/hooks/sessions.ts
@@ -18,7 +18,7 @@ interface Session {
 
 export function useGetActiveSessions(recordingId: RecordingId, sessionId: string) {
   const { user } = useAuth0();
-  const { data, loading } = useQuery(
+  const { data, error, loading } = useQuery(
     gql`
       query GetActiveSessions($recordingId: uuid!, $sessionId: String!) {
         sessions(
@@ -45,6 +45,10 @@ export function useGetActiveSessions(recordingId: RecordingId, sessionId: string
     }
   );
 
+  if (error) {
+    console.error("Apollo error while getting active sessions", error);
+  }
+
   if (loading) {
     return { loading };
   }
@@ -67,7 +71,7 @@ export function useGetActiveSessions(recordingId: RecordingId, sessionId: string
 }
 
 export function useGetRecording(recordingId: RecordingId) {
-  const { data, loading: queryIsLoading } = useQuery(
+  const { data, error, loading: queryIsLoading } = useQuery(
     gql`
       query GetRecording($recordingId: uuid!) {
         recordings(where: { id: { _eq: $recordingId } }) {
@@ -84,6 +88,10 @@ export function useGetRecording(recordingId: RecordingId) {
       variables: { recordingId },
     }
   );
+
+  if (error) {
+    console.error("Apollo error while getting the recording", error);
+  }
 
   return { data, queryIsLoading };
 }
@@ -104,7 +112,7 @@ export async function fetchUserId(authId: string) {
 }
 
 export function useAddSessionUser() {
-  const [AddSessionUser] = useMutation(gql`
+  const [AddSessionUser, { error }] = useMutation(gql`
     mutation AddSessionUser($id: String!, $user_id: uuid!) {
       update_sessions_by_pk(pk_columns: { id: $id }, _set: { user_id: $user_id }) {
         id
@@ -112,5 +120,10 @@ export function useAddSessionUser() {
       }
     }
   `);
+
+  if (error) {
+    console.error("Apollo error while adding a session user", error);
+  }
+
   return AddSessionUser;
 }


### PR DESCRIPTION
Right now, we don't have a way to see query/mutation errors in Sentry. 

Those errors are not handled, which leads to bugs in the UI. Those bugs produce some type of error which ends up being caught by Sentry. But it makes it difficult to figure out what the root cause of the bug was in the first place.

This logs any errors so that when we see a query/mutation related bug in Sentry, we can check the logs to see what the original error was.