### PR TITLE
Don't create a session if the recording is uninitialized (#2624)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -28,10 +28,10 @@ const ReactDOM = require("react-dom");
 const { Provider } = require("react-redux");
 const { BrowserRouter: Router, Route, Switch } = require("react-router-dom");
 const tokenManager = require("ui/utils/tokenManager").default;
+const { isRecordingInitialized } = require("ui/hooks/recordings");
 const { setupTelemetry } = require("ui/utils/telemetry");
 const { ApolloWrapper } = require("ui/utils/apolloClient");
 const App = require("ui/components/App").default;
-const BlankLoadingScreen = require("ui/components/shared/BlankScreen").BlankLoadingScreen;
 
 require("image/image.css");
 
@@ -47,7 +47,17 @@ function PageSwitch() {
 
   useEffect(() => {
     async function importAndInitialize() {
-      const imported = await (recordingId ? import("./app") : import("./library"));
+      let imported;
+      if (recordingId) {
+        const recordingInitialized = await isRecordingInitialized(recordingId);
+        if (recordingInitialized === false && !test) {
+          imported = await import("./upload");
+        } else {
+          imported = await import("./app");
+        }
+      } else {
+        imported = await import("./library");
+      }
       const pageWithStore = await imported.initialize();
       setPageWithStore(pageWithStore);
     }

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -1,5 +1,6 @@
 import { RecordingId } from "@recordreplay/protocol";
 import { ApolloError, gql, useQuery, useMutation } from "@apollo/client";
+import { query } from "ui/utils/apolloClient";
 import { Recording, User } from "ui/types";
 import { ExpectedError, WorkspaceId } from "ui/state/app";
 import { CollaboratorDbData } from "ui/components/shared/SharingModal/CollaboratorsList";
@@ -126,6 +127,29 @@ const GET_MY_RECORDINGS = gql`
     }
   }
 `;
+
+/**
+ * Returns true if the recording is accessible and initialized, false if it is
+ * accessible but uninitialized and undefined if it is inaccessible (private
+ * or uninitialized and owned by someone else)
+ */
+export async function isRecordingInitialized(
+  recordingId: RecordingId
+): Promise<boolean | undefined> {
+  const result = await query({
+    query: gql`
+      query IsRecordingAccessible($recordingId: UUID!) {
+        recording(uuid: $recordingId) {
+          uuid
+          isInitialized
+        }
+      }
+    `,
+    variables: { recordingId },
+  });
+
+  return result.data.recording?.isInitialized;
+}
 
 export function useGetRecording(
   recordingId: RecordingId | null

--- a/src/upload.tsx
+++ b/src/upload.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect } from "react";
+import { combineReducers, applyMiddleware } from "redux";
+import { connect, ConnectedProps } from "react-redux";
+const LogRocket = require("ui/utils/logrocket").default;
+import { isDevelopment, skipTelemetry } from "ui/utils/environment";
+import { sanityCheckMiddleware } from "ui/utils/sanitize";
+const configureStore = require("devtools/client/debugger/src/actions/utils/create-store").default;
+import reducer from "ui/reducers/app";
+import { setExpectedError } from "ui/actions/session";
+import { useGetRecording, useHasExpectedError } from "ui/hooks/recordings";
+import { BlankLoadingScreen } from "ui/components/shared/BlankScreen";
+import UploadScreen from "ui/components/UploadScreen";
+
+const url = new URL(window.location.href);
+const recordingId = url.searchParams.get("id")!;
+
+function _UploadScreenWrapper({ setExpectedError }: PropsFromRedux) {
+  const expectedError = useHasExpectedError(recordingId);
+  const { recording } = useGetRecording(recordingId);
+
+  useEffect(() => {
+    if (expectedError) {
+      setExpectedError(expectedError);
+    }
+  }, [expectedError]);
+
+  useEffect(() => {
+    if (recording?.isInitialized) {
+      window.onbeforeunload = null;
+      document.location.reload();
+    }
+  });
+
+  if (expectedError) {
+    return null;
+  }
+
+  return recording ? <UploadScreen recording={recording} /> : <BlankLoadingScreen />;
+}
+
+const connector = connect(null, { setExpectedError });
+type PropsFromRedux = ConnectedProps<typeof connector>;
+const UploadScreenWrapper = connector(_UploadScreenWrapper);
+
+export async function initialize() {
+  const middleware = skipTelemetry()
+    ? isDevelopment()
+      ? applyMiddleware(sanityCheckMiddleware)
+      : undefined
+    : applyMiddleware(LogRocket.reduxMiddleware());
+
+  const createStore = configureStore();
+  const store = createStore(combineReducers({ app: reducer }), {}, middleware);
+  store.dispatch({ type: "setup_app", recordingId });
+
+  return { store, Page: UploadScreenWrapper };
+}

--- a/src/upload.tsx
+++ b/src/upload.tsx
@@ -32,7 +32,7 @@ function _UploadScreenWrapper({ setExpectedError }: PropsFromRedux) {
   });
 
   if (expectedError) {
-    return null;
+    return <BlankLoadingScreen />;
   }
 
   return recording ? <UploadScreen recording={recording} /> : <BlankLoadingScreen />;


### PR DESCRIPTION
This PR still has some issues:
- after clicking "Save & Upload" on the UploadScreen, the app needs to be reloaded so that it is reinitialized (currently it gets stuck on a BlankLoadingScreen)
- there are errors in the browser console because some code that tries to access the session is still running
