### PR TITLE
Use the user_id_by_email function to fetch the user_id for an email

### DIFF
--- a/src/ui/components/shared/SharingModal.js
+++ b/src/ui/components/shared/SharingModal.js
@@ -35,9 +35,8 @@ const GET_OWNER_AND_COLLABORATORS = gql`
 
 const GET_COLLABORATOR_ID = gql`
   query GetCollaboratorId($email: String = "") {
-    users(where: { email: { _eq: $email } }) {
+    user_id_by_email(args: { email: $email }) {
       id
-      email
     }
   }
 `;
@@ -171,12 +170,16 @@ function EmailForm({ recordingId }) {
   if (status.type === "fetched-user") {
     if (status.error) {
       return <ErrorHandler message={"We can not fetch that collaborator right now."} />;
-    } else if (status.data.users.length === 0) {
+    } else if (status.data.user_id_by_email.length === 0) {
       return <ErrorHandler message={"That e-mail address is not a valid Replay user."} />;
     }
 
     return (
-      <Submitter setStatus={setStatus} userId={status.data.users[0].id} recordingId={recordingId} />
+      <Submitter
+        setStatus={setStatus}
+        userId={status.data.user_id_by_email[0].id}
+        recordingId={recordingId}
+      />
     );
   }
 


### PR DESCRIPTION
We want to restrict access to the users table, but when a user wants to add another user as a collaborator, these restrictions should not apply (otherwise he could never add collaborators that he hasn't collaborated with before). For this purpose I have created a user defined function called user_id_by_email in the database that allows us to fetch the user_id for a given email.
When this PR has landed, we can add the restrictions to the users table.