### PR TITLE
Revert "Remember the sourceId when setting a breakpoint (#2482)"

### DIFF
--- a/src/devtools/client/debugger/src/utils/breakpoint/index.js
+++ b/src/devtools/client/debugger/src/utils/breakpoint/index.js
@@ -61,8 +61,9 @@ export function makeBreakpointLocation(state, location) {
   };
   if (source.url) {
     breakpointLocation.sourceUrl = source.url;
+  } else {
+    breakpointLocation.sourceId = getSourceActorsForSource(state, source.id)[0].id;
   }
-  breakpointLocation.sourceId = getSourceActorsForSource(state, source.id)[0].id;
   return breakpointLocation;
 }
 


### PR DESCRIPTION
unfixing #2482 in order to fix the problem with navigations