### PR TITLE
Add flex styling to secondary toolbox to fix console scrolling

### DIFF
--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -67,6 +67,22 @@
 /* It's important to set min-height: 0 here, otherwise the console output
 overflows its container (https://drafts.csswg.org/css-flexbox-1/#min-size-auto) */
 .secondary-toolbox .secondary-toolbox-content {
-  height: 100%;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
   min-height: 0;
+  height: 100%;
+}
+
+.secondary-toolbox .toolbox-bottom-panels {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.secondary-toolbox .toolbox-bottom-panels .toolbox-panel {
+  flex: 1;
+  min-height: 0;
+  height: 100%;
 }

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -90,7 +90,7 @@ function PanelButtons({
 
 function ConsolePanel() {
   return (
-    <div className="toolbox-bottom-panels" style={{ overflow: "hidden" }}>
+    <div className="toolbox-bottom-panels">
       <div className={classnames("toolbox-panel")} id="toolbox-content-console">
         <WebConsoleApp />
       </div>


### PR DESCRIPTION
Add additional flexbox rules to ensure that the console is correctly sized for scrolling.

The DOM here could use some future refactoring. There is some unnecessary nesting that, if removed, would help simplify the styling as well.