### PR TITLE
Render promises as regular objects (#2097)

### DIFF
--- a/src/devtools/client/debugger/packages/devtools-reps/src/reps/rep.js
+++ b/src/devtools/client/debugger/packages/devtools-reps/src/reps/rep.js
@@ -54,7 +54,6 @@ const reps = [
   TextNode,
   Attribute,
   Func,
-  PromiseRep,
   ArrayRep,
   Document,
   DocumentType,


### PR DESCRIPTION
`PromiseRep` expects special handling of promises by the backend, surfacing a promise's state and value. No such special handling currently exists in our backend (AFAIK), so with this PR promises are treated like regular objects.
Fixes #2097 