### PR TITLE
Allow users to add a new comment by clicking on the video

### DIFF
--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -152,6 +152,28 @@ export function replyToItem(item: Event | Comment | FloatingItem): UIThunkAction
   };
 }
 
+export function createComment(
+  time: number,
+  point: string,
+  position: { x: number; y: number }
+): UIThunkAction {
+  return async ({ dispatch, getState }) => {
+    const pendingComment: PendingComment = {
+      type: "new_comment",
+      comment: {
+        content: "",
+        time,
+        point,
+        has_frames: ThreadFront.currentPointHasFrames,
+        source_location: (await ThreadFront.getCurrentPauseSourceLocation()) || null,
+        position,
+      },
+    };
+
+    dispatch(setPendingComment(pendingComment));
+  };
+}
+
 export function editItem(item: Comment | Reply): UIThunkAction {
   return async ({ dispatch }) => {
     const { point, time, has_frames } = item;

--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -7,7 +7,6 @@ import { ThreadFront } from "protocol/thread";
 import isEqual from "lodash/isEqual";
 
 type SetPendingComment = Action<"set_pending_comment"> & { comment: PendingComment | null };
-type SetCommentPointer = Action<"set_comment_pointer"> & { value: boolean };
 type SetHoveredComment = Action<"set_hovered_comment"> & { comment: any };
 type SetShouldShowLoneEvents = Action<"set_should_show_lone_events"> & { value: boolean };
 type SetFloatingItem = Action<"set_floating_item"> & {
@@ -16,17 +15,12 @@ type SetFloatingItem = Action<"set_floating_item"> & {
 
 export type CommentsAction =
   | SetPendingComment
-  | SetCommentPointer
   | SetHoveredComment
   | SetShouldShowLoneEvents
   | SetFloatingItem;
 
 export function setPendingComment(comment: PendingComment): SetPendingComment {
   return { type: "set_pending_comment", comment };
-}
-
-export function setCommentPointer(value: boolean): SetCommentPointer {
-  return { type: "set_comment_pointer", value };
 }
 
 export function setHoveredComment(comment: any): SetHoveredComment {

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -67,11 +67,6 @@ function CommentEditor({
           Submit
         </button>
       </div>
-      {pendingComment &&
-        pendingComment.comment.time == comment.time &&
-        (pendingComment.type == "new_comment" || pendingComment.type == "edit_comment") && (
-          <CommentTool pendingComment={pendingComment} />
-        )}
     </div>
   );
 }

--- a/src/ui/components/Comments/VideoComments/CommentsOverlay.js
+++ b/src/ui/components/Comments/VideoComments/CommentsOverlay.js
@@ -34,6 +34,7 @@ function CommentsOverlay({
   hoveredComment,
   currentTime,
   setHoveredComment,
+  children,
 }) {
   const { comments: hasuraComments } = hooks.useGetComments(recordingId);
 
@@ -56,6 +57,7 @@ function CommentsOverlay({
     >
       <div className="canvas-comments">
         <VideoComment comment={comment} scale={scale} setHoveredComment={setHoveredComment} />
+        {children}
       </div>
     </div>
   );

--- a/src/ui/components/Dashboard/Navigation/WorkspaceDropdownButton.tsx
+++ b/src/ui/components/Dashboard/Navigation/WorkspaceDropdownButton.tsx
@@ -4,7 +4,7 @@ import useAuth0 from "ui/utils/useAuth0";
 import { selectors } from "ui/reducers";
 import { UIState } from "ui/state";
 import { Workspace } from "ui/types";
-import { ChevronDownIcon, LibraryIcon } from "@heroicons/react/solid";
+import { ChevronDownIcon } from "@heroicons/react/solid";
 import { Menu } from "@headlessui/react";
 
 type WorkspaceDropdownButtonProps = PropsFromRedux & {

--- a/src/ui/components/shared/CommentTool.css
+++ b/src/ui/components/shared/CommentTool.css
@@ -7,7 +7,3 @@ button.comment-tool:focus {
   background: var(--primary-accent);
   color: var(--theme-body-background);
 }
-
-#video.location-marker {
-  cursor: url("https://svgshare.com/i/TfA.svg"), auto;
-}

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -36,7 +36,6 @@ function CommentTool({
   comments,
   canvas,
   setPendingComment,
-  setCommentPointer,
   createComment,
 }: CommentToolProps) {
   const [showHelper, setShowHelper] = useState(false);
@@ -46,7 +45,6 @@ function CommentTool({
   );
 
   const addListeners = () => {
-    setCommentPointer(true);
     const videoNode = document.getElementById("graphics");
 
     if (videoNode) {
@@ -58,7 +56,6 @@ function CommentTool({
     }
   };
   const removeListeners = () => {
-    setCommentPointer(false);
     const videoNode = document.getElementById("graphics");
 
     if (videoNode) {
@@ -140,7 +137,6 @@ const connector = connect(
   }),
   {
     setPendingComment: actions.setPendingComment,
-    setCommentPointer: actions.setCommentPointer,
     createComment: actions.createComment,
   }
 );

--- a/src/ui/reducers/comments.ts
+++ b/src/ui/reducers/comments.ts
@@ -4,7 +4,6 @@ import { UIState } from "ui/state";
 
 function initialCommentsState(): CommentsState {
   return {
-    commentPointer: false,
     hoveredComment: null,
     pendingComment: null,
     shouldShowLoneEvents: true,
@@ -21,13 +20,6 @@ export default function update(
       return {
         ...state,
         pendingComment: action.comment,
-      };
-    }
-
-    case "set_comment_pointer": {
-      return {
-        ...state,
-        commentPointer: action.value,
       };
     }
 
@@ -59,7 +51,6 @@ export default function update(
 }
 
 export const getPendingComment = (state: UIState) => state.comments.pendingComment;
-export const getCommentPointer = (state: UIState) => state.comments.commentPointer;
 export const getHoveredComment = (state: UIState) => state.comments.hoveredComment;
 export const getShouldShowLoneEvents = (state: UIState) => state.comments.shouldShowLoneEvents;
 export const getFloatingItem = (state: UIState) => state.comments.floatingItem;

--- a/src/ui/state/comments.ts
+++ b/src/ui/state/comments.ts
@@ -2,7 +2,6 @@ import { RecordingId, MouseEvent } from "@recordreplay/protocol";
 
 export interface CommentsState {
   pendingComment: PendingComment | null;
-  commentPointer: boolean;
   hoveredComment: any;
   shouldShowLoneEvents: boolean;
   floatingItem: FloatingItem | null;


### PR DESCRIPTION
Fix #2254.

This adds a new mechanic for adding new comments by clicking on the video directly.
- The toggle playback behavior when clicking the video is now gone.
- In its place, the user sees an "Add New Comment" prompt beside the pointer while it hovers on the video.
- This prompt appears when there is no comment for the current pause point.
- For pause points where an existing comment already exist, hovering on the video shows no prompt and clicking on the video does nothing.
- While editing a comment, clicking on the video behaves as before—it changes the comment marker position, if it's a comment and not a reply.

Demo: https://share.descript.com/view/epqGokUmrzd
Screenshot:
![image](https://user-images.githubusercontent.com/15959269/115303826-1ce2e280-a132-11eb-9511-6082e10bffeb.png)