### PR TITLE
Fix video playback when switching modes

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -62,6 +62,8 @@ export type SetHoveredLineNumberLocation = Action<"set_hovered_line_number_locat
 };
 export type SetIsNodePickerActive = Action<"set_is_node_picker_active"> & { active: boolean };
 export type SetCanvas = Action<"set_canvas"> & { canvas: Canvas };
+export type SetVideoUrl = Action<"set_video_url"> & { videoUrl: string };
+export type SetVideoNode = Action<"set_video_node"> & { videoNode: HTMLVideoElement | null };
 export type SetWorkspaceId = Action<"set_workspace_id"> & { workspaceId: WorkspaceId | null };
 export type SetDefaultSettingsTab = Action<"set_default_settings_tab"> & {
   tabTitle: SettingsTabTitle;
@@ -99,6 +101,8 @@ export type AppActions =
   | SetHoveredLineNumberLocation
   | SetIsNodePickerActive
   | SetCanvas
+  | SetVideoUrl
+  | SetVideoNode
   | SetWorkspaceId
   | SetDefaultSettingsTab
   | SetRecordingTargetAction
@@ -249,6 +253,14 @@ export function setHoveredLineNumberLocation(
 
 export function setIsNodePickerActive(active: boolean): SetIsNodePickerActive {
   return { type: "set_is_node_picker_active", active };
+}
+
+export function setVideoUrl(videoUrl: string): SetVideoUrl {
+  return { type: "set_video_url", videoUrl };
+}
+
+export function setVideoNode(videoNode: HTMLVideoElement | null): SetVideoNode {
+  return { type: "set_video_node", videoNode };
 }
 
 export function setCanvas(canvas: Canvas): SetCanvas {

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -92,6 +92,12 @@
   background: var(--theme-toolbar-background-hover);
 }
 
+.timeline .commands > button[disabled] {
+  opacity: 0.4;
+  cursor: default;
+  background: transparent;
+}
+
 .timeline .commands > button .img {
   width: 28px;
   height: 28px;

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -34,9 +34,9 @@ import { UIState } from "ui/state";
 import { HoveredItem } from "ui/state/timeline";
 import MaterialIcon from "../shared/MaterialIcon";
 
-const { prefs } = require("ui/utils/prefs");
+const { prefs, features } = require("ui/utils/prefs");
 
-function ReplayButton({ onClick }: { onClick: MouseEventHandler }) {
+function ReplayButton({ onClick, disabled }: { onClick: MouseEventHandler; disabled: boolean }) {
   return (
     <button onClick={onClick}>
       <MaterialIcon className="refresh pause_play_circle material-icons-round">
@@ -141,12 +141,18 @@ class Timeline extends Component<PropsFromRedux> {
       stopPlayback,
       replayPlayback,
       clearPendingComment,
+      videoUrl,
     } = this.props;
+    const disabled = !videoUrl && features.videoPlayback;
     const replay = () => {
+      if (disabled) return;
+
       clearPendingComment();
       replayPlayback();
     };
     const togglePlayback = () => {
+      if (disabled) return;
+
       clearPendingComment();
       if (playback) {
         stopPlayback();
@@ -158,14 +164,14 @@ class Timeline extends Component<PropsFromRedux> {
     if (currentTime == recordingDuration) {
       return (
         <div className="commands">
-          <ReplayButton onClick={replay} />
+          <ReplayButton onClick={replay} disabled={disabled} />
         </div>
       );
     }
 
     return (
       <div className="commands">
-        <button onClick={togglePlayback}>
+        <button onClick={togglePlayback} disabled={disabled}>
           {playback ? (
             <MaterialIcon className="pause_play_circle material-icons-round">
               pause_circle_outline
@@ -327,6 +333,7 @@ const connector = connect(
     pointsForHoveredLineNumber: selectors.getPointsForHoveredLineNumber(state),
     hoveredItem: selectors.getHoveredItem(state),
     clickEvents: selectors.getEventsForType(state, "mousedown"),
+    videoUrl: selectors.getVideoUrl(state),
   }),
   {
     setTimelineToTime: actions.setTimelineToTime,

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -29,6 +29,8 @@ function initialAppState(): AppState {
     hoveredLineNumberLocation: null,
     isNodePickerActive: false,
     canvas: null,
+    videoUrl: null,
+    videoNode: null,
     workspaceId: null,
     defaultSettingsTab: "Invitations",
     recordingTarget: null,
@@ -165,6 +167,20 @@ export default function update(
       };
     }
 
+    case "set_video_node": {
+      return {
+        ...state,
+        videoNode: action.videoNode,
+      };
+    }
+
+    case "set_video_url": {
+      return {
+        ...state,
+        videoUrl: action.videoUrl,
+      };
+    }
+
     case "set_workspace_id": {
       return { ...state, workspaceId: action.workspaceId };
     }
@@ -229,6 +245,8 @@ export const getEventsForType = (state: UIState, type: string) =>
   state.app.events[type] || NO_EVENTS;
 export const getIsNodePickerActive = (state: UIState) => state.app.isNodePickerActive;
 export const getCanvas = (state: UIState) => state.app.canvas;
+export const getVideoUrl = (state: UIState) => state.app.videoUrl;
+export const getVideoNode = (state: UIState) => state.app.videoNode;
 export const getWorkspaceId = (state: UIState) => state.app.workspaceId;
 export const getDefaultSettingsTab = (state: UIState) => state.app.defaultSettingsTab;
 export const getRecordingTarget = (state: UIState) => state.app.recordingTarget;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -63,6 +63,8 @@ export interface AppState {
   events: Events;
   isNodePickerActive: boolean;
   canvas: Canvas | null;
+  videoUrl: string | null;
+  videoNode: HTMLVideoElement | null;
   workspaceId: WorkspaceId | null;
   defaultSettingsTab: SettingsTabTitle;
   recordingTarget: RecordingTarget | null;

--- a/src/ui/utils/sanitize.ts
+++ b/src/ui/utils/sanitize.ts
@@ -35,7 +35,7 @@ export function sanitize(obj: any, path: string, category: string, logSanitized:
   if (Array.isArray(obj)) {
     return obj.map((item, i) => sanitize(item, `${path}[${i}]`, category, logSanitized));
   }
-  if (typeof obj === "object") {
+  if (typeof obj === "object" && !(obj instanceof HTMLElement)) {
     const sanitized: Record<string, any> = {};
     for (const key in obj) {
       sanitized[key] = sanitize(obj[key], `${path}.${key}`, category, logSanitized);


### PR DESCRIPTION
## Issue

The video was being set up within graphics which cached the node. When switching between viewer and devtools, the node would be dropped and remounted breaking the cached node reference.

## Resolution

* Adds `videoNode` and `videoUrl` to redux so they can be updated across views
* Updates the `Video` class to pull the latest node from the store when executing a command