### PR TITLE
Stop importing all of lodash

### DIFF
--- a/src/devtools/client/debugger/dist/vendors.js
+++ b/src/devtools/client/debugger/dist/vendors.js
@@ -10,7 +10,6 @@
       require("react"),
       require("devtools-services"),
       require("react-dom"),
-      require("lodash"),
       require("devtools/client/framework/menu"),
       require("devtools/client/framework/menu-item")
     );
@@ -22,7 +21,6 @@
       "Services",
       "devtools/shared/flags",
       "react-dom",
-      "lodash",
       "devtools/client/framework/menu",
       "devtools/client/framework/menu-item",
     ], factory);
@@ -35,7 +33,6 @@
             require("react"),
             require("devtools/shared/flags"),
             require("react-dom"),
-            require("lodash"),
             require("devtools/client/framework/menu"),
             require("devtools/client/framework/menu-item")
           )
@@ -46,7 +43,6 @@
             root["Services"],
             root["devtools/shared/flags"],
             root["react-dom"],
-            root["lodash"],
             root["devtools/client/framework/menu"],
             root["devtools/client/framework/menu-item"]
           );

--- a/src/devtools/client/debugger/src/actions/breakpoints/breakpointPositions.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/breakpointPositions.js
@@ -4,7 +4,7 @@
 
 //
 
