### PR TITLE
Fix breakpoint messages not appearing in playwright tests (#1814)

### DIFF
--- a/src/devtools/client/debugger/src/client/commands.js
+++ b/src/devtools/client/debugger/src/client/commands.js
@@ -150,7 +150,6 @@ function removeBreakpoint(location) {
 }
 
 function runAnalysis(location, options) {
-  maybeClearLogpoint(location);
   options = maybeGenerateLogGroupId(options);
   const { condition, logValue, logGroupId } = options;
   const { line, column, sourceUrl, sourceId } = location;


### PR DESCRIPTION
To be honest, I don't fully understand what's going on here, but this seems to fix the issue.