### PR TITLE
Allow users to add a comment from the breakpoint widget

### DIFF
--- a/src/devtools/client/debugger/src/components/App.css
+++ b/src/devtools/client/debugger/src/components/App.css
@@ -12,16 +12,6 @@ button {
   font-size: inherit;
 }
 
-.debugger button:hover,
-.debugger button:focus {
-  background-color: var(--theme-toolbar-background-hover);
-}
-
-.theme-dark button:hover,
-.theme-dark button:focus {
-  background-color: var(--theme-toolbar-hover);
-}
-
 .split-box .debugger {
   display: flex;
   flex: 1;

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -23,11 +23,6 @@
   padding: 8px;
 }
 
-.breakpoint-panel *:focus:not(:focus-visible) {
-  outline: none;
-  background: inherit;
-}
-
 .breakpoint-panel button {
   height: 100%;
   border-radius: 4px;
@@ -70,12 +65,12 @@
   background: var(--theme-comment);
 }
 
-.breakpoint-panel .summary button {
+.breakpoint-panel .summary button.log,
+.breakpoint-panel .summary button.condition {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   padding: 4px;
-  color: var(--blue-80);
 }
 
 .breakpoint-panel .summary button:hover .expression {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -220,12 +220,6 @@
   min-width: 50px;
 }
 
-.breakpoint-panel .breakpoint-navigation-status {
-  background: #e8e8e8;
-  border-radius: 10px;
-  padding: 2px 8px;
-}
-
 .breakpoint-panel .breakpoint-navigation-commands .img {
   background: var(--theme-comment);
 }

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -15,6 +15,7 @@ import { connect } from "react-redux";
 import { actions } from "ui/actions";
 import { selectors } from "ui/reducers";
 import { inBreakpointPanel } from "devtools/client/debugger/src/utils/editor";
+import PanelSummary from "./PanelSummary";
 const { prefs } = require("ui/utils/prefs");
 
 function getPanelWidth({ editor }) {
@@ -23,41 +24,6 @@ function getPanelWidth({ editor }) {
   const panelIndent = 60;
 
   return editor.getScrollInfo().clientWidth - panelIndent;
-}
-
-function PanelSummary({ breakpoint, toggleEditingOn, isEditable, setInputToFocus }) {
-  const conditionValue = breakpoint.options.condition;
-  const logValue = breakpoint.options.logValue;
-
-  const handleClick = (event, input) => {
-    if (!isEditable) {
-      return;
-    }
-
-    event.stopPropagation();
-    toggleEditingOn();
-    setInputToFocus(input);
-  };
-
-  return (
-    <>
-      <div className="summary" onClick={e => handleClick(e, "logValue")}>
-        <div className="options">
-          {conditionValue ? (
-            <button className="condition" type="button" onClick={e => handleClick(e, "condition")}>
-              if (<span className="expression">{conditionValue}</span>)
-            </button>
-          ) : null}
-          <button className="log" type="button" onClick={e => handleClick(e, "logValue")}>
-            log(<span className="expression">{logValue}</span>)
-          </button>
-        </div>
-        <div className="action" tabIndex="0" onClick={e => handleClick(e, "logValue")}>
-          Edit
-        </div>
-      </div>
-    </>
-  );
 }
 
 function Panel({ breakpoint, editor, insertAt, setHoveredItem, clearHoveredItem, analysisPoints }) {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary.tsx
@@ -1,0 +1,107 @@
+import React, { Dispatch, SetStateAction } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { actions } from "ui/actions";
+import { selectors } from "ui/reducers";
+import { UIState } from "ui/state";
+const { getExecutionPoint } = require("devtools/client/debugger/src/reducers/pause");
+
+type Input = "condition" | "logValue";
+
+type PanelSummaryProps = PropsFromRedux & {
+  breakpoint: any;
+  toggleEditingOn: () => void;
+  isEditable: boolean;
+  setInputToFocus: Dispatch<SetStateAction<Input>>;
+};
+
+function PanelSummary({
+  breakpoint,
+  toggleEditingOn,
+  isEditable,
+  setInputToFocus,
+  createComment,
+  executionPoint,
+  currentTime,
+  analysisPoints,
+}: PanelSummaryProps) {
+  const conditionValue = breakpoint.options.condition;
+  const logValue = breakpoint.options.logValue;
+  const enableCommenting = analysisPoints?.find(
+    point => point.point == executionPoint && point.time == currentTime
+  );
+
+  const handleClick = (event: React.MouseEvent, input: Input) => {
+    if (!isEditable) {
+      return;
+    }
+
+    event.stopPropagation();
+    toggleEditingOn();
+    setInputToFocus(input);
+  };
+  const addComment = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    console.log(">>add comment");
+
+    createComment(currentTime, executionPoint, null);
+  };
+
+  return (
+    <>
+      <div className="summary" onClick={e => handleClick(e, "logValue")}>
+        <div className="options">
+          {conditionValue ? (
+            <button
+              className="condition hover:bg-gray-100"
+              type="button"
+              onClick={e => handleClick(e, "condition")}
+            >
+              if (<span className="expression">{conditionValue}</span>)
+            </button>
+          ) : null}
+          <button
+            className="log hover:bg-gray-200"
+            type="button"
+            onClick={e => handleClick(e, "logValue")}
+          >
+            log(<span className="expression">{logValue}</span>)
+          </button>
+        </div>
+        {enableCommenting ? (
+          <button
+            type="button"
+            onClick={addComment}
+            className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          >
+            Add a comment
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled={true}
+            onClick={e => e.stopPropagation()}
+            className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md shadow-sm text-gray-500 bg-gray-300"
+            style={{ cursor: "auto" }}
+          >
+            Add a comment
+          </button>
+        )}
+      </div>
+    </>
+  );
+}
+
+const connector = connect(
+  (state: UIState, { breakpoint }: { breakpoint: any }) => ({
+    executionPoint: getExecutionPoint(state),
+    currentTime: selectors.getCurrentTime(state),
+    analysisPoints: selectors.getAnalysisPointsForLocation(
+      state,
+      breakpoint.location,
+      breakpoint.options.condition
+    ),
+  }),
+  { createComment: actions.createComment }
+);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(PanelSummary);

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary.tsx
@@ -41,7 +41,6 @@ function PanelSummary({
   };
   const addComment = (e: React.MouseEvent) => {
     e.stopPropagation();
-    console.log(">>add comment");
 
     createComment(currentTime, executionPoint, null);
   };
@@ -80,7 +79,7 @@ function PanelSummary({
             type="button"
             disabled={true}
             onClick={e => e.stopPropagation()}
-            className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md shadow-sm text-gray-500 bg-gray-300"
+            className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md shadow-sm text-gray-500 bg-gray-200"
             style={{ cursor: "auto" }}
           >
             Add a comment

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
@@ -42,7 +42,6 @@
 }
 
 .breakpoint-navigation-status {
-  color: var(--theme-comment);
   border-radius: 4px;
   padding: 2px 6px;
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -94,7 +94,7 @@ function BreakpointNavigationStatus({ executionPoint, analysisPoints, indexed })
 
   return (
     <div className="breakpoint-navigation-status-container">
-      <div className="breakpoint-navigation-status">{status}</div>
+      <div className="px-3 py-0.5 rounded-2xl text-gray-500 bg-gray-200">{status}</div>
     </div>
   );
 }

--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -5,6 +5,7 @@ import { PendingComment, Event, Comment, Reply, FloatingItem } from "ui/state/co
 import { UIThunkAction } from ".";
 import { ThreadFront } from "protocol/thread";
 import isEqual from "lodash/isEqual";
+import { setSelectedPrimaryPanel } from "./app";
 
 type SetPendingComment = Action<"set_pending_comment"> & { comment: PendingComment | null };
 type SetHoveredComment = Action<"set_hovered_comment"> & { comment: any };
@@ -149,9 +150,11 @@ export function replyToItem(item: Event | Comment | FloatingItem): UIThunkAction
 export function createComment(
   time: number,
   point: string,
-  position: { x: number; y: number }
+  position: { x: number; y: number } | null
 ): UIThunkAction {
-  return async ({ dispatch, getState }) => {
+  return async ({ dispatch }) => {
+    dispatch(setSelectedPrimaryPanel("comments"));
+
     const pendingComment: PendingComment = {
       type: "new_comment",
       comment: {


### PR DESCRIPTION
Fix #2358.

This adds an "Add a comment" button to the breakpoint widget. This button is disabled except for when the user is currently paused on one of the breakpoint widget's hits. In that case, clicking the button forces the transcript panel to open and opens the comment editor at for that hit in the transcript.

Demo: 
https://share.descript.com/view/n4NyFQzS1Ra

Screenshot:
![image](https://user-images.githubusercontent.com/15959269/116636383-3274bb00-a92f-11eb-8318-98df11bea54d.png)