### PR TITLE
Ensure that stepping through breakpoint hits works in order.

### DIFF
--- a/src/protocol/logpoint.ts
+++ b/src/protocol/logpoint.ts
@@ -7,7 +7,7 @@
 // messages associated with the logpoint atomically.
 
 import { AnalysisEntry, ExecutionPoint, Location, PointDescription } from "@recordreplay/protocol";
-import { assert } from "./utils";
+import { assert, compareNumericStrings } from "./utils";
 import { ThreadFront, ValueFront, Pause, createPrimitiveValueFront } from "./thread";
 import { PrimitiveValue } from "./thread/value";
 import { logpointGetFrameworkEventListeners } from "./event-listeners";
@@ -257,6 +257,10 @@ export async function setLogpoint(
   }
 
   await analysisManager.runAnalysis(params, handler);
+
+  // The analysis points may have arrived in any order, so we have to sort
+  // them after they arrive.
+  points.sort((a, b) => compareNumericStrings(a.point, b.point));
 
   saveLogpointHits(points, results, locations, condition);
 }


### PR DESCRIPTION
See https://github.com/RecordReplay/devtools/issues/2157#issuecomment-803497028

We've got this case where hitting next/previous on a breakpoint will sometimes jump more than one point. This looks to be because the frontend doesn't do any sorting of the results.

We could do _some_ of this sorting in the server, but since `Analysis.analysisPoints` is an event, and there could be multiple events (though I think right now we only send one with the full result), even if we sorted the individual response points, points in the various response packets could still be interleaved with points in other events, so it seems like this should be up to the client.