### PR TITLE
Add a replay draft screen

### DIFF
--- a/src/ui/components/Dashboard/DashboardViewerHeader.js
+++ b/src/ui/components/Dashboard/DashboardViewerHeader.js
@@ -1,7 +1,5 @@
 import React from "react";
 import classnames from "classnames";
-import { useMutation } from "@apollo/client";
-import { DELETE_RECORDING } from "./RecordingItem/RecordingItemDropdown";
 import Dropdown from "devtools/client/debugger/src/components/shared/Dropdown";
 import "./DashboardViewerHeader.css";
 import hooks from "ui/hooks";
@@ -30,9 +28,7 @@ function ViewsToggle({ viewType, toggleViewType }) {
 function BatchActionDropdown({ selectedIds, setSelectedIds }) {
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
   const updateRecordingWorkspace = hooks.useUpdateRecordingWorkspace();
-  const [deleteRecording] = useMutation(DELETE_RECORDING, {
-    refetchQueries: ["GetMyRecordings"],
-  });
+  const deleteRecording = hooks.useDeleteRecording(["GetWorkspaceRecordings", "GetMyRecordings"]);
 
   if (loading) {
     return null;

--- a/src/ui/components/Dashboard/RecordingItem/RecordingItemDropdown.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingItemDropdown.js
@@ -2,16 +2,7 @@ import React from "react";
 import { actions } from "ui/actions";
 import { connect } from "react-redux";
 import { gql, useMutation } from "@apollo/client";
-
-export const DELETE_RECORDING = gql`
-  mutation DeleteRecording($recordingId: uuid!, $deletedAt: String) {
-    update_recordings(where: { id: { _eq: $recordingId } }, _set: { deleted_at: $deletedAt }) {
-      returning {
-        id
-      }
-    }
-  }
-`;
+import hooks from "ui/hooks";
 
 function Privacy({ isPrivate, toggleIsPrivate }) {
   if (isPrivate) {
@@ -36,9 +27,7 @@ const DropdownPanel = ({
   isPrivate,
   setModal,
 }) => {
-  const [deleteRecording] = useMutation(DELETE_RECORDING, {
-    refetchQueries: ["GetWorkspaceRecordings"],
-  });
+  const deleteRecording = hooks.useDeleteRecording(["GetWorkspaceRecordings", "GetMyRecordings"]);
 
   const onDeleteRecording = async recordingId => {
     await deleteRecording({ variables: { recordingId, deletedAt: new Date().toISOString() } });

--- a/src/ui/components/DraftScreen.css
+++ b/src/ui/components/DraftScreen.css
@@ -1,0 +1,155 @@
+.initialization-screen {
+  background: var(--cool-gray-100);
+  height: 100%;
+  width: 100%;
+  display: grid;
+  justify-content: center;
+  align-items: center;
+}
+
+.initialization-screen main {
+  display: flex;
+  flex-direction: row;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.initialization-screen .filler {
+  background: linear-gradient(to bottom right, #64D4FB, #52A6F9);
+  width: 560px;
+}
+
+.initialization-screen .content {
+  background: var(--theme-body-background);
+  margin: auto;
+  padding: 48px 96px;
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+}
+
+.initialization-screen .content > :not(:first-child) {
+  margin-top: 32px;
+}
+
+.initialization-screen h1 {
+  font-size: 30px;
+  font-weight: 800;
+}
+
+.initialization-screen h4 {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.initialization-screen .header {
+  display: flex;
+  flex-direction: column;
+  user-select: none;
+}
+
+.initialization-screen .header > :not(:first-child) {
+  margin-top: 24px;
+}
+
+.initialization-screen .logo {
+  width: 48px;
+  height: 48px;
+}
+
+.initialization-screen .content form.hidden {
+  visibility: hidden;
+}
+
+.initialization-screen .content form > :not(:first-child) {
+  margin-top: 32px;
+}
+
+.initialization-screen .replay-title {
+  display: flex;
+  flex-direction: column;
+}
+
+.initialization-screen .replay-title > :not(:first-child) {
+  margin-top: 8px;
+}
+
+.initialization-screen .replay-title label {
+  user-select: none;
+}
+
+.initialization-screen .replay-title input {
+  width: 400px;
+  font-size: 14px;
+  padding: 8px;
+  border: 1px solid var(--cool-gray-300);
+  border-radius: 4px;
+}
+
+.initialization-screen .replay-privacy {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  user-select: none;
+}
+
+.initialization-screen .replay-privacy > :not(:first-child) {
+  margin-left: 8px;
+}
+
+.initialization-screen .replay-workspace {
+  display: flex;
+  flex-direction: column;
+}
+
+.initialization-screen .replay-workspace > :not(:first-child) {
+  margin-top: 8px;
+}
+
+.initialization-screen .replay-workspace select {
+  border: 1px solid var(--cool-gray-300);
+  font-size: 14px;
+  border-radius: 4px;
+  padding: 8px 8px 8px 4px;
+}
+
+.initialization-screen .content form .actions {
+  margin-top: 60px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 20px;
+}
+
+.initialization-screen .actions .submit {
+  padding: 8px 52px;
+  color: var(--theme-body-background);
+  background: var(--new-blue-500);
+  border: none;
+  font-size: 20px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.initialization-screen .actions .submit:hover {
+  background: var(--new-blue-600);
+}
+
+.initialization-screen .actions .cancel {
+  text-decoration: underline;
+  background: transparent;
+  color: var(--theme-comment);
+  cursor: pointer;
+}
+
+.initialization-screen .actions .cancel:hover {
+  background: transparent;
+  color: var(--theme-toolbar-color);
+}
+
+@media only screen and (max-width: 1280px) {
+  .initialization-screen .filler {
+    display: none;
+  }
+}

--- a/src/ui/components/DraftScreen.tsx
+++ b/src/ui/components/DraftScreen.tsx
@@ -1,0 +1,158 @@
+import React, { useState, useEffect, useRef, Dispatch, SetStateAction } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { getRecordingId } from "ui/reducers/app";
+import { UIState } from "ui/state";
+import hooks from "ui/hooks";
+import "./DraftScreen.css";
+import { Workspace } from "ui/types";
+
+type DraftScreenProps = PropsFromRedux & {};
+type Status = "saving" | "deleting" | "deleted" | null;
+
+function WorkspaceDropdownList({
+  workspaces,
+  selectedWorkspaceId,
+  setSelectedWorkspaceId,
+}: {
+  workspaces: Workspace[];
+  selectedWorkspaceId: string | null;
+  setSelectedWorkspaceId: Dispatch<SetStateAction<string | null>>;
+}) {
+  const personalWorkspace = workspaces.find(workspace => workspace.is_personal)!;
+  const otherWorkspaces = workspaces.filter(workspace => !workspace.is_personal);
+  const displayedWorkspaces = [personalWorkspace, ...otherWorkspaces];
+
+  useEffect(() => {
+    setSelectedWorkspaceId(personalWorkspace.id);
+  }, [workspaces]);
+
+  const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedId = e.target.value;
+    setSelectedWorkspaceId(selectedId);
+  };
+
+  if (selectedWorkspaceId == null || displayedWorkspaces.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="replay-workspace">
+      <label>
+        <h4>Workspace</h4>
+      </label>
+      <select onChange={onChange} value={selectedWorkspaceId}>
+        {displayedWorkspaces.map(workspace => (
+          <option value={workspace.id} key={workspace.id}>
+            {workspace.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function DraftScreen({ recordingId }: DraftScreenProps) {
+  const {
+    recording: { title },
+  } = hooks.useGetRecording(recordingId!);
+  const [status, setStatus] = useState<Status>(null);
+  const [inputValue, setInputValue] = useState(title);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+  const textInputNode = useRef<HTMLInputElement>(null);
+  // const [isPublic, setIsPublic] = useState(true);
+
+  const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
+  const initializeRecording = hooks.useInitializeRecording();
+  const deleteRecording = hooks.useDeleteRecording([], () => setStatus("deleted"));
+
+  const isSaving = status == "saving";
+  // const isDeleting = status == "deleting";
+  const isDeleted = status == "deleted";
+
+  useEffect(() => {
+    if (textInputNode.current) {
+      textInputNode.current.focus();
+    }
+  }, []);
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    initializeRecording({
+      variables: { recordingId, title: inputValue, workspaceId: selectedWorkspaceId },
+    });
+    setStatus("saving");
+  };
+  // const onDiscard = (e: React.MouseEvent) => {
+  //   e.preventDefault();
+  //   deleteRecording({ variables: { recordingId, deletedAt: new Date().toISOString() } });
+  //   setStatus("deleting");
+  // };
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (isSaving) {
+      return;
+    }
+
+    setInputValue(e.target.value);
+  };
+
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <div className="initialization-screen">
+      <main>
+        <section className="content">
+          <div className="header">
+            <img className="logo" src="images/logo.svg" />
+            <h1>{isDeleted ? "Recording deleted" : "Recording complete"}</h1>
+          </div>
+          <form onSubmit={onSubmit} className={isDeleted ? "hidden" : ""}>
+            <div className="replay-title">
+              <label htmlFor="recordingTitle">
+                <h4>Replay Title</h4>
+              </label>
+              <input
+                id="recordingTitle"
+                type="text"
+                value={inputValue}
+                onChange={onChange}
+                ref={textInputNode}
+              />
+            </div>
+            {/* <div className="replay-privacy">
+              <input
+                id="replayPrivacy"
+                type="checkbox"
+                checked={isPublic}
+                onChange={() => setIsPublic(!isPublic)}
+              />
+              <label htmlFor="replayPrivacy">Publicly available</label>
+            </div> */}
+            <WorkspaceDropdownList
+              {...{ workspaces, selectedWorkspaceId, setSelectedWorkspaceId }}
+            />
+            <div className="actions">
+              <input
+                className="submit"
+                type="submit"
+                disabled={isSaving}
+                value={isSaving ? "Saving..." : `Save & Upload`}
+              />
+              {/* {!isSaving ? (
+                <button className="cancel" onClick={onDiscard}>
+                  {isDeleting ? "Discarding..." : "Or discard"}
+                </button>
+              ) : null} */}
+            </div>
+          </form>
+        </section>
+        <section className="filler" />
+      </main>
+    </div>
+  );
+}
+
+const connector = connect((state: UIState) => ({ recordingId: getRecordingId(state) }));
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(DraftScreen);

--- a/src/ui/components/shared/WorkspaceSettingsModal/Autocomplete.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/Autocomplete.tsx
@@ -4,7 +4,6 @@ import hooks from "ui/hooks";
 import { selectors } from "ui/reducers";
 import { UIState } from "ui/state";
 import { gql, useQuery } from "@apollo/client";
-import { useGetRecording } from "ui/hooks/sessions";
 
 function useFetchCollaborateorId(email: string) {
   const { data, loading, error } = useQuery(

--- a/src/ui/hooks/sessions.ts
+++ b/src/ui/hooks/sessions.ts
@@ -68,32 +68,6 @@ export function useGetActiveSessions(recordingId: RecordingId, sessionId: string
   return { users, loading };
 }
 
-export function useGetRecording(recordingId: RecordingId) {
-  const { data, error, loading } = useQuery(
-    gql`
-      query GetRecording($recordingId: uuid!) {
-        recordings(where: { id: { _eq: $recordingId } }) {
-          id
-          title
-          recordingTitle
-          is_private
-          date
-          deleted_at
-        }
-      }
-    `,
-    {
-      variables: { recordingId },
-    }
-  );
-
-  if (error) {
-    console.error("Apollo error while getting the recording", error);
-  }
-
-  return { data, loading };
-}
-
 export function useAddSessionUser() {
   const [AddSessionUser, { error }] = useMutation(gql`
     mutation AddSessionUser($id: String!, $user_id: uuid!) {


### PR DESCRIPTION
Fix #2192.

This adds a draft screen that shows up after recording a replay. This prompts the user to add a title and select the workspace for the new replay to be deposited in.

Ideally, all users who make new recordings go through this form to fill in those two inputs. In case they don't, the replay remains in "draft" mode and is not viewable to others until the author finishes the draft screen.

Follow-ups
- Add a `discard replay` option for when you make a mistake.
- Add a toggle for public/private.
- Default workspace logic.
- Messaging (e.g. longer than a minute).
- Progress bar.