### PR TITLE
Make the replay privacy in the upload screen private by default

### DIFF
--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -157,7 +157,10 @@ function UploadScreen({ recordingId, recording }: UploadScreenProps) {
 
   const [status, setStatus] = useState<Status>(null);
   const [inputValue, setInputValue] = useState(recording?.title || "Untitled");
-  const [isPublic, setIsPublic] = useState(!recording.private);
+  // The actual replay in the database is public by default, for test purposes.
+  // Before being initialized, public/private behaves similarly since non-authors
+  // can't view the replay.
+  const [isPublic, setIsPublic] = useState(false);
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
     userSettings?.defaultWorkspaceId || null
   );


### PR DESCRIPTION
Fix #2838.

![image](https://user-images.githubusercontent.com/15959269/122240976-2ff30400-ce90-11eb-9f04-eb145aac654e.png)
![image](https://user-images.githubusercontent.com/15959269/122241010-36817b80-ce90-11eb-8ed6-cdbe6ed377fc.png)
