### PR TITLE
Fix opening share modal from the library

### DIFF
--- a/src/ui/components/Dashboard/RecordingItem/RecordingItemDropdown.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingItemDropdown.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { actions } from "ui/actions";
 import { connect } from "react-redux";
-import { gql, useMutation } from "@apollo/client";
 import hooks from "ui/hooks";
 
 function Privacy({ isPrivate, toggleIsPrivate }) {

--- a/src/ui/components/shared/SharingModal/PrivateSettings.tsx
+++ b/src/ui/components/shared/SharingModal/PrivateSettings.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import { connect, ConnectedProps } from "react-redux";
 import hooks from "ui/hooks";
-import { selectors } from "ui/reducers";
-import { UIState } from "ui/state";
 import EmailForm from "./EmailForm";
 import CollaboratorsList from "./CollaboratorsList";
 import "./PrivateSettings.css";
+import { RecordingId } from "@recordreplay/protocol";
 
-type PrivateSettingsProps = PropsFromRedux & {};
+type PrivateSettingsProps = {
+  recordingId: RecordingId;
+};
 
-function PrivateSettings({ recordingId }: PrivateSettingsProps) {
+export default function PrivateSettings({ recordingId }: PrivateSettingsProps) {
   const { collaborators, recording, loading } = hooks.useGetOwnersAndCollaborators(recordingId!);
 
   if (loading || !collaborators || !recording) {
@@ -24,7 +24,3 @@ function PrivateSettings({ recordingId }: PrivateSettingsProps) {
     </section>
   );
 }
-
-const connector = connect((state: UIState) => ({ recordingId: selectors.getRecordingId(state) }));
-type PropsFromRedux = ConnectedProps<typeof connector>;
-export default connector(PrivateSettings);

--- a/src/ui/components/shared/SharingModal/ReplayLink.tsx
+++ b/src/ui/components/shared/SharingModal/ReplayLink.tsx
@@ -1,10 +1,8 @@
-import React, { useState } from "react";
-import { connect, ConnectedProps } from "react-redux";
-import { UIState } from "ui/state";
-import { selectors } from "ui/reducers";
+import React from "react";
 import "./ReplayLink.css";
+import { RecordingId } from "@recordreplay/protocol";
 
-function ReplayLink({ recordingId }: PropsFromRedux) {
+export default function ReplayLink({ recordingId }: { recordingId: RecordingId }) {
   return (
     <div className="copy-link">
       <input
@@ -16,10 +14,3 @@ function ReplayLink({ recordingId }: PropsFromRedux) {
     </div>
   );
 }
-
-const connector = connect((state: UIState) => ({
-  recordingId: selectors.getRecordingId(state),
-}));
-
-type PropsFromRedux = ConnectedProps<typeof connector>;
-export default connector(ReplayLink);

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -10,7 +10,8 @@ import { UIState } from "ui/state";
 import { RecordingId } from "@recordreplay/protocol";
 import PrivateSettings from "./PrivateSettings";
 
-function SharingModal({ recordingId }: PropsFromRedux) {
+function SharingModal({ modalOptions }: PropsFromRedux) {
+  const { recordingId } = modalOptions!;
   const { isPrivate, loading } = hooks.useGetIsPrivate(recordingId!);
   const updateIsPrivate = hooks.useUpdateIsPrivate(recordingId!, isPrivate);
 
@@ -30,7 +31,7 @@ function SharingModal({ recordingId }: PropsFromRedux) {
       <Modal>
         <section className="sharing-modal-content">
           <h1>Share</h1>
-          <ReplayLink />
+          <ReplayLink recordingId={recordingId} />
           <div className="privacy-choices">
             <div className={`privacy-choice ${!isPrivate ? "selected" : ""}`}>
               <input
@@ -74,12 +75,14 @@ function SharingModal({ recordingId }: PropsFromRedux) {
             </div>
           )}
         </section>
-        {isPrivate ? <PrivateSettings /> : <section className="filler" />}
+        {isPrivate ? <PrivateSettings recordingId={recordingId} /> : <section className="filler" />}
       </Modal>
     </div>
   );
 }
 
-const connector = connect((state: UIState) => ({ recordingId: selectors.getRecordingId(state) }));
+const connector = connect((state: UIState) => ({
+  modalOptions: selectors.getModalOptions(state),
+}));
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(SharingModal);


### PR DESCRIPTION
Fixes #2348.

This restores the old way we would pass a recordingId to the share modal in a way that works for both the library and a replay. Instead of referring to `state.app.recordingId`, the modal refers to a special `recordingId` in `state.app.modalOptions`.

Demo: https://share.descript.com/view/5KgEcgwgb8u