### PR TITLE
Fix source mapping in the SmartTrace component (#3088)

### DIFF
--- a/src/devtools/client/shared/components/SmartTrace.d.ts
+++ b/src/devtools/client/shared/components/SmartTrace.d.ts
@@ -13,6 +13,7 @@ export interface SmartTraceProps {
   stacktrace: SmartTraceStackFrame[];
   onViewSourceInDebugger: (location: DebuggerLocation) => void;
   onReady?: () => void;
+  mapSources?: boolean;
 }
 
 export default class SmartTrace extends Component<SmartTraceProps> {}

--- a/src/devtools/client/shared/components/SmartTrace.js
+++ b/src/devtools/client/shared/components/SmartTrace.js
@@ -27,6 +27,7 @@ class SmartTrace extends Component {
       // Function that will be called when the SmartTrace is ready, i.e. once it was
       // rendered.
       onReady: PropTypes.func,
+      mapSources: PropTypes.bool,
     };
   }
 
@@ -47,9 +48,13 @@ class SmartTrace extends Component {
   }
 
   UNSAFE_componentWillMount() {
+    if (!this.props.mapSources) {
+      return;
+    }
+
     const mappedStack = this.props.stacktrace.map(async frame => {
       const { lineNumber, columnNumber, filename } = frame;
-      const sourceIds = ThreadFront.getSourceIdsForURL(filename);
+      const sourceIds = ThreadFront.getGeneratedSourceIdsForURL(filename);
       if (sourceIds.length != 1) {
         return frame;
       }
@@ -92,7 +97,7 @@ class SmartTrace extends Component {
       return null;
     }
 
-    const { onViewSourceInDebugger, onViewSource } = this.props;
+    const { onViewSourceInDebugger, onViewSource, mapSources } = this.props;
 
     const stacktrace = this.state.isSourceMapped ? this.state.stacktrace : this.props.stacktrace;
 
@@ -130,7 +135,7 @@ class SmartTrace extends Component {
       disableFrameTruncate: true,
       disableContextMenu: true,
       frameworkGroupingOn: true,
-      displayFullUrl: !this.state || !this.state.isSourceMapped,
+      displayFullUrl: mapSources && (!this.state || !this.state.isSourceMapped),
       panel: "webconsole",
     });
   }

--- a/src/devtools/client/webconsole/utils/connected-object-inspector.tsx
+++ b/src/devtools/client/webconsole/utils/connected-object-inspector.tsx
@@ -39,7 +39,7 @@ function onInspectIconClick(object: ValueFront, e: React.MouseEvent) {
 }
 
 function renderStacktrace(stacktrace: SmartTraceStackFrame[]) {
-  return <SmartTrace key="stacktrace" stacktrace={stacktrace} />;
+  return <SmartTrace key="stacktrace" stacktrace={stacktrace} mapSources={true} />;
 }
 
 const connector = connect(null, {

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -359,6 +359,15 @@ class _ThreadFront {
     });
   }
 
+  getGeneratedSourceIdsForURL(url: string) {
+    // Ignore IDs which are original versions of another ID with the same URL.
+    const ids = this.urlSources.map.get(url) || [];
+    return ids.filter(id => {
+      const generatedIds = this.sources.get(id)?.generatedSourceIds;
+      return (generatedIds || []).every(generatedId => !ids.includes(generatedId));
+    });
+  }
+
   async getSourceContents(sourceId: SourceId) {
     assert(this.sessionId);
     const { contents, contentType } = await client.Debugger.getSourceContents(


### PR DESCRIPTION
The `SmartTrace` component (which renders stacktraces in the console) already tried to sourcemap the locations, but failed because it used `ThreadFront.getSourceIdsForURL()`, which favors original sources. I created `ThreadFront.getGeneratedSourceIdsForURL()` to fix that.
Then I noticed that the stacktraces for `console.error()` calls are already sourcemapped, only the stacktraces in `Error` objects aren't sourcemapped yet, hence the new prop `mapSources` which specifies if `SmartTrace` should attempt to sourcemap the locations itself.
But perhaps we want to do this in the backend instead, so that we handle stacktraces consistently?
