### PR TITLE
Visual adjustments to the header in preparation for teams feature

### DIFF
--- a/src/ui/components/Account/Account.css
+++ b/src/ui/components/Account/Account.css
@@ -51,7 +51,6 @@
 }
 
 #header .title-label {
-  color: var(--dark-blue);
   font-size: 20px;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/ui/components/Account/Library.tsx
+++ b/src/ui/components/Account/Library.tsx
@@ -9,7 +9,7 @@ function Header() {
   return (
     <div id="header">
       <div className="header-left">
-        <div className="title-label">Your Replay library</div>
+        <div className="title-label">Your library</div>
       </div>
       <UserOptions mode="account" />
     </div>

--- a/src/ui/components/Account/Library.tsx
+++ b/src/ui/components/Account/Library.tsx
@@ -9,8 +9,7 @@ function Header() {
   return (
     <div id="header">
       <div className="header-left">
-        <div className="logo" />
-        <div className="title-label">Replay</div>
+        <div className="title-label">Your Replay library</div>
       </div>
       <UserOptions mode="account" />
     </div>

--- a/src/ui/components/Header/UserOptions.css
+++ b/src/ui/components/Header/UserOptions.css
@@ -9,8 +9,15 @@
 }
 
 .user-options .material-icons.more {
-  border: 2px solid var(--theme-icon-color);
+  border: 2px solid var(--theme-icon-dimmed-color);
   border-radius: 50%;
+  cursor: pointer;
+  color: var(--theme-icon-dimmed-color);
+}
+
+.user-options .material-icons.more:hover {
+  color: var(--theme-icon-color);
+  border: 2px solid var(--theme-icon-color);
 }
 
 .user-options button.expand-dropdown .avatar.first-player img {


### PR DESCRIPTION
We'll soon have our Teams feature, so I've been designing ahead to prepare for that. These are some small tweaks to prepare for that future.

1. Removed outdated blue color
2. Moved logo (it'll conflict with our IA when we add teams, but we can discuss)
3. Added pointer and color highlight to menu highlight
4. Made the menu more subtle. It's big and bold and stands out from our wispy other icons.