### PR TITLE
Using more consistent font sizes across the app

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -45,18 +45,18 @@ function CommentItem({
           />
           <div className="flex-1 overflow-hidden">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-medium overflow-hidden overflow-ellipsis whitespace-pre">
+              <h3 className="text-md font-medium overflow-hidden overflow-ellipsis whitespace-pre">
                 {comment.user.name}
               </h3>
               <CommentActions comment={comment} isRoot={"replies" in comment} />
             </div>
-            <p className="text-lg text-gray-500 overflow-hidden overflow-ellipsis whitespace-pre">
+            <p className="text-md text-gray-500 overflow-hidden overflow-ellipsis whitespace-pre">
               {relativeDate}
             </p>
           </div>
         </div>
       </div>
-      <div className="space-y-6 px-4 pt-4 pb-4 text-lg">{comment.content}</div>
+      <div className="space-y-6 px-4 pt-4 pb-4 text-md">{comment.content}</div>
     </div>
   );
 }

--- a/src/ui/components/Header/UserOptions.css
+++ b/src/ui/components/Header/UserOptions.css
@@ -36,7 +36,7 @@
 .user-options .dropdown-container .content {
   width: 240px;
   right: -8px;
-  font-size: 13.5px;
+  font-size: 15px;
 }
 
 .user-options .dropdown-container .content button {

--- a/src/ui/components/Header/ViewToggle.css
+++ b/src/ui/components/Header/ViewToggle.css
@@ -26,7 +26,7 @@
 }
 
 .view-toggle .text {
-  font-size: 16px;
+  font-size: 15px;
   min-width: 145px;
   text-align: center;
   padding: 3px 36px;

--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -28,7 +28,7 @@
 }
 
 .secondary-toolbox-header button {
-  font-size: 1.1rem;
+  font-size: 12px;
   padding: 8px 12px;
   cursor: pointer;
   transition: color 200ms;

--- a/src/ui/components/SkeletonLoader.css
+++ b/src/ui/components/SkeletonLoader.css
@@ -92,7 +92,7 @@
 
 .loader header .message {
   max-width: 640px;
-  font-size: 20px;
+  font-size: 18px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -100,7 +100,6 @@
   line-height: 22px;
   margin-right: 0.5em;
   margin-left: 8px;
-  font-weight: 600;
   color: var(--grey-35);
 }
 

--- a/src/ui/components/Views/NonDevView.css
+++ b/src/ui/components/Views/NonDevView.css
@@ -15,7 +15,7 @@
 }
 
 .right-sidebar-toolbar-item {
-  font-size: 20px;
+  font-size: 15px;
   font-weight: 400;
   color: var(--theme-body-color);
   overflow: hidden;


### PR DESCRIPTION
Our font sizes are out of alignment. I'm bringing them closer and making things a smidge smaller to align better with devtools' editor and console. 

Viewer before:
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/9154902/122748095-ed8e5480-d2df-11eb-8ab8-d4d844c75798.png">

Viewer after:
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/9154902/122748203-08f95f80-d2e0-11eb-844d-4519627658e7.png">

Devtools before:
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/9154902/122748257-17e01200-d2e0-11eb-9d41-214c0d4df2c5.png">

Devtools after:
<img width="1171" alt="image" src="https://user-images.githubusercontent.com/9154902/122748827-bec4ae00-d2e0-11eb-9375-075f769dc3eb.png">
