### PR TITLE
Fix comments appearing twice (#2707)

### DIFF
--- a/src/ui/hooks/comments/useAddComment.tsx
+++ b/src/ui/hooks/comments/useAddComment.tsx
@@ -31,13 +31,14 @@ export default function useAddComment() {
   }
 
   return (comment: NewCommentVariable, recordingId: RecordingId) => {
+    const temporaryId = new Date().toISOString();
     addComment({
       variables: { input: comment },
       optimisticResponse: {
         addComment: {
           success: true,
           comment: {
-            id: new Date().toISOString(),
+            id: temporaryId,
             __typename: "Comment",
           },
           __typename: "AddComment",
@@ -76,7 +77,12 @@ export default function useAddComment() {
           ...data,
           recording: {
             ...data.recording,
-            comments: [...data.recording.comments, newComment],
+            comments: [
+              ...data.recording.comments.filter(
+                (c: any) => c.id !== temporaryId && c.id !== commentId
+              ),
+              newComment,
+            ],
           },
         };
 

--- a/src/ui/hooks/comments/useAddCommentReply.tsx
+++ b/src/ui/hooks/comments/useAddCommentReply.tsx
@@ -30,13 +30,14 @@ export default function useAddCommentReply() {
   }
 
   return (reply: NewReplyVariable, recordingId: RecordingId) => {
+    const temporaryId = new Date().toISOString();
     addCommentReply({
       variables: { input: reply },
       optimisticResponse: {
         addCommentReply: {
           success: true,
           commentReply: {
-            id: new Date().toISOString(),
+            id: temporaryId,
             __typename: "CommentReply",
           },
           __typename: "AddCommentReply",
@@ -77,7 +78,12 @@ export default function useAddCommentReply() {
 
         const newParentComment = {
           ...parentComment,
-          replies: [...parentComment.replies, newReply],
+          replies: [
+            ...parentComment.replies.filter(
+              (r: any) => r.id !== temporaryId && r.id !== commentReply.id
+            ),
+            newReply,
+          ],
         };
         const newData = {
           ...data,


### PR DESCRIPTION
The problem and its fix are different for comments and replies: in both cases, the `update` function is called twice (first with the `optimisticResponse` containing a temporary ID and the second time with the real response containing the final ID).
- for comments the issue is that in the second call, the list of comments may already contain the comment with the final ID if the `GET_COMMENTS` query was polled in the meantime (after the comment was added on the server but before the second call to `update`). Note that we never get the comment with the temporary ID back from the cache in the second call.
- for replies the issue is that in the second call, the list of replies contains the reply with the temporary ID that we added in the first call