### PR TITLE
Adding a download link to the dropdown

### DIFF
--- a/src/ui/components/Header/UserOptions.js
+++ b/src/ui/components/Header/UserOptions.js
@@ -31,6 +31,14 @@ function UserOptions({ recordingId, setModal }) {
     }
     window.location = dashboardUrl;
   };
+  const onLaunchClick = () => {
+    const launchUrl = `${window.location.origin}/welcome`;
+    if (event.metaKey) {
+      return window.open(launchUrl);
+    }
+    // right now we just send you to the download screen, but eventually this will launch Replay
+    window.location = launchUrl;
+  };
   const onShareClick = () => {
     setExpanded(false);
     setModal("sharing", { recordingId });
@@ -60,6 +68,10 @@ function UserOptions({ recordingId, setModal }) {
             <span>Share</span>
           </button>
         )}
+        <button className="row" onClick={onLaunchClick}>
+          <span className="material-icons">download</span>
+          <span>Download Replay</span>
+        </button>
         <button className="row" onClick={onSettingsClick}>
           <span className="material-icons">settings</span>
           <span>Settings</span>


### PR DESCRIPTION
Addresses https://github.com/RecordReplay/devtools/issues/2213 (sort of ... we're doing this as a short term fix, and the broader fix will be later)

Follow-ups:

1. The link should say "Launch Replay" and launch the app if it's installed
2. We might show things differently in library versus devtools
3. If you're using the Replay browser already, the link should go away

