### PR TITLE
Add invite system

### DIFF
--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -17,6 +17,7 @@ import { actions } from "ui/actions";
 import { hasLoadingParam } from "ui/utils/environment";
 import ResizeObserverPolyfill from "resize-observer-polyfill";
 import LogRocket from "ui/utils/logrocket";
+import hooks from "ui/hooks";
 
 import "styles.css";
 import { setUserInBrowserPrefs } from "ui/utils/browser";
@@ -59,6 +60,7 @@ function installViewportObserver({ updateNarrowMode }: Pick<AppProps, "updateNar
 
 function App({ theme, recordingId, modal, updateNarrowMode }: AppProps) {
   const auth = useAuth0();
+  const { loading } = hooks.useMaybeClaimInvite();
 
   useEffect(() => {
     document.body.parentElement!.className = theme || "";
@@ -76,7 +78,7 @@ function App({ theme, recordingId, modal, updateNarrowMode }: AppProps) {
     return <SkeletonLoader content={"Uploading resources"} />;
   }
 
-  if (!isDeployPreview() && auth.isLoading) {
+  if ((!isDeployPreview() && auth.isLoading) || loading) {
     return null;
   }
 

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -78,7 +78,11 @@ function App({ theme, recordingId, modal, updateNarrowMode }: AppProps) {
     return <SkeletonLoader content={"Uploading resources"} />;
   }
 
-  if ((!isDeployPreview() && auth.isLoading) || loading) {
+  if (loading) {
+    return <SkeletonLoader content={"Loading"} />;
+  }
+
+  if (!isDeployPreview() && auth.isLoading) {
     return null;
   }
 

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -57,7 +57,7 @@ function DevTools({
   );
   const { loading: settingsQueryLoading } = hooks.useGetUserSettings();
   const queriesAreLoading = recordingQueryLoading || settingsQueryLoading;
-  const { title, deleted_at, is_initialized, user_id } = recording || {};
+  const { title, deleted_at, is_initialized, user_id, user } = recording || {};
 
   useEffect(() => {
     // This shouldn't hit when the selectedPanel is "comments"
@@ -92,6 +92,11 @@ function DevTools({
 
   if (deleted_at) {
     setExpectedError({ message: "This replay has been deleted." });
+    return null;
+  }
+
+  if (user.invited == false) {
+    setExpectedError({ message: "The author of this Replay has not activated their account yet." });
     return null;
   }
 

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -16,13 +16,13 @@ import { UIState } from "ui/state";
 import { UploadInfo } from "ui/state/app";
 import { RecordingId } from "@recordreplay/protocol";
 
-type DevToolsProps = PropsFromRedux & {
-  recordingId: RecordingId;
-};
-
 function isTest() {
   return new URL(window.location.href).searchParams.get("test");
 }
+
+type DevToolsProps = PropsFromRedux & {
+  recordingId: RecordingId;
+};
 
 function getUploadingMessage(uploading: UploadInfo) {
   if (!uploading) {
@@ -95,7 +95,8 @@ function DevTools({
     return null;
   }
 
-  if (user.invited == false) {
+  // Test recordings don't have a user, so we skip this check in that case.
+  if (user && user.invited == false) {
     setExpectedError({ message: "The author of this Replay has not activated their account yet." });
     return null;
   }

--- a/src/ui/components/shared/SettingsModal/ReplayInvitations.css
+++ b/src/ui/components/shared/SettingsModal/ReplayInvitations.css
@@ -1,0 +1,50 @@
+.settings-modal main li.replay-invitations {
+  flex-grow: 1;
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+}
+
+.settings-modal main li.replay-invitations > :not(:first-child) {
+  margin-top: 20px;
+}
+
+.settings-modal main li.replay-invitations .setting-item {
+  flex-grow: unset;
+}
+
+.settings-modal .replay-invitations form {
+  width: 100%;
+}
+
+.settings-modal .replay-invitations form input {
+  font-size: 14px;
+}
+
+.settings-modal .invitations-list {
+  font-size: 14px;
+  overflow: auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-modal .invitations-list > :not(:first-child) {
+  margin-top: 8px;
+}
+
+.settings-modal .invitations {
+  display: grid;
+  column-gap: 12px;
+  align-items: center;
+  grid-template-columns: min-content auto;
+}
+
+.settings-modal .invitations .material-icons {
+  font-size: 16px;
+}
+
+.settings-modal .invitations .material-icons.finished {
+  color: var(--green-60);
+}

--- a/src/ui/components/shared/SettingsModal/ReplayInvitations.tsx
+++ b/src/ui/components/shared/SettingsModal/ReplayInvitations.tsx
@@ -6,7 +6,7 @@ import "./ReplayInvitations.css";
 export default function ReplayInvitations() {
   const [inputValue, setInputValue] = useState("");
   const { invitations, loading: inviteLoading } = hooks.useGetInvitations();
-  const { isInternal, loading: userLoading } = hooks.useGetUserInfo();
+  const { isInternal, invited, loading: userLoading } = hooks.useGetUserInfo();
   const addInvitation = hooks.useAddInvitation();
   const userId = getUserId();
 
@@ -21,6 +21,16 @@ export default function ReplayInvitations() {
       <li className="replay-invitations">
         <label className="setting-item">
           <div className="label">Loading...</div>
+        </label>
+      </li>
+    );
+  }
+
+  if (!invited) {
+    return (
+      <li className="replay-invitations">
+        <label className="setting-item">
+          <div className="label">Sorry! Invitations are only available to invited users.</div>
         </label>
       </li>
     );

--- a/src/ui/components/shared/SettingsModal/ReplayInvitations.tsx
+++ b/src/ui/components/shared/SettingsModal/ReplayInvitations.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import hooks from "ui/hooks";
+import { getUserId } from "ui/utils/useToken";
+import "./ReplayInvitations.css";
+
+export default function ReplayInvitations() {
+  const [inputValue, setInputValue] = useState("");
+  const { invitations, loading: inviteLoading } = hooks.useGetInvitations();
+  const { isInternal, loading: userLoading } = hooks.useGetUserInfo();
+  const addInvitation = hooks.useAddInvitation();
+  const userId = getUserId();
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setInputValue("");
+    addInvitation({ variables: { userId, email: inputValue } });
+  };
+
+  if (inviteLoading || userLoading) {
+    return (
+      <li className="replay-invitations">
+        <label className="setting-item">
+          <div className="label">Loading...</div>
+        </label>
+      </li>
+    );
+  }
+
+  const inviteCount = invitations.length;
+  // Replay folks get unlimited invites.
+  const maxInvites = isInternal ? Number.POSITIVE_INFINITY : 5;
+  const label = `You have ${maxInvites - inviteCount} invite${
+    maxInvites - inviteCount == 1 ? "" : "s"
+  } left`;
+
+  return (
+    <li className="replay-invitations">
+      <label className="setting-item">
+        <div className="label">{label}</div>
+        <div className="description">
+          Replay is meant for sharing. Invite your team and friends below so they can start creating
+          their own replays.
+        </div>
+      </label>
+      {inviteCount < maxInvites && (
+        <form onSubmit={onSubmit}>
+          <input
+            type="text"
+            placeholder="Email Address"
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+          ></input>
+          <input type="submit" value="Invite"></input>
+        </form>
+      )}
+      <div className="invitations-list">
+        {invitations.map((invite, i) => (
+          <div className="invitations" key={i}>
+            <div className={`material-icons ${invite.invited_user?.invited && "finished"}`}>
+              {invite.invited_user?.invited ? "check_circle" : "pending"}
+            </div>
+            <div>{invite.invited_email}</div>
+          </div>
+        ))}
+      </div>
+    </li>
+  );
+}

--- a/src/ui/components/shared/SettingsModal/SettingsBody.css
+++ b/src/ui/components/shared/SettingsModal/SettingsBody.css
@@ -1,6 +1,8 @@
 .settings-modal main {
   padding: 36px;
   flex-grow: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 .settings-modal main > :not(:first-child) {

--- a/src/ui/components/shared/SettingsModal/SettingsBody.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBody.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { SettingItem, Setting, UserSettings } from "./types";
 import useToken from "ui/utils/useToken";
 import hooks from "ui/hooks";
+import ReplayInvitations from "./ReplayInvitations";
 import "./SettingsBody.css";
 
 interface SettingsBodyItemProps {
@@ -67,6 +68,13 @@ export default function SettingsBody({ selectedSetting, userSettings }: Settings
       <main>
         <h1>{title}</h1>
         <Support />
+      </main>
+    );
+  } else if (title == "Invitations") {
+    return (
+      <main>
+        <h1>{title}</h1>
+        <ReplayInvitations />
       </main>
     );
   }

--- a/src/ui/components/shared/SettingsModal/SettingsModal.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsModal.tsx
@@ -11,6 +11,7 @@ import "./SettingsModal.css";
 const settings: Settings = [
   {
     title: "Experimental",
+    icon: "biotech",
     items: [
       {
         label: "Enable the Elements pane",
@@ -27,7 +28,13 @@ const settings: Settings = [
     ],
   },
   {
+    title: "Invitations",
+    icon: "stars",
+    items: [],
+  },
+  {
     title: "Support",
+    icon: "support",
     items: [],
   },
 ];

--- a/src/ui/components/shared/SettingsModal/SettingsNavigation.css
+++ b/src/ui/components/shared/SettingsModal/SettingsNavigation.css
@@ -17,26 +17,27 @@
 }
 
 .settings-modal nav li {
-  font-size: 17px;
+  font-size: 16px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.settings-modal nav li .material-icons {
+  font-size: 20px;
+  color: var(--theme-icon-color);
 }
 
 .settings-modal nav li.selected {
   color: var(--primary-accent);
 }
 
-.settings-modal nav li.selected .img {
-  background: var(--primary-accent);
+.settings-modal nav li.selected .material-icons {
+  color: var(--primary-accent);
 }
 
 .settings-modal nav li > :not(:first-child) {
   margin-left: 8px;
-}
-
-.settings-modal nav li .img {
-  height: 20px;
-  width: 20px;
-  background-color: var(--theme-icon-color);
 }
 
 .settings-modal nav li span {

--- a/src/ui/components/shared/SettingsModal/SettingsNavigation.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsNavigation.tsx
@@ -20,14 +20,14 @@ function SettingNavigationItem({
   selectedTab,
   setSelectedTab,
 }: SettingNavigationItemProps) {
-  const { title } = setting;
+  const { title, icon } = setting;
   const onClick = () => {
     setSelectedTab(title);
   };
 
   return (
     <li onClick={onClick} className={classnames({ selected: title === selectedTab })}>
-      <div className={`img settings-${title.toLowerCase()}`} />
+      <div className="material-icons">{icon}</div>
       <span>{title}</span>
     </li>
   );

--- a/src/ui/components/shared/SettingsModal/types.ts
+++ b/src/ui/components/shared/SettingsModal/types.ts
@@ -1,10 +1,17 @@
-export type SelectedTab = "Appearance" | "Team" | "Privacy" | "Experimental" | "Support";
+export type SelectedTab =
+  | "Appearance"
+  | "Team"
+  | "Privacy"
+  | "Experimental"
+  | "Support"
+  | "Invitations";
 
 export type Settings = Setting[];
 
 export interface Setting {
   title: SelectedTab;
   items: SettingItem[];
+  icon?: string;
 }
 
 export interface SettingItem {

--- a/src/ui/hooks/index.ts
+++ b/src/ui/hooks/index.ts
@@ -5,6 +5,8 @@ import * as settingsHooks from "./settings";
 import * as collaboratorsHooks from "./collaborators";
 import * as workspacesHooks from "./workspaces";
 import * as workspaceMembersHooks from "./workspaces_user";
+import * as invitationsHooks from "./invitations";
+import * as usersHooks from "./users";
 
 export default {
   ...commentsHooks,
@@ -14,4 +16,6 @@ export default {
   ...collaboratorsHooks,
   ...workspacesHooks,
   ...workspaceMembersHooks,
+  ...invitationsHooks,
+  ...usersHooks,
 };

--- a/src/ui/hooks/invitations.ts
+++ b/src/ui/hooks/invitations.ts
@@ -1,0 +1,101 @@
+import { gql, useQuery, useMutation } from "@apollo/client";
+import { getUserId } from "ui/utils/useToken";
+import { useGetUserInfo } from "./users";
+
+export interface Invitation {
+  created_at: string;
+  invited_email: string;
+  pending: boolean;
+  invited_user: InvitedUser;
+}
+
+export interface InvitedUser {
+  invited: boolean;
+}
+
+export function useGetInvitations() {
+  const userId = getUserId();
+  const { data, loading, error } = useQuery(
+    gql`
+      query GetInvitations($userId: uuid) {
+        invitations(where: { user_id: { _eq: $userId } }) {
+          created_at
+          invited_email
+          pending
+          invited_user {
+            invited
+          }
+        }
+      }
+    `,
+    {
+      variables: { userId },
+    }
+  );
+
+  if (error) {
+    console.error("Apollo error while fetching invitations:", error);
+  }
+
+  const invitations: Invitation[] = data?.invitations;
+  console.log({ invitations });
+  return { invitations, loading };
+}
+
+export function useAddInvitation() {
+  const [addInvitation] = useMutation(
+    gql`
+      mutation AddInvitation($userId: uuid, $email: String) {
+        insert_invitations(objects: { invited_email: $email, user_id: $userId }) {
+          affected_rows
+        }
+      }
+    `,
+    {
+      refetchQueries: ["GetInvitations"],
+    }
+  );
+
+  return addInvitation;
+}
+
+export function useMaybeClaimInvite() {
+  const { invitations, invited, email, loading } = useGetUserInfo();
+  const claimInvitation = useClaimInvitation();
+
+  if (loading) {
+    return { loading };
+  }
+
+  // If the user is invited/activated already, bail.
+  if (invited) {
+    return { loading: false };
+  }
+
+  // Claim the existing invitations for that user's email, if they exist. This
+  // also updated the user record to be invited/activated.
+  if (invitations) {
+    claimInvitation({ variables: { email } });
+    return { loading: false };
+  }
+
+  return { loading: false };
+}
+
+export function useClaimInvitation() {
+  const [claimInvitation] = useMutation(
+    gql`
+      mutation ClaimInvitation($email: String) {
+        update_invitations(where: { invited_email: { _eq: $email } }, _set: { pending: false }) {
+          affected_rows
+        }
+        update_users(where: { email: { _eq: $email } }, _set: { invited: true }) {
+          affected_rows
+        }
+      }
+    `,
+    { refetchQueries: ["GetRecording"] }
+  );
+
+  return claimInvitation;
+}

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -26,6 +26,9 @@ export function useGetRecording(recordingId: RecordingId) {
           is_initialized
           date
           deleted_at
+          user {
+            invited
+          }
         }
       }
     `,

--- a/src/ui/hooks/sessions.ts
+++ b/src/ui/hooks/sessions.ts
@@ -68,6 +68,35 @@ export function useGetActiveSessions(recordingId: RecordingId, sessionId: string
   return { users, loading };
 }
 
+export function useGetRecording(recordingId: RecordingId) {
+  const { data, error, loading } = useQuery(
+    gql`
+      query GetRecording($recordingId: uuid!) {
+        recordings(where: { id: { _eq: $recordingId } }) {
+          id
+          title
+          recordingTitle
+          is_private
+          date
+          deleted_at
+          user {
+            invited
+          }
+        }
+      }
+    `,
+    {
+      variables: { recordingId },
+    }
+  );
+
+  if (error) {
+    console.error("Apollo error while getting the recording", error);
+  }
+
+  return { data, loading };
+}
+
 export function useAddSessionUser() {
   const [AddSessionUser, { error }] = useMutation(gql`
     mutation AddSessionUser($id: String!, $user_id: uuid!) {

--- a/src/ui/hooks/sessions.ts
+++ b/src/ui/hooks/sessions.ts
@@ -68,35 +68,6 @@ export function useGetActiveSessions(recordingId: RecordingId, sessionId: string
   return { users, loading };
 }
 
-export function useGetRecording(recordingId: RecordingId) {
-  const { data, error, loading } = useQuery(
-    gql`
-      query GetRecording($recordingId: uuid!) {
-        recordings(where: { id: { _eq: $recordingId } }) {
-          id
-          title
-          recordingTitle
-          is_private
-          date
-          deleted_at
-          user {
-            invited
-          }
-        }
-      }
-    `,
-    {
-      variables: { recordingId },
-    }
-  );
-
-  if (error) {
-    console.error("Apollo error while getting the recording", error);
-  }
-
-  return { data, loading };
-}
-
 export function useAddSessionUser() {
   const [AddSessionUser, { error }] = useMutation(gql`
     mutation AddSessionUser($id: String!, $user_id: uuid!) {

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -1,0 +1,35 @@
+import { gql, useQuery } from "@apollo/client";
+import { getUserId } from "ui/utils/useToken";
+import { Invitation } from "./invitations";
+
+export function useGetUserInfo() {
+  const userId = getUserId();
+  const { data, loading, error } = useQuery(
+    gql`
+      query GetUser($userId: uuid!) {
+        users_by_pk(id: $userId) {
+          invited
+          email
+          invitations {
+            pending
+          }
+          internal
+        }
+      }
+    `,
+    {
+      variables: { userId },
+    }
+  );
+
+  if (error) {
+    console.error("Apollo error while fetching user:", error);
+  }
+
+  const invited: boolean = data?.users_by_pk.invited;
+  const email: string = data?.users_by_pk.email;
+  const invitations: Invitation[] = data?.users_by_pk.invitations;
+  const isInternal: boolean = data?.users_by_pk.internal;
+
+  return { invitations, invited, email, isInternal, loading };
+}


### PR DESCRIPTION
Fix #2229.

This adds basic invitation support to Replay.
- New users can register for a Replay account provided that they have access to the web app link, which prompts them to register for one.
- New users start off as non-invited. Non-invited users can create replays, but the replays they create are not viewable until the user is invited.
- To invite a user, an invited user can go into the Settings panel and access the Invitations tab where they can invite users using their email addresses. Note that this action doesn't currently send that user an e-mail.
- Non-invited users see an error page when they try to open their settings panel's invitations tab.
- There is currently no verification for the email input. So its easy to invite an invalid email, e.g. yourself, an existing Replay user, an invalid email address, etc. This should be done as a follow up.
- Regular users have 5 invitations. Replay employees have infinite invitations.
- We cross-check non-invited users with outstanding invitations from the client. Once a non-invited user has an invitation that matches their e-mail, we mark their account as invited.

![image](https://user-images.githubusercontent.com/15959269/113365320-ddd82300-9323-11eb-934b-376cf49c4c2a.png)
 