### PR TITLE
Partial loading

### DIFF
--- a/src/ui/components/Toolbar.js
+++ b/src/ui/components/Toolbar.js
@@ -10,11 +10,13 @@ import MaterialIcon from "ui/components/shared/MaterialIcon";
 
 function IndexingLoader({ loadedRegions }) {
   const { loaded, loading } = loadedRegions;
-  const progressPercentage = (loaded[0].end - loaded[0].begin) / loading[0].end;
 
-  if (!loadedRegions) {
-    return;
+  if (!loaded[0] || !loading[0]) {
+    return null;
   }
+
+  const progressPercentage =
+    (loaded[0].end - loaded[0].begin) / (loading[0].end - loading[0].begin);
 
   return (
     <div className="w-8 h-8" title={`Indexing (${(progressPercentage * 100).toFixed()}%)`}>


### PR DESCRIPTION
When the recording is unloaded from the beginning we should factor that in.

such as it is here
http://localhost:8080/index.html?id=8d73591c-7e7c-486c-83fc-5662c85e66d6&point=649037107345178429090913237074067&time=707.7966951903217&hasFrames=true