### PR TITLE
Swap the stepIn button to be before stepOut

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.js
@@ -133,18 +133,17 @@ class CommandBar extends Component {
       ),
       <div key="divider-3" className="divider" />,
       debugBtn(
-        () => this.props.stepOut(cx),
-        "stepOut",
-        className,
-        L10N.getFormatStr("stepOutTooltip", formatKey("stepOut")),
-        !cx.isPaused
-      ),
-
-      debugBtn(
         () => this.props.stepIn(cx),
         "stepIn",
         className,
         L10N.getFormatStr("stepInTooltip", formatKey("stepIn")),
+        !cx.isPaused
+      ),
+      debugBtn(
+        () => this.props.stepOut(cx),
+        "stepOut",
+        className,
+        L10N.getFormatStr("stepOutTooltip", formatKey("stepOut")),
         !cx.isPaused
       ),
     ];


### PR DESCRIPTION
I once again hit the wrong button because our buttons are in a different order than Chrome and FF.