### PR TITLE
Adding a comment should open the panel

### DIFF
--- a/src/devtools/client/debugger/src/reducers/ui.js
+++ b/src/devtools/client/debugger/src/reducers/ui.js
@@ -44,6 +44,11 @@ function update(state = createUIState(), action) {
       return { ...state, startPanelCollapsed: action.paneCollapsed };
     }
 
+    case "set_selected_primary_panel": {
+      prefs.startPanelCollapsed = false;
+      return { ...state, startPanelCollapsed: false };
+    }
+
     case "TOGGLE_SOURCES": {
       prefs.sourcesCollapsed = action.sourcesCollapsed;
       return { ...state, sourcesCollapsed: action.sourcesCollapsed };


### PR DESCRIPTION
Max and I noticed that "Adding a comment" doesn't open the primary pane open.
https://replay.io/view?id=dcb0acba-6872-491e-a82c-a95fff8bfe28