### PR TITLE
Softer error messaging when the user is not allowed to view a recording

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -9,6 +9,7 @@ const { prefs } = require("ui/utils/prefs");
 import { getTest, isTest } from "ui/utils/environment";
 
 import { ExpectedError } from "ui/state/app";
+import { getExpectedError } from "ui/reducers/app";
 
 export type SetUnexpectedErrorAction = Action<"set_unexpected_error"> & { error: sessionError };
 export type SetExpectedErrorAction = Action<"set_expected_error"> & { error: ExpectedError };
@@ -53,7 +54,12 @@ export async function createSession(store: UIStore, recordingId: string) {
     prefs.recordingId = recordingId;
   } catch (e) {
     if (e.code == 9 || e.code == 31) {
-      store.dispatch(setExpectedError(e));
+      const currentExpectedError = getExpectedError(store.getState());
+
+      // Don't overwrite an existing error.
+      if (!currentExpectedError) {
+        store.dispatch(setExpectedError(e));
+      }
     } else {
       throw e;
     }

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -104,7 +104,11 @@ function DevTools({
   if (!loaderResult) {
     if (!isAuthorized) {
       if (userId) {
-        expectedError = { message: "You don't have permission to view this replay." };
+        expectedError = {
+          message: "You don't have permission to view this replay.",
+          content:
+            "Sorry, you can't access this Replay. If you were given this URL, make sure you were invited.",
+        };
       } else {
         expectedError = {
           message: "You need to sign in to view this replay.",

--- a/src/ui/components/shared/Error.js
+++ b/src/ui/components/shared/Error.js
@@ -50,7 +50,7 @@ function Error({ children, refresh, expected, unexpected, error }) {
   return (
     <ErrorContainer unexpected={unexpected} expected={expected}>
       <div className="error-content">
-        <h1>Whoops</h1>
+        <h1 className="text-3xl font-semibold">Whoops</h1>
         {children}
         {error.message ? <p className="error-message">{error.message}</p> : null}
         <ActionButton action={refresh ? "refresh" : error?.action} />
@@ -77,11 +77,13 @@ function ExpectedError({ error }) {
   }
 
   const isServerError = error.code;
-  const content = isServerError ? "Looks like something went wrong with this page" : error.message;
+  const content = isServerError
+    ? "Looks like something went wrong with this page"
+    : error.content || error.message;
 
   return (
     <Error error={error} expected>
-      <p>{content}</p>
+      <p className="text-center">{content}</p>
     </Error>
   );
 }

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -7,6 +7,7 @@ import {
   MouseEvent,
 } from "@recordreplay/protocol";
 import { RecordingTarget } from "protocol/thread/thread";
+import { ReactElement } from "react";
 
 export type PanelName = "console" | "debugger" | "inspector";
 export type PrimaryPanelName = "explorer" | "debug" | "comments";
@@ -17,6 +18,7 @@ export type SettingsTabTitle = "Experimental" | "Invitations" | "Support" | "Per
 
 export interface ExpectedError {
   message: string;
+  content?: string | ReactElement | ReactElement[];
   action?: string;
   type?: "timeout";
 }


### PR DESCRIPTION
Fix #2415.

Demo: https://share.descript.com/view/4MeKCvpfxNI

Screenshots:
User logged in but is not allowed to view the recording
![image](https://user-images.githubusercontent.com/15959269/116752150-19254a80-a9d3-11eb-95ad-c4d2e4e468f9.png)
User is logged out and is trying to view a private recording
![image](https://user-images.githubusercontent.com/15959269/116752210-35c18280-a9d3-11eb-8f01-e5b2ce7bb5da.png)
