### PR TITLE
Fix commenting for node targets

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -21,6 +21,7 @@ import {
   WorkspaceId,
   SettingsTabTitle,
 } from "ui/state/app";
+import { RecordingTarget } from "protocol/thread/thread";
 
 export type SetupAppAction = Action<"setup_app"> & { recordingId: RecordingId };
 export type LoadingAction = Action<"loading"> & { loading: number };
@@ -59,6 +60,9 @@ export type SetWorkspaceId = Action<"set_workspace_id"> & { workspaceId: Workspa
 export type SetDefaultSettingsTab = Action<"set_default_settings_tab"> & {
   tabTitle: SettingsTabTitle;
 };
+export type SetRecordingTargetAction = Action<"set_recording_target"> & {
+  recordingTarget: RecordingTarget;
+};
 
 export type AppActions =
   | SetupAppAction
@@ -80,7 +84,8 @@ export type AppActions =
   | SetIsNodePickerActive
   | SetCanvas
   | SetWorkspaceId
-  | SetDefaultSettingsTab;
+  | SetDefaultSettingsTab
+  | SetRecordingTargetAction;
 
 const NARROW_MODE_WIDTH = 800;
 
@@ -227,4 +232,8 @@ export function setWorkspaceId(workspaceId: WorkspaceId | null): SetWorkspaceId 
 
 export function setDefaultSettingsTab(tabTitle: SettingsTabTitle): SetDefaultSettingsTab {
   return { type: "set_default_settings_tab", tabTitle };
+}
+
+export function setRecordingTarget(recordingTarget: RecordingTarget): SetRecordingTargetAction {
+  return { type: "set_recording_target", recordingTarget };
 }

--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -87,6 +87,7 @@ export function replyToItem(item: Event | Comment | FloatingItem): UIThunkAction
     const { point, time } = item;
     const state = getState();
     const canvas = selectors.getCanvas(state);
+    const recordingTarget = selectors.getRecordingTarget(state);
 
     if ("has_frames" in item) {
       dispatch(actions.seek(point, time, item.has_frames));
@@ -125,6 +126,14 @@ export function replyToItem(item: Event | Comment | FloatingItem): UIThunkAction
 
       dispatch(setPendingComment(pendingComment));
     } else {
+      const position =
+        recordingTarget == "node"
+          ? null
+          : {
+              x: canvas!.width * 0.5,
+              y: canvas!.height * 0.5,
+            };
+
       // Add a new comment to an event or a temporary pause item.
       const pendingComment: PendingComment = {
         type: "new_comment",
@@ -134,10 +143,7 @@ export function replyToItem(item: Event | Comment | FloatingItem): UIThunkAction
           point,
           has_frames: "has_frames" in item && item.has_frames,
           source_location: (await ThreadFront.getCurrentPauseSourceLocation()) || null,
-          position: {
-            x: canvas!.width * 0.5,
-            y: canvas!.height * 0.5,
-          },
+          position,
         },
       };
 

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -47,6 +47,8 @@ export async function createSession(store: UIStore, recordingId: string) {
 
     window.sessionId = sessionId;
     ThreadFront.setSessionId(sessionId);
+    const recordingTarget = await ThreadFront.recordingTargetWaiter.promise;
+    store.dispatch(actions.setRecordingTarget(recordingTarget));
     store.dispatch(actions.setUploading(null));
     prefs.recordingId = recordingId;
   } catch (e) {

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
@@ -46,10 +46,7 @@ function NewCommentEditor({
       source_location,
       parent_id,
       recording_id: recordingId,
-      position: {
-        x: canvas!.width * 0.5,
-        y: canvas!.height * 0.5,
-      },
+      position: null,
     };
 
     addComment({ variables: { object: reply } });
@@ -72,8 +69,8 @@ function NewCommentEditor({
       recording_id: recordingId,
       parent_id: null,
       position: {
-        x: comment.position.x,
-        y: comment.position.y,
+        x: comment.position?.x,
+        y: comment.position?.y,
       },
     };
 

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -5,6 +5,8 @@ import "./CommentTool.css";
 
 import { actions } from "ui/actions";
 import { PendingEditComment, PendingNewComment } from "ui/state/comments";
+import { UIState } from "ui/state";
+import { selectors } from "ui/reducers";
 
 const mouseEventCanvasPosition = (e: MouseEvent) => {
   const canvas = document.getElementById("graphics");
@@ -30,7 +32,16 @@ interface CommentToolProps extends PropsFromRedux {
       };
 }
 
-function CommentTool({ pendingComment, setPendingComment, setCommentPointer }: CommentToolProps) {
+function CommentTool({
+  pendingComment,
+  setPendingComment,
+  setCommentPointer,
+  recordingTarget,
+}: CommentToolProps) {
+  if (recordingTarget == "node") {
+    return null;
+  }
+
   const addListeners = () => {
     setCommentPointer(true);
     const videoNode = document.getElementById("video");
@@ -68,10 +79,15 @@ function CommentTool({ pendingComment, setPendingComment, setCommentPointer }: C
   return null;
 }
 
-const connector = connect(null, {
-  setPendingComment: actions.setPendingComment,
-  setCommentPointer: actions.setCommentPointer,
-});
+const connector = connect(
+  (state: UIState) => ({
+    recordingTarget: selectors.getRecordingTarget(state),
+  }),
+  {
+    setPendingComment: actions.setPendingComment,
+    setCommentPointer: actions.setCommentPointer,
+  }
+);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 export default connector(CommentTool);

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -31,6 +31,7 @@ function initialAppState(): AppState {
     canvas: null,
     workspaceId: null,
     defaultSettingsTab: "Experimental",
+    recordingTarget: null,
   };
 }
 
@@ -153,6 +154,10 @@ export default function update(
       return { ...state, defaultSettingsTab: action.tabTitle };
     }
 
+    case "set_recording_target": {
+      return { ...state, recordingTarget: action.recordingTarget };
+    }
+
     default: {
       return state;
     }
@@ -196,3 +201,4 @@ export const getIsNodePickerActive = (state: UIState) => state.app.isNodePickerA
 export const getCanvas = (state: UIState) => state.app.canvas;
 export const getWorkspaceId = (state: UIState) => state.app.workspaceId;
 export const getDefaultSettingsTab = (state: UIState) => state.app.defaultSettingsTab;
+export const getRecordingTarget = (state: UIState) => state.app.recordingTarget;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -6,6 +6,7 @@ import {
   Location,
   MouseEvent,
 } from "@recordreplay/protocol";
+import { RecordingTarget } from "protocol/thread/thread";
 
 export type PanelName = "console" | "debugger" | "inspector";
 export type PrimaryPanelName = "explorer" | "debug" | "comments";
@@ -49,6 +50,7 @@ export interface AppState {
   canvas: Canvas | null;
   workspaceId: WorkspaceId | null;
   defaultSettingsTab: SettingsTabTitle;
+  recordingTarget: RecordingTarget | null;
 }
 
 export interface AnalysisPoints {

--- a/src/ui/state/comments.ts
+++ b/src/ui/state/comments.ts
@@ -95,7 +95,7 @@ export type PendingComment =
 
 export interface PendingNewComment extends PendingBlankComment {
   content: "";
-  position: CommentPosition;
+  position: CommentPosition | null;
 }
 
 export interface PendingNewReply extends PendingBlankComment {


### PR DESCRIPTION
This allows comment positions to be `null` in cases like debugging a node recording target.

Node replay: http://localhost:8080/view?id=c6937662-1614-48a0-b173-94a5b200a204&point=0&time=20&hasFrames=false
Demo: https://share.descript.com/view/wMIB8C4l9tm