### PR TITLE
Handle more request failures

### DIFF
--- a/src/devtools/client/inspector/boxmodel/box-model.js
+++ b/src/devtools/client/inspector/boxmodel/box-model.js
@@ -149,7 +149,7 @@ BoxModel.prototype = {
       const bounds = await nodeFront.getBoundingClientRect();
       const style = await nodeFront.getComputedStyle();
 
-      if (!bounds) {
+      if (!bounds || !style) {
         return null;
       }
 

--- a/src/devtools/client/inspector/computed/computed.js
+++ b/src/devtools/client/inspector/computed/computed.js
@@ -531,6 +531,9 @@ CssComputedView.prototype = {
     }
 
     const computed = this._viewedElement.getComputedStyle();
+    if (!computed) {
+      return;
+    }
 
     this._matchedProperties = new Set([...computed.keys()]);
     /*

--- a/src/devtools/client/inspector/markup/actions/eventTooltip.ts
+++ b/src/devtools/client/inspector/markup/actions/eventTooltip.ts
@@ -23,7 +23,7 @@ export function showEventTooltip(nodeId: string): UIThunkAction {
   return async ({ dispatch }) => {
     assert(ThreadFront.currentPause);
     const nodeFront = ThreadFront.currentPause.getNodeFront(nodeId);
-    const listenerRaw = nodeFront.getEventListeners();
+    const listenerRaw = nodeFront.getEventListeners() || [];
     const frameworkListeners = await nodeFront.getFrameworkEventListeners();
 
     const listenerInfo = [...listenerRaw, ...frameworkListeners].map(listener => {

--- a/src/devtools/client/inspector/markup/components/ElementNode.tsx
+++ b/src/devtools/client/inspector/markup/components/ElementNode.tsx
@@ -86,9 +86,8 @@ class ElementNode extends PureComponent<ElementNodeProps> {
 
   renderDisplayBadge() {
     const { displayType } = this.props.node;
-    assert(displayType);
 
-    if (!(displayType in DISPLAY_TYPES)) {
+    if (!displayType || !(displayType in DISPLAY_TYPES)) {
       return null;
     }
 

--- a/src/devtools/client/inspector/markup/markup.js
+++ b/src/devtools/client/inspector/markup/markup.js
@@ -182,7 +182,7 @@ class MarkupView {
    */
   async onShowEventTooltip(nodeId, target) {
     const nodeFront = ThreadFront.currentPause.getNodeFront(nodeId);
-    const listenerRaw = nodeFront.getEventListeners();
+    const listenerRaw = nodeFront.getEventListeners() || [];
     const frameworkListeners = await nodeFront.getFrameworkEventListeners();
 
     const listenerInfo = [...listenerRaw, ...frameworkListeners].map(listener => {

--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -205,14 +205,17 @@ export class NodeFront {
     this._loadWaiter = defer();
 
     await Promise.all([
-      this._pause
-        .sendMessage(client.CSS.getComputedStyle, { node: this._object.objectId })
-        .then(({ computedStyle }) => {
+      this._pause.sendMessage(client.CSS.getComputedStyle, { node: this._object.objectId }).then(
+        ({ computedStyle }) => {
           this._computedStyle = new Map();
           for (const { name, value } of computedStyle) {
             this._computedStyle.set(name, value);
           }
-        }),
+        },
+        () => {
+          this._computedStyle = null;
+        }
+      ),
       this._pause.sendMessage(client.CSS.getAppliedRules, { node: this._object.objectId }).then(
         ({ rules, data }) => {
           this._rules = uniqBy(rules, (rule: AppliedRule) => `${rule.rule}|${rule.pseudoElement}`);
@@ -276,7 +279,7 @@ export class NodeFront {
   // The computed display style property value of the node.
   get displayType() {
     assert(this._loaded);
-    return this._computedStyle!.get("display");
+    return this._computedStyle?.get("display");
   }
 
   getComputedStyle() {

--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -225,16 +225,19 @@ export class NodeFront {
           this._rules = null;
         }
       ),
-      this._pause
-        .sendMessage(client.DOM.getEventListeners, { node: this._object.objectId })
-        .then(({ listeners, data }) => {
+      this._pause.sendMessage(client.DOM.getEventListeners, { node: this._object.objectId }).then(
+        ({ listeners, data }) => {
           this._pause.addData(data);
           this._listeners = listeners.map(listener => ({
             ...listener,
             handler: new ValueFront(this._pause, { object: listener.handler }),
             node: this._pause.getNodeFront(listener.node),
           }));
-        }),
+        },
+        () => {
+          this._listeners = null;
+        }
+      ),
       this._pause.sendMessage(client.DOM.getBoxModel, { node: this._object.objectId }).then(
         ({ model }) => {
           this._quads = model;
@@ -295,7 +298,7 @@ export class NodeFront {
 
   getEventListeners() {
     assert(this._loaded);
-    return this._listeners!;
+    return this._listeners;
   }
 
   async getFrameworkEventListeners() {


### PR DESCRIPTION
There were 2 remaining requests in `NodeFront` that broke the elements panel when they failed.