### PR TITLE
Tightening this div to make the text look less wide

### DIFF
--- a/src/ui/components/shared/Error.css
+++ b/src/ui/components/shared/Error.css
@@ -58,7 +58,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 640px;
+  width: 420px;
   height: 460px;
   border-radius: 8px;
   padding: 40px;


### PR DESCRIPTION
Old:
<img width="895" alt="image" src="https://user-images.githubusercontent.com/9154902/117521771-a421c880-b003-11eb-90c0-ab13b4a36707.png">

New:
<img width="635" alt="image" src="https://user-images.githubusercontent.com/9154902/117521759-94a27f80-b003-11eb-9b2e-19985824ae89.png">
