### PR TITLE
Fix assertion failure in selectLocation (#3000)

### DIFF
--- a/src/devtools/client/debugger/src/actions/sources/select.js
+++ b/src/devtools/client/debugger/src/actions/sources/select.js
@@ -104,6 +104,7 @@ export function selectLocation(cx, initialLocation, { keepContext = true } = {})
       return dispatch(clearSelectedLocation(cx));
     }
 
+    await ThreadFront.ensureAllSources();
     const sourceId = ThreadFront.pickCorrespondingSourceId(initialSource.id, initialSource.url);
     const source = getSource(getState(), sourceId);
     const location = { ...initialLocation, sourceId };


### PR DESCRIPTION
This ensures that `Debugger.findSources` has finished before calling `ThreadFront.pickCorrespondingSourceId()`.
The only other place where `ThreadFront.pickCorrespondingSourceId()` is [called](https://github.com/RecordReplay/devtools/blob/de5e97b859014db176f6dca19e07f4d6b00aa219/src/devtools/client/debugger/src/actions/sources/newSources.js#L84) already waits for `Debugger.findSources` to finish.