### PR TITLE
Adjust ViewToggle border radius and do some component clean up

### DIFF
--- a/src/ui/components/Header/ViewToggle.css
+++ b/src/ui/components/Header/ViewToggle.css
@@ -47,5 +47,5 @@
   right: 0;
   top: 0;
   background-color: white;
-  border-radius: 8px;
+  border-radius: 6px;
 }

--- a/src/ui/components/Header/ViewToggle.js
+++ b/src/ui/components/Header/ViewToggle.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { connect } from "react-redux";
+import classnames from "classnames";
 import "./ViewToggle.css";
 import { setViewMode } from "../../actions/app";
 import { getViewMode } from "../../reducers/app";
@@ -7,13 +8,12 @@ import { getViewMode } from "../../reducers/app";
 function Handle({ text, isOn, motion }) {
   return (
     <div className="option">
-      <div className={`text ${isOn ? "active" : null}`}>{text}</div>
+      <div className={classnames("text", isOn && "active")}>{text}</div>
 
       {isOn && (
         <motion.div
           className="handle"
           layoutId="handle"
-          animate={{ borderRadius: "8px" }}
           transition={{
             type: "spring",
             stiffness: 600,
@@ -30,7 +30,7 @@ function ViewToggle({ viewMode, setViewMode }) {
 
   useEffect(() => {
     import("framer-motion").then(framerMotion => setFramerMotion(framerMotion));
-  });
+  }, []);
 
   // Don't show anything while waiting for framer-motion to be imported.
   if (!framerMotion) {
@@ -39,13 +39,7 @@ function ViewToggle({ viewMode, setViewMode }) {
 
   const { motion, AnimateSharedLayout } = framerMotion;
 
-  const onClick = () => {
-    if (viewMode == "dev") {
-      setViewMode("non-dev");
-    } else {
-      setViewMode("dev");
-    }
-  };
+  const onClick = () => setViewMode(viewMode === "dev" ? "non-dev" : "dev");
 
   return (
     <AnimateSharedLayout type="crossfade">


### PR DESCRIPTION
Notes:

- Adjusts the border radius for the sliding pill to better match the container's border radius
  - Before:
  
    <img width="214" alt="image" src="https://user-images.githubusercontent.com/18542095/110216655-47c4f000-7e7e-11eb-847e-486968526d1c.png">
  
  - After:
    
    ![image](https://user-images.githubusercontent.com/18542095/110216668-57dccf80-7e7e-11eb-88e5-9dbaac9b6c9a.png)

- There was a bug that caused the pill's border radius to be unset after clicking the first time
    - Before:
    
      ![view-toggle-border-radius-disappear](https://user-images.githubusercontent.com/18542095/110216827-3defbc80-7e7f-11eb-8049-1e2d77378496.gif)
      
    - After:
 
      ![view-toggle-border-radius-no-disappear](https://user-images.githubusercontent.com/18542095/110216844-61b30280-7e7f-11eb-962b-26094f5f8d0b.gif)
      
- Prevents a class name of `null` from rendering for the inactive view mode button
- Only attempt to load Framer  on component mount instead of on every rerender
 