### PR TITLE
Add launch button to user options menu

### DIFF
--- a/src/ui/components/Account/Library.tsx
+++ b/src/ui/components/Account/Library.tsx
@@ -44,7 +44,7 @@ function Header({
       </div>
       <div className="flex-auto" />
       <LaunchButton />
-      <UserOptions mode="account" />
+      <UserOptions mode="account" noBrowserItem />
     </div>
   );
 }

--- a/src/ui/components/Header/UserOptions.js
+++ b/src/ui/components/Header/UserOptions.js
@@ -10,7 +10,9 @@ import { isDeployPreview } from "ui/utils/environment";
 import useAuth0 from "ui/utils/useAuth0";
 import "./UserOptions.css";
 
-function UserOptions({ recordingId, setModal }) {
+const { features } = require("ui/utils/prefs");
+
+function UserOptions({ recordingId, setModal, noBrowserItem }) {
   const [expanded, setExpanded] = useState(false);
   const { isAuthenticated } = useAuth0();
 
@@ -28,14 +30,6 @@ function UserOptions({ recordingId, setModal }) {
     return <LoginButton />;
   }
 
-  const onLibraryClick = () => {
-    const dashboardUrl = `${window.location.origin}/view`;
-
-    if (event.metaKey) {
-      return window.open(dashboardUrl);
-    }
-    window.location = dashboardUrl;
-  };
   const onDocsClick = () => {
     const docsUrl = `https://www.notion.so/Docs-56758667f53a4d51b7c6fc7a641adb02`;
 
@@ -45,12 +39,16 @@ function UserOptions({ recordingId, setModal }) {
     window.open(docsUrl, "replaydocs");
   };
   const onLaunchClick = () => {
-    const launchUrl = `${window.location.origin}/welcome`;
-    if (event.metaKey) {
-      return window.open(launchUrl);
+    if (features.launchBrowser) {
+      setModal("browser-launch");
+    } else {
+      const launchUrl = `${window.location.origin}/welcome`;
+      if (event.metaKey) {
+        return window.open(launchUrl);
+      }
+      // right now we just send you to the download screen, but eventually this will launch Replay
+      window.location = launchUrl;
     }
-    // right now we just send you to the download screen, but eventually this will launch Replay
-    window.location = launchUrl;
   };
   const onShareClick = () => {
     setExpanded(false);
@@ -77,10 +75,19 @@ function UserOptions({ recordingId, setModal }) {
           <MaterialIcon>settings</MaterialIcon>
           <span>Settings</span>
         </button>
-        <button className="row" onClick={onLaunchClick}>
-          <MaterialIcon>download</MaterialIcon>
-          <span>Download Replay</span>
-        </button>
+        {features.launchBrowser ? (
+          window.__IS_RECORD_REPLAY_RUNTIME__ || noBrowserItem ? null : (
+            <button className="row" onClick={onLaunchClick}>
+              <MaterialIcon>download</MaterialIcon>
+              <span>Launch Replay</span>
+            </button>
+          )
+        ) : (
+          <button className="row" onClick={onLaunchClick}>
+            <MaterialIcon>download</MaterialIcon>
+            <span>Download Replay</span>
+          </button>
+        )}
         <LoginButton />
       </Dropdown>
     </div>


### PR DESCRIPTION
Replaces "Download Replay" menu option with "Launch Replay" option that shows a modal to allow downloading if needed.

Fixed #2335 