### PR TITLE
Fix start() in the e2e test harness

### DIFF
--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -33,7 +33,7 @@ async function waitUntil(fn) {
 
 function start() {
   app.actions.setViewMode("dev");
-  return waitUntil(() => document.querySelector(".view-toggle-dev.active"));
+  return waitUntil(() => document.querySelector(".view-toggle .active")?.innerText === "DevTools");
 }
 
 function finish() {
@@ -714,7 +714,7 @@ const commands = mapValues(testCommands, (command, name) => {
 
 async function describe(description, cbk) {
   console.log(`# Test ${description}`);
-  start();
+  await start();
   await cbk();
   finish();
 }


### PR DESCRIPTION
`start()` switches to the DevTools view and tries to wait for the switch to happen, but the check is outdated and so "waitUntil() timed out" errors show up in the browser console after running tests.
Currently this doesn't cause any other issues, but it could in the future.