### PR TITLE
Add retryImport to add resiliency to dynamic imports

### DIFF
--- a/src/devtools/client/debugger/src/utils/editor/create-editor.js
+++ b/src/devtools/client/debugger/src/utils/editor/create-editor.js
@@ -5,6 +5,7 @@
 //
 
 import { assert } from "protocol/utils";
+import retryImport from "utils/retryImport";
 import { features, prefs } from "../prefs";
 
 let editorWaiter;
@@ -13,7 +14,7 @@ let CodeMirror;
 
 export async function waitForEditor() {
   if (!editorWaiter) {
-    editorWaiter = import("./source-editor").then(imported => {
+    editorWaiter = retryImport(() => import("./source-editor")).then(imported => {
       SourceEditor = imported.default;
       CodeMirror = imported.CodeMirror;
       return SourceEditor;

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/use-draftjs.ts
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/use-draftjs.ts
@@ -6,6 +6,8 @@ import "draft-js/dist/Draft.css";
 import "@draft-js-plugins/emoji/lib/plugin.css";
 import "@draft-js-plugins/mention/lib/plugin.css";
 
+import retryImport from "utils/retryImport";
+
 // Defining a partial interface for the module so consumers can use strongly
 // typed interfaces when using DraftJS returned from the hook
 export interface DraftJSModule {
@@ -33,7 +35,7 @@ let config: LazyLoadDraftConfig;
 function useDraftJS() {
   function load() {
     if (config) return Promise.resolve(config);
-    return import("./draftjs").then(
+    return retryImport(() => import("./draftjs")).then(
       ({
         DraftJS,
         Editor,

--- a/src/utils/retryImport.ts
+++ b/src/utils/retryImport.ts
@@ -1,0 +1,20 @@
+// Adapted from https://goenning.net/2018/11/16/how-to-retry-dynamic-import-with-react-lazy/
+function retryImport<T>(fn: () => Promise<T>, retriesLeft = 5, interval = 1000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    fn()
+      .then(resolve)
+      .catch((error: unknown) => {
+        if (retriesLeft === 1) {
+          reject(error);
+        } else {
+          setTimeout(() => {
+            // Passing on "reject" is the important part
+            retryImport(fn, retriesLeft - 1, interval).then(resolve, reject);
+          }, interval);
+        }
+      });
+  });
+}
+
+export default retryImport;
+export { retryImport };


### PR DESCRIPTION
This will add some resiliency to dynamic imports by retrying 5 (by default) times. It might not fix #2547 just yet because it appears that in that case the promise would resolve but with an empty object. However, this fix will give us an entry point to further patch for that scenario too by checking the response and then retrying (after possibly cleaning up webpack cache ...).