### PR TITLE
Don't fetch screenshots during video playback

### DIFF
--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -333,7 +333,9 @@ export async function getGraphicsAtTime(
   }
 
   const screenPromise = forPlayback
-    ? screenshotCache.getScreenshotForPlayback(point, paintHash)
+    ? features.videoPlayback
+      ? Promise.resolve(undefined)
+      : screenshotCache.getScreenshotForPlayback(point, paintHash)
     : screenshotCache.getScreenshotForPreview(point, paintHash);
 
   const screen = await screenPromise;


### PR DESCRIPTION
If we try to fetch screenshots during video playback, the timeline may stall to wait for these downloads while the video keeps playing, i.e. timeline and video can get out of sync.