### PR TITLE
Add team leader flow

### DIFF
--- a/src/ui/components/Account/Library.tsx
+++ b/src/ui/components/Account/Library.tsx
@@ -10,7 +10,7 @@ import { ModalType } from "ui/state/app";
 import { UIState } from "ui/state";
 import * as selectors from "ui/reducers/app";
 import { Nag, useGetUserInfo } from "ui/hooks/users";
-import { isOpenedFromEmail } from "ui/utils/environment";
+import { isTeamLeaderInvite, isTeamMemberInvite } from "ui/utils/environment";
 const UserOptions = require("ui/components/Header/UserOptions").default;
 
 function Header({
@@ -65,14 +65,19 @@ function Library({ setWorkspaceId, setModal, currentWorkspaceId }: PropsFromRedu
       return;
     }
 
+    const isLinkedFromEmail = isTeamMemberInvite() || isTeamLeaderInvite();
+
     // Only show the team member onboarding modal if there's only one outstanding pending team.
-    if (isOpenedFromEmail() && pendingWorkspaces?.length === 1) {
+    if (isTeamMemberInvite() && pendingWorkspaces?.length === 1) {
       setModal("team-member-onboarding");
       // Skip showing the regular onboarding to make sure the new user lands in the right team first.
       return;
+    } else if (isTeamLeaderInvite()) {
+      setModal("team-leader-onboarding");
+      return;
     }
 
-    if (!isOpenedFromEmail() && userInfo?.nags && !userInfo.nags.includes(Nag.FIRST_REPLAY)) {
+    if (!isLinkedFromEmail && userInfo?.nags && !userInfo.nags.includes(Nag.FIRST_REPLAY)) {
       setModal("onboarding");
     }
   }, [userInfo, loading1, loading2]);

--- a/src/ui/components/Account/index.js
+++ b/src/ui/components/Account/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import useAuth0 from "ui/utils/useAuth0";
 import { setUserInBrowserPrefs } from "../../utils/browser";
-import { isOpenedFromEmail } from "ui/utils/environment";
+import { isTeamMemberInvite } from "ui/utils/environment";
 import Library from "./Library";
 
 import "./Account.css";
@@ -32,7 +32,7 @@ function WelcomePage() {
           <div className="space-y-4 place-content-center">
             <img className="w-16 h-16 mx-auto" src="images/logo.svg" />
           </div>
-          {isOpenedFromEmail() ? (
+          {isTeamMemberInvite() ? (
             <div className="text-center space-y-2">
               <div className="font-bold text-2xl">Almost there!</div>
               <div className="font-medium text-xl">

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -24,6 +24,7 @@ import { useGetRecording } from "ui/hooks/recordings";
 import "styles.css";
 import UploadingScreen from "./UploadingScreen";
 import TeamMemberOnboardingModal from "./shared/OnboardingModal/TeamMemberOnboardingModal";
+import TeamLeaderOnboardingModal from "./shared/TeamLeaderOnboardingModal";
 var FontFaceObserver = require("fontfaceobserver");
 
 function AppModal({ modal }: { modal: ModalType }) {
@@ -48,6 +49,9 @@ function AppModal({ modal }: { modal: ModalType }) {
     }
     case "team-member-onboarding": {
       return <TeamMemberOnboardingModal />;
+    }
+    case "team-leader-onboarding": {
+      return <TeamLeaderOnboardingModal />;
     }
     default: {
       return null;

--- a/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -10,7 +10,7 @@ import "./NewWorkspaceModal.css";
 
 function NewWorkspaceModal({ hideModal }: PropsFromRedux) {
   const [inputValue, setInputValue] = useState("");
-  const createNewWorkspace = hooks.useCreateNewWorkspace();
+  const createNewWorkspace = hooks.useCreateNewWorkspace(() => {});
   const handleSave = (e: React.FormEvent) => {
     e.preventDefault();
 

--- a/src/ui/components/shared/OnboardingModal/TeamMemberOnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/TeamMemberOnboardingModal.tsx
@@ -3,6 +3,7 @@ import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
+import BlankScreen from "../BlankScreen";
 import Modal from "../NewModal";
 import Spinner from "../Spinner";
 const { prefs } = require("ui/utils/prefs");
@@ -113,17 +114,20 @@ function TeamMemberOnboardingModal({
   }
 
   return (
-    <Modal options={{ maskTransparency: "translucent" }}>
-      <div
-        className="p-12 bg-white rounded-lg shadow-xl text-xl space-y-8 relative flex flex-col justify-between"
-        style={{ width: "520px" }}
-      >
-        <div className="space-y-8 flex flex-col items-center">
-          <h2 className="font-bold text-3xl text-gray-900">{`You're invited to join the ${workspaceTarget.name} team`}</h2>
-          {callToAction}
+    <>
+      <BlankScreen className="fixed" />
+      <Modal options={{ maskTransparency: "transparent" }}>
+        <div
+          className="p-12 bg-white rounded-lg shadow-xl text-xl space-y-8 relative flex flex-col justify-between"
+          style={{ width: "520px" }}
+        >
+          <div className="space-y-8 flex flex-col items-center">
+            <h2 className="font-bold text-3xl text-gray-900">{`You're invited to join the ${workspaceTarget.name} team`}</h2>
+            {callToAction}
+          </div>
         </div>
-      </div>
-    </Modal>
+      </Modal>
+    </>
   );
 }
 

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
@@ -1,0 +1,261 @@
+import classNames from "classnames";
+import React, { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import * as actions from "ui/actions/app";
+import hooks from "ui/hooks";
+import { Nag } from "ui/hooks/users";
+import { Workspace } from "ui/types";
+import useToken from "ui/utils/useToken";
+import BlankScreen from "../BlankScreen";
+import { TextInput } from "../Forms";
+import Modal from "../NewModal";
+const { prefs } = require("ui/utils/prefs");
+
+function SlideContent({
+  headerText,
+  children,
+}: {
+  headerText: string;
+  children: React.ReactElement | React.ReactElement[];
+}) {
+  return (
+    <div className="space-y-12 flex flex-col flex-grow">
+      <h2 className="font-bold text-3xl text-gray-900">{headerText}</h2>
+      <div className="text-gray-500 flex flex-col flex-grow space-y-4">{children}</div>
+    </div>
+  );
+}
+
+function NextButton({
+  current,
+  total,
+  setCurrent,
+  onNext,
+  allowNext,
+}: {
+  current: number;
+  total: number;
+  setCurrent: Dispatch<SetStateAction<number>>;
+  hideModal: typeof actions.hideModal;
+  onNext?: () => void;
+  allowNext: boolean;
+}) {
+  const [nextClicked, setNextClicked] = useState<boolean>(false);
+
+  const onClick = () => {
+    if (onNext) {
+      onNext();
+    }
+    setNextClicked(true);
+  };
+
+  useEffect(() => {
+    // Only navigate to the next slide the work that eventually turns
+    // allowNext to true is finished. This allows us to do mutations
+    // in between navigations.
+    if (allowNext && nextClicked) {
+      setCurrent(current + 1);
+    }
+  }, [allowNext, nextClicked]);
+
+  const inferLoading = nextClicked && !allowNext;
+  const buttonText = inferLoading ? "Loading" : "Next";
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={current == total}
+      type="button"
+      className={classNames(
+        "items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500",
+        {
+          "text-white bg-blue-600 hover:bg-blue-700": current < total,
+        }
+      )}
+    >
+      {buttonText}
+    </button>
+  );
+}
+
+type SlideBodyProps = PropsFromRedux & {
+  setCurrent: Dispatch<SetStateAction<number>>;
+  setNewWorkspace: Dispatch<SetStateAction<Workspace | null>>;
+  newWorkspace: Workspace | null;
+  total: number;
+  current: number;
+};
+
+function SlideBody1({ hideModal, setCurrent, total, current }: SlideBodyProps) {
+  const userInfo = hooks.useGetUserInfo();
+  const updateUserNags = hooks.useUpdateUserNags();
+
+  useEffect(() => {
+    // Skip showing the user the first replay nag, since they will be going straight to a team
+    // once this flow is finished.
+    const newNags = [...userInfo.nags, Nag.FIRST_REPLAY];
+    updateUserNags({
+      variables: { newNags },
+    });
+  }, []);
+
+  const onSkip = () => {
+    window.history.pushState({}, document.title, window.location.pathname);
+    hideModal();
+  };
+  const content = (
+    <div className="text-xl">{`We're excited to have you! Next, we'll guide you through creating your own team and inviting your team members to Replay.`}</div>
+  );
+
+  return (
+    <>
+      <SlideContent headerText="Welcome to Replay">{content}</SlideContent>
+      <div className="grid grid-cols-2 gap-4">
+        <button
+          onClick={onSkip}
+          className="items-center px-4 py-2 border border-gray-200 text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 justify-center text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+        >
+          Skip
+        </button>
+        <NextButton allowNext={true} {...{ current, total, setCurrent, hideModal }} />
+      </div>
+    </>
+  );
+}
+
+function SlideBody2({ hideModal, setNewWorkspace, setCurrent, total, current }: SlideBodyProps) {
+  const [inputValue, setInputValue] = useState<string>("");
+  const [allowNext, setAllowNext] = useState<boolean>(false);
+  const { id: userId } = hooks.useGetUserInfo();
+
+  const createNewWorkspace = hooks.useCreateNewWorkspace(onNewWorkspaceCompleted);
+  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
+
+  function onNewWorkspaceCompleted(workspace: Workspace) {
+    setNewWorkspace(workspace);
+    updateDefaultWorkspace({
+      variables: {
+        workspaceId: workspace.id,
+      },
+    });
+    setAllowNext(true);
+  }
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+  const handleSave = () => createNewWorkspace({ variables: { name: inputValue, userId } });
+
+  return (
+    <>
+      <SlideContent headerText="Your team name">
+        <div className="text-xl">{`To start, what would you like your team's name to be?`}</div>
+        {/* <form onSubmit={handleSave} className="flex flex-col space-y-4"> */}
+        <div className="py-4 flex flex-col">
+          <TextInput
+            placeholder="Team name"
+            value={inputValue}
+            onChange={onChange}
+            id="replay-title"
+          />
+        </div>
+        {/* </form> */}
+      </SlideContent>
+      <div className="grid">
+        <NextButton onNext={handleSave} {...{ current, total, setCurrent, hideModal, allowNext }} />
+      </div>
+    </>
+  );
+}
+
+type SlideBody3Props = PropsFromRedux & {
+  setCurrent: Dispatch<SetStateAction<number>>;
+  setNewWorkspace: Dispatch<SetStateAction<Workspace | null>>;
+  newWorkspace: Workspace;
+  total: number;
+  current: number;
+};
+
+function SlideBody3({ setWorkspaceId, hideModal, newWorkspace }: SlideBody3Props) {
+  const onClick = () => {
+    prefs.defaultLibraryTeam = JSON.stringify(newWorkspace.id);
+    window.history.pushState({}, document.title, window.location.pathname);
+
+    setWorkspaceId(newWorkspace.id);
+    hideModal();
+  };
+
+  return (
+    <>
+      <SlideContent headerText="Team setup complete">
+        <div className="text-xl">{`Now every time you create a Replay, it's marked private and is saved in your team's library. That means only your team members can view it.`}</div>
+        <div className="text-xl">
+          {`To learn more about creating a Replay, `}
+          <a
+            className="underline"
+            href="https://replay.io/welcome"
+            target="_blank"
+            rel="noreferrer"
+          >
+            click here
+          </a>
+          {`.`}
+        </div>
+        <div className="flex flex-col flex-grow justify-end">
+          <button
+            type="button"
+            onClick={onClick}
+            className={classNames(
+              "max-w-max items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 text-white bg-blue-600 hover:bg-blue-700"
+            )}
+          >
+            {`Take me to my team`}
+          </button>
+        </div>
+      </SlideContent>
+    </>
+  );
+}
+
+function OnboardingModal(props: PropsFromRedux) {
+  const [current, setCurrent] = useState<number>(1);
+  const [newWorkspace, setNewWorkspace] = useState<Workspace | null>(null);
+
+  let slide;
+  const newProps = {
+    ...props,
+    setCurrent,
+    setNewWorkspace,
+    newWorkspace,
+    current,
+    total: 3,
+  };
+
+  if (current === 1) {
+    slide = <SlideBody1 {...newProps} />;
+  } else if (current === 2) {
+    slide = <SlideBody2 {...newProps} />;
+  } else {
+    slide = <SlideBody3 {...{ ...newProps, newWorkspace: newWorkspace! }} />;
+  }
+
+  return (
+    <>
+      <BlankScreen className="fixed" />
+      <Modal options={{ maskTransparency: "translucent" }}>
+        <div
+          className="p-12 bg-white rounded-lg shadow-xl text-xl space-y-8 relative flex flex-col justify-between"
+          style={{ width: "520px", height: "360px" }}
+        >
+          {slide}
+        </div>
+      </Modal>
+    </>
+  );
+}
+
+const connector = connect(() => ({}), {
+  hideModal: actions.hideModal,
+  setWorkspaceId: actions.setWorkspaceId,
+});
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(OnboardingModal);

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/index.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/index.tsx
@@ -1,0 +1,3 @@
+import TeamLeaderOnboardingModal from "./TeamLeaderOnboardingModal";
+
+export default TeamLeaderOnboardingModal;

--- a/src/ui/hooks/workspaces.ts
+++ b/src/ui/hooks/workspaces.ts
@@ -3,17 +3,23 @@ import { Workspace } from "ui/types";
 
 const NO_WORKSPACES: Workspace[] = [];
 
-export function useCreateNewWorkspace() {
+export function useCreateNewWorkspace(onCompleted: (data: any) => void) {
   const [createNewWorkspace, { error }] = useMutation(
     gql`
       mutation CreateNewWorkspace($name: String!) {
         createWorkspace(input: { name: $name }) {
           success
+          workspace {
+            id
+          }
         }
       }
     `,
     {
       refetchQueries: ["GetNonPendingWorkspaces"],
+      onCompleted: data => {
+        onCompleted(data.createWorkspace.workspace);
+      },
     }
   );
 

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -20,7 +20,6 @@ function initialAppState(): AppState {
     loading: 4,
     uploading: null,
     sessionId: null,
-    // modal: "team-member-onboarding",
     modal: null,
     modalOptions: null,
     analysisPoints: {},

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -19,7 +19,8 @@ export type ModalType =
   | "new-workspace"
   | "workspace-settings"
   | "onboarding"
-  | "team-member-onboarding";
+  | "team-member-onboarding"
+  | "team-leader-onboarding";
 export type WorkspaceId = string;
 export type SettingsTabTitle = "Experimental" | "Invitations" | "Support" | "Personal";
 

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -20,8 +20,12 @@ export function getTest() {
   return url.searchParams.get("test");
 }
 
-export function isOpenedFromEmail() {
-  return url.searchParams.get("emailinvite");
+export function isTeamMemberInvite() {
+  return new URL(window.location.href).searchParams.get("teaminvite");
+}
+
+export function isTeamLeaderInvite() {
+  return new URL(window.location.href).searchParams.get("replayinvite");
 }
 
 export function isTest() {


### PR DESCRIPTION
Demo: https://share.descript.com/view/VAWRH51PHBj

This adds a `replayinvite=true` URL parameter to the link that we send when we invite somebody to Replay via the settings panel. That URL parameter forces the user down the "team leader" flow. This flow hand-holds them through creating a team, and then brings them to that team afterwards.

Follow up items:
- There should also be a step in the team leader flow where they can invite team members.
- The final step of the flow should be to get the user to install the Replay browser and create their first replay.