### PR TITLE
Aligning our type ramp across devtools

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Tabs.css
+++ b/src/devtools/client/debugger/src/components/Editor/Tabs.css
@@ -43,7 +43,7 @@
   padding: 4px 10px;
   cursor: default;
   height: calc(var(--editor-header-height) - 1px);
-  font-size: 12px;
+  font-size: 15px;
   background-color: transparent;
   vertical-align: bottom;
 }
@@ -56,8 +56,7 @@
   width: 100%;
   height: 2px;
   background-color: var(--tab-line-color, transparent);
-  transition: transform 250ms var(--animation-curve),
-    opacity 250ms var(--animation-curve);
+  transition: transform 250ms var(--animation-curve), opacity 250ms var(--animation-curve);
   opacity: 0;
   transform: scaleX(0);
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/CommandBar.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .command-bar {
-  flex: 0 0 29px;
+  flex: 0 0 36px;
   border-bottom: 1px solid var(--theme-splitter-color);
   display: flex;
   overflow: hidden;

--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -18,9 +18,9 @@
   background-color: var(--theme-accordion-header-background);
   border-bottom: 1px solid var(--theme-splitter-color);
   display: flex;
-  font-size: 12px;
+  font-size: 15px;
   line-height: calc(16 / 12);
-  padding: 4px 6px;
+  padding: 8px;
   width: 100%;
   align-items: center;
   margin: 0px;

--- a/src/devtools/client/shared/components/Accordion.css
+++ b/src/devtools/client/shared/components/Accordion.css
@@ -58,8 +58,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 12px;
-  line-height: 16px;
+  font-size: 15px;
+  padding: 8px;
   color: var(--theme-toolbar-color);
 }
 

--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -28,7 +28,7 @@
 }
 
 .secondary-toolbox-header button {
-  font-size: 12px;
+  font-size: 15px;
   padding: 8px 12px;
   cursor: pointer;
   transition: color 200ms;

--- a/src/ui/components/Transcript/Transcript.css
+++ b/src/ui/components/Transcript/Transcript.css
@@ -17,5 +17,5 @@
   flex-grow: 1;
   overflow: auto;
   width: 100%;
-  padding: 1px 24px 24px;
+  padding: 0px 8px 24px;
 }

--- a/src/ui/components/Views/NonDevView.css
+++ b/src/ui/components/Views/NonDevView.css
@@ -10,8 +10,11 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 12px 24px;
+  padding: 8px;
   justify-content: space-between;
+  border-bottom: 1px solid var(--theme-splitter-color);
+  margin-bottom: 8px;
+  background-color: var(--theme-accordion-header-background);
 }
 
 .right-sidebar-toolbar-item {


### PR DESCRIPTION
The devtools had a big visual design clash between Comments and the other sections. These tweaks align those headers so when you click between devtools tabs, they follow the same design pattern. Example here: https://share.descript.com/view/P0eBXSDgyj2