### PR TITLE
Add error page for browser errors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -26,17 +26,20 @@ const React = require("react");
 const { useEffect, useState } = React;
 const ReactDOM = require("react-dom");
 const { Provider } = require("react-redux");
-const { BrowserRouter: Router } = require("react-router-dom");
+const { BrowserRouter: Router, Route, Switch } = require("react-router-dom");
 const tokenManager = require("ui/utils/tokenManager").default;
 const { setupTelemetry } = require("ui/utils/telemetry");
 const { ApolloWrapper } = require("ui/utils/apolloClient");
 const App = require("ui/components/App").default;
+const BlankLoadingScreen = require("ui/components/shared/BlankScreen").BlankLoadingScreen;
 
 require("image/image.css");
 
 document.body.addEventListener("contextmenu", e => e.preventDefault());
 
 setupTelemetry({ recordingId });
+
+const BrowserError = React.lazy(() => import("views/browser/error"));
 
 function PageSwitch() {
   const [pageWithStore, setPageWithStore] = useState(null);
@@ -65,12 +68,19 @@ function PageSwitch() {
 }
 
 ReactDOM.render(
-  <Router>
-    <tokenManager.Auth0Provider>
-      <ApolloWrapper recordingId={recordingId}>
-        <PageSwitch />
-      </ApolloWrapper>
-    </tokenManager.Auth0Provider>
-  </Router>,
+  <React.Suspense fallback={() => <div>Loading</div>}>
+    <Router>
+      <Switch>
+        <Route exact path="/browser/error" component={BrowserError} />
+        <Route>
+          <tokenManager.Auth0Provider>
+            <ApolloWrapper recordingId={recordingId}>
+              <PageSwitch />
+            </ApolloWrapper>
+          </tokenManager.Auth0Provider>
+        </Route>
+      </Switch>
+    </Router>
+  </React.Suspense>,
   document.querySelector("#app")
 );

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -130,3 +130,4 @@ const connector = connect((state: UIState) => ({
 }));
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(_AppErrors);
+export { ExpectedErrorScreen, UnexpectedErrorScreen };

--- a/src/views/browser/error.tsx
+++ b/src/views/browser/error.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { useLocation } from "react-router";
+import { ExpectedErrorScreen } from "ui/components/shared/Error";
+
+const BrowserError = () => {
+  const content = new URLSearchParams(useLocation().search).get("message") || "Please try again";
+  return <ExpectedErrorScreen error={{ message: "Unexpected recording error", content }} />;
+};
+
+export default BrowserError;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,10 +14,6 @@ module.exports = {
   },
   devServer: {
     before: app => {
-      app.get("/view", (req, res) => {
-        res.sendFile("index.html", { root: "." });
-      });
-
       app.get("/test", (req, res) => {
         const testFile = req.url.substring(6);
         res.sendFile(testFile, { root: "./test/scripts" });
@@ -27,6 +23,16 @@ module.exports = {
     index: "index.html",
     liveReload: false,
     disableHostCheck: true,
+    historyApiFallback: {
+      rewrites: [
+        {
+          from: /\/(dist|images)\//,
+          to: function (context) {
+            return context.parsedUrl.pathname.replace(/.*(\/(dist|images)\/.*)/, "$1");
+          },
+        },
+      ],
+    },
   },
   plugins: [
     new MiniCssExtractPlugin(),


### PR DESCRIPTION
Adds a generic error page which gecko can use to message unusuable recordings (or other future error conditions).

Notes:
* The title text is hard-coded in the view and the subtitle text comes from the browser.
* This PR adds new routing to isolate the browser-specific pages (currently just this one but likely new-tab and welcome-to-replay from the website later). I expect this will have impacts on the web server config for production that will also need to be resolved.
* This PR adds a new folder structure to house this. I think this will help migrate to better bundling in the future.


![image](https://user-images.githubusercontent.com/788456/120596464-a60b5b80-c3f8-11eb-9c9c-da2a69c70c0c.png)
