### PR TITLE
Simplified upload screen

### DIFF
--- a/src/library.ts
+++ b/src/library.ts
@@ -21,6 +21,7 @@ export async function initialize() {
   const store = createStore(combineReducers({ app: reducer }), {}, middleware);
 
   const settings = await getUserSettings();
+  console.log({ settings });
   store.dispatch(setWorkspaceId(settings.defaultWorkspaceId));
 
   (window as any).app = {

--- a/src/upload.tsx
+++ b/src/upload.tsx
@@ -10,6 +10,7 @@ import { setExpectedError } from "ui/actions/session";
 import { useGetRecording, useHasExpectedError } from "ui/hooks/recordings";
 import { BlankLoadingScreen } from "ui/components/shared/BlankScreen";
 import UploadScreen from "ui/components/UploadScreen";
+import hooks from "ui/hooks";
 
 const url = new URL(window.location.href);
 const recordingId = url.searchParams.get("id")!;
@@ -17,6 +18,8 @@ const recordingId = url.searchParams.get("id")!;
 function _UploadScreenWrapper({ setExpectedError }: PropsFromRedux) {
   const expectedError = useHasExpectedError(recordingId);
   const { recording } = useGetRecording(recordingId);
+  // Make sure to get the user's settings before showing the upload screen.
+  const { loading } = hooks.useGetUserSettings();
 
   useEffect(() => {
     if (expectedError) {
@@ -31,7 +34,7 @@ function _UploadScreenWrapper({ setExpectedError }: PropsFromRedux) {
     }
   });
 
-  if (expectedError) {
+  if (expectedError || loading) {
     return <BlankLoadingScreen />;
   }
 


### PR DESCRIPTION
Fix #2862.

Some changes:
- Made the copy more specific. Used "who can view" instead of "available"/"restricted"
  - `"Available to anyone with the link"` -> `"This replay can be viewed by anyone with the link"`
  - `"Available to team Team A"` -> `"This replay can be viewed by anyone from Team A"`
  - `"This replay is available to anyone with a link"` -> `"This replay can be viewed by anyone with the link"`
- Used a separate icon (one person) for My Library + Private case

Quick note that in the current state, only the Private cases actually apply to this UI. The edit button is not toggle-able, meaning it only brings you to the editing state but doesn't let you go back to the summary state. Replays are private by default, so there's no opportunity for you to hit edit, change it to public, and view the summary again with the Public states.






x | My Library | Team Library
--- | --- | ---
Public | ![image](https://user-images.githubusercontent.com/15959269/123302832-1c2c4b00-d4eb-11eb-892c-dc6eed1e18ff.png) | ![image](https://user-images.githubusercontent.com/15959269/123302915-3534fc00-d4eb-11eb-9204-8bb10a895a40.png)
Private | ![image](https://user-images.githubusercontent.com/15959269/123302789-0f0f5c00-d4eb-11eb-8a1c-01adcb303826.png) | ![image](https://user-images.githubusercontent.com/15959269/123302947-3cf4a080-d4eb-11eb-9002-0419eccbe592.png)