### PR TITLE
Disable related interactions to console/transcript/widget hover

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -84,7 +84,7 @@ function Widget({ location, children, editor, insertAt }) {
   return ReactDOM.createPortal(<>{children}</>, node);
 }
 
-function Panel({ breakpoint, editor, insertAt, setHoveredItem }) {
+function Panel({ breakpoint, editor, insertAt, setHoveredItem, clearHoveredItem }) {
   const [editing, setEditing] = useState(false);
   const [width, setWidth] = useState(getPanelWidth(editor));
   const [inputToFocus, setInputToFocus] = useState("logValue");
@@ -109,7 +109,7 @@ function Panel({ breakpoint, editor, insertAt, setHoveredItem }) {
   };
   const onMouseLeave = e => {
     if (!inBreakpointPanel(e)) {
-      setHoveredItem(null);
+      clearHoveredItem();
     }
   };
 
@@ -146,4 +146,7 @@ function Panel({ breakpoint, editor, insertAt, setHoveredItem }) {
   );
 }
 
-export default connect(null, { setHoveredItem: actions.setHoveredItem })(Panel);
+export default connect(null, {
+  setHoveredItem: actions.setHoveredItem,
+  clearHoveredItem: actions.clearHoveredItem,
+})(Panel);

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimelinePoint.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimelinePoint.js
@@ -36,6 +36,7 @@ function BreakpointTimelinePoint({
   seek,
   hoveredItem,
   setHoveredItem,
+  clearHoveredItem,
 }) {
   const onMouseEnter = () =>
     setHoveredItem({
@@ -47,7 +48,7 @@ function BreakpointTimelinePoint({
 
   const onMouseLeave = e => {
     if (!inBreakpointPanel(e)) {
-      setHoveredItem(null);
+      clearHoveredItem();
     }
   };
 
@@ -112,5 +113,6 @@ export default connect(
   {
     seek: actions.seek,
     setHoveredItem: actions.setHoveredItem,
+    clearHoveredItem: actions.clearHoveredItem,
   }
 )(MemoizedBreakpointTimelinePoint);

--- a/src/devtools/client/webconsole/actions/toolbox.js
+++ b/src/devtools/client/webconsole/actions/toolbox.js
@@ -5,7 +5,7 @@
 "use strict";
 
 import { ThreadFront } from "protocol/thread";
-import { setHoveredItem } from "ui/actions/timeline";
+import { setHoveredItem, clearHoveredItem } from "ui/actions/timeline";
 
 export function highlightDomElement(grip) {
   return async ({ toolbox }) => {
@@ -61,7 +61,7 @@ export function onMessageHover(type, message) {
       dispatch(setHoveredItem(hoveredItem));
     }
     if (type == "mouseleave") {
-      dispatch(setHoveredItem(null));
+      dispatch(clearHoveredItem);
     }
   };
 }

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -19,6 +19,7 @@ import { TimelineState, Tooltip, ZoomRegion, HoveredItem } from "ui/state/timeli
 import { getFirstComment } from "ui/hooks/comments";
 import { getTest } from "ui/utils/environment";
 import { waitForTime } from "protocol/utils";
+const { features } = require("ui/utils/prefs");
 
 export type SetTimelineStateAction = Action<"set_timeline_state"> & {
   state: Partial<TimelineState>;
@@ -393,12 +394,26 @@ export function goToPrevPaint(): UIThunkAction {
   };
 }
 
-export function setHoveredItem(hoveredItem: HoveredItem | null): UIThunkAction {
+export function setHoveredItem(hoveredItem: HoveredItem): UIThunkAction {
   return ({ dispatch, getState }) => {
+    const { target } = hoveredItem;
+
+    const hoverEnabledForTarget = features[`${target}Hover`];
+    if (!hoverEnabledForTarget) {
+      return;
+    }
+
     dispatch({ type: "set_hovered_item", hoveredItem });
 
     // Don't update the video if user is adding a new comment.
     const updateGraphics = !selectors.getPendingComment(getState());
     dispatch(setTimelineToTime(hoveredItem?.time || null, updateGraphics));
+  };
+}
+
+export function clearHoveredItem(): UIThunkAction {
+  return ({ dispatch }) => {
+    dispatch({ type: "set_hovered_item", hoveredItem: null });
+    dispatch(setTimelineToTime(null));
   };
 }

--- a/src/ui/components/Timeline/Marker.tsx
+++ b/src/ui/components/Timeline/Marker.tsx
@@ -59,7 +59,7 @@ class Marker extends React.Component<MarkerProps> {
 
   onMouseLeave: MouseEventHandler = (e: any) => {
     if (!inBreakpointPanel(e)) {
-      this.props.setHoveredItem(null);
+      this.props.clearHoveredItem();
     }
   };
 
@@ -113,6 +113,7 @@ class Marker extends React.Component<MarkerProps> {
 const connector = connect(null, {
   setHoveredItem: actions.setHoveredItem,
   seek: actions.seek,
+  clearHoveredItem: actions.clearHoveredItem,
 });
 type PropsFromRedux = ConnectedProps<typeof connector>;
 

--- a/src/ui/components/Transcript/TranscriptItem/TranscriptItem.tsx
+++ b/src/ui/components/Transcript/TranscriptItem/TranscriptItem.tsx
@@ -28,6 +28,7 @@ function TranscriptItem({
   clearPendingComment,
   seek,
   setHoveredItem,
+  clearHoveredItem,
   children,
 }: TranscriptItemProps) {
   const itemNode = useRef<HTMLDivElement>(null);
@@ -52,7 +53,7 @@ function TranscriptItem({
     clearPendingComment();
   };
   const onMouseLeave = () => {
-    setHoveredItem(null);
+    clearHoveredItem();
   };
   const onMouseEnter = () => {
     const hoveredItem: HoveredItem = {
@@ -96,6 +97,7 @@ const connector = connect(
   }),
   {
     setHoveredItem: actions.setHoveredItem,
+    clearHoveredItem: actions.clearHoveredItem,
     seek: actions.seek,
     clearPendingComment: actions.clearPendingComment,
   }

--- a/src/ui/utils/prefs.js
+++ b/src/ui/utils/prefs.js
@@ -35,6 +35,9 @@ pref("devtools.features.users", true);
 pref("devtools.features.auth0", true);
 pref("devtools.features.videoComments", false);
 pref("devtools.features.settings", false);
+pref("devtools.features.consoleHover", false);
+pref("devtools.features.transcriptHover", false);
+pref("devtools.features.widgetHover", false);
 
 export const prefs = new PrefsHelper("devtools", {
   splitConsole: ["Bool", "split-console"],
@@ -56,6 +59,9 @@ export const features = new PrefsHelper("devtools.features", {
   videoComments: ["Bool", "videoComments"],
   private: ["Bool", "private"],
   settings: ["Bool", "settings"],
+  consoleHover: ["Bool", "consoleHover"],
+  transcriptHover: ["Bool", "transcriptHover"],
+  widgetHover: ["Bool", "widgetHover"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {


### PR DESCRIPTION
Fix #2080.

Demo: https://share.descript.com/view/LLj8azpe9wg

To enable the transcript/console/widget hover effects, go to the console and manually set the feature flag like below:
1. Console `app.features.consoleHover = true`
2. Transcript `app.features.transcriptHover = true`
3. Widget `app.features.widgetHover = true`