### PR TITLE
Fix isPaused check

### DIFF
--- a/src/devtools/client/debugger/src/reducers/pause.js
+++ b/src/devtools/client/debugger/src/reducers/pause.js
@@ -276,7 +276,7 @@ export function isStepping(state) {
 }
 
 export function getIsPaused(state) {
-  return state.pause.frames?.length > 0;
+  return !!state.pause.frames;
 }
 
 export function getPreviousPauseFrameLocation(state) {
@@ -296,11 +296,6 @@ export function getShouldLogExceptions(state) {
 }
 
 export function getFrames(state) {
-  const { frames, framesLoading } = state.pause;
-  return framesLoading ? null : frames;
-}
-
-export function getCurrentFrames(state) {
   const { frames, framesLoading } = state.pause;
   return framesLoading ? null : frames;
 }

--- a/src/devtools/client/debugger/src/selectors/getCallStackFrames.js
+++ b/src/devtools/client/debugger/src/selectors/getCallStackFrames.js
@@ -5,7 +5,7 @@
 //
 
 import { getSources, getSelectedSource, getSourceInSources } from "../reducers/sources";
-import { getCurrentFrames } from "../reducers/pause";
+import { getFrames } from "../reducers/pause";
 import { annotateFrames } from "../utils/pause/frames";
 import { get } from "lodash";
 import { createSelector } from "reselect";
@@ -42,7 +42,7 @@ export function formatCallStackFrames(frames, sources, selectedSource) {
 
 // eslint-disable-next-line
 export const getCallStackFrames = createSelector(
-  getCurrentFrames,
+  getFrames,
   getSources,
   getSelectedSource,
   formatCallStackFrames

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -171,7 +171,7 @@ function waitForSelectedSource(url) {
 }
 
 async function waitForPaused(url) {
-  const { getSelectedScope, getCurrentFrames } = dbgSelectors;
+  const { getSelectedScope, getFrames } = dbgSelectors;
   // Make sure that the debug primary panel is selected so that the test can
   // interact with the pause navigation and info.
   store.dispatch({ type: "set_selected_primary_panel", panel: "debug" });
@@ -180,7 +180,7 @@ async function waitForPaused(url) {
     return isPaused() && !!getSelectedScope();
   });
 
-  await waitUntil(() => getCurrentFrames());
+  await waitUntil(() => getFrames());
   await waitForLoadedScopes();
   await waitForSelectedSource(url);
 }
@@ -194,7 +194,7 @@ async function waitForPausedNoSource() {
 }
 
 function hasFrames() {
-  const frames = dbgSelectors.getCurrentFrames();
+  const frames = dbgSelectors.getFrames();
   return frames.length > 0;
 }
 

--- a/src/ui/components/Toolbar.js
+++ b/src/ui/components/Toolbar.js
@@ -76,7 +76,7 @@ export default connect(
     panelCollapsed: selectors.getPaneCollapse(state),
     selectedPrimaryPanel: selectors.getSelectedPrimaryPanel(state),
     selectedPanel: selectors.getSelectedPanel(state),
-    isPaused: selectors.getIsPaused(state),
+    isPaused: selectors.getFrames(state)?.length > 0,
   }),
   {
     setSelectedPrimaryPanel: actions.setSelectedPrimaryPanel,


### PR DESCRIPTION
https://github.com/RecordReplay/devtools/commit/4fc2a622bb9ddf5949fc80d2b358332b1e2ea99c broke one of the tests because of an assumption that the frames array should not be empty.

This fixes this and refactors a couple of things