### PR TITLE
Add doctype and fix regressions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.css
@@ -60,10 +60,9 @@ body.scrubbing {
 
 .frame-timeline-progress {
   background-color: var(--replaying-marker-future-fill);
-  position: relative;
+  position: absolute;
   width: 50%;
   height: 100%;
-  position: relative;
   display: inline-block;
   border-radius: 4px;
 }

--- a/src/devtools/client/themes/inspector.css
+++ b/src/devtools/client/themes/inspector.css
@@ -18,6 +18,7 @@ window {
 /* The main Inspector panel container. */
 .inspector-responsive-container {
   height: 100%;
+  width: 100%;
   overflow: hidden;
 }
 

--- a/src/ui/components/Toolbox.css
+++ b/src/ui/components/Toolbox.css
@@ -34,6 +34,8 @@
 .toolbox-panel {
   display: flex;
   flex: 1;
+  height: 100%;
+  min-height: 0;
 }
 
 /* Toolbar Styles */


### PR DESCRIPTION
Fun fact: #3082 didn't actually add the doctype. I somehow missed it in my git clean up. When adding it back, I noticed a couple other regressions which I've fixed here as well.

* Adds doctype (for real this time)
* Fixes positioning of pause timeline slider
* Fixes elements panel to fill the available space