### PR TITLE
Add back privacy link

### DIFF
--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -60,7 +60,17 @@ function SharingModal({ recordingId }: PropsFromRedux) {
             </div>
           </div>
           {!isPrivate && (
-            <div className="privacy-warning">{`Important note: Replay records everything that happens in the browser, including  passwords you’ve typed and everything visible on the screen. Learn more.`}</div>
+            <div className="privacy-warning">
+              <strong>Important note:</strong> Replay records everything that happens in the
+              browser, including passwords you’ve typed and everything visible on the screen.{" "}
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://www.notion.so/replayio/Security-2af70ebdfb1c47e5b9246f25ca377ef2"
+              >
+                Learn more
+              </a>
+            </div>
           )}
         </section>
         {isPrivate ? <PrivateSettings /> : <section className="filler" />}


### PR DESCRIPTION
When I was messing around with tailwind, I noticed the privacy link was dropped so this adds it back.

Was:
![image](https://user-images.githubusercontent.com/788456/113946912-5163af80-97be-11eb-97f1-f67cc536936b.png)

Now:
![image](https://user-images.githubusercontent.com/788456/113946936-57f22700-97be-11eb-979a-1cbf0bca6307.png)