### PR TITLE
Always add the recordingId to graphql http headers

### DIFF
--- a/src/ui/utils/apolloClient.ts
+++ b/src/ui/utils/apolloClient.ts
@@ -33,9 +33,13 @@ export function createApolloClient(token: string | undefined, recordingId: strin
 }
 
 function createHttpLink(token: string | undefined, recordingId: string | undefined) {
-  const headers = token
-    ? { Authorization: `Bearer ${token}` }
-    : { "x-hasura-recording-id": recordingId };
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  if (recordingId) {
+    headers["x-hasura-recording-id"] = recordingId;
+  }
 
   return new HttpLink({
     uri: "https://graphql.replay.io/v1/graphql",


### PR DESCRIPTION
This is preparation for switching Hasura to webhooks for authentication: after the switch the `x-hasura-recording-id` session variable will be taken from the request's HTTP headers for authenticated users as well.
With this PR, the devtools are compatible with the current as well as the future authentication scheme.