### PR TITLE
Improve loading/indexing progress indicator accuracy (#2809)

### DIFF
--- a/src/ui/components/Toolbar.js
+++ b/src/ui/components/Toolbar.js
@@ -8,35 +8,26 @@ import "react-circular-progressbar/dist/styles.css";
 import IconWithTooltip from "ui/components/shared/IconWithTooltip";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 
-function getLoadingPercentage(loadedRegions) {
-  const { loaded, loading } = loadedRegions;
-  if (!loaded[0] || !loading[0]) {
-    return null;
-  }
-  return (loaded[0].end - loaded[0].begin) / (loading[0].end - loading[0].begin);
-}
-
-function IndexingLoader({ loadedRegions }) {
+function IndexingLoader({ progressPercentage }) {
   const [isDone, setDone] = useState(false);
-  const progressPercentage = getLoadingPercentage(loadedRegions);
 
   useEffect(() => {
     let timeout;
-    if (!isDone && progressPercentage == 1) {
+    if (!isDone && progressPercentage == 100) {
       timeout = setTimeout(() => setDone(true), 2000);
     }
 
     return () => clearTimeout(timeout);
-  }, [loadedRegions]);
+  }, [progressPercentage]);
 
   if (isDone || progressPercentage === null) {
     return null;
   }
 
   return (
-    <div className="w-8 h-8" title={`Indexing (${(progressPercentage * 100).toFixed()}%)`}>
+    <div className="w-8 h-8" title={`Indexing (${progressPercentage.toFixed()}%)`}>
       <CircularProgressbar
-        value={progressPercentage * 100}
+        value={progressPercentage}
         strokeWidth={10}
         styles={buildStyles({ pathColor: `#353535`, trailColor: `#ECECED` })}
       />
@@ -49,8 +40,7 @@ function Toolbar({
   setSelectedPrimaryPanel,
   togglePaneCollapse,
   panelCollapsed,
-  loadedRegions,
-  isPaused,
+  progressPercentage,
   viewMode,
 }) {
   const onClick = panel => {
@@ -113,7 +103,7 @@ function Toolbar({
           </>
         ) : null}
       </div>
-      <IndexingLoader {...{ loadedRegions }} />
+      <IndexingLoader {...{ progressPercentage }} />
     </div>
   );
 }
@@ -124,8 +114,7 @@ export default connect(
     panelCollapsed: selectors.getPaneCollapse(state),
     selectedPrimaryPanel: selectors.getSelectedPrimaryPanel(state),
     selectedPanel: selectors.getSelectedPanel(state),
-    loadedRegions: selectors.getLoadedRegions(state),
-    isPaused: selectors.getFrames(state)?.length > 0,
+    progressPercentage: selectors.getIndexing(state),
     viewMode: selectors.getViewMode(state),
   }),
   {

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -16,7 +16,8 @@ function initialAppState(): AppState {
     selectedPanel: prefs.selectedPanel,
     selectedPrimaryPanel: "comments",
     initializedPanels: [],
-    indexed: false,
+    recordingDuration: 0,
+    indexing: 0,
     loading: 4,
     uploading: null,
     sessionId: null,
@@ -47,12 +48,24 @@ export default function update(
       return { ...state, recordingId: action.recordingId };
     }
 
+    case "set_recording_duration": {
+      return { ...state, recordingDuration: action.duration };
+    }
+
+    case "indexing": {
+      return { ...state, indexing: action.indexing };
+    }
+
     case "set_uploading": {
       return { ...state, uploading: action.uploading };
     }
 
     case "set_loaded_regions": {
-      return { ...state, loadedRegions: action.parameters };
+      const recordingDuration = Math.max(
+        ...action.parameters.loading.map(r => r.end),
+        state.recordingDuration
+      );
+      return { ...state, loadedRegions: action.parameters, recordingDuration };
     }
 
     case "set_expected_error": {
@@ -85,10 +98,6 @@ export default function update(
 
     case "loading": {
       return { ...state, loading: action.loading };
-    }
-
-    case "indexed": {
-      return { ...state, indexed: true };
     }
 
     case "set_session_id": {
@@ -198,7 +207,9 @@ export const isInspectorSelected = (state: UIState) =>
   getViewMode(state) === "dev" && getSelectedPanel(state) == "inspector";
 export const getSelectedPrimaryPanel = (state: UIState) => state.app.selectedPrimaryPanel;
 export const getInitializedPanels = (state: UIState) => state.app.initializedPanels;
-export const getIndexed = (state: UIState) => state.app.indexed;
+export const getRecordingDuration = (state: UIState) => state.app.recordingDuration;
+export const getIndexing = (state: UIState) => state.app.indexing;
+export const getIndexed = (state: UIState) => state.app.indexing == 100;
 export const getLoading = (state: UIState) => state.app.loading;
 export const getLoadedRegions = (state: UIState) => state.app.loadedRegions;
 export const getUploading = (state: UIState) => state.app.uploading;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -47,7 +47,8 @@ export interface AppState {
   sessionId: SessionId | null;
   theme: string;
   splitConsoleOpen: boolean;
-  indexed: boolean;
+  recordingDuration: number;
+  indexing: number;
   loading: number;
   uploading: UploadInfo | null;
   expectedError: ExpectedError | null;


### PR DESCRIPTION
- we use both `loadedRegions` and `unprocessedRegions` events to calculate the recording's duration - in my experiments, the `unprocessedRegions` events contained the correct duration sooner than the `loadedRegions` events
- in the `onUnprocessedRegions()` callback we distinguish between the two processing levels
- the `IndexingLoader` component now uses the progress calculated from the `unprocessedRegions` events for the `executionIndexed` level