### PR TITLE
Sync video time with timeline before playback

### DIFF
--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -178,10 +178,12 @@ class VideoPlayer {
   play() {
     this.commands =
       this.commands &&
-      this.commands?.then(async () => {
+      this.commands.then(() => {
         const video = this.store?.getState().app.videoNode;
+        const currentTime = this.store?.getState().timeline.currentTime;
         if (video) {
-          await video.play();
+          video.currentTime = (currentTime || 0) / 1000;
+          return video.play();
         }
       });
   }


### PR DESCRIPTION
I noticed that playback seemed to fail when the `<video>`'s `currentTime` was at (or nearly so?) the end but the recording's timeline was at a different time. Syncing the timelines before kicking off playback seems to improve behavior in my testing.