### PR TITLE
Fix loading order so that workspaces and invitations appear immediately

### DIFF
--- a/src/ui/components/Dashboard/Dashboard.tsx
+++ b/src/ui/components/Dashboard/Dashboard.tsx
@@ -32,7 +32,13 @@ function PersonalDashboard() {
   const [filter, setFilter] = useState("");
   const { recordings, loading } = hooks.useGetPersonalRecordings();
 
-  if (loading || recordings == null) {
+  // Preload this for the Invitations component.
+  const { loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
+  const { loading: pendingLoading } = hooks.useGetPendingWorkspaces();
+
+  console.log({ pendingLoading });
+
+  if (loading || pendingLoading || nonPendingLoading || recordings == null) {
     return <Loader />;
   }
 
@@ -50,7 +56,13 @@ function WorkspaceDashboard({ currentWorkspaceId }: PropsFromRedux) {
   const [filter, setFilter] = useState("");
   const { recordings, loading } = hooks.useGetWorkspaceRecordings(currentWorkspaceId!);
 
-  if (loading || recordings == null) {
+  // Preload this for the Invitations component.
+  const { loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
+  const { loading: pendingLoading } = hooks.useGetPendingWorkspaces();
+
+  console.log({ pendingLoading });
+
+  if (loading || pendingLoading || nonPendingLoading || recordings == null) {
     return <Loader />;
   }
 

--- a/src/ui/components/Dashboard/Dashboard.tsx
+++ b/src/ui/components/Dashboard/Dashboard.tsx
@@ -33,10 +33,11 @@ function PersonalDashboard() {
   const { recordings, loading } = hooks.useGetPersonalRecordings();
 
   // Preload this for the Invitations component.
-  const { loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
-  const { loading: pendingLoading } = hooks.useGetPendingWorkspaces();
-
-  console.log({ pendingLoading });
+  const {
+    workspaces: nonPendingWorkspaces,
+    loading: nonPendingLoading,
+  } = hooks.useGetNonPendingWorkspaces();
+  const { pendingWorkspaces, loading: pendingLoading } = hooks.useGetPendingWorkspaces();
 
   if (loading || pendingLoading || nonPendingLoading || recordings == null) {
     return <Loader />;
@@ -46,7 +47,13 @@ function PersonalDashboard() {
 
   return (
     <main className="dashboard">
-      <DashboardNavigation recordings={recordings} setFilter={setFilter} filter={filter} />
+      <DashboardNavigation
+        recordings={recordings}
+        setFilter={setFilter}
+        filter={filter}
+        nonPendingWorkspaces={nonPendingWorkspaces}
+        pendingWorkspaces={pendingWorkspaces}
+      />
       <DashboardViewer recordings={filteredRecordings} filter={filter} />
     </main>
   );
@@ -57,10 +64,11 @@ function WorkspaceDashboard({ currentWorkspaceId }: PropsFromRedux) {
   const { recordings, loading } = hooks.useGetWorkspaceRecordings(currentWorkspaceId!);
 
   // Preload this for the Invitations component.
-  const { loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
-  const { loading: pendingLoading } = hooks.useGetPendingWorkspaces();
-
-  console.log({ pendingLoading });
+  const {
+    workspaces: nonPendingWorkspaces,
+    loading: nonPendingLoading,
+  } = hooks.useGetNonPendingWorkspaces();
+  const { pendingWorkspaces, loading: pendingLoading } = hooks.useGetPendingWorkspaces();
 
   if (loading || pendingLoading || nonPendingLoading || recordings == null) {
     return <Loader />;
@@ -70,7 +78,13 @@ function WorkspaceDashboard({ currentWorkspaceId }: PropsFromRedux) {
 
   return (
     <main className="dashboard">
-      <DashboardNavigation recordings={recordings} setFilter={setFilter} filter={filter} />
+      <DashboardNavigation
+        recordings={recordings}
+        setFilter={setFilter}
+        filter={filter}
+        nonPendingWorkspaces={nonPendingWorkspaces}
+        pendingWorkspaces={pendingWorkspaces}
+      />
       <DashboardViewer recordings={filteredRecordings} filter={filter} />
     </main>
   );

--- a/src/ui/components/Dashboard/Navigation/DashboardNavigation.tsx
+++ b/src/ui/components/Dashboard/Navigation/DashboardNavigation.tsx
@@ -15,20 +15,6 @@ interface Recording {
   url: string;
 }
 
-function getUniqueHosts(recordings: Recording[]) {
-  const uniqueUrls = recordings.reduce((acc, elem) => {
-    const hostUrl = new URL(elem.url).host;
-
-    if (acc.includes(hostUrl)) {
-      return acc;
-    } else {
-      return [...acc, hostUrl];
-    }
-  }, [] as string[]);
-
-  return uniqueUrls.filter(url => url != "").sort();
-}
-
 type DashboardNavigationProps = PropsFromRedux & {
   recordings: Recording[];
   filter: string;
@@ -39,11 +25,8 @@ type DashboardNavigationProps = PropsFromRedux & {
 
 function DashboardNavigation({
   currentWorkspaceId,
-  recordings,
-  filter,
   pendingWorkspaces,
   nonPendingWorkspaces,
-  setFilter,
   setModal,
 }: DashboardNavigationProps) {
   const {
@@ -68,7 +51,7 @@ function DashboardNavigation({
           <span>{`Settings & Members`}</span>
         </div>
       ) : null}
-      {pendingWorkspaces?.length && <Invitations {...{ pendingWorkspaces }} />}
+      {pendingWorkspaces?.length ? <Invitations {...{ pendingWorkspaces }} /> : null}
     </nav>
   );
 }

--- a/src/ui/components/Dashboard/Navigation/DashboardNavigation.tsx
+++ b/src/ui/components/Dashboard/Navigation/DashboardNavigation.tsx
@@ -32,6 +32,8 @@ function getUniqueHosts(recordings: Recording[]) {
 type DashboardNavigationProps = PropsFromRedux & {
   recordings: Recording[];
   filter: string;
+  nonPendingWorkspaces?: Workspace[];
+  pendingWorkspaces?: Workspace[];
   setFilter: Dispatch<SetStateAction<string>>;
 };
 
@@ -39,10 +41,11 @@ function DashboardNavigation({
   currentWorkspaceId,
   recordings,
   filter,
+  pendingWorkspaces,
+  nonPendingWorkspaces,
   setFilter,
   setModal,
 }: DashboardNavigationProps) {
-  const { workspaces } = hooks.useGetNonPendingWorkspaces();
   const {
     userSettings: { enable_teams },
   } = hooks.useGetUserSettings();
@@ -58,14 +61,14 @@ function DashboardNavigation({
 
   return (
     <nav className="left-sidebar">
-      <WorkspaceDropdown />
-      {workspaces && !isPersonal ? (
+      {nonPendingWorkspaces && <WorkspaceDropdown nonPendingWorkspaces={nonPendingWorkspaces} />}
+      {nonPendingWorkspaces && !isPersonal ? (
         <div className={classnames("left-sidebar-menu-item")} onClick={onSettingsClick}>
           <span className="material-icons">settings</span>
           <span>{`Settings & Members`}</span>
         </div>
       ) : null}
-      <Invitations />
+      {pendingWorkspaces?.length && <Invitations {...{ pendingWorkspaces }} />}
     </nav>
   );
 }

--- a/src/ui/components/Dashboard/Navigation/DashboardNavigation.tsx
+++ b/src/ui/components/Dashboard/Navigation/DashboardNavigation.tsx
@@ -8,8 +8,8 @@ import hooks from "ui/hooks";
 import classnames from "classnames";
 import WorkspaceDropdown from "./WorkspaceDropdown";
 import Invitations from "./Invitations";
-const { features } = require("ui/utils/prefs");
 import "./DashboardNavigation.css";
+import { Workspace } from "ui/types";
 
 interface Recording {
   url: string;
@@ -42,27 +42,30 @@ function DashboardNavigation({
   setFilter,
   setModal,
 }: DashboardNavigationProps) {
-  const { workspaces, loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
+  const { workspaces } = hooks.useGetNonPendingWorkspaces();
   const {
-    userSettings: { enable_teams, loading },
+    userSettings: { enable_teams },
   } = hooks.useGetUserSettings();
-  const hosts = getUniqueHosts(recordings);
 
   const isPersonal = currentWorkspaceId == null;
   const onSettingsClick = () => {
     setModal("workspace-settings");
   };
 
+  if (!enable_teams) {
+    return <nav className="left-sidebar"></nav>;
+  }
+
   return (
     <nav className="left-sidebar">
-      {enable_teams ? <WorkspaceDropdown /> : null}
-      {enable_teams && workspaces && !isPersonal ? (
+      <WorkspaceDropdown />
+      {workspaces && !isPersonal ? (
         <div className={classnames("left-sidebar-menu-item")} onClick={onSettingsClick}>
           <span className="material-icons">settings</span>
           <span>{`Settings & Members`}</span>
         </div>
       ) : null}
-      {enable_teams ? <Invitations /> : null}
+      <Invitations />
     </nav>
   );
 }

--- a/src/ui/components/Dashboard/Navigation/Invitations.tsx
+++ b/src/ui/components/Dashboard/Navigation/Invitations.tsx
@@ -45,13 +45,11 @@ function Invitation({ workspace }: { workspace: Workspace }) {
   );
 }
 
-function Invitations({}: PropsFromRedux) {
-  const { pendingWorkspaces, loading } = hooks.useGetPendingWorkspaces();
+type InvitationsProps = PropsFromRedux & {
+  pendingWorkspaces: Workspace[];
+};
 
-  if (loading || pendingWorkspaces?.length == 0) {
-    return null;
-  }
-
+function Invitations({ pendingWorkspaces }: InvitationsProps) {
   return (
     <div className="workspace-invites">
       <div className="navigation-subheader">{`INVITATIONS (${pendingWorkspaces.length})`}</div>

--- a/src/ui/components/Dashboard/Navigation/WorkspaceDropdown.tsx
+++ b/src/ui/components/Dashboard/Navigation/WorkspaceDropdown.tsx
@@ -7,17 +7,18 @@ import WorkspaceDropdownButton from "./WorkspaceDropdownButton";
 import hooks from "ui/hooks";
 import useToken from "ui/utils/useToken";
 import useAuth0 from "ui/utils/useAuth0";
+import { Workspace } from "ui/types";
 
-export default function WorkspaceDropdown() {
+export default function WorkspaceDropdown({
+  nonPendingWorkspaces,
+}: {
+  nonPendingWorkspaces: Workspace[];
+}) {
   const [expanded, setExpanded] = useState(false);
+  const workspaces = nonPendingWorkspaces;
   const { user } = useAuth0();
-  const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
   const { claims } = useToken();
   const userId = claims?.hasura.userId;
-
-  if (loading) {
-    return null;
-  }
 
   const sharedWorkspaces = workspaces.filter(workspace => !workspace.is_personal);
 


### PR DESCRIPTION
Fix #2265.

Before: https://replay.io/view?id=ba9c60ab-cdce-4716-9a91-dcdb23875555&point=33749929583581750599676199591478407&time=15123.4404551201&hasFrames=true
After: https://share.descript.com/view/PLepn1E8MSM