### PR TITLE
Split up DevTools component

### DIFF
--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -2,11 +2,9 @@ import React, { useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import useAuth0 from "ui/utils/useAuth0";
 
-import DevTools from "./DevTools";
 const Account = require("./Account").default;
 import AppErrors from "./shared/Error";
 const LoginModal = require("./shared/LoginModal").default;
-const SkeletonLoader = require("ui/components/SkeletonLoader").default;
 import SharingModal from "./shared/SharingModal";
 import NewWorkspaceModal from "./shared/NewWorkspaceModal";
 import WorkspaceSettingsModal from "./shared/WorkspaceSettingsModal";
@@ -27,6 +25,7 @@ import { useGetRecording } from "ui/hooks/recordings";
 
 import "styles.css";
 import UploadingScreen from "./UploadingScreen";
+import DevToolsLoader from "./DevToolsLoader";
 var FontFaceObserver = require("fontfaceobserver");
 
 function AppModal({ modal }: { modal: ModalType }) {
@@ -113,7 +112,7 @@ function App({ theme, recordingId, modal, updateNarrowMode, setFontLoading }: Ap
 
   return (
     <>
-      {recordingId ? <DevTools recordingId={recordingId} /> : <Account />}
+      {recordingId ? <DevToolsLoader recordingId={recordingId} /> : <Account />}
       {modal ? <AppModal modal={modal} /> : null}
       <AppErrors />
     </>

--- a/src/ui/components/DevToolsLoader.tsx
+++ b/src/ui/components/DevToolsLoader.tsx
@@ -1,0 +1,25 @@
+import { RecordingId } from "@recordreplay/protocol";
+import React from "react";
+import hooks from "ui/hooks";
+import DevToolsUserAuthenticator from "./DevToolsUserAuthenticator";
+import { BlankLoadingScreen } from "./shared/BlankScreen";
+
+export default function DevToolsLoader({ recordingId }: { recordingId: RecordingId }) {
+  const { recording, isAuthorized, loading: recordingQueryLoading } = hooks.useGetRecording(
+    recordingId
+  );
+  const { loading: settingsQueryLoading } = hooks.useGetUserSettings();
+  const { userId: cachedUserId, loading: userIdQueryLoading } = hooks.useGetUserId();
+
+  if (recordingQueryLoading || settingsQueryLoading || userIdQueryLoading) {
+    return <BlankLoadingScreen />;
+  }
+
+  return (
+    <DevToolsUserAuthenticator
+      userId={cachedUserId}
+      recording={recording!}
+      isAuthorized={isAuthorized}
+    />
+  );
+}

--- a/src/ui/components/DevToolsLoader.tsx
+++ b/src/ui/components/DevToolsLoader.tsx
@@ -4,6 +4,8 @@ import hooks from "ui/hooks";
 import DevToolsUserAuthenticator from "./DevToolsUserAuthenticator";
 import { BlankLoadingScreen } from "./shared/BlankScreen";
 
+// This component is responsible for making all of the database queries and handling
+// their loading states.
 export default function DevToolsLoader({ recordingId }: { recordingId: RecordingId }) {
   const { recording, isAuthorized, loading: recordingQueryLoading } = hooks.useGetRecording(
     recordingId

--- a/src/ui/components/DevToolsUserAuthenticator.tsx
+++ b/src/ui/components/DevToolsUserAuthenticator.tsx
@@ -7,23 +7,24 @@ import useAuth0 from "ui/utils/useAuth0";
 import { Recording } from "ui/types";
 import DevTools from "./DevTools";
 
-type DevToolsProps = PropsFromRedux & {
+type DevToolsAuthenticatorProps = PropsFromRedux & {
   userId: string;
   recording: Recording;
   isAuthorized: boolean;
 };
 
+// This component is responsible for taking the loaded query data and handling
+// unauthorized user access.
 function DevToolsUserAuthenticator({
   userId,
   recording,
   isAuthorized,
   setExpectedError,
   setRecordingWorkspace,
-}: DevToolsProps) {
+}: DevToolsAuthenticatorProps) {
   const { isAuthenticated } = useAuth0();
 
-  useEffect(() => {
-    // Handle unauthorized access error after the component mounts
+  useEffect(function handleUnauthorizedAccess() {
     if (!isAuthorized) {
       let error: ExpectedError | undefined;
 
@@ -43,16 +44,20 @@ function DevToolsUserAuthenticator({
       }
 
       setExpectedError(error);
-      return;
     }
-
+  }, []);
+  useEffect(function handleAuthorizedAccess() {
     document.title = `${recording.title} - Replay`;
 
+    // This sets the replay's workspace in state for mixpanel to reference.
     if (recording.workspace) {
       setRecordingWorkspace(recording.workspace);
     }
   }, []);
 
+  // If the user is not authorized, show a blank loading screen. After the first render cycle,
+  // the useEffect will handle setting the state so that we render the corresponding
+  // authentication error to be displayed to the user.
   if (!isAuthorized) {
     return <BlankLoadingScreen />;
   }

--- a/src/ui/components/DevToolsUserAuthenticator.tsx
+++ b/src/ui/components/DevToolsUserAuthenticator.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { actions } from "../actions";
+import { ExpectedError } from "ui/state/app";
+import { BlankLoadingScreen } from "./shared/BlankScreen";
+import useAuth0 from "ui/utils/useAuth0";
+import { Recording } from "ui/types";
+import DevTools from "./DevTools";
+
+type DevToolsProps = PropsFromRedux & {
+  userId: string;
+  recording: Recording;
+  isAuthorized: boolean;
+};
+
+function DevToolsUserAuthenticator({
+  userId,
+  recording,
+  isAuthorized,
+  setExpectedError,
+  setRecordingWorkspace,
+}: DevToolsProps) {
+  const { isAuthenticated } = useAuth0();
+
+  useEffect(() => {
+    // Handle unauthorized access error after the component mounts
+    if (!isAuthorized) {
+      let error: ExpectedError | undefined;
+
+      if (isAuthenticated) {
+        error = {
+          message: "You don't have permission to view this replay",
+          content:
+            "Sorry, you can't access this Replay. If you were given this URL, make sure you were invited.",
+        };
+      } else {
+        error = {
+          message: "You need to sign in to view this replay",
+          content:
+            "You're trying to view a private replay. To proceed, we're going to need to you to sign in.",
+          action: "sign-in",
+        };
+      }
+
+      setExpectedError(error);
+      return;
+    }
+
+    document.title = `${recording.title} - Replay`;
+
+    if (recording.workspace) {
+      setRecordingWorkspace(recording.workspace);
+    }
+  }, []);
+
+  if (!isAuthorized) {
+    return <BlankLoadingScreen />;
+  }
+
+  return <DevTools userId={userId} recording={recording} />;
+}
+
+const connector = connect(() => ({}), {
+  updateTimelineDimensions: actions.updateTimelineDimensions,
+  setExpectedError: actions.setExpectedError,
+  setRecordingWorkspace: actions.setRecordingWorkspace,
+});
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(DevToolsUserAuthenticator);


### PR DESCRIPTION
The code paths in the DevTools component is starting to become unwieldy. This is an overdue PR that splits that component's concerns up to keep it manageable.

1) **`<DevToolsLoader />`**: Handles all of the queries and the query loading state.
2) **`<DevToolsUserAuthenticator />`**: Handles the error in case the user is not authorized to view the Replay.
3) **`<DevTools />`**: Handles non-query-related loading states (e.g. recording information from the backend, remaining upload, scanning), the upload screen and rendering the actual devtools.