### PR TITLE
Precache graphics (#1843)

### DIFF
--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -21,7 +21,7 @@
   --replaying-marker-fill-hover: var(--blue-60);
   --hover-scrubber-line-background: var(--blue-50);
   --progress-recording-line: #d0021b;
-  --progressbar-background: var(--grey-30);
+  --progressbar-background: #eeeeee;
   --progressbar-line-color: var(--primary-accent);
   --proggressbar-border-color: var(--theme-splitter-color);
   --tick-future-background: #bfc9d2;
@@ -131,8 +131,12 @@
   background: var(--progressbar-background);
 }
 
-.timeline .progress-line.preview {
-  background: #bbbbc1;
+.timeline .progress-line.preview-min {
+  background: #c0c0c0;
+}
+
+.timeline .progress-line.preview-max {
+  background: #dadada;
 }
 
 .timeline .zoomboundary {

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -241,6 +241,7 @@ class Timeline extends Component<PropsFromRedux> {
       zoomRegion,
       currentTime,
       hoverTime,
+      precachedTime,
       hoveredLineNumberLocation,
       hoveredItem,
       viewMode,
@@ -249,6 +250,7 @@ class Timeline extends Component<PropsFromRedux> {
     } = this.props;
     const percent = getVisiblePosition({ time: currentTime, zoom: zoomRegion }) * 100;
     const hoverPercent = getVisiblePosition({ time: hoverTime, zoom: zoomRegion }) * 100;
+    const precachedPercent = getVisiblePosition({ time: precachedTime, zoom: zoomRegion }) * 100;
     const shouldDim = hoveredLineNumberLocation || hoveredItem;
 
     return (
@@ -265,7 +267,7 @@ class Timeline extends Component<PropsFromRedux> {
             <div className="progress-line full" />
             <div
               className="progress-line preview"
-              style={{ width: `${clamp(hoverPercent, 0, 100)}%` }}
+              style={{ width: `${clamp(precachedPercent, 0, 100)}%` }}
             />
             <div className="progress-line" style={{ width: `${clamp(percent, 0, 100)}%` }} />
             {percent >= 0 && percent <= 100 ? (
@@ -295,6 +297,7 @@ const connector = connect(
     zoomRegion: selectors.getZoomRegion(state),
     currentTime: selectors.getCurrentTime(state),
     hoverTime: selectors.getHoverTime(state),
+    precachedTime: selectors.getPlaybackPrecachedTime(state),
     playback: selectors.getPlayback(state),
     recordingDuration: selectors.getRecordingDuration(state),
     timelineDimensions: selectors.getTimelineDimensions(state),

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -266,8 +266,12 @@ class Timeline extends Component<PropsFromRedux> {
           >
             <div className="progress-line full" />
             <div
-              className="progress-line preview"
-              style={{ width: `${clamp(precachedPercent, 0, 100)}%` }}
+              className="progress-line preview-max"
+              style={{ width: `${clamp(Math.max(hoverPercent, precachedPercent), 0, 100)}%` }}
+            />
+            <div
+              className="progress-line preview-min"
+              style={{ width: `${clamp(Math.min(hoverPercent, precachedPercent), 0, 100)}%` }}
             />
             <div className="progress-line" style={{ width: `${clamp(percent, 0, 100)}%` }} />
             {percent >= 0 && percent <= 100 ? (

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -8,6 +8,7 @@ function initialTimelineState(): TimelineState {
     currentTime: 0,
     hoverTime: null,
     playback: null,
+    playbackPrecachedTime: 0,
     unprocessedRegions: [],
     shouldAnimate: true,
     recordingDuration: null,
@@ -45,6 +46,10 @@ export default function update(
       return { ...state, hoveredItem: action.hoveredItem };
     }
 
+    case "set_playback_precached_time": {
+      return { ...state, playbackPrecachedTime: action.time };
+    }
+
     default: {
       return state;
     }
@@ -63,3 +68,4 @@ export const getMouse = (state: UIState) => state.timeline.mouse;
 export const getTimelineDimensions = (state: UIState) => state.timeline.timelineDimensions;
 export const getTooltip = (state: UIState) => state.timeline.tooltip;
 export const getHoveredItem = (state: UIState) => state.timeline.hoveredItem;
+export const getPlaybackPrecachedTime = (state: UIState) => state.timeline.playbackPrecachedTime;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -19,6 +19,7 @@ export interface TimelineState {
     time: number;
     stalled?: boolean;
   } | null;
+  playbackPrecachedTime: number;
   screenShot: ScreenShot | null;
   mouse: MouseAndClickPosition | null | undefined;
   recordingDuration: number | null;


### PR DESCRIPTION
This will start precaching graphics for playback as long as the user stays in non-dev mode. The precaching progress can be queried with the `getPlaybackPrecachedTime()` selector.