### PR TITLE
Add back inline draft panel

### DIFF
--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -8,7 +8,7 @@ const SkeletonLoader = require("./SkeletonLoader").default;
 const NonDevView = require("./Views/NonDevView").default;
 const DevView = require("./Views/DevView").default;
 const { prefs } = require("ui/utils/prefs");
-import DraftScreen from "./DraftScreen";
+import { isTest } from "ui/utils/test";
 
 import { actions } from "../actions";
 import { selectors } from "../reducers";
@@ -42,6 +42,7 @@ function DevTools({
   selectedPanel,
   sessionId,
   viewMode,
+  setViewMode,
 }: DevToolsProps) {
   const [finishedLoading, setFinishedLoading] = useState(false);
   const { claims } = useToken();
@@ -74,6 +75,16 @@ function DevTools({
   useEffect(() => {
     if (title) {
       document.title = `${title} - Replay`;
+    }
+  }, [recording]);
+
+  useEffect(() => {
+    const isAuthor = userId && userId == recording.user_id;
+
+    // Force switch to viewer mode if the recording is being initialized
+    // by the author.
+    if (isAuthor && !recording.is_initialized && !isTest()) {
+      setViewMode("non-dev");
     }
   }, [recording]);
 
@@ -140,6 +151,7 @@ const connector = connect(
   {
     updateTimelineDimensions: actions.updateTimelineDimensions,
     setExpectedError: actions.setExpectedError,
+    setViewMode: actions.setViewMode,
   }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -8,7 +8,7 @@ const SkeletonLoader = require("./SkeletonLoader").default;
 const NonDevView = require("./Views/NonDevView").default;
 const DevView = require("./Views/DevView").default;
 const { prefs } = require("ui/utils/prefs");
-import { isTest } from "ui/utils/test";
+import { isTest } from "ui/utils/environment";
 
 import { actions } from "../actions";
 import { selectors } from "../reducers";

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -16,10 +16,6 @@ import { UIState } from "ui/state";
 import { UploadInfo } from "ui/state/app";
 import { RecordingId } from "@recordreplay/protocol";
 
-function isTest() {
-  return new URL(window.location.href).searchParams.get("test");
-}
-
 type DevToolsProps = PropsFromRedux & {
   recordingId: RecordingId;
 };

--- a/src/ui/components/DraftScreen.css
+++ b/src/ui/components/DraftScreen.css
@@ -1,155 +1,139 @@
-.initialization-screen {
+.initialization-panel {
   background: var(--cool-gray-100);
   height: 100%;
   width: 100%;
-  display: grid;
-  justify-content: center;
-  align-items: center;
+  min-width: 320px;
 }
 
-.initialization-screen main {
+.initialization-panel main {
   display: flex;
   flex-direction: row;
   border-radius: 8px;
   overflow: hidden;
 }
 
-.initialization-screen .filler {
-  background: linear-gradient(to bottom right, #64D4FB, #52A6F9);
-  width: 560px;
-}
-
-.initialization-screen .content {
+.initialization-panel {
   background: var(--theme-body-background);
   margin: auto;
-  padding: 48px 96px;
+  padding: 24px;
   display: flex;
   flex-direction: column;
   font-size: 14px;
 }
 
-.initialization-screen .content > :not(:first-child) {
+.initialization-panel > :not(:first-child) {
   margin-top: 32px;
 }
 
-.initialization-screen h1 {
+.initialization-panel h1 {
   font-size: 30px;
   font-weight: 800;
 }
 
-.initialization-screen h4 {
+.initialization-panel h4 {
   font-size: 14px;
   font-weight: 600;
 }
 
-.initialization-screen .header {
+.initialization-panel .header {
   display: flex;
   flex-direction: column;
   user-select: none;
 }
 
-.initialization-screen .header > :not(:first-child) {
+.initialization-panel .header > :not(:first-child) {
   margin-top: 24px;
 }
 
-.initialization-screen .logo {
-  width: 48px;
-  height: 48px;
-}
-
-.initialization-screen .content form.hidden {
+.initialization-panel form.hidden {
   visibility: hidden;
 }
 
-.initialization-screen .content form > :not(:first-child) {
-  margin-top: 32px;
+.initialization-panel form > :not(:first-child) {
+  margin-top: 16px;
 }
 
-.initialization-screen .replay-title {
+.initialization-panel .replay-title {
   display: flex;
   flex-direction: column;
 }
 
-.initialization-screen .replay-title > :not(:first-child) {
+.initialization-panel .replay-title > :not(:first-child) {
   margin-top: 8px;
 }
 
-.initialization-screen .replay-title label {
+.initialization-panel .replay-title label {
   user-select: none;
 }
 
-.initialization-screen .replay-title input {
-  width: 400px;
+.initialization-panel .replay-title input {
   font-size: 14px;
   padding: 8px;
   border: 1px solid var(--cool-gray-300);
   border-radius: 4px;
 }
 
-.initialization-screen .replay-privacy {
+.initialization-panel .replay-privacy {
   display: flex;
   flex-direction: row;
   align-items: center;
   user-select: none;
 }
 
-.initialization-screen .replay-privacy > :not(:first-child) {
+.initialization-panel .replay-privacy > :not(:first-child) {
   margin-left: 8px;
 }
 
-.initialization-screen .replay-workspace {
+.initialization-panel .replay-workspace {
   display: flex;
   flex-direction: column;
 }
 
-.initialization-screen .replay-workspace > :not(:first-child) {
+.initialization-panel .replay-workspace > :not(:first-child) {
   margin-top: 8px;
 }
 
-.initialization-screen .replay-workspace select {
+.initialization-panel .replay-workspace select {
   border: 1px solid var(--cool-gray-300);
   font-size: 14px;
   border-radius: 4px;
   padding: 8px 8px 8px 4px;
 }
 
-.initialization-screen .content form .actions {
+.initialization-panel form .actions {
   margin-top: 60px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  font-size: 20px;
+  font-size: 14px;
 }
 
-.initialization-screen .actions .submit {
-  padding: 8px 52px;
+.initialization-panel .actions > * {
+  padding: 8px 12px;
+}
+
+.initialization-panel .actions .submit {
   color: var(--theme-body-background);
   background: var(--new-blue-500);
   border: none;
-  font-size: 20px;
+  font-size: 14px;
   border-radius: 4px;
   cursor: pointer;
 }
 
-.initialization-screen .actions .submit:hover {
+.initialization-panel .actions .submit:hover {
   background: var(--new-blue-600);
 }
 
-.initialization-screen .actions .cancel {
+.initialization-panel .actions .cancel {
   text-decoration: underline;
   background: transparent;
   color: var(--theme-comment);
   cursor: pointer;
 }
 
-.initialization-screen .actions .cancel:hover {
+.initialization-panel .actions .cancel:hover {
   background: transparent;
   color: var(--theme-toolbar-color);
-}
-
-@media only screen and (max-width: 1280px) {
-  .initialization-screen .filler {
-    display: none;
-  }
 }

--- a/src/ui/components/DraftScreen.tsx
+++ b/src/ui/components/DraftScreen.tsx
@@ -26,7 +26,9 @@ function WorkspaceDropdownList({
     setSelectedWorkspaceId(selectedId);
   };
 
-  if (displayedWorkspaces.length == 0) {
+  // If there are no other workspaces apart from the personal "---" one,
+  // don't display the workspace dropdown.
+  if (displayedWorkspaces.length == 1) {
     return null;
   }
 
@@ -49,6 +51,7 @@ function WorkspaceDropdownList({
 function DraftScreen({ recordingId }: DraftScreenProps) {
   const {
     recording: { title },
+    loading: recordingLoading,
   } = hooks.useGetRecording(recordingId!);
   const [status, setStatus] = useState<Status>(null);
   const [inputValue, setInputValue] = useState(title);
@@ -96,7 +99,7 @@ function DraftScreen({ recordingId }: DraftScreenProps) {
     setInputValue(e.target.value);
   };
 
-  if (loading) {
+  if (loading || recordingLoading) {
     return null;
   }
 

--- a/src/ui/components/DraftScreen.tsx
+++ b/src/ui/components/DraftScreen.tsx
@@ -15,25 +15,18 @@ function WorkspaceDropdownList({
   setSelectedWorkspaceId,
 }: {
   workspaces: Workspace[];
-  selectedWorkspaceId: string | null;
-  setSelectedWorkspaceId: Dispatch<SetStateAction<string | null>>;
+  selectedWorkspaceId: string;
+  setSelectedWorkspaceId: Dispatch<SetStateAction<string>>;
 }) {
-  const personalWorkspace = workspaces.find(workspace => workspace.is_personal)!;
   const otherWorkspaces = workspaces.filter(workspace => !workspace.is_personal);
-  const displayedWorkspaces = [personalWorkspace, ...otherWorkspaces];
-
-  useEffect(() => {
-    if (personalWorkspace) {
-      setSelectedWorkspaceId(personalWorkspace.id);
-    }
-  }, [workspaces]);
+  const displayedWorkspaces = [{ id: "", key: "", name: "---" }, ...otherWorkspaces];
 
   const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedId = e.target.value;
     setSelectedWorkspaceId(selectedId);
   };
 
-  if (selectedWorkspaceId == null || displayedWorkspaces.length <= 1) {
+  if (displayedWorkspaces.length == 0) {
     return null;
   }
 
@@ -59,36 +52,42 @@ function DraftScreen({ recordingId }: DraftScreenProps) {
   } = hooks.useGetRecording(recordingId!);
   const [status, setStatus] = useState<Status>(null);
   const [inputValue, setInputValue] = useState(title);
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>("");
   const textInputNode = useRef<HTMLInputElement>(null);
-  // const [isPublic, setIsPublic] = useState(true);
+  const [isPublic, setIsPublic] = useState(true);
 
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
+  const { recording } = hooks.useGetRecording(recordingId!);
   const initializeRecording = hooks.useInitializeRecording();
   const deleteRecording = hooks.useDeleteRecording([], () => setStatus("deleted"));
 
   const isSaving = status == "saving";
-  // const isDeleting = status == "deleting";
+  const isDeleting = status == "deleting";
   const isDeleted = status == "deleted";
 
   useEffect(() => {
     if (textInputNode.current) {
       textInputNode.current.focus();
     }
+
+    setIsPublic(!recording.is_private);
   }, []);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+
+    const workspaceId = selectedWorkspaceId == "" ? null : selectedWorkspaceId;
+
     initializeRecording({
-      variables: { recordingId, title: inputValue, workspaceId: selectedWorkspaceId },
+      variables: { recordingId, title: inputValue, workspaceId, isPrivate: !isPublic },
     });
     setStatus("saving");
   };
-  // const onDiscard = (e: React.MouseEvent) => {
-  //   e.preventDefault();
-  //   deleteRecording({ variables: { recordingId, deletedAt: new Date().toISOString() } });
-  //   setStatus("deleting");
-  // };
+  const onDiscard = (e: React.MouseEvent) => {
+    e.preventDefault();
+    deleteRecording({ variables: { recordingId, deletedAt: new Date().toISOString() } });
+    setStatus("deleting");
+  };
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (isSaving) {
       return;
@@ -102,56 +101,45 @@ function DraftScreen({ recordingId }: DraftScreenProps) {
   }
 
   return (
-    <div className="initialization-screen">
-      <main>
-        <section className="content">
-          <div className="header">
-            <img className="logo" src="images/logo.svg" />
-            <h1>{isDeleted ? "Recording deleted" : "Recording complete"}</h1>
-          </div>
-          <form onSubmit={onSubmit} className={isDeleted ? "hidden" : ""}>
-            <div className="replay-title">
-              <label htmlFor="recordingTitle">
-                <h4>Replay Title</h4>
-              </label>
-              <input
-                id="recordingTitle"
-                type="text"
-                value={inputValue}
-                onChange={onChange}
-                ref={textInputNode}
-              />
-            </div>
-            {/* <div className="replay-privacy">
-              <input
-                id="replayPrivacy"
-                type="checkbox"
-                checked={isPublic}
-                onChange={() => setIsPublic(!isPublic)}
-              />
-              <label htmlFor="replayPrivacy">Publicly available</label>
-            </div> */}
-            <WorkspaceDropdownList
-              {...{ workspaces, selectedWorkspaceId, setSelectedWorkspaceId }}
-            />
-            <div className="actions">
-              <input
-                className="submit"
-                type="submit"
-                disabled={isSaving}
-                value={isSaving ? "Saving..." : `Save & Upload`}
-              />
-              {/* {!isSaving ? (
-                <button className="cancel" onClick={onDiscard}>
-                  {isDeleting ? "Discarding..." : "Or discard"}
-                </button>
-              ) : null} */}
-            </div>
-          </form>
-        </section>
-        <section className="filler" />
-      </main>
-    </div>
+    <section className="initialization-panel">
+      <form onSubmit={onSubmit} className={isDeleted ? "hidden" : ""}>
+        <div className="replay-title">
+          <label htmlFor="recordingTitle">
+            <h4>Replay Title</h4>
+          </label>
+          <input
+            id="recordingTitle"
+            type="text"
+            value={inputValue}
+            onChange={onChange}
+            ref={textInputNode}
+          />
+        </div>
+        <div className="replay-privacy">
+          <input
+            id="replayPrivacy"
+            type="checkbox"
+            checked={isPublic}
+            onChange={() => setIsPublic(!isPublic)}
+          />
+          <label htmlFor="replayPrivacy">Publicly available</label>
+        </div>
+        <WorkspaceDropdownList {...{ workspaces, selectedWorkspaceId, setSelectedWorkspaceId }} />
+        <div className="actions">
+          <input
+            className="submit"
+            type="submit"
+            disabled={isSaving}
+            value={isSaving ? "Continuing..." : `Continue`}
+          />
+          {!isSaving ? (
+            <button className="cancel" onClick={onDiscard}>
+              {isDeleting ? "Discarding..." : "Or discard"}
+            </button>
+          ) : null}
+        </div>
+      </form>
+    </section>
   );
 }
 

--- a/src/ui/components/Header/Header.js
+++ b/src/ui/components/Header/Header.js
@@ -56,7 +56,7 @@ function Links({ recordingId, sessionId }) {
 function HeaderTitle({ recordingId, editingTitle, setEditingTitle }) {
   const { recording } = hooks.useGetRecording(recordingId);
   const userId = getUserId();
-  const isAuthor = userId == recording.user_id;
+  const isAuthor = userId && userId == recording.user_id;
   const { data } = useQuery(GET_RECORDING_TITLE, {
     variables: { id: recordingId },
   });

--- a/src/ui/components/Header/Header.js
+++ b/src/ui/components/Header/Header.js
@@ -10,7 +10,7 @@ import UserOptions from "ui/components/Header/UserOptions";
 import { prefs } from "ui/utils/prefs";
 import hooks from "ui/hooks";
 import { getUserId } from "ui/utils/useToken";
-import { isTest } from "ui/utils/test";
+import { isTest } from "ui/utils/environment";
 
 import "./Header.css";
 
@@ -54,7 +54,7 @@ function Links({ recordingId, sessionId }) {
 }
 
 function HeaderTitle({ recordingId, editingTitle, setEditingTitle }) {
-  const { recording } = hooks.useGetRecording(recordingId);
+  const { recording, loading } = hooks.useGetRecording(recordingId);
   const userId = getUserId();
   const isAuthor = userId && userId == recording.user_id;
   const { data } = useQuery(GET_RECORDING_TITLE, {
@@ -63,6 +63,10 @@ function HeaderTitle({ recordingId, editingTitle, setEditingTitle }) {
 
   if (!recordingId) {
     return <div className="title">Recordings</div>;
+  }
+
+  if (loading) {
+    return null;
   }
 
   if (isAuthor && !recording.is_initialized && !isTest()) {

--- a/src/ui/components/Header/Header.js
+++ b/src/ui/components/Header/Header.js
@@ -8,6 +8,9 @@ import Title from "ui/components/shared/Title";
 import ViewToggle from "ui/components/Header/ViewToggle";
 import UserOptions from "ui/components/Header/UserOptions";
 import { prefs } from "ui/utils/prefs";
+import hooks from "ui/hooks";
+import { getUserId } from "ui/utils/useToken";
+import { isTest } from "ui/utils/test";
 
 import "./Header.css";
 
@@ -51,6 +54,9 @@ function Links({ recordingId, sessionId }) {
 }
 
 function HeaderTitle({ recordingId, editingTitle, setEditingTitle }) {
+  const { recording } = hooks.useGetRecording(recordingId);
+  const userId = getUserId();
+  const isAuthor = userId == recording.user_id;
   const { data } = useQuery(GET_RECORDING_TITLE, {
     variables: { id: recordingId },
   });
@@ -59,7 +65,16 @@ function HeaderTitle({ recordingId, editingTitle, setEditingTitle }) {
     return <div className="title">Recordings</div>;
   }
 
-  const { recordingTitle, title, date } = data.recordings?.[0] || {};
+  if (isAuthor && !recording.is_initialized && !isTest()) {
+    return (
+      <div className="title-container">
+        <div className="title">New Recording</div>
+      </div>
+    );
+  }
+
+  const { recordingTitle, title } = data.recordings?.[0] || {};
+
   return (
     <div className="title-container">
       <Title

--- a/src/ui/components/Header/ViewToggle.js
+++ b/src/ui/components/Header/ViewToggle.js
@@ -40,7 +40,7 @@ function Handle({ text, mode, localViewMode, handleToggle, motion }) {
 function ViewToggle({ viewMode, recordingId, setViewMode }) {
   const { recording } = hooks.useGetRecording(recordingId);
   const userId = getUserId();
-  const isAuthor = userId == recording.user_id;
+  const isAuthor = userId && userId == recording.user_id;
   const [framerMotion, setFramerMotion] = useState(null);
   const [localViewMode, setLocalViewMode] = useState(viewMode);
   const toggleTimeoutKey = useRef(null);

--- a/src/ui/components/Header/ViewToggle.js
+++ b/src/ui/components/Header/ViewToggle.js
@@ -4,6 +4,10 @@ import classnames from "classnames";
 import "./ViewToggle.css";
 import { setViewMode } from "../../actions/app";
 import { getViewMode } from "../../reducers/app";
+import { getUserId } from "ui/utils/useToken";
+import hooks from "ui/hooks";
+import { selectors } from "ui/reducers";
+import { isTest } from "ui/utils/test";
 
 function Handle({ text, mode, localViewMode, handleToggle, motion }) {
   const isActive = mode == localViewMode;
@@ -33,7 +37,10 @@ function Handle({ text, mode, localViewMode, handleToggle, motion }) {
   );
 }
 
-function ViewToggle({ viewMode, setViewMode }) {
+function ViewToggle({ viewMode, recordingId, setViewMode }) {
+  const { recording } = hooks.useGetRecording(recordingId);
+  const userId = getUserId();
+  const isAuthor = userId == recording.user_id;
   const [framerMotion, setFramerMotion] = useState(null);
   const [localViewMode, setLocalViewMode] = useState(viewMode);
   const toggleTimeoutKey = useRef(null);
@@ -59,6 +66,10 @@ function ViewToggle({ viewMode, setViewMode }) {
       setViewMode(mode);
     }, 300);
   };
+
+  if (isAuthor && !recording.is_initialized && !isTest()) {
+    return null;
+  }
 
   return (
     <AnimateSharedLayout type="crossfade">
@@ -87,6 +98,7 @@ function ViewToggle({ viewMode, setViewMode }) {
 export default connect(
   state => ({
     viewMode: getViewMode(state),
+    recordingId: selectors.getRecordingId(state),
   }),
   {
     setViewMode,

--- a/src/ui/components/Header/ViewToggle.js
+++ b/src/ui/components/Header/ViewToggle.js
@@ -7,7 +7,7 @@ import { getViewMode } from "../../reducers/app";
 import { getUserId } from "ui/utils/useToken";
 import hooks from "ui/hooks";
 import { selectors } from "ui/reducers";
-import { isTest } from "ui/utils/test";
+import { isTest } from "ui/utils/environment";
 
 function Handle({ text, mode, localViewMode, handleToggle, motion }) {
   const isActive = mode == localViewMode;
@@ -38,7 +38,7 @@ function Handle({ text, mode, localViewMode, handleToggle, motion }) {
 }
 
 function ViewToggle({ viewMode, recordingId, setViewMode }) {
-  const { recording } = hooks.useGetRecording(recordingId);
+  const { recording, loading } = hooks.useGetRecording(recordingId);
   const userId = getUserId();
   const isAuthor = userId && userId == recording.user_id;
   const [framerMotion, setFramerMotion] = useState(null);
@@ -67,7 +67,9 @@ function ViewToggle({ viewMode, recordingId, setViewMode }) {
     }, 300);
   };
 
-  if (isAuthor && !recording.is_initialized && !isTest()) {
+  const shouldHide = isAuthor && !recording.is_initialized && !isTest();
+
+  if (loading | shouldHide) {
     return null;
   }
 

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -55,7 +55,7 @@ function Transcript({
   const { comments } = hooks.useGetComments(recordingId!);
   const { recording } = hooks.useGetRecording(recordingId!);
   const userId = getUserId();
-  const isAuthor = userId == recording.user_id;
+  const isAuthor = userId && userId == recording.user_id;
 
   const entries: Entry[] = createEntries(comments, clickEvents, shouldShowLoneEvents);
 

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -4,6 +4,8 @@ import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
 import sortBy from "lodash/sortBy";
 import hooks from "ui/hooks";
+import { getUserId } from "ui/utils/useToken";
+import { isTest } from "ui/utils/test";
 
 import TranscriptFilter from "ui/components/Transcript/TranscriptFilter";
 import {
@@ -12,6 +14,7 @@ import {
   FloatingTranscriptItem,
 } from "./TranscriptItem";
 import "./Transcript.css";
+import DraftScreen from "../DraftScreen";
 
 import { UIState } from "ui/state";
 import { Event, Comment, FloatingItem } from "ui/state/comments";
@@ -50,6 +53,10 @@ function Transcript({
   hideFloatingItem,
 }: PropsFromRedux) {
   const { comments } = hooks.useGetComments(recordingId!);
+  const { recording } = hooks.useGetRecording(recordingId!);
+  const userId = getUserId();
+  const isAuthor = userId == recording.user_id;
+
   const entries: Entry[] = createEntries(comments, clickEvents, shouldShowLoneEvents);
 
   useEffect(
@@ -70,6 +77,12 @@ function Transcript({
 
   if (floatingItem) {
     displayedEntries.push(floatingItem);
+  }
+
+  // Only show the initialization screen if the replay is not being opened
+  // for testing purposes.
+  if (isAuthor && !recording.is_initialized && !isTest()) {
+    return <DraftScreen />;
   }
 
   return (

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -5,7 +5,7 @@ import { actions } from "ui/actions";
 import sortBy from "lodash/sortBy";
 import hooks from "ui/hooks";
 import { getUserId } from "ui/utils/useToken";
-import { isTest } from "ui/utils/test";
+import { isTest } from "ui/utils/environment";
 
 import TranscriptFilter from "ui/components/Transcript/TranscriptFilter";
 import {
@@ -53,7 +53,7 @@ function Transcript({
   hideFloatingItem,
 }: PropsFromRedux) {
   const { comments } = hooks.useGetComments(recordingId!);
-  const { recording } = hooks.useGetRecording(recordingId!);
+  const { recording, loading } = hooks.useGetRecording(recordingId!);
   const userId = getUserId();
   const isAuthor = userId && userId == recording.user_id;
 
@@ -72,6 +72,10 @@ function Transcript({
     },
     [currentTime, comments]
   );
+
+  if (loading) {
+    return null;
+  }
 
   const displayedEntries: (Entry | FloatingItem)[] = [...entries];
 

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -450,10 +450,20 @@ export function useDeleteRecording(refetchQueries?: string[], onCompleted?: () =
 export function useInitializeRecording() {
   const [initializeRecording] = useMutation(
     gql`
-      mutation InitializeRecording($recordingId: uuid!, $title: String, $workspaceId: uuid) {
+      mutation InitializeRecording(
+        $recordingId: uuid!
+        $title: String
+        $workspaceId: uuid
+        $isPrivate: Boolean
+      ) {
         update_recordings_by_pk(
           pk_columns: { id: $recordingId }
-          _set: { is_initialized: true, recordingTitle: $title, workspace_id: $workspaceId }
+          _set: {
+            is_initialized: true
+            recordingTitle: $title
+            workspace_id: $workspaceId
+            is_private: $isPrivate
+          }
         ) {
           id
           is_initialized

--- a/src/ui/utils/test.ts
+++ b/src/ui/utils/test.ts
@@ -1,0 +1,3 @@
+export function isTest() {
+  return new URL(window.location.href).searchParams.get("test");
+}

--- a/src/ui/utils/test.ts
+++ b/src/ui/utils/test.ts
@@ -1,3 +1,0 @@
-export function isTest() {
-  return new URL(window.location.href).searchParams.get("test");
-}


### PR DESCRIPTION
Fix #2255.

This adds back the draft panel UI. 
- New replays are considered non-initialized
- When the replay author opens a non-initialized Replay, the draft panel in place of the Transcript panel
- When a non-author opens a non-initialized Replay, the Replay appears like usual
- The user can set the replay's title, privacy and/or workspace from the draft panel
- The replay settings are saved when the user presses "Continue"
- The replay is soft-deleted when the user presses "Or discard"
- When the draft screen is displayed, the view toggle is hidden and the recording title simply says "New Recording"

Demo: https://share.descript.com/view/DwVfmp6VmJR

![image](https://user-images.githubusercontent.com/15959269/114439469-03242700-9b97-11eb-9bca-cc0bcf1da14e.png)
![image](https://user-images.githubusercontent.com/15959269/114439994-a07f5b00-9b97-11eb-9232-0b04e615f5f4.png)

