### PR TITLE
Fix the permission check in RecordingGridItem

### DIFF
--- a/src/ui/components/Account/index.js
+++ b/src/ui/components/Account/index.js
@@ -62,10 +62,10 @@ function getRecordings(data) {
   }
 
   const user = data.users[0];
-  const { recordings, collaborators, name, email, picture, auth_id } = user;
+  const { recordings, collaborators, name, email, picture, id } = user;
 
   return [
-    ...recordings.map(recording => ({ ...recording, user: { name, email, picture, auth_id } })),
+    ...recordings.map(recording => ({ ...recording, user: { name, email, picture, id } })),
     ...collaborators.map(({ recording }) => recording),
     ...data.recordings,
   ];

--- a/src/ui/components/Dashboard/RecordingItem/RecordingGridItem.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingGridItem.js
@@ -14,8 +14,9 @@ export default function RecordingGridItem({
   setEditingTitle,
   toggleIsPrivate,
 }) {
-  const { userId } = useToken();
-  const isOwner = userId == data.user.auth_id;
+  const { claims } = useToken();
+  const userId = claims?.hasura.userId;
+  const isOwner = userId == data.user.id;
 
   return (
     <div className="recording-item">


### PR DESCRIPTION
The permission check concluded that the user is the owner of all recordings that he can see because `undefined == undefined` (we don't use `auth_id` to identify users anymore).