### PR TITLE
Add launch replay button and page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,7 @@ document.body.addEventListener("contextmenu", e => e.preventDefault());
 setupTelemetry({ recordingId });
 
 const BrowserError = React.lazy(() => import("views/browser/error"));
+const BrowserLaunch = React.lazy(() => import("views/browser/launch"));
 
 function PageSwitch() {
   const [pageWithStore, setPageWithStore] = useState(null);
@@ -72,6 +73,7 @@ ReactDOM.render(
     <Router>
       <Switch>
         <Route exact path="/browser/error" component={BrowserError} />
+        <Route exact path="/browser/launch" component={BrowserLaunch} />
         <Route>
           <tokenManager.Auth0Provider>
             <ApolloWrapper recordingId={recordingId}>

--- a/src/ui/components/Account/Library.tsx
+++ b/src/ui/components/Account/Library.tsx
@@ -11,6 +11,7 @@ import { UIState } from "ui/state";
 import * as selectors from "ui/reducers/app";
 import { Nag, useGetUserInfo } from "ui/hooks/users";
 import { isTeamLeaderInvite, isTeamMemberInvite } from "ui/utils/environment";
+import LaunchButton from "../shared/LaunchButton";
 const UserOptions = require("ui/components/Header/UserOptions").default;
 
 function Header({
@@ -41,6 +42,8 @@ function Header({
 
         <WorkspaceDropdown nonPendingWorkspaces={nonPendingWorkspaces} />
       </div>
+      <div className="flex-auto" />
+      <LaunchButton />
       <UserOptions mode="account" />
     </div>
   );

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -5,6 +5,7 @@ import useAuth0 from "ui/utils/useAuth0";
 import AppErrors from "./shared/Error";
 const LoginModal = require("./shared/LoginModal").default;
 import SharingModal from "./shared/SharingModal";
+import LaunchBrowserModal from "./shared/LaunchBrowserModal";
 import NewWorkspaceModal from "./shared/NewWorkspaceModal";
 import WorkspaceSettingsModal from "./shared/WorkspaceSettingsModal";
 import SettingsModal from "./shared/SettingsModal/index";
@@ -52,6 +53,9 @@ function AppModal({ modal }: { modal: ModalType }) {
     }
     case "team-leader-onboarding": {
       return <TeamLeaderOnboardingModal />;
+    }
+    case "browser-launch": {
+      return <LaunchBrowserModal />;
     }
     default: {
       return null;

--- a/src/ui/components/shared/LaunchBrowserModal.tsx
+++ b/src/ui/components/shared/LaunchBrowserModal.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect } from "react";
+import { connect } from "react-redux";
+import { actions } from "ui/actions";
+import { UIState } from "ui/state";
+import Modal from "./NewModal";
+
+function LaunchBrowser({
+  path = "replay:library",
+  children,
+}: {
+  path?: string;
+  children?: React.ReactNode;
+}) {
+  useEffect(() => {
+    document.location.href = path;
+  }, [path]);
+
+  return (
+    <section className="max-w-2xl w-full m-auto bg-white shadow-lg rounded-lg overflow-hidden relative">
+      <div className="p-16 h-84 space-y-12 items-center flex flex-col">
+        <div className="space-y-4 place-content-center">
+          <img className="w-16 h-16 mx-auto" src="/images/logo.svg" />
+        </div>
+        <div className="text-center space-y-4">
+          <div className="font-bold text-2xl">Launching Replay ...</div>
+          <div className="text-xl text-gray-500 space-y-8">
+            <p>
+              Click <strong>Open Replay</strong> in the dialog shown by your browser
+            </p>
+            {children}
+            <p className="text-sm">
+              Don&apos;t have Replay installed? <a href="/welcome">Download Now</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function LaunchBrowserModalBase({
+  path = "replay:library",
+  onClose,
+}: {
+  path?: string;
+  onClose?: () => void;
+}) {
+  return (
+    <Modal
+      actions={
+        <>
+          <button className="hover:underline" onClick={onClose}>
+            Close
+          </button>
+        </>
+      }
+    >
+      <LaunchBrowser path={path} />
+    </Modal>
+  );
+}
+
+const LaunchBrowserModal = connect(null, {
+  onClose: actions.hideModal,
+})(LaunchBrowserModalBase);
+
+export default LaunchBrowserModal;
+export { LaunchBrowser };

--- a/src/ui/components/shared/LaunchButton.tsx
+++ b/src/ui/components/shared/LaunchButton.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { connect, ConnectedProps } from "react-redux";
+import * as actions from "ui/actions/app";
+import * as selectors from "ui/reducers/app";
+import { UIState } from "ui/state";
+
+const { features } = require("ui/utils/prefs");
+
+function ShareButton({ setModal, recordingId }: PropsFromRedux) {
+  const onClick = () => setModal("browser-launch");
+
+  if (window.__IS_RECORD_REPLAY_RUNTIME__ || !features.launchBrowser) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      // This height matches the height of the icon button + border
+      style={{ height: 26 }}
+      className="inline-flex items-center px-6 rounded-full text-white bg-primaryAccent hover:bg-primaryAccentHover hover:bg-primaryAccent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white box-content mr-2"
+    >
+      Launch Replay
+    </button>
+  );
+}
+
+const connector = connect((state: UIState) => ({ recordingId: selectors.getRecordingId(state) }), {
+  setModal: actions.setModal,
+});
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(ShareButton);

--- a/src/ui/components/shared/NewModal.tsx
+++ b/src/ui/components/shared/NewModal.tsx
@@ -2,11 +2,13 @@ import classNames from "classnames";
 import React from "react";
 
 export default function Modal({
+  actions,
   children,
   options = {
     maskTransparency: "transparent",
   },
 }: {
+  actions?: React.ReactNode;
   children: React.ReactElement | React.ReactElement[];
   options?: {
     maskTransparency: "transparent" | "translucent";
@@ -25,7 +27,10 @@ export default function Modal({
           "opacity-0": maskTransparency === "transparent",
         })}
       />
-      <div className="z-10">{children}</div>
+      <div className="z-10 relative">
+        {children}
+        {actions ? <div className="absolute top-4 right-4">{actions}</div> : null}
+      </div>
     </div>
   );
 }

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -20,7 +20,8 @@ export type ModalType =
   | "workspace-settings"
   | "onboarding"
   | "team-member-onboarding"
-  | "team-leader-onboarding";
+  | "team-leader-onboarding"
+  | "browser-launch";
 export type WorkspaceId = string;
 export type SettingsTabTitle = "Experimental" | "Invitations" | "Support" | "Personal";
 

--- a/src/ui/utils/prefs.js
+++ b/src/ui/utils/prefs.js
@@ -46,6 +46,7 @@ pref("devtools.features.widgetHover", false);
 pref("devtools.features.reactDevtools", false);
 pref("devtools.features.smoothPlayback", true);
 pref("devtools.features.videoPlayback", false);
+pref("devtools.features.launchBrowser", false);
 
 export const prefs = new PrefsHelper("devtools", {
   splitConsole: ["Bool", "split-console"],
@@ -78,6 +79,7 @@ export const features = new PrefsHelper("devtools.features", {
   reactDevtools: ["Bool", "reactDevtools"],
   smoothPlayback: ["Bool", "smoothPlayback"],
   videoPlayback: ["Bool", "videoPlayback"],
+  launchBrowser: ["Bool", "launchBrowser"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {

--- a/src/views/browser/launch.tsx
+++ b/src/views/browser/launch.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from "react";
+import BlankScreen from "ui/components/shared/BlankScreen";
+import { LaunchBrowser } from "ui/components/shared/LaunchBrowserModal";
+
+const BrowserLaunch = () => {
+  const library = "replay:library";
+
+  return (
+    <BlankScreen className="absolute z-10">
+      <LaunchBrowser path={library}>
+        <p className="text-center">
+          <a className="inline-flex items-center bg-blue-500 text-white h-12 px-4" href={library}>
+            Open Replay
+          </a>
+        </p>
+      </LaunchBrowser>
+    </BlankScreen>
+  );
+};
+
+export default BrowserLaunch;


### PR DESCRIPTION
Adding this behind `features.launchBrowser`

* Adds a "Launch Replay" button to the library which will open a modal and launch `replay:library`to trigger opening the browser

![image](https://user-images.githubusercontent.com/788456/121929310-ebcbfc00-ccf5-11eb-9205-858ef86f0841.png)

![image](https://user-images.githubusercontent.com/788456/121929338-f2f30a00-ccf5-11eb-8abd-e9c8a66ba587.png)

* Adds `/browser/launch` endpoint which presents a similar dialog over the blank screen so we can direct link to a launcher.

![image](https://user-images.githubusercontent.com/788456/121929389-02725300-ccf6-11eb-8da8-4869043d4906.png)


Fixes #2688