### PR TITLE
Revising the library in preparation for teams and filters

### DIFF
--- a/src/ui/components/Dashboard/DashboardViewerContent.js
+++ b/src/ui/components/Dashboard/DashboardViewerContent.js
@@ -108,7 +108,7 @@ function DashboardViewerContentHeader({
       </th>
       <th>PREVIEW</th>
       <th>TITLE</th>
-      <th>DURATION</th>
+      <th>LENGTH</th>
       <th className="sorter" onClick={() => setAscOrder(!ascOrder)}>
         <span className="label">CREATED</span>
         {ascOrder ? <div className="img arrow-up-2" /> : <div className="img arrow-down-2" />}

--- a/src/ui/components/Dashboard/DashboardViewerContent.js
+++ b/src/ui/components/Dashboard/DashboardViewerContent.js
@@ -108,13 +108,13 @@ function DashboardViewerContentHeader({
       </th>
       <th>PREVIEW</th>
       <th>TITLE</th>
-      <th>LENGTH</th>
-      <th className="sorter" onClick={() => setAscOrder(!ascOrder)}>
+      <th className="length">LENGTH</th>
+      <th className="sorter created" onClick={() => setAscOrder(!ascOrder)}>
         <span className="label">CREATED</span>
         {ascOrder ? <div className="img arrow-up-2" /> : <div className="img arrow-down-2" />}
       </th>
-      <th>PRIVACY</th>
-      <th>OWNER</th>
+      <th className="privacy">PRIVACY</th>
+      <th className="owner">OWNER</th>
       <th></th>
     </tr>
   );

--- a/src/ui/components/Dashboard/DashboardViewerHeader.js
+++ b/src/ui/components/Dashboard/DashboardViewerHeader.js
@@ -98,7 +98,6 @@ function HeaderActions({
       >
         {editing ? "Done" : "Edit"}
       </button>
-      <ViewsToggle viewType={viewType} toggleViewType={toggleViewType} />
     </div>
   );
 }

--- a/src/ui/components/Dashboard/Navigation/DashboardNavigation.tsx
+++ b/src/ui/components/Dashboard/Navigation/DashboardNavigation.tsx
@@ -72,19 +72,7 @@ function DashboardNavigation({
           <span>All</span>
         </div>
       </div>
-      <div className="recording-hosts">
-        <div className="navigation-subheader">BY URL</div>
-        {hosts.map((hostUrl, i) => (
-          <div
-            className={classnames("left-sidebar-menu-item", { active: filter == hostUrl })}
-            key={i}
-            onClick={() => setFilter(hostUrl)}
-          >
-            <span className="material-icons">description</span>
-            <span>{hostUrl}</span>
-          </div>
-        ))}
-      </div>
+
       {features.workspaces ? <Invitations /> : null}
     </nav>
   );

--- a/src/ui/components/Dashboard/Navigation/WorkspaceDropdown.css
+++ b/src/ui/components/Dashboard/Navigation/WorkspaceDropdown.css
@@ -31,6 +31,7 @@
   overflow: hidden;
   margin: 0px 8px;
   text-align: left;
+  font-size: 14px;
 }
 
 .workspace-profile-content > * {
@@ -40,7 +41,7 @@
 }
 
 .workspace-profile-content .subtitle {
-  font-size: 10px;
+  font-size: 12px;
   color: var(--theme-comment);
 }
 
@@ -56,7 +57,7 @@
   border-radius: 50%;
 }
 
-.workspace-dropdown-container .create-new-workspace:hover ,
+.workspace-dropdown-container .create-new-workspace:hover,
 .workspace-dropdown-container .workspace-item:hover {
   background: #e8e8e8;
 }

--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.css
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.css
@@ -63,8 +63,13 @@
   border-bottom: 1px solid var(--theme-splitter-color);
   position: sticky;
   top: 0px;
-  background: white;
   z-index: 1;
+}
+
+.recording-list.list thead.dashboard-viewer-content-header th.length,
+.recording-list.list thead.dashboard-viewer-content-header th.privacy,
+.recording-list.list thead.dashboard-viewer-content-header th.created {
+  padding-right: 16px;
 }
 
 .recording-list.list thead.dashboard-viewer-content-header th:first-child {
@@ -72,7 +77,7 @@
 }
 
 .recording-list.list thead.dashboard-viewer-content-header th:last-child {
-  padding-right: 40px;
+  padding-right: 20px;
 }
 
 .recording-list.list thead.dashboard-viewer-content-header .img {

--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.css
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.css
@@ -5,7 +5,15 @@
 
 .recording-list.list table.dashboard-viewer-content-table {
   display: grid;
-  grid-template-columns: auto 140px 2fr 0.5fr 0.75fr 0.5fr auto auto;
+  grid-template-columns: 30px 100px auto auto auto auto auto auto;
+}
+
+.dashboard-viewer-header-title {
+  visibility: hidden;
+}
+
+.replays {
+  visibility: hidden;
 }
 
 /* Table Body styling */
@@ -18,7 +26,7 @@
 .recording-list.list tbody.dashboard-viewer-content-body td {
   display: flex;
   align-items: center;
-  padding: 20px;
+  padding: 4px;
   border-bottom: 1px solid var(--theme-splitter-color);
   transition: background 200ms;
 }
@@ -28,11 +36,11 @@
 }
 
 .recording-list.list tbody.dashboard-viewer-content-body td:first-child {
-  padding-left: 40px;
+  padding-left: 10px;
 }
 
 .recording-list.list tbody.dashboard-viewer-content-body td:last-child {
-  padding-right: 40px;
+  padding-right: 10px;
 }
 
 /* Table Header styling */
@@ -51,7 +59,7 @@
 .recording-list.list thead.dashboard-viewer-content-header th {
   display: flex;
   align-items: center;
-  padding: 20px;
+  padding: 4px 4px 4px 0;
   border-bottom: 1px solid var(--theme-splitter-color);
   position: sticky;
   top: 0px;
@@ -60,7 +68,7 @@
 }
 
 .recording-list.list thead.dashboard-viewer-content-header th:first-child {
-  padding-left: 40px;
+  padding-left: 10px;
 }
 
 .recording-list.list thead.dashboard-viewer-content-header th:last-child {

--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.css
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.css
@@ -5,7 +5,7 @@
 
 .recording-list.list table.dashboard-viewer-content-table {
   display: grid;
-  grid-template-columns: 30px 100px auto auto auto auto auto auto;
+  grid-template-columns: 30px 112px auto auto auto auto auto auto;
 }
 
 .dashboard-viewer-header-title {

--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.js
@@ -59,7 +59,7 @@ function ItemCreatedDate({ date }) {
   const daysSince = (new Date().getTime() - new Date(date).getTime()) / (1000 * 3600 * 24);
 
   // Show relative time if under 3 days, otherwise, use the template below.
-  if (daysSince > 3) {
+  if (daysSince > 2) {
     content = formatDate(new Date(date), "M/d/yyyy");
   }
 


### PR DESCRIPTION
Previous design:
![image](https://user-images.githubusercontent.com/9154902/114123666-e396bf80-9946-11eb-8ab8-f469dfa29aaf.png)

Revision:
![image](https://user-images.githubusercontent.com/9154902/114123681-e85b7380-9946-11eb-826b-9151024e6fb8.png)

This is a pretty big visual change! Here's what's going on.

* We need to prepare for Teams and a fantastic filter/search experience
* The old design was cutting off Replay description
* The new design works to have better information density ... while removing low priority information
* Under consideration: what if Teams were listed along the left-hand side? It'd be a fantastically clear mental model and also make Teams more prominent. To discuss.

This is not the final design, but living with it for a few days is going to help us make the next step forward on the UI.