### PR TITLE
Show generated scopes if original scopes are unavailable (#2783)

### DIFF
--- a/src/devtools/client/debugger/src/client/commands.js
+++ b/src/devtools/client/debugger/src/client/commands.js
@@ -267,12 +267,15 @@ function convertScope(protocolScope) {
 }
 
 async function getFrameScopes(frame) {
-  const scopes = await ThreadFront.getScopes(frame.asyncIndex, frame.protocolId);
+  const { scopes, originalScopesUnavailable } = await ThreadFront.getScopes(
+    frame.asyncIndex,
+    frame.protocolId
+  );
   const converted = scopes.map(convertScope);
   for (let i = 0; i + 1 < converted.length; i++) {
     converted[i].parent = converted[i + 1];
   }
-  return converted[0];
+  return { scopes: converted[0], originalScopesUnavailable };
 }
 
 async function blackBox(sourceActor, isBlackBoxed, range) {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Scopes.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Scopes.css
@@ -99,3 +99,12 @@ html[dir="rtl"] .scopes-content .object-node {
   line-height: 15px;
   min-width: fit-content;
 }
+
+.scopes-list .warning {
+  margin: 4px 8px;
+  padding: 4px 8px;
+  border: 1px solid var(--theme-warning-border);
+  background-color: var(--theme-warning-background);
+  color: var(--theme-warning-color);
+  white-space: normal;
+}

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Scopes.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Scopes.js
@@ -131,6 +131,7 @@ class Scopes extends PureComponent {
       setExpandedScope,
       expandedScopes,
       selectedFrame,
+      originalScopesUnavailable,
     } = this.props;
     const { scopes } = this.state;
 
@@ -146,6 +147,9 @@ class Scopes extends PureComponent {
       }));
       return (
         <div className="pane scopes-list">
+          {originalScopesUnavailable ? (
+            <div className="warning">The variables could not be mapped to their original names</div>
+          ) : null}
           <ObjectInspector
             roots={roots}
             autoExpandAll={false}
@@ -187,9 +191,10 @@ const mapStateToProps = state => {
   const cx = getThreadContext(state);
   const selectedFrame = getSelectedFrame(state);
   const frameScope = getFrameScope(state, selectedFrame?.id);
-  const { scope, pending } = frameScope || {
+  const { scope, pending, originalScopesUnavailable } = frameScope || {
     scope: null,
     pending: false,
+    originalScopesUnavailable: false,
   };
 
   return {
@@ -198,6 +203,7 @@ const mapStateToProps = state => {
     isLoading: pending,
     why: getPauseReason(state),
     frameScopes: scope,
+    originalScopesUnavailable,
     expandedScopes: getLastExpandedScopes(state),
   };
 };

--- a/src/devtools/client/debugger/src/reducers/pause.js
+++ b/src/devtools/client/debugger/src/reducers/pause.js
@@ -105,7 +105,8 @@ function update(state = createPauseState(), action) {
         ...state.frameScopes,
         [selectedFrameId]: {
           pending: status !== "done",
-          scope: value,
+          originalScopesUnavailable: !!value?.originalScopesUnavailable,
+          scope: value?.scopes,
         },
       };
 


### PR DESCRIPTION
With this PR, the Scopes panel automatically switches to generated scopes if all variables in the original scopes are unavailable (and would be shown as "optimized away") and shows a warning message:
![image](https://user-images.githubusercontent.com/16060807/122233219-2c757200-cebc-11eb-8f2d-c32b97247e4c.png)
