### PR TITLE
Remove duration

### DIFF
--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -246,7 +246,6 @@ class _ThreadFront {
     const sessionId = await this.waitForSession();
 
     client.Session.addLoadedRegionsListener((parameters: loadedRegions) => {
-      console.log("LoadedRegions", parameters);
       listenerCallback(parameters);
     });
 

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -119,14 +119,9 @@ export function setupApp(recordingId: RecordingId, store: UIStore) {
 
   ThreadFront.ensureProcessed("basic", undefined, regions =>
     store.dispatch(onUnprocessedRegions(regions))
-  ).then(() => {
-    store.dispatch(setLoading(100));
-  });
+  ).then(() => store.dispatch(setLoading(100)));
 
-  ThreadFront.ensureProcessed("executionIndexed").then(() => {
-    console.log("indexed");
-    store.dispatch(setIndexing(100));
-  });
+  ThreadFront.ensureProcessed("executionIndexed").then(() => store.dispatch(setIndexing(100)));
 
   ThreadFront.listenForLoadChanges((parameters: loadedRegions) =>
     store.dispatch({ type: "set_loaded_regions", parameters })
@@ -135,15 +130,11 @@ export function setupApp(recordingId: RecordingId, store: UIStore) {
 
 function onUnprocessedRegions({ level, regions }: unprocessedRegions): UIThunkAction {
   return ({ dispatch, getState }) => {
-    let endPoint = Math.max(...regions.map(r => r.end), 0);
-    if (endPoint == 0) {
+    const endPoint = selectors.getRecordingDuration(getState());
+
+    // Wait until we have started loading regions
+    if (endPoint === 0) {
       return;
-    }
-    const state = getState();
-    if (endPoint > selectors.getRecordingDuration(state)) {
-      dispatch(setRecordingDuration(endPoint));
-    } else {
-      endPoint = selectors.getRecordingDuration(state);
     }
 
     const unprocessedProgress = regions.reduce(


### PR DESCRIPTION
I think this simplifies the logic a bit without introducing any regressions:

Here's a replay with the change
https://replay.io/view?id=006fbe06-b0bb-4f51-92ae-65c53eecc3e2

Here's a replay where i saw the value of the `endPoint == 0` check :)
https://replay.io/view?id=6a30b9d8-2e8f-48e7-a4b9-a5ff0c30775a&point=27259558510959546365715416566727139&time=38402.68472280999&hasFrames=true

worst case scenario, i think these callbacks could be out of order, in which case it's possible the endPoint might be slightly lower in one case, but I don't think that should have a significant impact. 