### PR TITLE
Publish protocol as a separate NPM package that can be re-used #1876

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/modify.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/modify.js
@@ -78,6 +78,26 @@ export function enableBreakpoint(cx, initialBreakpoint) {
   };
 }
 
+function maybeShowPrimitiveLogPoint({ options, location, logGroupId }) {
+  return ({ store }) => {
+    const { logValue, condition } = options;
+    const primitives = primitiveValues(logValue);
+
+    if (!primitives) {
+      return false;
+    }
+
+    const primitiveFronts = primitives?.map(literal => createPrimitiveValueFront(literal));
+
+    const points = getAnalysisPointsForLocation(store.getState(), location, condition);
+    if (!points) {
+      return false;
+    }
+
+    return showPrimitiveLogpoints(logGroupId, points, primitiveFronts);
+  };
+}
+
 export function addBreakpoint(
   cx,
   initialLocation,
@@ -112,6 +132,8 @@ export function addBreakpoint(
     if (!source) {
       return;
     }
+
+    const isPrimitive = dispatch(maybeShowPrimitiveLogPoint({ location, options }));
 
     const symbols = getSymbols(getState(), source);
     const astLocation = getASTLocation(source, symbols, location);

--- a/src/devtools/client/webconsole/actions/messages.js
+++ b/src/devtools/client/webconsole/actions/messages.js
@@ -30,8 +30,20 @@ let throttledDispatchPromise = null;
 export function setupMessages(store) {
   LogpointHandlers.onPointLoading = (logGroupId, point, time, location) =>
     store.dispatch(onLogpointLoading(logGroupId, point, time, location));
-  LogpointHandlers.onResult = (logGroupId, point, time, location, pause, values) =>
+
+  LogpointHandlers.onResult = (logGroupId, point, time, location, pause, values) => {
     store.dispatch(onLogpointResult(logGroupId, point, time, location, pause, values));
+
+    if (condition) {
+      points = points.filter(point =>
+        results.some(result => result.key === point.point && result.value.time === point.time)
+      );
+    }
+    for (const location of locations) {
+      store.dispatch(setAnalysisPoints(points, location, condition));
+    }
+  };
+
   LogpointHandlers.clearLogpoint = logGroupId => store.dispatch(messagesClearLogpoint(logGroupId));
 
   ThreadFront.findConsoleMessages((_, msg) => store.dispatch(onConsoleMessage(msg)));

--- a/src/protocol/README.md
+++ b/src/protocol/README.md
@@ -1,0 +1,14 @@
+### Replay's Devtools Client
+
+We believe being able to replay your software opens a new world of opportunities. And that our UI should be one of many and probably the most boring one :)
+
+We're committed to helping as much as possible
+
+1. Building a community + ecosystem (discord and friends)
+2. Publishing documentation and examples
+3. Publishing packages that streamline the process
+4. Helping folks to hack on the devtools frontend so they can quickly prototype ideas
+
+**Devtools Client**
+
+Our DevTools frontend does a lot of things, such as showing a video of the recording, adding print statements, etc... This package is our attempt to share that functionality so that it is easy to get started.

--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -13,9 +13,17 @@ import {
 } from "@recordreplay/protocol";
 import { client } from "./socket";
 import { actions, UIStore } from "ui/actions";
-import { Canvas } from "ui/state/app";
 
 export const screenshotCache = new ScreenshotCache();
+
+export interface Canvas {
+  gDevicePixelRatio: number;
+  height: number;
+  left: number;
+  scale: number;
+  top: number;
+  width: number;
+}
 
 interface Timed {
   time: number;

--- a/src/protocol/package.json
+++ b/src/protocol/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@recordreplay/client",
+  "version": "1.0.0",
+  "description": "DevTools Client adds utilities for common tasks",
+  "main": "index.js",
+  "dependencies": {
+    "@recordreplay/protocol": "^0.4.0"
+  },
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/RecordReplay/devtools/issues"
+  },
+  "homepage": "https://github.com/RecordReplay/devtools#readme"
+}

--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -10,7 +10,7 @@ import { Pause, WiredObject } from "./pause";
 import { defer, assert, DisallowEverythingProxyHandler, Deferred } from "../utils";
 import { FrameworkEventListener, getFrameworkEventListeners } from "../event-listeners";
 import { ValueFront } from "./value";
-const { uniqBy } = require("lodash");
+const uniqBy = require("lodash/uniqby");
 const HTML_NS = "http://www.w3.org/1999/xhtml";
 
 export interface WiredEventListener {

--- a/src/protocol/thread/style.ts
+++ b/src/protocol/thread/style.ts
@@ -1,7 +1,11 @@
 import { StyleDeclaration } from "@recordreplay/protocol";
 import { Pause, WiredObject } from "./pause";
 import { assert, DisallowEverythingProxyHandler } from "../utils";
-const { ELEMENT_STYLE } = require("devtools/client/inspector/rules/constants");
+
+// The PageStyle actor flattens the DOM CSS objects a little bit, merging
+// Rules and their Styles into one actor. For elements (which have a style
+// but no associated rule) we fake a rule with the following style id.
+const ELEMENT_STYLE = 100;
 
 // Manages interaction with a CSSStyleDeclaration. StyleFront represents an inline
 // element style.

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -7,6 +7,8 @@ import {
   MouseEvent,
 } from "@recordreplay/protocol";
 
+import { Canvas } from "protocol/graphics";
+
 export type PanelName = "console" | "debugger" | "inspector";
 export type PrimaryPanelName = "explorer" | "debug" | "comments";
 export type ViewMode = "dev" | "non-dev";
@@ -53,12 +55,3 @@ interface Events {
 }
 
 export type Event = "mousedown";
-
-export interface Canvas {
-  gDevicePixelRatio: number;
-  height: number;
-  left: number;
-  scale: number;
-  top: number;
-  width: number;
-}


### PR DESCRIPTION
One of the things that comes up when i talk with others is that many people would like to experiment with building their own frontends.

This is one of our goals and is something we should definitely encourage. I think there are several things we can do to make this process easy

1. Build a community + ecosystem (discord and friends)
2. Publish documentation and examples
3. Publish packages that streamline the process
4. Make it easy for folks to hack on the devtools frontend so they can quickly prototype ideas

**Devtools Client**

Our devtools client does a bunch of things pretty well. 

1. wrap graphics so that it is easy to show a video
2. wrap analysis so that it is easy to add logpoints
3. ...

If we publish this as a package others, can easily get started. It will also help us ensure a nice separation of concerns between our redux store for the app and what the protocol needs.

This PR is mostly cleanup, which helps regardless:

1. move the redux logic out, which arguably should never have been in there
2. small import tweaks