### PR TITLE
Hide the comment overlay while the node picker is active

### DIFF
--- a/src/ui/components/NodePicker.js
+++ b/src/ui/components/NodePicker.js
@@ -45,6 +45,7 @@ class NodePicker extends React.Component {
     ThreadFront.loadMouseTargets();
     this.addNodePickerListeners();
     this.props.setIsNodePickerActive(true);
+    this.props.setSelectedPanel("inspector");
   }
 
   addNodePickerListeners() {
@@ -135,4 +136,5 @@ class NodePicker extends React.Component {
 
 export default connect(null, {
   setIsNodePickerActive: actions.setIsNodePickerActive,
+  setSelectedPanel: actions.setSelectedPanel,
 })(NodePicker);

--- a/src/ui/components/Video.js
+++ b/src/ui/components/Video.js
@@ -36,15 +36,17 @@ function Video({ recordingId, playback, isNodePickerActive, pendingComment, reco
     }
   };
 
+  const showCommentTool = isPaused && !isNodeTarget && isAuthenticated && !isNodePickerActive;
+
   return (
     <div id="video">
       <video id="graphicsVideo" />
       <canvas id="graphics" onMouseDown={onMouseDown} />
-      <CommentsOverlay>
-        {isPaused && !isNodeTarget && isAuthenticated ? (
+      {showCommentTool ? (
+        <CommentsOverlay>
           <CommentLoader recordingId={recordingId} />
-        ) : null}
-      </CommentsOverlay>
+        </CommentsOverlay>
+      ) : null}
       <div id="highlighter-root"></div>
     </div>
   );


### PR DESCRIPTION
Fix #2846.

https://user-images.githubusercontent.com/15959269/121956858-9ca2bd00-cd2f-11eb-9314-214955717e79.mov

