### PR TITLE
Optimize library checkboxes

### DIFF
--- a/src/ui/components/Dashboard/DashboardViewerContent.js
+++ b/src/ui/components/Dashboard/DashboardViewerContent.js
@@ -39,6 +39,10 @@ function RecordingsList({
   ascOrder,
   setAscOrder,
 }) {
+  const addSelectedId = recordingId => setSelectedIds([...selectedIds, recordingId]);
+  const removeSelectedId = recordingId =>
+    setSelectedIds(selectedIds.filter(id => id !== recordingId));
+
   return (
     <table className="dashboard-viewer-content-table">
       <thead className="dashboard-viewer-content-header">
@@ -52,12 +56,13 @@ function RecordingsList({
       </thead>
       <tbody className="dashboard-viewer-content-body">
         {recordings &&
-          recordings.map((recording, i) => (
+          recordings.map(recording => (
             <Recording
               data={recording}
               key={recording.id}
-              selectedIds={selectedIds}
-              setSelectedIds={setSelectedIds}
+              selected={selectedIds.includes(recording.id)}
+              addSelectedId={addSelectedId}
+              removeSelectedId={removeSelectedId}
               editing={editing}
             />
           ))}

--- a/src/ui/components/Dashboard/RecordingItem/RecordingItem.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingItem.js
@@ -3,7 +3,13 @@ import hooks from "ui/hooks";
 import RecordingListItem from "./RecordingListItem";
 import RecordingItemDropdown from "./RecordingItemDropdown";
 
-export default function RecordingItem({ data, viewType, selectedIds, setSelectedIds, editing }) {
+export default function RecordingItem({
+  data,
+  selected,
+  addSelectedId,
+  removeSelectedId,
+  editing,
+}) {
   const [editingTitle, setEditingTitle] = useState(false);
   const [isPrivate, setIsPrivate] = useState(data.private);
   const updateIsPrivate = hooks.useUpdateIsPrivate();
@@ -44,8 +50,9 @@ export default function RecordingItem({ data, viewType, selectedIds, setSelected
       editingTitle={editingTitle}
       setEditingTitle={setEditingTitle}
       toggleIsPrivate={toggleIsPrivate}
-      selectedIds={selectedIds}
-      setSelectedIds={setSelectedIds}
+      selected={selected}
+      addSelectedId={addSelectedId}
+      removeSelectedId={removeSelectedId}
       editing={editing}
     />
   );

--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.js
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.js
@@ -121,8 +121,9 @@ export default function RecordingListItem({
   editingTitle,
   setEditingTitle,
   toggleIsPrivate,
-  setSelectedIds,
-  selectedIds,
+  addSelectedId,
+  removeSelectedId,
+  selected,
   editing,
 }) {
   const { userId, loading } = hooks.useGetUserId();
@@ -131,15 +132,13 @@ export default function RecordingListItem({
   }
 
   const { id: recordingId } = data;
-  const selected = selectedIds.includes(recordingId);
-
   const isOwner = userId == data.user?.id;
 
   const toggleChecked = () => {
     if (selected) {
-      setSelectedIds(selectedIds.filter(id => id !== recordingId));
+      removeSelectedId(recordingId);
     } else {
-      setSelectedIds([...selectedIds, recordingId]);
+      addSelectedId(recordingId);
     }
   };
 


### PR DESCRIPTION
Fix #2523.

We used to pass down an array of checked rows to every row. This triggered a re-render of all the rows every time a row was toggled.

This PR changes it such that when a checkbox is toggled, only the relevant row is re-rendered.