### PR TITLE
Remove floating item references

### DIFF
--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -1,24 +1,16 @@
 import { Action } from "redux";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
-import { PendingComment, Event, Comment, Reply, FloatingItem } from "ui/state/comments";
+import { PendingComment, Event, Comment, Reply } from "ui/state/comments";
 import { UIThunkAction } from ".";
 import { ThreadFront } from "protocol/thread";
-import isEqual from "lodash/isEqual";
 import { setSelectedPrimaryPanel } from "./app";
 
 type SetPendingComment = Action<"set_pending_comment"> & { comment: PendingComment | null };
 type SetHoveredComment = Action<"set_hovered_comment"> & { comment: any };
 type SetShouldShowLoneEvents = Action<"set_should_show_lone_events"> & { value: boolean };
-type SetFloatingItem = Action<"set_floating_item"> & {
-  floatingItem: FloatingItem | null;
-};
 
-export type CommentsAction =
-  | SetPendingComment
-  | SetHoveredComment
-  | SetShouldShowLoneEvents
-  | SetFloatingItem;
+export type CommentsAction = SetPendingComment | SetHoveredComment | SetShouldShowLoneEvents;
 
 export function setPendingComment(comment: PendingComment): SetPendingComment {
   return { type: "set_pending_comment", comment };
@@ -32,114 +24,10 @@ export function clearPendingComment(): SetPendingComment {
   return { type: "set_pending_comment", comment: null };
 }
 
-export function setFloatingItem(floatingItem: FloatingItem | null): SetFloatingItem {
-  return { type: "set_floating_item", floatingItem };
-}
-
 export function toggleShowLoneEvents(): UIThunkAction {
   return ({ dispatch, getState }) => {
     const newValue = !selectors.getShouldShowLoneEvents(getState());
     dispatch({ type: "set_should_show_lone_events", value: newValue });
-  };
-}
-
-export function showFloatingItem(): UIThunkAction {
-  return async ({ dispatch, getState }) => {
-    const initialFloatingItem = selectors.getFloatingItem(getState());
-
-    const newFloatingItem: FloatingItem = {
-      itemType: "pause",
-      time: selectors.getCurrentTime(getState()),
-      point: ThreadFront.currentPoint,
-      hasFrames: ThreadFront.currentPointHasFrames,
-      location: await ThreadFront.getCurrentPauseSourceLocation(),
-    };
-
-    const currentFloatingItem = selectors.getFloatingItem(getState());
-
-    // We should bail if the newFloatingItem is now stale. This happens in cases where
-    // the state's floatingItem changes while we wait for the newFloatingItem to resolve.
-    if (initialFloatingItem !== currentFloatingItem) {
-      return;
-    }
-
-    if (isEqual(currentFloatingItem, newFloatingItem)) {
-      return;
-    }
-
-    dispatch(setFloatingItem(newFloatingItem));
-  };
-}
-
-export function hideFloatingItem(): UIThunkAction {
-  return async ({ dispatch }) => {
-    dispatch(setFloatingItem(null));
-  };
-}
-
-export function replyToItem(item: Event | Comment | FloatingItem): UIThunkAction {
-  return async ({ dispatch, getState }) => {
-    const { point, time } = item;
-    const state = getState();
-    const canvas = selectors.getCanvas(state);
-    const recordingTarget = selectors.getRecordingTarget(state);
-
-    dispatch(seekToComment(item));
-
-    if ("comment" in item && item.comment && "id" in item.comment) {
-      // Add a reply to an event's comment.
-      const pendingComment: PendingComment = {
-        type: "new_reply",
-        comment: {
-          content: "",
-          time,
-          point,
-          hasFrames: false,
-          sourceLocation: null,
-          parentId: item.comment.id,
-        },
-      };
-
-      dispatch(setPendingComment(pendingComment));
-    } else if ("id" in item) {
-      // Add a reply to a non-event's comment.
-      const pendingComment: PendingComment = {
-        type: "new_reply",
-        comment: {
-          content: "",
-          time,
-          point,
-          hasFrames: "hasFrames" in item && item.hasFrames,
-          sourceLocation: null,
-          parentId: item.id,
-        },
-      };
-
-      dispatch(setPendingComment(pendingComment));
-    } else {
-      const position =
-        recordingTarget == "node"
-          ? null
-          : {
-              x: canvas!.width * 0.5,
-              y: canvas!.height * 0.5,
-            };
-
-      // Add a new comment to an event or a temporary pause item.
-      const pendingComment: PendingComment = {
-        type: "new_comment",
-        comment: {
-          content: "",
-          time,
-          point,
-          hasFrames: "hasFrames" in item && item.hasFrames,
-          sourceLocation: (await ThreadFront.getCurrentPauseSourceLocation()) || null,
-          position,
-        },
-      };
-
-      dispatch(setPendingComment(pendingComment));
-    }
   };
 }
 
@@ -203,7 +91,7 @@ export function editItem(item: Comment | Reply): UIThunkAction {
   };
 }
 
-export function seekToComment(item: Comment | Reply | Event | FloatingItem): UIThunkAction {
+export function seekToComment(item: Comment | Reply | Event): UIThunkAction {
   return ({ dispatch, getState }) => {
     dispatch(clearPendingComment());
 

--- a/src/ui/reducers/comments.ts
+++ b/src/ui/reducers/comments.ts
@@ -7,7 +7,6 @@ function initialCommentsState(): CommentsState {
     hoveredComment: null,
     pendingComment: null,
     shouldShowLoneEvents: true,
-    floatingItem: null,
   };
 }
 
@@ -37,13 +36,6 @@ export default function update(
       };
     }
 
-    case "set_floating_item": {
-      return {
-        ...state,
-        floatingItem: action.floatingItem,
-      };
-    }
-
     default: {
       return state;
     }
@@ -53,4 +45,3 @@ export default function update(
 export const getPendingComment = (state: UIState) => state.comments.pendingComment;
 export const getHoveredComment = (state: UIState) => state.comments.hoveredComment;
 export const getShouldShowLoneEvents = (state: UIState) => state.comments.shouldShowLoneEvents;
-export const getFloatingItem = (state: UIState) => state.comments.floatingItem;

--- a/src/ui/state/comments.ts
+++ b/src/ui/state/comments.ts
@@ -4,7 +4,6 @@ export interface CommentsState {
   pendingComment: PendingComment | null;
   hoveredComment: any;
   shouldShowLoneEvents: boolean;
-  floatingItem: FloatingItem | null;
 }
 
 export interface SourceLocation {
@@ -23,14 +22,6 @@ interface User {
   picture: string;
   name: string;
   id: string;
-}
-
-export interface FloatingItem {
-  itemType: "pause";
-  time: number;
-  point: string;
-  hasFrames: boolean;
-  location?: SourceLocation;
 }
 
 export interface Comment {


### PR DESCRIPTION
This removes references to the old `FloatingItem` which we used for point in time comments in the older comments UI.