### PR TITLE
Fix new team member rows in modals

### DIFF
--- a/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -14,6 +14,7 @@ import { Workspace, WorkspaceUser } from "ui/types";
 import { validateEmail } from "ui/utils/helpers";
 import { TextInput } from "../Forms";
 import Modal from "../NewModal";
+import { WorkspaceMembers } from "../WorkspaceSettingsModal/WorkspaceSettingsModal";
 import InvitationLink from "./InvitationLink";
 const { prefs } = require("ui/utils/prefs");
 
@@ -217,13 +218,7 @@ function SlideBody2({ hideModal, setCurrent, newWorkspace, total, current }: Sli
           {errorMessage ? <div>{errorMessage}</div> : null}
         </form>
         <div className="overflow-auto flex-grow">
-          {!loading && sortedMembers ? (
-            <div className="flex flex-col space-y-2">
-              {sortedMembers.map(m => (
-                <div key={m.email}>{m.email}</div>
-              ))}
-            </div>
-          ) : null}
+          {!loading && sortedMembers ? <WorkspaceMembers members={sortedMembers} /> : null}
         </div>
         <InvitationLink workspaceId={newWorkspace!.id} />
       </SlideContent>

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
@@ -18,6 +18,7 @@ import BlankScreen from "../BlankScreen";
 import { TextInput } from "../Forms";
 import Modal from "../NewModal";
 import InvitationLink from "../NewWorkspaceModal/InvitationLink";
+import { WorkspaceMembers } from "../WorkspaceSettingsModal/WorkspaceSettingsModal";
 const { prefs } = require("ui/utils/prefs");
 
 function ModalButton({
@@ -239,7 +240,6 @@ function SlideBody3({ hideModal, setCurrent, newWorkspace, total, current }: Sli
     inviteNewWorkspaceMember({ variables: { workspaceId: newWorkspace!.id, email: inputValue } });
   };
 
-  console.log({ newWorkspace });
   return (
     <>
       <SlideContent headerText="Your team members">
@@ -254,13 +254,7 @@ function SlideBody3({ hideModal, setCurrent, newWorkspace, total, current }: Sli
           {errorMessage ? <div>{errorMessage}</div> : null}
         </form>
         <div className="overflow-auto flex-grow">
-          {!loading && sortedMembers ? (
-            <div className="flex flex-col space-y-2">
-              {sortedMembers.map(m => (
-                <div key={m.email}>{m.email}</div>
-              ))}
-            </div>
-          ) : null}
+          {!loading && sortedMembers ? <WorkspaceMembers members={sortedMembers} /> : null}
         </div>
         <InvitationLink workspaceId={newWorkspace!.id} />
       </SlideContent>

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.css
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.css
@@ -3,63 +3,12 @@
   overflow: auto;
 }
 
-.workspace-members-container .workspace-members > :not(:first-child) {
-  margin-top: 8px;
-}
-
-.workspace-members-container .workspace-member {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.workspace-members-container .workspace-member > :not(:first-child) {
-  margin-left: 8px;
-}
-
-.workspace-members-container .workspace-member img {
-  border-radius: 50%;
-  height: 28px;
-  width: 28px;
-}
-
-.workspace-members-container .workspace-member-content {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-}
-
-.workspace-members-container .workspace-member-content .subtitle {
-  font-size: 12px;
-  color: var(--theme-comment);
-}
-
-.workspace-members-container .workspace-member .material-icons {
-  font-size: 28px;
-}
-
 /* Permissions dropdown */
 
 .workspace-members-container .member-permissions .expand-dropdown {
   padding: 0px;
   color: var(--theme-toolbar-color);
   background: inherit;
-}
-
-.workspace-members-container .permission-container {
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-}
-
-.workspace-members-container .workspace-member .permission-container .material-icons {
-  font-size: 16px;
-  color: var(--theme-comment);
-  visibility: hidden;
-}
-
-.workspace-members-container .permission-container:hover .material-icons {
-  visibility: visible;
 }
 
 .permissions-dropdown-item {

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
@@ -13,6 +13,17 @@ import MaterialIcon from "../MaterialIcon";
 
 type WorkspaceMemberProps = { member: WorkspaceUser } & PropsFromRedux;
 
+function Status({ children }: { children: string }) {
+  return (
+    <div className="flex flex-row items-center group">
+      <MaterialIcon className="material-icons opacity-0 group-hover:opacity-100">
+        expand_more
+      </MaterialIcon>
+      <span>{children}</span>
+    </div>
+  );
+}
+
 export function NonRegisteredWorkspaceMember({ member }: { member: WorkspaceUser }) {
   const deleteUserFromWorkspace = hooks.useDeleteUserFromWorkspace();
   const [expanded, setExpanded] = useState(false);
@@ -27,18 +38,13 @@ export function NonRegisteredWorkspaceMember({ member }: { member: WorkspaceUser
   };
 
   return (
-    <li className="workspace-member">
-      <MaterialIcon>mail_outline</MaterialIcon>
-      <div className="workspace-member-content">
-        <div className="title">{member.email}</div>
+    <li className="flex flex-row items-center space-x-2">
+      <div className="grid justify-center items-center" style={{ width: "28px", height: "28px" }}>
+        <MaterialIcon className="text-3xl">mail_outline</MaterialIcon>
       </div>
+      <div className="flex-grow">{member.email}</div>
       <PortalDropdown
-        buttonContent={
-          <div className="permission-container">
-            <MaterialIcon>expand_more</MaterialIcon>
-            <span>Pending</span>
-          </div>
-        }
+        buttonContent={<Status>Pending</Status>}
         setExpanded={setExpanded}
         expanded={expanded}
         buttonStyle=""
@@ -90,12 +96,7 @@ function Role({
 
   let content = (
     <PortalDropdown
-      buttonContent={
-        <div className="permission-container">
-          <MaterialIcon>expand_more</MaterialIcon>
-          <span>Admin</span>
-        </div>
-      }
+      buttonContent={<Status>Admin</Status>}
       setExpanded={setExpanded}
       expanded={expanded}
       buttonStyle=""
@@ -110,12 +111,7 @@ function Role({
   if (member.pending) {
     content = (
       <PortalDropdown
-        buttonContent={
-          <div className="permission-container">
-            <MaterialIcon>expand_more</MaterialIcon>
-            <span>Pending</span>
-          </div>
-        }
+        buttonContent={<Status>Pending</Status>}
         setExpanded={setExpanded}
         expanded={expanded}
         buttonStyle=""
@@ -128,16 +124,18 @@ function Role({
     );
   }
 
-  return <div className="member-permissions">{content}</div>;
+  return content;
 }
 
 function WorkspaceMember({ member, setWorkspaceId, hideModal }: WorkspaceMemberProps) {
   return (
-    <li className="workspace-member">
-      <img src={member.user!.picture} />
-      <div className="workspace-member-content">
-        <div className="title">{member.user!.name}</div>
-      </div>
+    <li className="flex flex-row items-center space-x-2">
+      <img
+        src={member.user!.picture}
+        className="rounded-full"
+        style={{ width: "28px", height: "28px" }}
+      />
+      <div className="flex-grow">{member.user!.name}</div>
       <Role member={member} setWorkspaceId={setWorkspaceId} hideModal={hideModal} />
     </li>
   );

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -41,7 +41,7 @@ function ModalButton({
 
 export function WorkspaceMembers({ members }: { members: WorkspaceUser[] }) {
   return (
-    <ul className="workspace-members">
+    <ul className="flex flex-col space-y-3">
       {members.map(member =>
         member.email ? (
           <NonRegisteredWorkspaceMember member={member} key={`non-registered-${member.email}`} />

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -27,7 +27,6 @@ pref("devtools.toolbox-height", "50%");
 pref("devtools.non-dev-side-panel-width", "25%");
 pref("devtools.view-mode", "non-dev");
 pref("devtools.dev-secondary-panel-height", "50%");
-pref("devtools.video", !!urlPrefs.video);
 pref("devtools.maxHitsDisplayed", 500);
 pref("devtools.maxHitsEditable", 200);
 pref("devtools.libraryFilterTime", "all");
@@ -58,7 +57,6 @@ export const prefs = new PrefsHelper("devtools", {
   nonDevSidePanelWidth: ["String", "non-dev-side-panel-width"],
   viewMode: ["String", "view-mode"],
   secondaryPanelHeight: ["String", "dev-secondary-panel-height"],
-  video: ["Bool", "video"],
   maxHitsDisplayed: ["Int", "maxHitsDisplayed"],
   maxHitsEditable: ["Int", "maxHitsEditable"],
   libraryFilterTime: ["String", "libraryFilterTime"],


### PR DESCRIPTION
This reuses the same workspace member UI from the workspace settings. That way, users can edit the invited team members while in the team leader onboarding modal, and when they're creating a new team.

Fixes #2891.

![image](https://user-images.githubusercontent.com/15959269/123818939-62a4ef80-d8c7-11eb-87d2-cf8a7f229605.png)
![image](https://user-images.githubusercontent.com/15959269/123819684-f70f5200-d8c7-11eb-8dc7-dca82186717e.png)
![image](https://user-images.githubusercontent.com/15959269/123821237-38ecc800-d8c9-11eb-9d7b-18374550aaba.png)

