### PR TITLE
Add playback.stalled flag to redux state (#1843)

### DIFF
--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -32,6 +32,11 @@ export default function update(
       return { ...state, ...action.state };
     }
 
+    case "set_playback_stalled": {
+      const playback = state.playback ? { ...state.playback, stalled: action.stalled } : null;
+      return { ...state, playback };
+    }
+
     case "update_tooltip": {
       return { ...state, tooltip: action.tooltip };
     }
@@ -50,6 +55,7 @@ export const getZoomRegion = (state: UIState) => state.timeline.zoomRegion;
 export const getCurrentTime = (state: UIState) => state.timeline.currentTime;
 export const getHoverTime = (state: UIState) => state.timeline.hoverTime;
 export const getPlayback = (state: UIState) => state.timeline.playback;
+export const isPlaybackStalled = (state: UIState) => state.timeline.playback?.stalled || false;
 export const getUnprocessedRegions = (state: UIState) => state.timeline.unprocessedRegions;
 export const getRecordingDuration = (state: UIState) => state.timeline.recordingDuration;
 export const getScreenShot = (state: UIState) => state.timeline.screenShot;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -17,6 +17,7 @@ export interface TimelineState {
     startTime: number;
     startDate: number;
     time: number;
+    stalled?: boolean;
   } | null;
   screenShot: ScreenShot | null;
   mouse: MouseAndClickPosition | null | undefined;


### PR DESCRIPTION
The flag can be queried with the `isPlaybackStalled()` selector. It's set to `true` whenever playback is stalled for at least 500 milliseconds waiting for the next graphics.