### PR TITLE
Fine-tuning the devtools to make the heights and headers match

### DIFF
--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -41,7 +41,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: var(--theme-toolbar-color);
+  color: var(--theme-body-color);
 }
 
 .accordion ._header .header-buttons {

--- a/src/devtools/client/debugger/src/components/variables.css
+++ b/src/devtools/client/debugger/src/components/variables.css
@@ -4,7 +4,7 @@
 
 :root {
   /* header height is 28px + 1px for its border */
-  --editor-header-height: 29px;
+  --editor-header-height: 36px;
   /* footer height is 29px + 1px for its border */
   --editor-footer-height: 29px;
   /* searchbar height is 29px + 1px for its top border */

--- a/src/ui/components/Transcript/Transcript.css
+++ b/src/ui/components/Transcript/Transcript.css
@@ -17,5 +17,5 @@
   flex-grow: 1;
   overflow: auto;
   width: 100%;
-  padding: 0px 8px 24px;
+  padding: 0px 4px 24px;
 }

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -41,7 +41,7 @@ function Transcript({ recordingId, pendingComment }: PropsFromRedux) {
   return (
     <div className="right-sidebar">
       <div className="right-sidebar-toolbar">
-        <div className="right-sidebar-toolbar-item">Comments</div>
+        <div className="right-sidebar-toolbar-item comments">Comments</div>
       </div>
       <div className="transcript-panel">
         {displayedComments.length > 0 ? (

--- a/src/ui/components/Views/NonDevView.css
+++ b/src/ui/components/Views/NonDevView.css
@@ -17,6 +17,10 @@
   background-color: var(--theme-accordion-header-background);
 }
 
+.comments {
+  margin-bottom: 1px;
+}
+
 .right-sidebar-toolbar-item {
   font-size: 15px;
   font-weight: 400;


### PR DESCRIPTION
Before:
<img width="209" alt="image" src="https://user-images.githubusercontent.com/9154902/123176163-1167bb00-d4d7-11eb-92f3-fea77d86e479.png">

After:
<img width="209" alt="image" src="https://user-images.githubusercontent.com/9154902/123176144-09a81680-d4d7-11eb-93e9-8111a51568ab.png">

Before:
<img width="160" alt="image" src="https://user-images.githubusercontent.com/9154902/123176317-50960c00-d4d7-11eb-9a55-e7d86b527063.png">

After:
<img width="245" alt="image" src="https://user-images.githubusercontent.com/9154902/123176334-5855b080-d4d7-11eb-9e73-70f4b991a34e.png">


I also changed the color to be consistent across the headers. (Dark grey versus black)