### PR TITLE
Fix how comment pins are shown fixes #1908

### DIFF
--- a/src/ui/components/Comments/VideoComments/VideoComment.tsx
+++ b/src/ui/components/Comments/VideoComments/VideoComment.tsx
@@ -18,15 +18,23 @@ function VideoComment({
   setHoveredComment,
   setActiveComment,
   hoveredComment,
+  currentTime,
+  hoverTime,
 }: PropsFromRedux) {
-  if (!canvas) {
+  if (!canvas || !comment) {
     return null;
   }
 
   const { scale } = canvas;
   const position = comment.position;
 
-  if (inCenter(canvas, comment)) {
+  // Hide pins while the user is hovering in the timeline
+  if (!hoveredComment && hoverTime && hoverTime != currentTime) {
+    return null;
+  }
+
+  // Hide pins that were never moved
+  if (comment.content != "" && inCenter(canvas, comment)) {
     return null;
   }
 
@@ -56,6 +64,7 @@ function VideoComment({
 const connector = connect(
   (state: UIState) => ({
     currentTime: selectors.getCurrentTime(state),
+    hoverTime: selectors.getHoverTime(state),
     pendingComment: selectors.getPendingComment(state),
     recordingId: selectors.getRecordingId(state),
     canvas: selectors.getCanvas(state),


### PR DESCRIPTION
This updates a couple of things to make comment pins smoother

1. find the pin for the currently hovered pin
2. only show draft pins in the center
3. show the pin if we're hovering on the comment