### PR TITLE
Add the download links to empty teams

### DIFF
--- a/src/ui/components/Dashboard/DashboardViewerContent.js
+++ b/src/ui/components/Dashboard/DashboardViewerContent.js
@@ -4,6 +4,53 @@ import Recording from "./RecordingItem/index";
 import sortBy from "lodash/sortBy";
 import { isReplayBrowser } from "ui/utils/environment";
 
+function getErrorText() {
+  if (isReplayBrowser()) {
+    return "Please open a new tab and press the blue record button to record a Replay";
+  }
+
+  return <DownloadLinks />;
+}
+
+function DownloadLinks() {
+  const [clicked, setClicked] = useState(false);
+
+  if (clicked) {
+    return (
+      <div className="flex flex-col space-y-8" style={{ maxWidth: "32rem" }}>
+        <div>Download started.</div>
+        <div>{`Once the download is finished, open the Replay Browser installer to install Replay`}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col space-y-8" style={{ maxWidth: "32rem" }}>
+      <div>{`There's nothing here yet. To create your first replay, you first need to download the Replay Browser`}</div>
+      <div className="grid gap-4 grid-cols-2">
+        <a
+          href="https://replay.io/downloads/replay.dmg"
+          className={
+            "w-full text-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 text-white bg-blue-600 hover:bg-blue-700"
+          }
+          onClick={() => setClicked(true)}
+        >
+          Download for Mac
+        </a>
+        <a
+          href="https://replay.io/downloads/linux-replay.tar.bz2"
+          className={
+            "w-full text-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 text-white bg-blue-600 hover:bg-blue-700"
+          }
+          onClick={() => setClicked(true)}
+        >
+          Download for Linux
+        </a>
+      </div>
+    </div>
+  );
+}
+
 export default function DashboardViewerContent({
   recordings,
   selectedIds,
@@ -24,9 +71,7 @@ export default function DashboardViewerContent({
     if (timeFilter != "all" || associationFilter != "all" || searchString) {
       errorText = "No replays found, please expand your search";
     } else {
-      errorText = isReplayBrowser()
-        ? "Please open a new tab and press the blue record button to record a Replay"
-        : "Please open the Replay browser and press the blue record button to get started.";
+      errorText = getErrorText();
     }
 
     return (

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
@@ -99,10 +99,6 @@ function SlideBody1({ hideModal, setCurrent, total, current }: SlideBodyProps) {
     });
   }, []);
 
-  const onSkip = () => {
-    window.history.pushState({}, document.title, window.location.pathname);
-    hideModal();
-  };
   const content = (
     <div className="text-xl">{`We're excited to have you! Next, we'll guide you through creating your own team and inviting your team members to Replay.`}</div>
   );
@@ -110,13 +106,7 @@ function SlideBody1({ hideModal, setCurrent, total, current }: SlideBodyProps) {
   return (
     <>
       <SlideContent headerText="Welcome to Replay">{content}</SlideContent>
-      <div className="grid grid-cols-2 gap-4">
-        <button
-          onClick={onSkip}
-          className="items-center px-4 py-2 border border-gray-200 text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 justify-center text-gray-500 hover:bg-gray-100 hover:text-gray-700"
-        >
-          Skip
-        </button>
+      <div className="grid">
         <NextButton allowNext={true} {...{ current, total, setCurrent, hideModal }} />
       </div>
     </>
@@ -143,6 +133,10 @@ function SlideBody2({ hideModal, setNewWorkspace, setCurrent, total, current }: 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
   };
+  const onSkip = () => {
+    window.history.pushState({}, document.title, window.location.pathname);
+    hideModal();
+  };
   const handleSave = () => createNewWorkspace({ variables: { name: inputValue, userId } });
 
   return (
@@ -160,7 +154,13 @@ function SlideBody2({ hideModal, setNewWorkspace, setCurrent, total, current }: 
         </div>
         {/* </form> */}
       </SlideContent>
-      <div className="grid">
+      <div className="grid grid-cols-2 gap-4">
+        <button
+          onClick={onSkip}
+          className="items-center px-4 py-2 border border-gray-200 text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 justify-center text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+        >
+          Skip
+        </button>
         <NextButton onNext={handleSave} {...{ current, total, setCurrent, hideModal, allowNext }} />
       </div>
     </>


### PR DESCRIPTION
This resumes the flow from #2797. Once a team leader creates a team, that team is empty. To start filling it up, they need to download the Replay browser. This makes sure that the link is within arm's reach at that exact moment.

![image](https://user-images.githubusercontent.com/15959269/121272264-827e6000-c893-11eb-8693-ef46cbfb55e1.png)
![image](https://user-images.githubusercontent.com/15959269/121272273-890cd780-c893-11eb-9e87-cfe7e1e96586.png)
