### PR TITLE
Fix draftjs bundling

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/draftjs.ts
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/draftjs.ts
@@ -1,0 +1,15 @@
+import DraftJS from "draft-js";
+import Editor from "@draft-js-plugins/editor";
+import createEmojiPlugin, { defaultTheme as defaultEmojiTheme } from "@draft-js-plugins/emoji";
+import createMentionPlugin, {
+  defaultTheme as defaultMentionTheme,
+} from "@draft-js-plugins/mention";
+
+export {
+  DraftJS,
+  Editor,
+  createEmojiPlugin,
+  defaultEmojiTheme,
+  createMentionPlugin,
+  defaultMentionTheme,
+};

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/use-draftjs.ts
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/use-draftjs.ts
@@ -33,18 +33,15 @@ let config: LazyLoadDraftConfig;
 function useDraftJS() {
   function load() {
     if (config) return Promise.resolve(config);
-    return Promise.all([
-      import("draft-js"),
-      import("@draft-js-plugins/editor"),
-      import("@draft-js-plugins/emoji"),
-      import("@draft-js-plugins/mention"),
-    ]).then(
-      ([
+    return import("./draftjs").then(
+      ({
         DraftJS,
         Editor,
-        { default: createEmojiPlugin, defaultTheme: defaultEmojiTheme },
-        { default: createMentionPlugin, defaultTheme: defaultMentionTheme },
-      ]) => {
+        createEmojiPlugin,
+        defaultEmojiTheme,
+        createMentionPlugin,
+        defaultMentionTheme,
+      }) => {
         const cfg: LazyLoadDraftConfig = {
           modules: {
             DraftJS,


### PR DESCRIPTION
Rework draftjs imports so they are all bundled in the same chunk. This patch produces two bundles: one for the draftjs.ts importer file and one for the draftjs and plugin node_modules.