### PR TITLE
Seek to first comment or first meaningful paint

### DIFF
--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -92,9 +92,7 @@ interface TimeStampedPointWithPaintHash extends TimeStampedPoint {
 // All paints that have occurred in the recording, in order. Include the
 // beginning point of the recording as well, which is not painted and has
 // a known point and time.
-export const gPaintPoints: TimeStampedPointWithPaintHash[] = [
-  { point: "0", time: 0, paintHash: "" },
-];
+const gPaintPoints: TimeStampedPointWithPaintHash[] = [{ point: "0", time: 0, paintHash: "" }];
 
 // All mouse events that have occurred in the recording, in order.
 const gMouseEvents: MouseEvent[] = [];
@@ -124,7 +122,7 @@ function onMouseEvents(events: MouseEvent[], store: UIStore) {
 }
 
 let onRefreshGraphics: (canvas: Canvas) => void;
-export let paintPointsWaiter: Promise<findPaintsResult>;
+let paintPointsWaiter: Promise<findPaintsResult>;
 
 export function setupGraphics(store: UIStore) {
   onRefreshGraphics = (canvas: Canvas) => {

--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -408,3 +408,27 @@ export function installObserver() {
     setTimeout(installObserver, 100);
   }
 }
+
+async function getScreenshotDimensions(screen: ScreenShot) {
+  const img = new Image();
+  await new Promise(resolve => {
+    img.onload = resolve;
+    img.src = `data:${screen.mimeType};base64,${screen.data}`;
+  });
+  return { width: img.width, height: img.height };
+}
+
+export async function getFirstMeaningfulPaint(limit: number = 10) {
+  await paintPointsWaiter;
+  for (const paintPoint of gPaintPoints.slice(0, limit)) {
+    const { screen } = await getGraphicsAtTime(paintPoint.time, false);
+    if (!screen) {
+      continue;
+    }
+
+    const { width, height } = await getScreenshotDimensions(screen);
+    if (screen.data.length > (width * height) / 40) {
+      return paintPoint;
+    }
+  }
+}

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -156,15 +156,12 @@ class _ThreadFront {
   off!: (name: string, handler: (value?: any) => void) => void;
   emit!: (name: string, value?: any) => void;
 
-  async setSessionId(sessionId: SessionId) {
+  setSessionId(sessionId: SessionId) {
     this.sessionId = sessionId;
     this.mappedLocations.sessionId = sessionId;
     this.sessionWaiter.resolve(sessionId);
 
     log(`GotSessionId ${sessionId}`);
-
-    const { endpoint } = await client.Session.getEndpoint({}, sessionId);
-    this.emit("endpoint", endpoint);
   }
 
   async initializeToolbox() {

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -166,9 +166,7 @@ class _ThreadFront {
 
   async initializeToolbox() {
     const sessionId = await this.waitForSession();
-    // const { endpoint } = await client.Session.getEndpoint({}, sessionId);
 
-    // this.timeWarp(endpoint.point, endpoint.time, /* hasFrames */ false, /* force */ true);
     await this.initializedWaiter.promise;
     this.ensureCurrentPause();
 

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -169,7 +169,7 @@ class _ThreadFront {
     // const { endpoint } = await client.Session.getEndpoint({}, sessionId);
 
     // this.timeWarp(endpoint.point, endpoint.time, /* hasFrames */ false, /* force */ true);
-    this.initializedWaiter.resolve();
+    await this.initializedWaiter.promise;
     this.ensureCurrentPause();
 
     if (this.testName) {

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -166,9 +166,9 @@ class _ThreadFront {
 
   async initializeToolbox() {
     const sessionId = await this.waitForSession();
-    const { endpoint } = await client.Session.getEndpoint({}, sessionId);
+    // const { endpoint } = await client.Session.getEndpoint({}, sessionId);
 
-    this.timeWarp(endpoint.point, endpoint.time, /* hasFrames */ false, /* force */ true);
+    // this.timeWarp(endpoint.point, endpoint.time, /* hasFrames */ false, /* force */ true);
     this.initializedWaiter.resolve();
     this.ensureCurrentPause();
 

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -20,6 +20,7 @@ import { PauseEventArgs, RecordingDescription } from "protocol/thread/thread";
 import { TimelineState, Tooltip, ZoomRegion, HoveredPoint } from "ui/state/timeline";
 import { query } from "ui/utils/apolloClient";
 import { gql } from "@apollo/client";
+import { getTest } from "ui/utils/environment";
 
 export type SetTimelineStateAction = Action<"set_timeline_state"> & {
   state: Partial<TimelineState>;
@@ -71,27 +72,29 @@ export async function setupTimeline(recordingId: RecordingId, store: UIStore) {
     setTimelineState({ currentTime: time, recordingDuration: time, zoomRegion: newZoomRegion })
   );
 
-  const firstCommentResult = await query({
-    query: GET_FIRST_COMMENT_POINT,
-    variables: { recordingId },
-  });
-  const firstComment = firstCommentResult?.data?.comments?.[0];
-  if (firstComment) {
-    const { point, time, has_frames } = firstComment;
-    ThreadFront.timeWarp(point, time, has_frames);
-    return;
-  }
+  if (!getTest()) {
+    const firstCommentResult = await query({
+      query: GET_FIRST_COMMENT_POINT,
+      variables: { recordingId },
+    });
+    const firstComment = firstCommentResult?.data?.comments?.[0];
+    if (firstComment) {
+      const { point, time, has_frames } = firstComment;
+      ThreadFront.timeWarp(point, time, has_frames);
+      return;
+    }
 
-  await paintPointsWaiter;
-  for (const paintPoint of gPaintPoints.slice(0, 10)) {
-    const { point, time } = paintPoint;
-    const { screen } = await getGraphicsAtTime(time, false);
-    if (screen) {
-      const { width, height } = await getScreenshotDimensions(screen);
-      if (screen.data.length > (width * height) / 40) {
-        ThreadFront.timeWarp(point, time);
-        ThreadFront.initializedWaiter.resolve();
-        return;
+    await paintPointsWaiter;
+    for (const paintPoint of gPaintPoints.slice(0, 10)) {
+      const { point, time } = paintPoint;
+      const { screen } = await getGraphicsAtTime(time, false);
+      if (screen) {
+        const { width, height } = await getScreenshotDimensions(screen);
+        if (screen.data.length > (width * height) / 40) {
+          ThreadFront.timeWarp(point, time);
+          ThreadFront.initializedWaiter.resolve();
+          return;
+        }
       }
     }
   }

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -90,12 +90,14 @@ export async function setupTimeline(recordingId: RecordingId, store: UIStore) {
       const { width, height } = await getScreenshotDimensions(screen);
       if (screen.data.length > (width * height) / 40) {
         ThreadFront.timeWarp(point, time);
+        ThreadFront.initializedWaiter.resolve();
         return;
       }
     }
   }
 
   ThreadFront.timeWarp(point, time, /* hasFrames */ false, /* force */ true);
+  ThreadFront.initializedWaiter.resolve();
 }
 
 async function getScreenshotDimensions(screen: ScreenShot) {

--- a/src/ui/hooks/comments.ts
+++ b/src/ui/hooks/comments.ts
@@ -1,5 +1,6 @@
 import { RecordingId } from "@recordreplay/protocol";
 import { gql, useQuery, useMutation, ApolloError } from "@apollo/client";
+import { query } from "ui/utils/apolloClient";
 import { Comment } from "ui/state/comments";
 
 const UPDATE_COMMENT_CONTENT = gql`
@@ -142,4 +143,25 @@ export function useDeleteCommentReplies(callback: Function) {
   }
 
   return deleteCommentReplies;
+}
+
+export async function getFirstComent(recordingId: string) {
+  const firstCommentResult = await query({
+    query: gql`
+      query GetFirstCommentTime($recordingId: uuid) {
+        comments(
+          where: { recording_id: { _eq: $recordingId }, _and: { parent_id: { _is_null: true } } }
+          order_by: { time: asc }
+          limit: 1
+        ) {
+          time
+          point
+          has_frames
+        }
+      }
+    `,
+    variables: { recordingId },
+  });
+
+  return firstCommentResult?.data?.comments?.[0];
 }

--- a/src/ui/hooks/comments.ts
+++ b/src/ui/hooks/comments.ts
@@ -145,7 +145,9 @@ export function useDeleteCommentReplies(callback: Function) {
   return deleteCommentReplies;
 }
 
-export async function getFirstComent(recordingId: string) {
+export async function getFirstComment(
+  recordingId: string
+): Promise<{ time: number; point: string; has_frames: boolean } | undefined> {
   const firstCommentResult = await query({
     query: gql`
       query GetFirstCommentTime($recordingId: uuid) {

--- a/src/ui/utils/apolloClient.ts
+++ b/src/ui/utils/apolloClient.ts
@@ -2,14 +2,10 @@ import { ApolloClient, InMemoryCache, NormalizedCacheObject } from "@apollo/clie
 import { HttpLink } from "apollo-link-http";
 import { DocumentNode } from "graphql";
 import { assert } from "protocol/utils";
-import { getTest } from "ui/utils/environment";
 
 let apolloClient: ApolloClient<NormalizedCacheObject> | null = null;
 
 export function query({ variables = {}, query }: { variables: any; query: DocumentNode }) {
-  if (!getTest()) {
-    return null;
-  }
   assert(apolloClient);
   return apolloClient.query({ variables, query });
 }

--- a/src/ui/utils/apolloClient.ts
+++ b/src/ui/utils/apolloClient.ts
@@ -2,10 +2,14 @@ import { ApolloClient, InMemoryCache, NormalizedCacheObject } from "@apollo/clie
 import { HttpLink } from "apollo-link-http";
 import { DocumentNode } from "graphql";
 import { assert } from "protocol/utils";
+import { getTest } from "ui/utils/environment";
 
 let apolloClient: ApolloClient<NormalizedCacheObject> | null = null;
 
 export function query({ variables = {}, query }: { variables: any; query: DocumentNode }) {
+  if (!getTest()) {
+    return null;
+  }
   assert(apolloClient);
   return apolloClient.query({ variables, query });
 }


### PR DESCRIPTION
With this PR Replay will seek to the first paint point with a screen larger than 30000 bytes.
* we really want to seek to the first "meaningful paint". Choosing it by its jpeg size works for some recordings, but not all
* the current logic will wait for the recording to be scanned completely and then start looking at the screen sizes, this would be faster if we started while the recording is still being scanned