-import { uniqBy, zip } from "lodash";
+import uniqBy from "lodash/uniqBy";
 
 import {
   getSource,

--- a/src/devtools/client/debugger/src/actions/event-listeners.js
+++ b/src/devtools/client/debugger/src/actions/event-listeners.js
@@ -4,7 +4,8 @@
 
 //
 
-import { uniq, remove } from "lodash";
+import uniq from "lodash/uniq";
+import remove from "lodash/remove";
 
 const { getAvailableEventBreakpoints } = require("devtools/server/actors/utils/event-breakpoints");
 import { getActiveEventListeners, getEventListenerExpanded } from "../selectors";

--- a/src/devtools/client/debugger/src/actions/pause/setFramePositions.js
+++ b/src/devtools/client/debugger/src/actions/pause/setFramePositions.js
@@ -5,7 +5,7 @@
 //
 
 import { getSourceByActorId, getSelectedFrame } from "../../selectors";
-import { zip } from "lodash";
+import zip from "lodash/zip";
 
 const { ThreadFront } = require("protocol/thread");
 

--- a/src/devtools/client/debugger/src/actions/sources/breakableLines.js
+++ b/src/devtools/client/debugger/src/actions/sources/breakableLines.js
@@ -6,7 +6,6 @@
 
 import { getSourceActorsForSource, getBreakableLines } from "../../selectors";
 import { setBreakpointPositions } from "../breakpoints/breakpointPositions";
-import { union } from "lodash";
 import { loadSourceActorBreakableLines } from "../source-actors";
 
 function calculateBreakableLines(positions) {

--- a/src/devtools/client/debugger/src/actions/utils/middleware/promise.js
+++ b/src/devtools/client/debugger/src/actions/utils/middleware/promise.js
@@ -4,7 +4,8 @@
 
 //
 
-import { fromPairs, toPairs } from "lodash";
+import fromPairs from "lodash/fromPairs";
+import toPairs from "lodash/toPairs";
 import { executeSoon } from "../../../utils/DevToolsUtils";
 
 import { pending, rejected, fulfilled } from "../../../utils/async-value";

--- a/src/devtools/client/debugger/src/components/Editor/HighlightLines.js
+++ b/src/devtools/client/debugger/src/components/Editor/HighlightLines.js
@@ -4,7 +4,8 @@
 
 //
 import { Component } from "react";
-import { range, isEmpty } from "lodash";
+import range from "lodash/range";
+import isEmpty from "lodash/isEmpty";
 import { connect } from "../../utils/connect";
 import { getHighlightedLineRange } from "../../selectors";
 

--- a/src/devtools/client/debugger/src/components/Editor/SearchBar.js
+++ b/src/devtools/client/debugger/src/components/Editor/SearchBar.js
@@ -26,7 +26,7 @@ import { scrollList } from "../../utils/result-list";
 import classnames from "classnames";
 
 import SearchInput from "../shared/SearchInput";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import "./SearchBar.css";
 import { PluralForm } from "devtools-modules";
 

--- a/src/devtools/client/debugger/src/components/Editor/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/index.js
@@ -10,7 +10,7 @@ import { bindActionCreators } from "redux";
 import ReactDOM from "react-dom";
 import { connect } from "../../utils/connect";
 import classnames from "classnames";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 
 import { isFirefox } from "ui/utils/environment";
 import { getIndentation } from "../../utils/indentation";

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
@@ -26,7 +26,8 @@ import {
 import OutlineFilter from "./OutlineFilter";
 import "./Outline.css";
 import PreviewFunction from "../shared/PreviewFunction";
-import { uniq, sortBy } from "lodash";
+import uniq from "lodash/uniq";
+import sortBy from "lodash/sortBy";
 
 /**
  * Check whether the name argument matches the fuzzy filter argument

--- a/src/devtools/client/debugger/src/components/QuickOpenModal.js
+++ b/src/devtools/client/debugger/src/components/QuickOpenModal.js
@@ -7,7 +7,7 @@ import React, { Component } from "react";
 import { connect } from "../utils/connect";
 import fuzzyAldrin from "fuzzaldrin-plus";
 import { basename } from "../utils/path";
-import { throttle } from "lodash";
+import throttle from "lodash/throttle";
 import { createSelector } from "reselect";
 import actions from "../actions";
 import {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -1,6 +1,7 @@
 import React from "react";
 import classnames from "classnames";
-import { findLast, find } from "lodash";
+import findLast from "lodash/findLast";
+import find from "lodash/find";
 import { compareNumericStrings } from "protocol/utils";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointOptions.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointOptions.js
@@ -2,7 +2,7 @@ import React from "react";
 import actions from "../../../actions";
 import { getContext } from "../../../selectors";
 import { connect } from "../../../utils/connect";
-import { memoize } from "lodash";
+import memoize from "lodash/memoize";
 
 const highlightText = memoize(
   (text = "", editor) => {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/FrameMenu.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/FrameMenu.js
@@ -5,7 +5,7 @@
 //
 import { showMenu } from "devtools-contextmenu";
 import { copyToTheClipboard } from "../../../utils/clipboard";
-import { kebabCase } from "lodash";
+import kebabCase from "lodash/kebabCase";
 
 const blackboxString = "blackboxContextItem.blackbox";
 const unblackboxString = "blackboxContextItem.unblackbox";

--- a/src/devtools/client/debugger/src/components/shared/PreviewFunction.js
+++ b/src/devtools/client/debugger/src/components/shared/PreviewFunction.js
@@ -7,7 +7,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
-import { times, zip, flatten } from "lodash";
+import times from "lodash/times";
+import zip from "lodash/zip";
+import flatten from "lodash/flatten";
 
 import "./PreviewFunction.css";
 

--- a/src/devtools/client/debugger/src/reducers/pause.js
+++ b/src/devtools/client/debugger/src/reducers/pause.js
@@ -12,7 +12,8 @@
 
 import { prefs } from "../utils/prefs";
 import { getSelectedFrame, getFramePositions } from "../selectors/pause";
-import { findLast, find } from "lodash";
+import find from "lodash/find";
+import findLast from "lodash/findLast";
 import { compareNumericStrings } from "protocol/utils";
 
 function createPauseState() {

--- a/src/devtools/client/debugger/src/reducers/sources.js
+++ b/src/devtools/client/debugger/src/reducers/sources.js
@@ -33,7 +33,7 @@ import {
   getSourceActors,
   getBreakableLinesForSourceActors,
 } from "./source-actors";
-import { uniq } from "lodash";
+import uniq from "lodash/uniq";
 
 export function initialSourcesState() {
   return {

--- a/src/devtools/client/debugger/src/reducers/threads.js
+++ b/src/devtools/client/debugger/src/reducers/threads.js
@@ -9,7 +9,6 @@
  * @module reducers/threads
  */
 
-import { sortBy } from "lodash";
 import { createSelector } from "reselect";
 
 import { features } from "../utils/prefs";

--- a/src/devtools/client/debugger/src/selectors/breakpointSources.js
+++ b/src/devtools/client/debugger/src/selectors/breakpointSources.js
@@ -4,7 +4,8 @@
 
 //
 
-import { sortBy, uniq } from "lodash";
+import sortBy from "lodash/sortBy";
+import uniq from "lodash/uniq";
 import { createSelector } from "reselect";
 import {
   getSources,

--- a/src/devtools/client/debugger/src/selectors/getCallStackFrames.js
+++ b/src/devtools/client/debugger/src/selectors/getCallStackFrames.js
@@ -7,7 +7,7 @@
 import { getSources, getSelectedSource, getSourceInSources } from "../reducers/sources";
 import { getFrames } from "../reducers/pause";
 import { annotateFrames } from "../utils/pause/frames";
-import { get } from "lodash";
+import get from "lodash/get";
 import { createSelector } from "reselect";
 
 function getLocation(frame) {

--- a/src/devtools/client/debugger/src/selectors/test/getCallStackFrames.spec.js
+++ b/src/devtools/client/debugger/src/selectors/test/getCallStackFrames.spec.js
@@ -5,7 +5,7 @@
 //
 
 import { getCallStackFrames } from "../getCallStackFrames";
-import { pullAt } from "lodash";
+import pullAt from "lodash/pullAt";
 import { insertResources, createInitial } from "../../utils/resource";
 
 describe("getCallStackFrames selector", () => {

--- a/src/devtools/client/debugger/src/selectors/visibleBreakpoints.js
+++ b/src/devtools/client/debugger/src/selectors/visibleBreakpoints.js
@@ -5,7 +5,7 @@
 //
 
 import { createSelector } from "reselect";
-import { uniqBy } from "lodash";
+import uniqBy from "lodash/uniqBy";
 
 import { getBreakpointsList, getRequestedBreakpointsList } from "./breakpoints";
 import { getSelectedSource } from "../reducers/sources";

--- a/src/devtools/client/debugger/src/selectors/visibleColumnBreakpoints.js
+++ b/src/devtools/client/debugger/src/selectors/visibleColumnBreakpoints.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 //
 
-import { groupBy } from "lodash";
+import groupBy from "lodash/groupBy";
 import { createSelector } from "reselect";
 
 import {

--- a/src/devtools/client/debugger/src/utils/breakpoint/index.js
+++ b/src/devtools/client/debugger/src/utils/breakpoint/index.js
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { isEqual } from "lodash";
 import { getBreakpoint, getSource, getSourceActorsForSource } from "../../selectors";
 import assert from "../assert";
 import { features } from "../prefs";
-import { sortBy } from "lodash";
+import sortBy from "lodash/sortBy";
 
 export * from "./astBreakpointLocation";
 export * from "./breakpointPositions";

--- a/src/devtools/client/debugger/src/utils/build-query.js
+++ b/src/devtools/client/debugger/src/utils/build-query.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 //
-import { escapeRegExp } from "lodash";
+import escapeRegExp from "lodash/escapeRegExp";
 
 /**
  * Ignore doing outline matches for less than 3 whitespaces

--- a/src/devtools/client/debugger/src/utils/editor/token-events.js
+++ b/src/devtools/client/debugger/src/utils/editor/token-events.js
@@ -5,7 +5,7 @@
 //
 
 import { getTokenLocation } from ".";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 
 function isValidToken(target) {
   if (!target || !target.innerText) {

--- a/src/devtools/client/debugger/src/utils/location.js
+++ b/src/devtools/client/debugger/src/utils/location.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 //
-import { sortBy } from "lodash";
+import sortBy from "lodash/sortBy";
 
 export function comparePosition(a, b) {
   return a && b && a.line == b.line && a.column == b.column;

--- a/src/devtools/client/debugger/src/utils/pause/frames/annotateFrames.js
+++ b/src/devtools/client/debugger/src/utils/pause/frames/annotateFrames.js
@@ -4,7 +4,9 @@
 
 //
 
-import { flatMap, zip, range } from "lodash";
+import flatMap from "lodash/flatMap";
+import zip from "lodash/zip";
+import range from "lodash/range";
 
 import { getFrameUrl } from "./getFrameUrl";
 import { getLibraryFromUrl } from "./getLibraryFromUrl";

--- a/src/devtools/client/debugger/src/utils/pause/frames/collapseFrames.js
+++ b/src/devtools/client/debugger/src/utils/pause/frames/collapseFrames.js
@@ -4,7 +4,8 @@
 
 //
 
-import { get, findIndex } from "lodash";
+import get from "lodash/get";
+import findIndex from "lodash/findIndex";
 
 // eslint-disable-next-line max-len
 import { getFrameUrl } from "./getFrameUrl";

--- a/src/devtools/client/debugger/src/utils/pause/frames/getFrameUrl.js
+++ b/src/devtools/client/debugger/src/utils/pause/frames/getFrameUrl.js
@@ -4,7 +4,7 @@
 
 //
 
-import { get } from "lodash";
+import get from "lodash/get";
 
 export function getFrameUrl(frame) {
   return get(frame, "source.url", "") || "";

--- a/src/devtools/client/debugger/src/utils/pause/scopes/getVariables.js
+++ b/src/devtools/client/debugger/src/utils/pause/scopes/getVariables.js
@@ -5,8 +5,6 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 //
-import { toPairs } from "lodash";
-
 // VarAndBindingsPair actually is [name: string, contents: BindingContents]
 
 // Scope's bindings field which holds variables and arguments

--- a/src/devtools/client/debugger/src/utils/source-queue.js
+++ b/src/devtools/client/debugger/src/utils/source-queue.js
@@ -4,7 +4,7 @@
 
 //
 
-import { throttle } from "lodash";
+import throttle from "lodash/throttle";
 
 let newQueuedSources;
 let queuedSources;

--- a/src/devtools/client/debugger/src/utils/tests/build-query.spec.js
+++ b/src/devtools/client/debugger/src/utils/tests/build-query.spec.js
@@ -4,7 +4,7 @@
 
 //
 
-import { escapeRegExp } from "lodash";
+import escapeRegExp from "lodash/escapeRegExp";
 import buildQuery from "../build-query";
 
 describe("build-query", () => {

--- a/src/devtools/client/debugger/src/utils/timings.js
+++ b/src/devtools/client/debugger/src/utils/timings.js
@@ -4,7 +4,7 @@
 
 //
 
-import { zip } from "lodash";
+import zip from "lodash/zip";
 
 export function getAsyncTimes(name) {
   return zip(

--- a/src/devtools/client/debugger/src/utils/url.js
+++ b/src/devtools/client/debugger/src/utils/url.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 //
-import { memoize } from "lodash";
+import memoize from "lodash/memoize";
 import { URL } from "whatwg-url";
 
 const defaultUrl = {

--- a/src/protocol/thread/node.ts
+++ b/src/protocol/thread/node.ts
@@ -10,7 +10,7 @@ import { Pause, WiredObject } from "./pause";
 import { defer, assert, DisallowEverythingProxyHandler, Deferred } from "../utils";
 import { FrameworkEventListener, getFrameworkEventListeners } from "../event-listeners";
 import { ValueFront } from "./value";
-const { uniqBy } = require("lodash");
+import uniqBy from "lodash/uniqBy";
 const HTML_NS = "http://www.w3.org/1999/xhtml";
 
 export interface WiredEventListener {

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -3,7 +3,8 @@
 
 const { ThreadFront } = require("protocol/thread");
 const { assert, waitForTime } = require("protocol/utils");
-const { mapValues, isEqual } = require("lodash");
+const mapValues = require("lodash/mapValues");
+const isEqual = require("lodash/isEqual");
 
 const dbg = gToolbox.getPanel("debugger").getVarsForTests();
 

--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -4,7 +4,7 @@ import { actions } from "ui/actions";
 import { PendingComment, Event, Comment, Reply, FloatingItem } from "ui/state/comments";
 import { UIThunkAction } from ".";
 import { ThreadFront } from "protocol/thread";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 
 type SetPendingComment = Action<"set_pending_comment"> & { comment: PendingComment | null };
 type SetCommentPointer = Action<"set_comment_pointer"> & { value: boolean };

--- a/src/ui/components/Comments/index.js
+++ b/src/ui/components/Comments/index.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import hooks from "ui/hooks";
 import CommentMarker from "./CommentMarker";
 import { selectors } from "../../reducers";
-import { sortBy } from "lodash";
+import sortBy from "lodash/sortBy";
 
 import "./Comments.css";
 

--- a/src/ui/components/Dashboard/DashboardViewerContent.js
+++ b/src/ui/components/Dashboard/DashboardViewerContent.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import classnames from "classnames";
 import Recording from "./RecordingItem/index";
-import { sortBy } from "lodash";
+import sortBy from "lodash/sortBy";
 
 export default function DashboardViewerContent({
   recordings,

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
-import { sortBy } from "lodash";
+import sortBy from "lodash/sortBy";
 import hooks from "ui/hooks";
 
 import TranscriptFilter from "ui/components/Transcript/TranscriptFilter";


### PR DESCRIPTION
I also had to remove `lodash` from the UMD bundle `src/devtools/client/debugger/dist/vendors.js` (sounds scary, but our e2e tests say I didn't break anything), otherwise the final bundle size would go up rather than down.