### PR TITLE
Add limits to how many Replays can be displayed

### DIFF
--- a/src/ui/components/Dashboard/DashboardViewer.tsx
+++ b/src/ui/components/Dashboard/DashboardViewer.tsx
@@ -15,6 +15,7 @@ const TIME_IN_MS = {
 
 type TimeFilter = "all" | "month" | "week" | "day";
 type AssociationFilter = "all" | "collaborator" | "comment" | "author";
+type Limit = "all" | "100" | "50" | "20";
 
 const subStringInString = (subString: string, string: string | null) => {
   if (!string) {
@@ -64,6 +65,7 @@ export default function DashboardViewer({ recordings }: { recordings: Recording[
   const [searchString, setSearchString] = useState<string>("");
   const [timeFilter, setTimeFilter] = useState<TimeFilter>("all");
   const [associationFilter, setAssociationFilter] = useState<AssociationFilter>("all");
+  const [limit, setLimit] = useState<Limit>("20");
 
   const toggleEditing = () => {
     if (editing) {
@@ -117,11 +119,23 @@ export default function DashboardViewer({ recordings }: { recordings: Recording[
               value={searchString}
               onChange={e => setSearchString(e.target.value)}
             />
+            <SelectMenu
+              selected={limit}
+              setSelected={value => setLimit(value as Limit)}
+              options={[
+                { id: "all", name: "Show all" },
+                { id: "20", name: "20" },
+                { id: "50", name: "50" },
+                { id: "100", name: "100" },
+              ]}
+              className="w-32"
+            />
           </>
         }
       />
       <DashboardViewerContent
         recordings={filteredRecordings}
+        limit={limit}
         selectedIds={selectedIds}
         setSelectedIds={setSelectedIds}
         editing={editing}

--- a/src/ui/components/Dashboard/DashboardViewerContent.js
+++ b/src/ui/components/Dashboard/DashboardViewerContent.js
@@ -8,6 +8,7 @@ export default function DashboardViewerContent({
   selectedIds,
   setSelectedIds,
   editing,
+  limit,
 }) {
   const [ascOrder, setAscOrder] = useState(false);
   let sortedRecordings = sortBy(recordings, recording => {
@@ -15,11 +16,14 @@ export default function DashboardViewerContent({
     return order * new Date(recording.date);
   });
 
+  const displayedRecordings =
+    limit === "all" ? sortedRecordings : sortedRecordings.slice(0, +limit);
+
   return (
     <section className="dashboard-viewer-content">
       <div className={classnames("recording-list")}>
         <RecordingsList
-          recordings={sortedRecordings}
+          recordings={displayedRecordings}
           selectedIds={selectedIds}
           setSelectedIds={setSelectedIds}
           editing={editing}


### PR DESCRIPTION
Fix #2596.

We can't render 100+ rows of Replays reasonably snappy-ly. At some point we'll introduce proper pagination, but this is just for plugging the hole until we get there.

For now, this just adds a dropdown for limiting the number of Replays displayed at one time. Definitely not the most elegant solution since (outside of the time/association filters) there's no affordances for cases where you can see 1-20 but would like to see 20-40.