### PR TITLE
Aligning login UX

### DIFF
--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -36,8 +36,7 @@ function RefreshButton() {
       onClick={onClick}
       disabled={clicked}
       className={classNames(
-        "inline-flex items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500",
-        "text-white bg-primaryAccent hover:bg-primaryAccentHover"
+        "w-full inline-flex items-center justify-center px-24 py-3 border border-transparent text-2xl font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
       )}
     >
       {clicked ? `Refreshing...` : `Refresh`}
@@ -57,11 +56,10 @@ function SignInButton() {
       type="button"
       onClick={onClick}
       className={classNames(
-        "inline-flex items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500",
-        "text-white bg-primaryAccent hover:bg-primaryAccentHover"
+        "w-full inline-flex items-center justify-center px-24 py-3 border border-transparent text-2xl font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
       )}
     >
-      Sign In
+      Sign in to Replay
     </button>
   );
 }
@@ -88,8 +86,8 @@ function Error({ error }: { error: ExpectedError | UnexpectedError }) {
           <img className="w-16 h-16 mx-auto" src="images/logo.svg" />
         </div>
         <div className="text-center space-y-4">
-          <div className="font-bold text-2xl">{message}</div>
-          <div className="text-xl text-gray-500">{content}</div>
+          {message ? <div className="font-bold text-2xl">{message}</div> : null}
+          {content ? <div className="text-xl text-gray-500">{content}</div> : null}
         </div>
         {action ? <ActionButton action={action} /> : null}
       </div>

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -820,9 +820,8 @@ export function useHasExpectedError(recordingId: RecordingId): ExpectedError | u
   }
 
   return {
-    message: "You need to sign in to view this replay",
-    content:
-      "You're trying to view a private replay. To proceed, we're going to need to you to sign in.",
+    message: "",
+    content: "",
     action: "sign-in",
   };
 }


### PR DESCRIPTION
Old:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/9154902/122865174-08ada280-d37a-11eb-8145-513babe0310a.png">

New:
<img width="439" alt="image" src="https://user-images.githubusercontent.com/9154902/122865073-dac85e00-d379-11eb-8de4-396d92894705.png">

Aligning with this existing pattern:
<img width="481" alt="image" src="https://user-images.githubusercontent.com/9154902/122865093-e3b92f80-d379-11eb-8121-83dfd35b52e6.png">

(There's still a little extra whitespace -- will address in follow-up)

Closes https://github.com/RecordReplay/devtools/issues/2913