### PR TITLE
Add confirm dialogs to destructive database actions

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentActions.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentActions.tsx
@@ -26,13 +26,26 @@ function CommentActions({ comment, editItem, isRoot }: CommentActionsProps) {
   }
 
   const handleDelete = () => {
-    deleteComment({ variables: { id: comment.id } });
+    setExpanded(false);
 
-    if (isRoot) {
-      deleteCommentReplies({ variables: { parentId: comment.id } });
+    const replyCount = comment.replies?.length || 0;
+    const commentMsg = `Deleting this comment will permanently delete this comment. \n\nAre you sure you want to proceed?`;
+    const replyMsg = `Deleting this comment will permanently delete this comment${
+      replyCount ? ` and its ${replyCount} repl${replyCount == 1 ? "y" : "ies"}` : ""
+    }. \n\nAre you sure you want to proceed?`;
+    const message = replyCount ? replyMsg : commentMsg;
+
+    if (window.confirm(message)) {
+      deleteComment({ variables: { id: comment.id } });
+
+      if (isRoot) {
+        deleteCommentReplies({ variables: { parentId: comment.id } });
+      }
     }
   };
   const editComment = () => {
+    setExpanded(false);
+
     editItem(comment);
   };
 

--- a/src/ui/components/Comments/TranscriptComments/CommentActions.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentActions.tsx
@@ -29,11 +29,9 @@ function CommentActions({ comment, editItem, isRoot }: CommentActionsProps) {
     setExpanded(false);
 
     const replyCount = comment.replies?.length || 0;
-    const commentMsg = `Deleting this comment will permanently delete this comment. \n\nAre you sure you want to proceed?`;
-    const replyMsg = `Deleting this comment will permanently delete this comment${
+    const message = `Deleting this comment will permanently delete this comment${
       replyCount ? ` and its ${replyCount} repl${replyCount == 1 ? "y" : "ies"}` : ""
     }. \n\nAre you sure you want to proceed?`;
-    const message = replyCount ? replyMsg : commentMsg;
 
     if (window.confirm(message)) {
       deleteComment({ variables: { id: comment.id } });

--- a/src/ui/components/Dashboard/DashboardViewerHeader.js
+++ b/src/ui/components/Dashboard/DashboardViewerHeader.js
@@ -36,10 +36,17 @@ function BatchActionDropdown({ selectedIds, setSelectedIds }) {
   }
 
   const deleteSelectedIds = () => {
-    selectedIds.forEach(recordingId =>
-      deleteRecording({ variables: { recordingId, deletedAt: new Date().toISOString() } })
-    );
-    setSelectedIds([]);
+    const count = selectedIds.length;
+    const message = `This action will permanently delete ${count == 1 ? "this" : count} replay${
+      count == 1 ? "" : "s"
+    }. \n\nAre you sure you want to proceed?`;
+
+    if (window.confirm(message)) {
+      selectedIds.forEach(recordingId =>
+        deleteRecording({ variables: { recordingId, deletedAt: new Date().toISOString() } })
+      );
+      setSelectedIds([]);
+    }
   };
   const updateRecordings = workspaceId => {
     selectedIds.forEach(recordingId =>

--- a/src/ui/components/Dashboard/RecordingItem/RecordingItemDropdown.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingItemDropdown.js
@@ -28,8 +28,13 @@ const DropdownPanel = ({
 }) => {
   const deleteRecording = hooks.useDeleteRecording(["GetWorkspaceRecordings", "GetMyRecordings"]);
 
-  const onDeleteRecording = async recordingId => {
-    await deleteRecording({ variables: { recordingId, deletedAt: new Date().toISOString() } });
+  const onDeleteRecording = recordingId => {
+    const message =
+      "This action will permanently delete this replay. \n\nAre you sure you want to proceed?";
+
+    if (window.confirm(message)) {
+      deleteRecording({ variables: { recordingId, deletedAt: new Date().toISOString() } });
+    }
   };
 
   const { recording_id } = recording;

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
@@ -45,15 +45,24 @@ function Role({
   const { user_id: userId } = member;
 
   const handleDelete = () => {
-    deleteUserFromWorkspace({
-      variables: { userId, workspaceId },
-    });
+    setExpanded(false);
 
-    // If the user is the member leaving, hide the modal and go back
-    // to the pesronal workspace.
-    if (localUserId == userId) {
-      hideModal();
-      setWorkspaceId(null);
+    const leaveMsg = `Are you sure you want to leave this team?`;
+    const kickMsg = `Are you sure you want to remove ${member.user.name} from this team?`;
+    const isPersonal = localUserId == userId;
+    const message = isPersonal ? leaveMsg : kickMsg;
+
+    if (window.confirm(message)) {
+      deleteUserFromWorkspace({
+        variables: { userId, workspaceId },
+      });
+
+      // If the user is the member leaving, hide the modal and go back
+      // to the personal workspace.
+      if (isPersonal) {
+        hideModal();
+        setWorkspaceId(null);
+      }
     }
   };
 


### PR DESCRIPTION
Fix #2388.

This adds a dialog for:
- deleting comments
- deleting a recording
- deleting multiple recordings
- leaving a team
- removing a team member from a team

Demo: https://share.descript.com/view/brgzvfyQace