### PR TITLE
Fix tailwind purge for dev environments

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -10,7 +10,7 @@ build:
     COPY tailwind.config.js .
     COPY webpack.config.js .
     ARG GIT_SHA
-    RUN REPLAY_BUILD_VISUALIZE=1 ./node_modules/.bin/webpack --mode=production --env REPLAY_RELEASE=$GIT_SHA
+    RUN REPLAY_BUILD_VISUALIZE=1 NODE_ENV=production ./node_modules/.bin/webpack --env REPLAY_RELEASE=$GIT_SHA
     SAVE ARTIFACT dist /dist AS LOCAL ./dist
 
 dist:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   purge: {
     content: ["./src/**/*.{js,jsx,ts,tsx}"],
-    enabled: true,
   },
   darkMode: false, // or 'media' or 'class'
   theme: {


### PR DESCRIPTION
* Changes tailwind to only purge unused classes in prod
* Config "prod" in the earthly build via the NODE_ENV so it is correctly picked up by both tailwind and webpack.