### PR TITLE
Moving icons to Material style

### DIFF
--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -59,15 +59,15 @@
   --new-blue-800: #2569ad;
   --new-blue-900: #215487;
 
-  --cool-gray-50: #F9FAFB;
-  --cool-gray-100: #F3F4F6;
-  --cool-gray-200: #E5E7EB;
-  --cool-gray-300: #D1D5DB;
-  --cool-gray-400: #9CA3AF;
-  --cool-gray-500: #6B7280;
-  --cool-gray-600: #4B5563;
+  --cool-gray-50: #f9fafb;
+  --cool-gray-100: #f3f4f6;
+  --cool-gray-200: #e5e7eb;
+  --cool-gray-300: #d1d5db;
+  --cool-gray-400: #9ca3af;
+  --cool-gray-500: #6b7280;
+  --cool-gray-600: #4b5563;
   --cool-gray-700: #374151;
-  --cool-gray-800: #1F2937;
+  --cool-gray-800: #1f2937;
   --cool-gray-900: #111827;
 
   --magenta-50: #ff1ad9;
@@ -138,7 +138,6 @@
   /* Toolbar */
   --theme-tab-toolbar-background: var(--grey-10);
   --theme-toolbar-background: var(--grey-10);
-  --theme-toolbar-color: var(--grey-90);
   --theme-toolbar-selected-color: var(--blue-60);
   --theme-toolbar-highlighted-color: var(--green-60);
   --theme-toolbar-background-hover: rgba(221, 225, 228, 0.66);
@@ -217,7 +216,7 @@
   /* Common popup styles(used by HTMLTooltip and autocomplete) */
   --theme-popup-background: white;
   --theme-popup-color: var(--grey-70);
-  --theme-errant-popup-color: #991B1B;
+  --theme-errant-popup-color: #991b1b;
   --theme-popup-border-color: ThreeDShadow;
   --theme-popup-dimmed: hsla(0, 0%, 80%, 0.3);
 
@@ -269,7 +268,7 @@
   /* Toolbar */
   --theme-tab-toolbar-background: var(--grey-90);
   --theme-toolbar-background: #18181a;
-  --theme-toolbar-color: var(--grey-40);
+  --theme-toolbar-color: var(--grey-20);
   --theme-toolbar-selected-color: white;
   --theme-toolbar-highlighted-color: var(--green-50);
   --theme-toolbar-background-hover: #232327;

--- a/src/ui/components/Header/UserOptions.css
+++ b/src/ui/components/Header/UserOptions.css
@@ -46,7 +46,6 @@
 .user-options .user.row {
   margin-bottom: 12px;
   overflow: hidden;
-  background-color: inherit;
 }
 
 .user-options .user-avatar {
@@ -95,7 +94,7 @@
 
 .user-options .dropdown-wrapper button {
   width: 100%;
-  color: var(--theme-toolbar-color);
+  color: var(--theme-icon-color);
   background: transparent;
   line-height: 16px;
 }

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -7,7 +7,7 @@
   border-top: 1px solid var(--theme-splitter-color);
   --progressbar-transition: 200ms;
   display: flex;
-  padding: 8px 24px 12px 20px;
+  padding: 10px 24px 12px 12px;
   align-items: center;
 }
 
@@ -29,8 +29,12 @@
   --tick-recording-background: #d0021b;
 }
 
