### PR TITLE
Be more careful about recording being possibly undefined

### DIFF
--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -79,7 +79,7 @@ function DevTools({
   }, [recording]);
 
   useEffect(() => {
-    const isAuthor = userId && userId == recording.user_id;
+    const isAuthor = userId && userId == recording?.user_id;
 
     // Force switch to viewer mode if the recording is being initialized
     // by the author.

--- a/src/ui/components/DraftScreen.tsx
+++ b/src/ui/components/DraftScreen.tsx
@@ -49,18 +49,14 @@ function WorkspaceDropdownList({
 }
 
 function DraftScreen({ recordingId }: DraftScreenProps) {
-  const {
-    recording: { title },
-    loading: recordingLoading,
-  } = hooks.useGetRecording(recordingId!);
+  const { recording, loading: recordingLoading } = hooks.useGetRecording(recordingId!);
   const [status, setStatus] = useState<Status>(null);
-  const [inputValue, setInputValue] = useState(title);
+  const [inputValue, setInputValue] = useState(recording?.title);
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>("");
   const textInputNode = useRef<HTMLInputElement>(null);
   const [isPublic, setIsPublic] = useState(true);
 
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
-  const { recording } = hooks.useGetRecording(recordingId!);
   const initializeRecording = hooks.useInitializeRecording();
   const deleteRecording = hooks.useDeleteRecording([], () => setStatus("deleted"));
 
@@ -73,7 +69,7 @@ function DraftScreen({ recordingId }: DraftScreenProps) {
       textInputNode.current.focus();
     }
 
-    setIsPublic(!recording.is_private);
+    setIsPublic(!recording?.is_private);
   }, []);
 
   const onSubmit = (e: React.FormEvent) => {

--- a/src/ui/components/Header/ViewToggle.js
+++ b/src/ui/components/Header/ViewToggle.js
@@ -40,7 +40,7 @@ function Handle({ text, mode, localViewMode, handleToggle, motion }) {
 function ViewToggle({ viewMode, recordingId, setViewMode }) {
   const { recording, loading } = hooks.useGetRecording(recordingId);
   const userId = getUserId();
-  const isAuthor = userId && userId == recording.user_id;
+  const isAuthor = userId && userId == recording?.user_id;
   const [framerMotion, setFramerMotion] = useState(null);
   const [localViewMode, setLocalViewMode] = useState(viewMode);
   const toggleTimeoutKey = useRef(null);

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -55,7 +55,7 @@ function Transcript({
   const { comments } = hooks.useGetComments(recordingId!);
   const { recording, loading } = hooks.useGetRecording(recordingId!);
   const userId = getUserId();
-  const isAuthor = userId && userId == recording.user_id;
+  const isAuthor = userId && userId == recording?.user_id;
 
   const entries: Entry[] = createEntries(comments, clickEvents, shouldShowLoneEvents);
 


### PR DESCRIPTION
I found a few more places where the devtools could throw if `recording` is `undefined` (because it's still loading).