### PR TITLE
Remove user setting for the default team

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ const { setupExceptions } = require("devtools/client/debugger/src/actions/logExc
 import { selectors } from "ui/reducers";
 import { getUserSettings } from "ui/hooks/settings";
 import DevTools from "ui/components/DevTools";
+import { setWorkspaceId } from "ui/actions/app";
 
 const url = new URL(window.location.href);
 const recordingId = url.searchParams.get("id")!;
@@ -84,6 +85,7 @@ export async function initialize() {
 
   const settings = await getUserSettings();
   updateEnableRepaint(settings.enableRepaint);
+  store.dispatch(setWorkspaceId(settings.defaultWorkspaceId));
 
   return { store, Page: DevTools };
 }

--- a/src/ui/components/Account/Library.tsx
+++ b/src/ui/components/Account/Library.tsx
@@ -50,12 +50,14 @@ function Library({ setWorkspaceId, setModal, currentWorkspaceId }: PropsFromRedu
   const userInfo = useGetUserInfo();
   const { workspaces, loading: loading1 } = hooks.useGetNonPendingWorkspaces();
   const { pendingWorkspaces, loading: loading2 } = hooks.useGetPendingWorkspaces();
+  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
 
   useEffect(() => {
     // After rendering null, update the workspaceId to display the user's library
     // instead of the non-existent team.
     if (!loading2 && ![{ id: null }, ...workspaces].find(ws => ws.id === currentWorkspaceId)) {
       setWorkspaceId(null);
+      updateDefaultWorkspace({ variables: { workspaceId: null } });
     }
   }, [workspaces, loading2]);
 

--- a/src/ui/components/Dashboard/Navigation/Invitations.tsx
+++ b/src/ui/components/Dashboard/Navigation/Invitations.tsx
@@ -73,6 +73,7 @@ function AcceptedInvitation({
   setWorkspaceId: (id: string) => void;
   hideAcceptedInvitation: (team: Workspace) => void;
 }) {
+  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
   const [shouldHide, setShouldHide] = useState(false);
 
   const onHide = () => {
@@ -81,6 +82,7 @@ function AcceptedInvitation({
   const onGo = () => {
     setShouldHide(true);
     setWorkspaceId(workspace.id);
+    updateDefaultWorkspace({ variables: { workspaceId: workspace.id } });
   };
 
   useEffect(() => {

--- a/src/ui/components/Dashboard/Navigation/WorkspaceItem.tsx
+++ b/src/ui/components/Dashboard/Navigation/WorkspaceItem.tsx
@@ -7,6 +7,7 @@ import { Menu } from "@headlessui/react";
 import { Workspace } from "ui/types";
 import { UserGroupIcon, UserIcon } from "@heroicons/react/solid";
 import classnames from "classnames";
+import hooks from "ui/hooks";
 const { prefs } = require("ui/utils/prefs");
 
 type WorkspaceItemProps = PropsFromRedux & {
@@ -14,9 +15,13 @@ type WorkspaceItemProps = PropsFromRedux & {
 };
 
 function WorkspaceItem({ workspace, currentWorkspaceId, setWorkspaceId }: WorkspaceItemProps) {
+  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
+
   const onClick = () => {
     setWorkspaceId(workspace.id);
-    prefs.defaultLibraryTeam = JSON.stringify(workspace.id);
+    updateDefaultWorkspace({
+      variables: { workspaceId: workspace.id },
+    });
   };
 
   let icon: ReactElement;

--- a/src/ui/components/shared/OnboardingModal/TeamMemberOnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/TeamMemberOnboardingModal.tsx
@@ -40,6 +40,7 @@ function TeamMemberOnboardingModal({
   const [status, setState] = useState<Status>("pending");
   const userInfo = hooks.useGetUserInfo();
   const updateUserNags = hooks.useUpdateUserNags();
+  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
   // Keep the workspace info (id, name) here so that we can reference it even after the
   // user accepts the invitation. Otherwise, it disappears from the query.
   const [workspaceTarget] = useState(workspace);
@@ -63,7 +64,8 @@ function TeamMemberOnboardingModal({
     });
 
     setWorkspaceId(workspaceTarget.id);
-    prefs.defaultLibraryTeam = JSON.stringify(workspaceTarget.id);
+    updateDefaultWorkspace({ variables: { workspaceId: workspaceTarget.id } });
+
     setTimeout(
       () => (window.location.href = window.location.origin + window.location.pathname),
       1000

--- a/src/ui/components/shared/SettingsModal/SettingsBodyItem.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBodyItem.tsx
@@ -49,38 +49,11 @@ function Dropdown({
   value: string;
   setShowRefresh: Dispatch<SetStateAction<boolean>>;
 }) {
-  const { key, needsRefresh } = item;
-  const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
-  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
-
-  const displayedWorkspaces: { id: string | null; name: string }[] = [
-    { id: null, name: "My Library" },
-  ];
-
-  if (workspaces) {
-    displayedWorkspaces.push(...workspaces);
-    displayedWorkspaces.sort();
-  }
-
-  const onChange = (selectedValue: string | null) => {
-    if (needsRefresh) {
-      setShowRefresh(true);
-    }
-
-    updateDefaultWorkspace({
-      variables: {
-        workspaceId: selectedValue,
-      },
-    });
-  };
-
-  if (loading) {
-    return null;
-  }
+  const onChange = () => {};
 
   return (
     <div className="w-64">
-      <SelectMenu selected={value} setSelected={onChange} options={displayedWorkspaces} />
+      <SelectMenu selected={value} setSelected={onChange} options={[]} />
     </div>
   );
 }

--- a/src/ui/components/shared/SettingsModal/SettingsModal.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsModal.tsx
@@ -14,20 +14,20 @@ import { SettingsTabTitle } from "ui/state/app";
 import * as actions from "ui/actions/app";
 
 const settings: Settings = [
-  {
-    title: "Personal",
-    icon: "person",
-    items: [
-      {
-        label: "Default workspace",
-        type: "dropdown",
-        key: "defaultWorkspaceId",
-        description: "New replays will be saved here automatically",
-        disabled: false,
-        needsRefresh: false,
-      },
-    ],
-  },
+  // {
+  //   title: "Personal",
+  //   icon: "person",
+  //   items: [
+  //     {
+  //       label: "Default workspace",
+  //       type: "dropdown",
+  //       key: "defaultWorkspaceId",
+  //       description: "New replays will be saved here automatically",
+  //       disabled: false,
+  //       needsRefresh: false,
+  //     },
+  //   ],
+  // },
   {
     title: "Experimental",
     icon: "biotech",

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
@@ -273,11 +273,14 @@ type SlideBody4Props = PropsFromRedux & {
 };
 
 function SlideBody4({ setWorkspaceId, hideModal, newWorkspace }: SlideBody4Props) {
+  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
+
   const onClick = () => {
     prefs.defaultLibraryTeam = JSON.stringify(newWorkspace.id);
     window.history.pushState({}, document.title, window.location.pathname);
 
     setWorkspaceId(newWorkspace.id);
+    updateDefaultWorkspace({ variables: { workspaceId: newWorkspace.id } });
     hideModal();
   };
 

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
@@ -38,6 +38,7 @@ function Role({
 }) {
   const [expanded, setExpanded] = useState(false);
   const deleteUserFromWorkspace = hooks.useDeleteUserFromWorkspace();
+  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
   const { userId: localUserId } = hooks.useGetUserId();
   const { userId, membershipId } = member;
 
@@ -57,7 +58,7 @@ function Role({
       if (isPersonal) {
         hideModal();
         setWorkspaceId(null);
-        prefs.defaultLibraryTeam = JSON.stringify(null);
+        updateDefaultWorkspace({ variables: { workspaceId: null } });
       }
     }
   };

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -29,7 +29,7 @@ function initialAppState(): AppState {
     hoveredLineNumberLocation: null,
     isNodePickerActive: false,
     canvas: null,
-    workspaceId: JSON.parse(prefs.defaultLibraryTeam),
+    workspaceId: null,
     defaultSettingsTab: "Personal",
     recordingTarget: null,
     fontLoading: true,

--- a/src/ui/utils/prefs.js
+++ b/src/ui/utils/prefs.js
@@ -30,7 +30,6 @@ pref("devtools.dev-secondary-panel-height", "50%");
 pref("devtools.video", !!urlPrefs.video);
 pref("devtools.maxHitsDisplayed", 500);
 pref("devtools.maxHitsEditable", 200);
-pref("devtools.defaultLibraryTeam", "null");
 pref("devtools.libraryFilterTime", "all");
 pref("devtools.libraryFilterAssociation", "all");
 
@@ -60,7 +59,6 @@ export const prefs = new PrefsHelper("devtools", {
   video: ["Bool", "video"],
   maxHitsDisplayed: ["Int", "maxHitsDisplayed"],
   maxHitsEditable: ["Int", "maxHitsEditable"],
-  defaultLibraryTeam: ["String", "defaultLibraryTeam"],
   libraryFilterTime: ["String", "libraryFilterTime"],
   libraryFilterAssociation: ["String", "libraryFilterAssociation"],
 });


### PR DESCRIPTION
Fix #2800.

We currently store the most recently opened team in the library as a pref. This pref was used to determine what team to land the user on when they open `replay.io/view`.

We also have a separate mechanism for the user to indicate a "default" team through the settings panel. Setting a team using that dropdown would make sure that when the user sees an upload screen, the first visible team is the default team.

This PR removes the default team from the settings and merges these two concepts. The user's settings maintains a default workspace ID, which is used for both the team library, as well as the default selection in the upload screen. This setting is changed in the following scenarios:
- The user switches teams in the library using the team dropdown on the top left. 
- A non-new user accepts an invitation to a team and navigates to that team.
- A new user is onboarded using the team member flow, accepts the invitation, and navigates to that team.
- The UI tries to navigate to a team ID, but the user is no longer part of that team. This resets the default to personal library.
- A user leaves a team that happens to be their default team. This resets the default to their personal library.