### PR TITLE
Expose promise state in object preview.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1517,9 +1517,9 @@
       }
     },
     "@recordreplay/protocol": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.6.0.tgz",
-      "integrity": "sha512-NJI7Zb4Jx9SBQx5+1iUD76XJaG49jgbnnoLBS0+c1fncnRvRgz1H8Vt+9Jp13PG7rgEesh5+aMDZmkBgyI3ruA=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.6.1.tgz",
+      "integrity": "sha512-dZLVYBLw6vBa9bs2GF4T2E+3Z3z0CuS5+6lU+R6lCOq11YAK6BwTS8l1P4tw/G/K3wGNunfmT/IeU1w6t+7r3w=="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/types": "^7.12.0",
     "@draft-js-plugins/editor": "^4.1.0",
     "@draft-js-plugins/emoji": "^4.2.0",
-    "@recordreplay/protocol": "^0.6.0",
+    "@recordreplay/protocol": "^0.6.1",
     "@sentry/apm": "^5.27.1",
     "@sentry/react": "^5.30.0",
     "apollo-link-http": "^1.5.17",

--- a/src/devtools/client/debugger/packages/devtools-reps/src/reps/rep.js
+++ b/src/devtools/client/debugger/packages/devtools-reps/src/reps/rep.js
@@ -54,7 +54,6 @@ const reps = [
   TextNode,
   Attribute,
   Func,
-  PromiseRep,
   ArrayRep,
   Document,
   DocumentType,

--- a/src/protocol/thread/pause.ts
+++ b/src/protocol/thread/pause.ts
@@ -33,10 +33,14 @@ export type WiredObject = Omit<ObjectDescription, "preview"> & {
 
 export type WiredObjectPreview = Omit<
   ObjectPreview,
-  "properties" | "containerEntries" | "getterValues"
+  "properties" | "containerEntries" | "promiseState" | "getterValues"
 > & {
   properties: WiredProperty[];
   containerEntries: WiredContainerEntry[];
+  promiseState?: {
+    state: ValueFront;
+    value?: ValueFront;
+  };
   getterValues: WiredNamedValue[];
   prototypeValue: ValueFront;
 };
@@ -203,7 +207,7 @@ export class Pause {
 
     (objects || []).forEach(object => {
       if (object.preview) {
-        const { properties, containerEntries, getterValues } = object.preview;
+        const { properties, containerEntries, promiseState, getterValues } = object.preview;
 
         const newProperties = [];
         for (const p of properties || []) {
@@ -228,6 +232,15 @@ export class Pause {
           });
         }
         (object as WiredObject).preview!.containerEntries = newEntries;
+
+        if (promiseState) {
+          const { state, value } = promiseState;
+
+          (object as WiredObject).preview!.promiseState = {
+            state: new ValueFront(this, { value: state }),
+            value: value ? new ValueFront(this, value) : undefined,
+          };
+        }
 
         const newGetterValues: WiredNamedValue[] = [];
         for (const v of getterValues || []) {

--- a/src/protocol/thread/value.ts
+++ b/src/protocol/thread/value.ts
@@ -127,6 +127,11 @@ export class ValueFront {
     return [];
   }
 
+  previewPromiseState() {
+    // Older recordings did not set promiseState so this could be null.
+    return (this.hasPreview() && this._object!.preview!.promiseState) || null;
+  }
+
   className() {
     if (this._object) {
       return this._object.className;
@@ -306,6 +311,23 @@ export class ValueFront {
         name: "<entries>",
         contents: createElementsFront(elements),
       });
+    }
+    if (this.className() === "Promise") {
+      const result = this.previewPromiseState();
+      if (result) {
+        const { state, value } = result;
+
+        if (value) {
+          rv.unshift({
+            name: "<value>",
+            contents: value,
+          });
+        }
+        rv.unshift({
+          name: "<state>",
+          contents: state,
+        });
+      }
     }
     rv.push({
       name: "<prototype>",

--- a/test/scripts/object_preview-01.js
+++ b/test/scripts/object_preview-01.js
@@ -72,6 +72,18 @@ f();
     ["<entries>"]
   );
 
+  await Test.executeInConsole("new Promise(() => {})");
+  msg = await Test.waitForMessage("Promise {  }");
+  await Test.checkMessageObjectContents(msg, ['"pending"'], []);
+
+  await Test.executeInConsole("Promise.resolve({ a: 1 })");
+  msg = await Test.waitForMessage("Promise {  }");
+  await Test.checkMessageObjectContents(msg, ['"fulfilled"', "a: 1"], ["<value>"]);
+
+  await Test.executeInConsole("Promise.reject({ a: 1 })");
+  msg = await Test.waitForMessage("Promise {  }");
+  await Test.checkMessageObjectContents(msg, ['"rejected"', "a: 1"], ["<value>"]);
+
   await Test.executeInConsole("baz");
   msg = await Test.waitForMessage("function baz()");
   Test.checkJumpIcon(msg);


### PR DESCRIPTION
I'm not totally clear on if this is the right way to do it, but I did this while testing out the backend changes so figured I'd post it. If there's a better way, feel free to take over.

Depends on https://github.com/RecordReplay/backend/issues/1568 and https://github.com/RecordReplay/gecko-dev/pull/324

Fixes #2097