### PR TITLE
Always set the DebugLine on the source picked for display (#2927)

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/setFramePositions.js
+++ b/src/devtools/client/debugger/src/actions/pause/setFramePositions.js
@@ -20,7 +20,9 @@ export function setFramePositions() {
     const { sourceId: protocolSourceId } = await ThreadFront.getPreferredLocation(
       positions[0].frame
     );
-    const sourceId = getSourceByActorId(getState(), protocolSourceId)?.id;
+    const source = getSourceByActorId(getState(), protocolSourceId);
+    const sourceId = source?.id;
+    const sourceUrl = source?.url;
 
     if (!sourceId) {
       return;
@@ -29,7 +31,7 @@ export function setFramePositions() {
     const locations = await Promise.all(
       positions.map(async ({ frame }) => {
         const { line, column } = await ThreadFront.getPreferredLocation(frame);
-        return { line, column, sourceId };
+        return { line, column, sourceId, sourceUrl };
       })
     );
 

--- a/src/devtools/client/debugger/src/client/create.js
+++ b/src/devtools/client/debugger/src/client/create.js
@@ -20,8 +20,10 @@ export async function createFrame(frame, index = 0, asyncIndex = 0) {
   }
 
   const { sourceId, line, column } = await ThreadFront.getPreferredLocation(frame.location);
+  const sourceUrl = await ThreadFront.getSourceURL(sourceId);
   const location = {
     sourceId: clientCommands.getSourceForActor(sourceId),
+    sourceUrl,
     line,
     column,
   };
@@ -29,8 +31,10 @@ export async function createFrame(frame, index = 0, asyncIndex = 0) {
   let alternateLocation;
   const alternate = await ThreadFront.getAlternateLocation(frame.location);
   if (alternate) {
+    const alternateSourceUrl = await ThreadFront.getSourceURL(alternate.sourceId);
     alternateLocation = {
       sourceId: clientCommands.getSourceForActor(alternate.sourceId),
+      sourceUrl: alternateSourceUrl,
       line: alternate.line,
       column: alternate.column,
     };

--- a/src/devtools/client/debugger/src/components/Editor/DebugLine.js
+++ b/src/devtools/client/debugger/src/components/Editor/DebugLine.js
@@ -4,6 +4,7 @@
 
 //
 import { PureComponent } from "react";
+import { ThreadFront } from "protocol/thread";
 import {
   toEditorLine,
   toEditorColumn,
@@ -114,6 +115,12 @@ const mapStateToProps = state => {
   const frame = getVisibleSelectedFrame(state);
   const previewLocation = getPausePreviewLocation(state);
   const location = previewLocation || (frame && frame.location);
+  if (location) {
+    location.sourceId = ThreadFront.pickCorrespondingSourceId(
+      location.sourceId,
+      location.sourceUrl
+    );
+  }
   return {
     frame,
     location,

--- a/src/devtools/client/debugger/src/selectors/debugLine.ts
+++ b/src/devtools/client/debugger/src/selectors/debugLine.ts
@@ -1,0 +1,18 @@
+import { ThreadFront } from "protocol/thread";
+import { UIState } from "ui/state";
+import { getVisibleSelectedFrame, getSourceWithContent, getPausePreviewLocation } from ".";
+import { hasDocument } from "../utils/editor";
+
+export function getDebugLineLocation(state: UIState) {
+  const frame = getVisibleSelectedFrame(state);
+  const previewLocation = getPausePreviewLocation(state);
+  const location = previewLocation || (frame && frame.location);
+  if (!location) {
+    return undefined;
+  }
+  location.sourceId = ThreadFront.pickCorrespondingSourceId(location.sourceId, location.sourceUrl);
+  const source = getSourceWithContent(state, location.sourceId);
+  if (source && source.content && hasDocument(location.sourceId)) {
+    return location;
+  }
+}

--- a/src/devtools/client/debugger/src/selectors/debugLine.ts
+++ b/src/devtools/client/debugger/src/selectors/debugLine.ts
@@ -10,6 +10,8 @@ export function getDebugLineLocation(state: UIState) {
   if (!location) {
     return undefined;
   }
+  // this is bad design: a redux selector should only use redux state, but here we use
+  // the state stored in ThreadFront. This will be fixed in #3065.
   location.sourceId = ThreadFront.pickCorrespondingSourceId(location.sourceId, location.sourceUrl);
   const source = getSourceWithContent(state, location.sourceId);
   if (source && source.content && hasDocument(location.sourceId)) {

--- a/src/devtools/client/debugger/src/selectors/index.d.ts
+++ b/src/devtools/client/debugger/src/selectors/index.d.ts
@@ -1,3 +1,18 @@
 import { UIState } from "ui/state";
+import { Location } from "@recordreplay/protocol";
+
+export interface UrlLocation extends Location {
+  sourceUrl: string;
+}
+
+export interface SelectedFrame {
+  id: string;
+  displayName: string;
+  location: UrlLocation;
+}
 
 export function getThreadContext(state: UIState): any;
+export function getVisibleSelectedFrame(state: UIState): SelectedFrame | null;
+export function getSourceWithContent(state: UIState, sourceId: string): any;
+export function getPausePreviewLocation(state: UIState): UrlLocation;
+export function getDebugLineLocation(state: UIState): UrlLocation | undefined;

--- a/src/devtools/client/debugger/src/selectors/index.js
+++ b/src/devtools/client/debugger/src/selectors/index.js
@@ -35,3 +35,4 @@ export { getCallStackFrames } from "./getCallStackFrames";
 export { getBreakpointSources } from "./breakpointSources";
 export * from "./visibleColumnBreakpoints";
 export { getSelectedFrame, getVisibleSelectedFrame, getFramePositions } from "./pause";
+export * from "./debugLine";

--- a/src/devtools/client/debugger/src/utils/editor/index.d.ts
+++ b/src/devtools/client/debugger/src/utils/editor/index.d.ts
@@ -1,1 +1,2 @@
 export function inBreakpointPanel(e: React.MouseEvent<HTMLDivElement, MouseEvent>): boolean;
+export function hasDocument(sourceId: string): boolean;

--- a/test/scripts/breakpoints-07.js
+++ b/test/scripts/breakpoints-07.js
@@ -30,11 +30,13 @@
     // click the first source link in the console
     document.querySelectorAll(".webconsole-output .frame-link-source")[0].click();
     await checkBreakpointPanel(1);
+    await checkDebugLine();
 
     closeEditor();
     // click the second source link in the console
     document.querySelectorAll(".webconsole-output .frame-link-source")[1].click();
     await checkBreakpointPanel(1);
+    await checkDebugLine();
 
     // reload the recording
     url.searchParams.append("navigated", "true");
@@ -63,6 +65,12 @@ async function checkBreakpointPanel(selectedBreakpoint) {
     const statusElement = document.querySelector(".breakpoint-navigation-status-container");
     return statusElement && statusElement.textContent === `${selectedBreakpoint}/2`;
   });
+}
+
+async function checkDebugLine() {
+  await Test.waitUntil(() =>
+    document.querySelector(".editor-pane .CodeMirror-code .new-debug-line")
+  );
 }
 
 function closeEditor() {


### PR DESCRIPTION
- uses `ThreadFront.pickCorrespondingSourceId` in the `DebugLine` connector to ensure the line is set on the correct source
- adds `sourceUrl` to frame and pause preview locations because that is needed for `ThreadFront.pickCorrespondingSourceId`