### PR TITLE
Refactor DraftJS so it doesn't hold up rendering the CommentEditor

### DIFF
--- a/src/ui/components/Comments/CommentEditor.js
+++ b/src/ui/components/Comments/CommentEditor.js
@@ -8,7 +8,7 @@ import { actions } from "ui/actions";
 import CommentTool from "ui/components/shared/CommentTool";
 import "draft-js/dist/Draft.css";
 
-function DraftJSEditor({ editorState, setEditorState, DraftJS, setDraftJS }) {
+function DraftJSEditorLoader({ editorState, setEditorState, DraftJS, setDraftJS }) {
   useEffect(function importDraftJS() {
     import("draft-js").then(DraftJS => {
       setEditorState(DraftJS.EditorState.createEmpty());
@@ -20,15 +20,31 @@ function DraftJSEditor({ editorState, setEditorState, DraftJS, setDraftJS }) {
     return null;
   }
 
+  return <DraftJSEditor {...{ editorState, setEditorState, DraftJS }} />;
+}
+
+function DraftJSEditor({ editorState, setEditorState, DraftJS }) {
+  const editorNode = useRef(null);
+  const wrapperNode = useRef(null);
   const { Editor, getDefaultKeyBinding } = DraftJS;
 
+  useEffect(() => {
+    // The order is important here — we focus the editor first before scrolling the
+    // wrapper into view. Otherwise, the scrolling animation is interrupted by the focus.
+    editorNode.current.focus();
+    wrapperNode.current.scrollIntoView({ block: "center", behavior: "smooth" });
+  }, []);
+
   return (
-    <Editor
-      editorState={editorState}
-      onChange={setEditorState}
-      handleKeyCommand={e => getDefaultKeyBinding(e)}
-      placeholder={"Type a comment ..."}
-    />
+    <div ref={wrapperNode}>
+      <Editor
+        editorState={editorState}
+        onChange={setEditorState}
+        handleKeyCommand={e => getDefaultKeyBinding(e)}
+        placeholder={"Type a comment ..."}
+        ref={editorNode}
+      />
+    </div>
   );
 }
 
@@ -107,7 +123,7 @@ function CommentEditor({
     <div className="comment-input-container">
       <img src={user.picture} className="comment-picture" />
       <div className="comment-input">
-        <DraftJSEditor {...{ editorState, setEditorState, DraftJS, setDraftJS }} />
+        <DraftJSEditorLoader {...{ editorState, setEditorState, DraftJS, setDraftJS }} />
       </div>
       <button className="img paper-airplane" onClick={handleSave} />
       {isNewComment && <CommentTool comment={comment} />}

--- a/src/ui/components/Comments/CommentEditor.js
+++ b/src/ui/components/Comments/CommentEditor.js
@@ -8,6 +8,30 @@ import { actions } from "ui/actions";
 import CommentTool from "ui/components/shared/CommentTool";
 import "draft-js/dist/Draft.css";
 
+function DraftJSEditor({ editorState, setEditorState, DraftJS, setDraftJS }) {
+  useEffect(function importDraftJS() {
+    import("draft-js").then(DraftJS => {
+      setEditorState(DraftJS.EditorState.createEmpty());
+      setDraftJS(DraftJS);
+    });
+  }, []);
+
+  if (!DraftJS) {
+    return null;
+  }
+
+  const { Editor, getDefaultKeyBinding } = DraftJS;
+
+  return (
+    <Editor
+      editorState={editorState}
+      onChange={setEditorState}
+      handleKeyCommand={e => getDefaultKeyBinding(e)}
+      placeholder={"Type a comment ..."}
+    />
+  );
+}
+
 function CommentEditor({
   comment,
   clearPendingComment,
@@ -19,21 +43,7 @@ function CommentEditor({
   const { user } = useAuth0();
   const [editorState, setEditorState] = useState(null);
   const [DraftJS, setDraftJS] = useState();
-
   const addComment = hooks.useAddComment(clearPendingComment);
-
-  useEffect(() => {
-    import("draft-js").then(DraftJS => {
-      setEditorState(DraftJS.EditorState.createEmpty());
-      setDraftJS(DraftJS);
-    });
-  }, []);
-
-  if (!DraftJS) {
-    return null;
-  }
-
-  const { Editor, EditorState, getDefaultKeyBinding } = DraftJS;
 
   const isNewComment = comment.content === "";
 
@@ -69,7 +79,7 @@ function CommentEditor({
     addComment({
       variables: { object: reply },
     });
-    setEditorState(EditorState.createEmpty());
+    setEditorState(DraftJS.EditorState.createEmpty());
   };
   const handleNewSave = () => {
     const inputValue = editorState.getCurrentContent().getPlainText();
@@ -97,12 +107,7 @@ function CommentEditor({
     <div className="comment-input-container">
       <img src={user.picture} className="comment-picture" />
       <div className="comment-input">
-        <Editor
-          editorState={editorState}
-          onChange={setEditorState}
-          handleKeyCommand={e => getDefaultKeyBinding(e)}
-          placeholder={"Type a comment ..."}
-        />
+        <DraftJSEditor {...{ editorState, setEditorState, DraftJS, setDraftJS }} />
       </div>
       <button className="img paper-airplane" onClick={handleSave} />
       {isNewComment && <CommentTool comment={comment} />}

--- a/src/ui/components/Comments/CommentThread.js
+++ b/src/ui/components/Comments/CommentThread.js
@@ -33,7 +33,7 @@ function CommentThread({
   };
 
   useEffect(() => {
-    if (comment.time === currentTime || pendingComment?.id == comment.id) {
+    if (comment.time === currentTime) {
       commentEl.current.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   }, [currentTime, pendingComment]);

--- a/src/ui/components/Transcript/AddCommentButton.css
+++ b/src/ui/components/Transcript/AddCommentButton.css
@@ -1,4 +1,4 @@
-.comments-panel button.add-comment {
+.transcript-panel button.add-comment {
   border: 1px solid var(--dark-blue);
   color: var(--dark-blue);
   padding: 8px 12px;
@@ -12,29 +12,29 @@
   flex-direction: column;
 }
 
-.comments-panel button.add-comment:hover {
+.transcript-panel button.add-comment:hover {
   background: var(--dark-blue);
   color: var(--theme-body-background);
   border: 1px solid var(--dark-blue);
 }
 
-.comments-panel button.add-comment.disabled {
+.transcript-panel button.add-comment.disabled {
   background: var(--grey-30);
   border: 1px solid var(--grey-30);
   color: var(--theme-body-color);
   cursor: auto;
 }
 
-.comments-panel button.add-comment.disabled:focus {
+.transcript-panel button.add-comment.disabled:focus {
   outline: none;
 }
 
-.comments-panel button.add-comment .img {
+.transcript-panel button.add-comment .img {
   margin-right: 4px;
   background: var(--theme-body-background);
 }
 
-.comments-panel .add-comment {
+.transcript-panel .add-comment {
   padding: 12px;
   color: white;
   align-self: center;

--- a/src/ui/components/Transcript/Transcript.css
+++ b/src/ui/components/Transcript/Transcript.css
@@ -1,4 +1,4 @@
-.comments-panel {
+.transcript-panel {
   flex-grow: 1;
   overflow: auto;
   overflow-x: hidden;
@@ -9,11 +9,22 @@
   height: 100%;
   padding: 16px;
 }
-.comments-panel > :not(:first-child) {
+
+.transcript-panel > :not(:first-child) {
+  margin-top: 16px;
+}
+
+.transcript-list {
+  flex-grow: 1;
+  overflow: auto;
+  width: 100%;
+}
+
+.transcript-list > :not(:first-child) {
   margin-top: 8px;
 }
 
-.comments-panel .comment-container {
+.transcript-list .comment-container {
   margin-left: 40px;
   margin-top: 20px;
   padding: 0px 16px;
@@ -21,7 +32,7 @@
   border-radius: 8px;
 }
 
-.comments-panel .comment {
+.transcript-list .comment {
   line-height: 1.25rem;
   font-size: 1rem;
   display: flex;
@@ -57,17 +68,17 @@
   margin-inline-end: 4px;
 }
 
-.comments-panel p {
+.transcript-list p {
   color: var(--theme-comment);
   padding: 16px;
   line-height: 1.5em;
 }
 
-.comments-panel .comment {
+.transcript-list .comment {
   overflow: hidden;
 }
 
-.comments-panel .comment-avatar {
+.transcript-list .comment-avatar {
   width: 24px;
   height: 24px;
   margin-inline-end: 12px;
@@ -78,34 +89,34 @@
   flex-shrink: 0;
 }
 
-.comments-panel .comment-avatar img {
+.transcript-list .comment-avatar img {
   width: inherit;
   height: inherit;
   border-radius: 50%;
 }
 
-.comments-panel .comment-body {
+.transcript-list .comment-body {
   align-self: center;
   padding: 16px 0px;
   width: 100%;
 }
 
-.comments-panel .comment-body > :not(:first-child) {
+.transcript-list .comment-body > :not(:first-child) {
   margin-top: 8px;
 }
 
-.comments-panel .comment-body-header {
+.transcript-list .comment-body-header {
   display: flex;
   flex-direction: row;
   align-items: center;
   height: 32px;
 }
 
-.comments-panel .comment-body-header > :not(:first-child) {
+.transcript-list .comment-body-header > :not(:first-child) {
   margin-left: 16px;
 }
 
-.comments-panel .comment-body-header-label {
+.transcript-list .comment-body-header-label {
   display: flex;
   flex-grow: 1;
   flex-direction: row;
@@ -113,7 +124,7 @@
   overflow: hidden;
 }
 
-.comments-panel .comment-body-header-label > :not(:first-child) {
+.transcript-list .comment-body-header-label > :not(:first-child) {
   margin-left: 8px;
 }
 
@@ -144,19 +155,14 @@
   height: min-content;
 }
 
-.comments-panel .dropdown-block {
+.transcript-list .dropdown-block {
   align-self: flex-start;
   flex-shrink: 0;
 }
 
-.comments-panel .dropdown {
+.transcript-list .dropdown {
   left: -150px;
 }
-
-/* .comments-panel .dropdown-button {
-  height: 28px;
-  width: 28px;
-} */
 
 .right-sidebar button.comment {
   mask-repeat: no-repeat;
@@ -164,31 +170,31 @@
   mask-position: center;
 }
 
-.comments-panel .comment .item-label {
+.transcript-list .comment .item-label {
   font-size: 14px;
   color: var(--theme-body-color);
   font-weight: bold;
 }
 
-.comments-panel .item-content {
+.transcript-list .item-content {
   font-size: 12px;
   padding-left: 40px;
   line-height: 18px;
   color: var(--theme-comment);
 }
 
-.comments-panel img {
+.transcript-list img {
   width: 24px;
   height: 24px;
   border-radius: 12px;
 }
 
-.comments-panel .comment-actions {
+.transcript-list .comment-actions {
   display: flex;
   flex-direction: row;
 }
 
-.comments-panel .comment-actions .dropdown-button {
+.transcript-list .comment-actions .dropdown-button {
   font-size: 12px;
   font-family: monospace;
   background: var(--grey-20);
@@ -200,11 +206,11 @@
   font-weight: bold;
 }
 
-.comments-panel .comment-actions .dropdown-button:hover {
+.transcript-list .comment-actions .dropdown-button:hover {
   background: var(--grey-30);
 }
 
-.comments-panel .comment-actions .img {
+.transcript-list .comment-actions .img {
   width: 20px;
   height: 20px;
 }
@@ -229,13 +235,13 @@
   cursor: pointer;
 }
 
-.comments-panel .comment-actions .img:hover {
+.transcript-list .comment-actions .img:hover {
   background: var(--primary-accent);
 }
 
 /* Comment Input */
 
-.comments-panel .comment-input-container {
+.transcript-list .comment-input-container {
   padding: 16px 0px;
   display: flex;
 }
@@ -244,16 +250,16 @@
   border-top: 1px solid var(--theme-splitter-color);
 }
 
-.comments-panel .comment-input-container img {
+.transcript-list .comment-input-container img {
   opacity: 50%;
   align-self: start;
 }
 
-.comments-panel .comment-input-container > :not(:first-child) {
+.transcript-list .comment-input-container > :not(:first-child) {
   margin-left: 16px;
 }
 
-.comments-panel .comment-input {
+.transcript-list .comment-input {
   flex-grow: 1;
   font-size: 12px;
   line-height: 18px;
@@ -261,7 +267,7 @@
   color: var(--theme-comment);
 }
 
-.comments-panel .responsive-textarea {
+.transcript-list .responsive-textarea {
   overflow-y: hidden;
   resize: none;
   font-family: sans-serif;
@@ -269,11 +275,11 @@
   border: none;
 }
 
-.comments-panel .responsive-textarea:focus {
+.transcript-list .responsive-textarea:focus {
   outline: none;
 }
 
-.comments-panel .img.paper-airplane {
+.transcript-list .img.paper-airplane {
   width: 20px;
   height: 20px;
   margin-bottom: 2px;
@@ -283,6 +289,6 @@
   align-self: flex-end;
 }
 
-.comments-panel .img.paper-airplane:hover {
+.transcript-list .img.paper-airplane:hover {
   background: var(--primary-accent);
 }

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -32,15 +32,17 @@ function Transcript({ recordingId, clickEvents, pendingComment }: PropsFromRedux
   }
 
   return (
-    <div className="comments-panel">
+    <div className="transcript-panel">
       <AddCommentButton />
-      {sortBy(entries, ["time", "kind", "created_at"]).map((entry, i) => {
-        if ("content" in entry) {
-          return <CommentTranscriptItem comment={entry} key={i} />;
-        } else {
-          return <EventTranscriptItem event={entry} key={i} />;
-        }
-      })}
+      <div className="transcript-list">
+        {sortBy(entries, ["time", "kind", "created_at"]).map((entry, i) => {
+          if ("content" in entry) {
+            return <CommentTranscriptItem comment={entry} key={i} />;
+          } else {
+            return <EventTranscriptItem event={entry} key={i} />;
+          }
+        })}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fix #1760. Fix #1773.

Upon clicking add comment, the new comment card would look flat/collapsed. This was because the CommentEditor component would not render fully until DraftJS was fully loaded. Once DraftJS was loaded, the CommentEditor and the new comment card renders fully. 

To make this interaction look less jumpy, this PR extracts the DraftJS editor component. This allows the rest of the CommentEditor (picture, save button) to render fully, even while DraftJS has not fully loaded. 

This reduces the visual difference between the DraftJS loading and loaded state to the placeholder text being visible ("Type a comment...").

Editor loading Demo: https://replay.io/view?id=45cd34c7-a260-431d-a4ab-352ecd20bced
Focus Demo: https://share.descript.com/view/IjMFpRGOBkI