### PR TITLE
Handle invalid recording id errors in the frontend once

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -65,7 +65,7 @@ export async function createSession(store: UIStore, recordingId: string) {
     store.dispatch(actions.setUploading(null));
     prefs.recordingId = recordingId;
   } catch (e) {
-    if (e.code == 9 || e.code == 31) {
+    if (e.code == 31) {
       const currentError = getUnexpectedError(store.getState());
 
       // Don't overwrite an existing error.


### PR DESCRIPTION
Fix #2664.

Currently, we handle the invalid recording ID error that the backend throws in the frontend. This is in addition to the frontend separately identifying invalid Recording IDs through the getRecording query. That's one too much.

This takes out backend error handling for invalid recording IDs.