### PR TITLE
Fix timeline replay button disabled state when video is loading

### DIFF
--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -38,7 +38,7 @@ const { prefs, features } = require("ui/utils/prefs");
 
 function ReplayButton({ onClick, disabled }: { onClick: MouseEventHandler; disabled: boolean }) {
   return (
-    <button onClick={onClick}>
+    <button onClick={onClick} disabled={disabled}>
       <MaterialIcon className="refresh pause_play_circle material-icons-round">
         refresh
       </MaterialIcon>


### PR DESCRIPTION
#2921 added the `disabled` prop to the replay button but failed to pass it on to the `<button>` to apply the style. This PR fixes that!

Fixes #2984 