### PR TITLE
Show the domain at the top level

### DIFF
--- a/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -159,7 +159,7 @@ class SourceTreeItem extends Component {
 
     if (isDirectory(item)) {
       // Domain level
-      if (depth === 1) {
+      if (depth === 0) {
         return <AccessibleImage className="globe-small" />;
       }
       return <AccessibleImage className="folder" />;


### PR DESCRIPTION
Firefox devtools had the thread at the top, but that is no longer the case
https://replay.io/view?id=8dbc98bd-30e6-4591-a406-59c355277864&point=23365335865783286389771392639828736&time=9790.162359539621&hasFrames=true

<img width="284" alt="Screen Shot 2021-06-23 at 4 45 10 PM" src="https://user-images.githubusercontent.com/254562/123181916-25fa7380-d443-11eb-99e4-c5258e24550e.png">
