### PR TITLE
Don't show recordings by authors who are not invited

### DIFF
--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -5,6 +5,7 @@ import { ExpectedError, WorkspaceId } from "ui/state/app";
 import useToken from "ui/utils/useToken";
 import { CollaboratorDbData } from "ui/components/shared/SharingModal/CollaboratorsList";
 import { useGetUserId } from "./users";
+import useAuth0 from "ui/utils/useAuth0";
 
 function isTest() {
   return new URL(window.location.href).searchParams.get("test");
@@ -20,6 +21,7 @@ export const GET_RECORDING = gql`
       createdAt
       private
       isInitialized
+      ownerNeedsInvite
       owner {
         id
         name
@@ -166,6 +168,7 @@ function convertRecording(rec: any): Recording | undefined {
     workspace: rec.workspace,
     comments: rec.comments,
     collaborators,
+    ownerNeedsInvite: rec.ownerNeedsInvite,
   };
 }
 
@@ -720,21 +723,41 @@ export function useUpdateRecordingTitle() {
 }
 
 export function useHasExpectedError(recordingId: RecordingId): ExpectedError | undefined {
-  const { claims } = useToken();
-  const userId = claims?.hasura.userId;
-
+  const { isAuthenticated } = useAuth0();
   const { recording, isAuthorized, loading } = useGetRecording(recordingId);
+  const { userId } = useGetUserId();
 
   // Recordings are only unavailable when the graphql api is down
   if (!recording) {
     return undefined;
   }
 
-  if (loading || isAuthorized) {
+  if (loading) {
     return undefined;
   }
 
-  if (userId) {
+  if (recording.ownerNeedsInvite) {
+    const isAuthor = userId && userId == recording.userId;
+
+    if (isAuthor) {
+      return {
+        message: "Your replay can not be viewed",
+        content:
+          "Your Replay account is currently unactivated because you have not been invited to Replay by an existing user. Until you are invited, your authored Replays will be unviewable.",
+      };
+    } else {
+      return {
+        message: "This replay can not be viewed",
+        content: "The author for this replay is currently using an unactivated account.",
+      };
+    }
+  }
+
+  if (isAuthorized) {
+    return undefined;
+  }
+
+  if (isAuthenticated) {
     return {
       message: "You don't have permission to view this replay",
       content:

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -20,6 +20,7 @@ export interface Recording {
   duration: number;
   date: string;
   private: boolean;
+  ownerNeedsInvite: boolean;
   user?: User;
   userId?: string;
   isInitialized: boolean;


### PR DESCRIPTION
Fix #2684.

This shouldn't get tripped when the recording doesn't have an associated user. [The backend](https://github.com/RecordReplay/backend/blob/master/src/graphql-api/schema.ts#L178) sets `ownerNeedsInvite` to false when there's no user associated with a recording. 

Replay from an uninvited user: http://localhost:8080/view?id=c8002fb8-5de0-4702-b7c4-0ab734336acc

When the author is viewing it:
![image](https://user-images.githubusercontent.com/15959269/120674616-4184e680-c462-11eb-9373-dca9842eb0a5.png)

When anybody else is viewing it:
![image](https://user-images.githubusercontent.com/15959269/120674374-05518600-c462-11eb-8b02-34f045a36275.png)