### PR TITLE
mixpanel: use user-specific property to set email

### DIFF
--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -68,7 +68,7 @@ function setTelemetryContext(userId: string | undefined, userEmail: string | und
   }
 
   if (userEmail) {
-    mixpanel.register({ userEmail });
+    mixpanel.people.set({ $email: userEmail });
     sentryContext["userEmail"] = userEmail;
   }
 


### PR DESCRIPTION
Mixpanel has special ways that you are supposed to tell it about users:
1) Use `mixpanel.people.set` instead of `mixpanel.register`
2) Use appropriate reserved property names that start with `$`