### PR TITLE
Fix TypeErrors associated with unexpected API results

### DIFF
--- a/src/ui/components/Header/Header.js
+++ b/src/ui/components/Header/Header.js
@@ -16,10 +16,10 @@ import IconWithTooltip from "ui/components/shared/IconWithTooltip";
 
 import "./Header.css";
 
-function Avatars({ recordingId, sessionId }) {
-  const { users, loading } = useGetActiveSessions(recordingId);
+function Avatars({ recordingId }) {
+  const { users, loading, error } = useGetActiveSessions(recordingId);
 
-  if (loading) {
+  if (loading || error) {
     return null;
   }
 
@@ -109,7 +109,8 @@ function Header({ recordingId, sessionId, recordingTarget }) {
     window.location = dashboardUrl;
   };
 
-  if (loading) {
+  // Recordings are unavailable when the graphql api is down
+  if (!recording || loading) {
     return <div id="header"></div>;
   }
 

--- a/src/ui/components/SecondaryToolbox/index.js
+++ b/src/ui/components/SecondaryToolbox/index.js
@@ -11,13 +11,13 @@ import NodePicker from "../NodePicker";
 import { selectors } from "../../reducers";
 import { actions } from "../../actions";
 import { ReactDevtoolsPanel } from "./ReactDevTools";
-import { isTest } from "ui/utils/environment";
 
 function PanelButtons({ selectedPanel, setSelectedPanel, narrowMode, isNode }) {
   const { userSettings } = hooks.useGetUserSettings();
 
-  const showElements = userSettings.showElements || isTest();
-  const showReact = userSettings.showReact || isTest();
+  const showReact = userSettings.showReact;
+  const showElements = userSettings.showElements;
+
   const onClick = panel => {
     setSelectedPanel(panel);
 
@@ -89,7 +89,7 @@ function InspectorPanel() {
 
 function SecondaryToolbox({ selectedPanel, setSelectedPanel, narrowMode, recordingTarget }) {
   const { userSettings } = hooks.useGetUserSettings();
-  const showReact = userSettings.showReact || isTest();
+  const showReact = userSettings.showReact;
   const isNode = recordingTarget === "node";
   return (
     <div className={classnames(`secondary-toolbox`, { node: isNode })}>

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -1,5 +1,6 @@
 import { gql, useQuery, useMutation } from "@apollo/client";
 import { query } from "ui/utils/apolloClient";
+import { isTest } from "ui/utils/environment";
 import { SettingItemKey } from "ui/components/shared/SettingsModal/types";
 import useAuth0 from "ui/utils/useAuth0";
 import type { UserSettings } from "../types";
@@ -20,7 +21,7 @@ const GET_USER_SETTINGS = gql`
   }
 `;
 
-const anonymousSettings: UserSettings = {
+const emptySettings: UserSettings = {
   showElements: false,
   showReact: false,
   enableTeams: true,
@@ -28,45 +29,61 @@ const anonymousSettings: UserSettings = {
   defaultWorkspaceId: null,
 };
 
+const testSettings: UserSettings = {
+  showElements: true,
+  showReact: true,
+  enableTeams: true,
+  enableRepaint: false,
+  defaultWorkspaceId: null,
+};
+
 export async function getUserSettings(): Promise<UserSettings> {
   const result = await query({ query: GET_USER_SETTINGS, variables: {} });
+
+  if (isTest()) {
+    return testSettings;
+  }
+
   return convertUserSettings(result.data);
 }
 
 export function useGetUserSettings() {
   const { isAuthenticated } = useAuth0();
-
-  if (!isAuthenticated) {
-    return { userSettings: anonymousSettings, loading: false };
-  }
-
   const { data, error, loading } = useQuery(GET_USER_SETTINGS);
 
+  if (isTest()) {
+    return { userSettings: testSettings, loading: false };
+  }
+
+  if (!isAuthenticated) {
+    return { userSettings: emptySettings, loading: false };
+  }
+
   if (loading) {
-    return { userSettings: null, error, loading };
+    return { userSettings: emptySettings, error, loading };
   }
 
   if (error) {
     console.error("Apollo error while getting user settings:", error);
-    return { userSettings: null, error, loading };
+    return { userSettings: emptySettings, error, loading };
   }
 
   return { userSettings: convertUserSettings(data), error, loading };
 }
 
 function convertUserSettings(data: any): UserSettings {
-  let userSettings = anonymousSettings;
-  if (data?.viewer) {
-    const settings = data.viewer.settings;
-    userSettings = {
-      showElements: settings.showElements,
-      showReact: settings.showReact,
-      enableTeams: settings.enableTeams,
-      enableRepaint: settings.enableRepaint,
-      defaultWorkspaceId: data.viewer.defaultWorkspace?.id || null,
-    };
+  if (!data?.viewer) {
+    return emptySettings;
   }
-  return userSettings;
+
+  const settings = data.viewer.settings;
+  return {
+    showElements: settings.showElements,
+    showReact: settings.showReact,
+    enableTeams: settings.enableTeams,
+    enableRepaint: settings.enableRepaint,
+    defaultWorkspaceId: data.viewer.defaultWorkspace?.id || null,
+  };
 }
 
 export function useUpdateUserSetting(key: SettingItemKey, type: "uuid" | "Boolean") {

--- a/src/ui/utils/bootstrap/bootstrap.tsx
+++ b/src/ui/utils/bootstrap/bootstrap.tsx
@@ -18,6 +18,7 @@ import { ApolloProvider } from "@apollo/client";
 import { skipTelemetry } from "../environment";
 import { UIStore } from "ui/actions";
 import { BlankLoadingScreen } from "ui/components/shared/BlankScreen";
+import { isTest } from "ui/utils/environment";
 
 export function setupTelemetry(context: Record<string, any>) {
   const ignoreList = ["Current thread has paused or resumed", "Current thread has changed"];
@@ -59,7 +60,7 @@ function ApolloWrapper({
 }) {
   const { loading, token, error } = useToken();
 
-  if (loading) {
+  if (!isTest() && loading) {
     return recordingId ? <BlankLoadingScreen /> : null;
   }
 


### PR DESCRIPTION
This PR makes a couple of changes to ensure that DevTools can open for tests even when the graphql api is down

1. Fixes some TypeErrors when recording is missing
2. extracts useHasExpectedError so it is easier to guard
3. suppresses some blankScreens when testing since queries might timeout
4. updates useGetUserSettings so that userSettings always have reasonable values