+.pause_play_circle {
+  font-size: 29px;
+}
+
 .timeline > *:not(:last-child) {
-  margin-right: 20px;
+  margin-right: 8px;
 }
 
 .timeline .commands :focus:not(:focus-visible) {

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -32,13 +32,16 @@ import { getLocationKey } from "devtools/client/debugger/src/utils/breakpoint";
 import "./Timeline.css";
 import { UIState } from "ui/state";
 import { HoveredItem } from "ui/state/timeline";
+import MaterialIcon from "../shared/MaterialIcon";
 
 const { prefs } = require("ui/utils/prefs");
 
 function ReplayButton({ onClick }: { onClick: MouseEventHandler }) {
   return (
     <button onClick={onClick}>
-      <div className="img replay-lg" style={{ transform: "scaleX(-1)" }} />
+      <MaterialIcon className="refresh pause_play_circle material-icons-round">
+        refresh
+      </MaterialIcon>
     </button>
   );
 }
@@ -164,9 +167,13 @@ class Timeline extends Component<PropsFromRedux> {
       <div className="commands">
         <button onClick={togglePlayback}>
           {playback ? (
-            <div className="img pause-circle-lg" />
+            <MaterialIcon className="pause_play_circle material-icons-round">
+              pause_circle_outline
+            </MaterialIcon>
           ) : (
-            <div className="img play-circle-lg" />
+            <MaterialIcon className="pause_play_circle material-icons-round">
+              play_circle_outline
+            </MaterialIcon>
           )}
         </button>
       </div>

--- a/src/ui/components/Toolbar.js
+++ b/src/ui/components/Toolbar.js
@@ -85,8 +85,8 @@ function Toolbar({
             >
               <IconWithTooltip
                 icon={
-                  <MaterialIcon className="pest_control toolbar-panel-icon">
-                    pest_control
+                  <MaterialIcon className="motion_photos_paused toolbar-panel-icon">
+                    motion_photos_paused
                   </MaterialIcon>
                 }
                 content={"Pause Information"}

--- a/src/ui/components/Toolbar.js
+++ b/src/ui/components/Toolbar.js
@@ -6,6 +6,7 @@ import { selectors } from "../reducers";
 import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 import "react-circular-progressbar/dist/styles.css";
 import IconWithTooltip from "ui/components/shared/IconWithTooltip";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
 
 function IndexingLoader({ loadedRegions }) {
   const { loaded, loading } = loadedRegions;
@@ -19,7 +20,7 @@ function IndexingLoader({ loadedRegions }) {
     <div className="w-8 h-8" title={`Indexing (${(progressPercentage * 100).toFixed()}%)`}>
       <CircularProgressbar
         value={progressPercentage * 100}
-        strokeWidth={8}
+        strokeWidth={10}
         styles={buildStyles({ pathColor: `#353535`, trailColor: `#ECECED` })}
       />
     </div>
@@ -54,7 +55,7 @@ function Toolbar({
           })}
         >
           <IconWithTooltip
-            icon={<div className="img comments-panel-icon toolbar-panel-icon" />}
+            icon={<MaterialIcon className="forum toolbar-panel-icon">forum</MaterialIcon>}
             content={"Comments"}
             handleClick={() => onClick("comments")}
           />
@@ -68,7 +69,11 @@ function Toolbar({
               })}
             >
               <IconWithTooltip
-                icon={<div className="img explorer-panel toolbar-panel-icon" />}
+                icon={
+                  <MaterialIcon className="description toolbar-panel-icon">
+                    description
+                  </MaterialIcon>
+                }
                 content={"Source Explorer"}
                 handleClick={() => onClick("explorer")}
               />
@@ -80,11 +85,9 @@ function Toolbar({
             >
               <IconWithTooltip
                 icon={
-                  <div
-                    className={classnames("img debugger-panel toolbar-panel-icon", {
-                      paused: isPaused,
-                    })}
-                  />
+                  <MaterialIcon className="pest_control toolbar-panel-icon">
+                    pest_control
+                  </MaterialIcon>
                 }
                 content={"Pause Information"}
                 handleClick={() => onClick("debug")}

--- a/src/ui/components/Toolbox.css
+++ b/src/ui/components/Toolbox.css
@@ -58,6 +58,7 @@
   mask-repeat: no-repeat;
   mask-size: cover;
   margin: 4px;
+  color: ;
 }
 
 .toolbar-panel-button.active {
@@ -65,13 +66,13 @@
 }
 
 .toolbar-panel-icon {
-  background: var(--theme-toolbar-color);
+  color: #bcbcbc;
 }
 
 .toolbar-panel-button.active .toolbar-panel-icon {
-  background: var(--primary-accent);
+  color: var(--primary-accent);
 }
 
 .debugger-panel.toolbar-panel-icon.paused {
-  background-color: var(--secondary-accent);
+  /* background-color: var(--secondary-accent); */
 }

--- a/src/ui/components/Views/NonDevView.css
+++ b/src/ui/components/Views/NonDevView.css
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 24px;
+  padding: 12px 24px;
   justify-content: space-between;
 }
 
@@ -47,8 +47,8 @@
 }
 
 .right-sidebar .event-listeners .event-listeners-content {
-    height: 300px;
-    overflow-y: auto;
+  height: 300px;
+  overflow-y: auto;
 }
 
 .right-sidebar .comments-panel {


### PR DESCRIPTION
We have an annoying blend of line weights and positions in our current UI. This is our first step towards standardising them to the Material iconset. Then we'll keep iterating from here.


Old:
![image](https://user-images.githubusercontent.com/9154902/120743296-dc59ef80-c54c-11eb-8fe5-37f082bb7bd8.png)

New:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/9154902/120874991-7da07e80-c5fd-11eb-8916-8efdd803d25c.png">
--

Old:
![image](https://user-images.githubusercontent.com/9154902/120743336-f398dd00-c54c-11eb-98d3-501b0b93119c.png)

New:
![image](https://user-images.githubusercontent.com/9154902/120743367-fdbadb80-c54c-11eb-9cfd-d3fe18e6f2c6.png)

