### PR TITLE
Changing message to clarify this isn’t an error

### DIFF
--- a/src/protocol/socket.ts
+++ b/src/protocol/socket.ts
@@ -144,7 +144,7 @@ function onSocketClose() {
       dispatch(
         setExpectedError({
           type: "timeout",
-          message: "Apologies! A quick refresh should do the trick.",
+          message: "Replays disconnect after 5 minutes to reduce server load. Ready when you are!",
         })
       );
     }


### PR DESCRIPTION
Was "Apologies! A refresh should do the trick" which implied failure.

Now is "Replays disconnect after five minutes to reduce server load. Ready when you are!" which explains what happened and that it's all a perfectly normal and healthy thing.
