### PR TITLE
Fix the initial access token refresh

### DIFF
--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -57,6 +57,9 @@ class TokenManager {
         <Auth0Context.Consumer>
           {auth0Client => {
             this.auth0Client = auth0Client;
+            if (!this.auth0Client || this.auth0Client.isLoading) {
+              return;
+            }
 
             setTimeout(() => {
               this.update(this.init);


### PR DESCRIPTION
Without this change, the initial access token refresh didn't work and logged in users could not view other users' public recordings. 