### PR TITLE
Allow coordinates to differ by less than 1 pixel in checkHighlighterShape

### DIFF
--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -633,10 +633,17 @@ async function checkHighlighterVisible(visible) {
 }
 
 async function checkHighlighterShape(svgPath) {
+  const expectedCoords = svgPath.substring(1).split(/ L|,/);
   await waitUntil(() => {
     const highlighterNode = document.getElementById("box-model-content");
     const highlighterPath = highlighterNode?.attributes["d"].textContent;
-    return highlighterPath === svgPath;
+    const highlighterCoords = highlighterPath.substring(1).split(/ L|,/);
+    for (let i = 0; i < 8; i++) {
+      if (Math.abs(highlighterCoords[i] - expectedCoords[i]) >= 1) {
+        return false;
+      }
+    }
+    return true;
   });
 }
 


### PR DESCRIPTION
Interestingly the highlighter coordinates differ by fractions of a pixel, depending on whether the example was recorded on MacOS or Linux.