### PR TITLE
Set the Dev sidepanel to a fixed width

### DIFF
--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -204,23 +204,10 @@ class Debugger extends Component {
     const { startPanelCollapsed } = this.props;
 
     return (
-      <SplitBox
-        style={{ width: "100%" }}
-        initialSize={prefs.startPanelSize}
-        minSize={30}
-        maxSize="85%"
-        splitterSize={1}
-        onResizeEnd={num => {
-          prefs.startPanelSize = num;
-        }}
-        startPanelCollapsed={startPanelCollapsed}
-        startPanel={
-          <div className="panes" style={{ width: "100%" }}>
-            <SidePanel />
-          </div>
-        }
-        endPanel={this.renderEditorPane()}
-      />
+      <div className="horizontal-panels">
+        <SidePanel />
+        {this.renderEditorPane()}
+      </div>
     );
   };
 

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -7,8 +7,10 @@ import Events from "ui/components/Events";
 const PrimaryPanes = require("devtools/client/debugger/src/components/PrimaryPanes").default;
 const SecondaryPanes = require("devtools/client/debugger/src/components/SecondaryPanes").default;
 
-function SidePanel({ selectedPrimaryPanel }: PropsFromRedux) {
-  let sidepanel;
+const SIDEPANEL_WIDTH = 320;
+
+function SidePanel({ selectedPrimaryPanel, narrowMode }: PropsFromRedux) {
+  let sidepanel, style;
 
   if (selectedPrimaryPanel === "explorer") {
     sidepanel = <PrimaryPanes />;
@@ -20,10 +22,21 @@ function SidePanel({ selectedPrimaryPanel }: PropsFromRedux) {
     sidepanel = <Events />;
   }
 
-  return <div style={{ width: "400px" }}>{sidepanel}</div>;
+  if (!narrowMode) {
+    style = {
+      width: `${SIDEPANEL_WIDTH}px`,
+      height: "100%",
+      borderRight: "1px solid var(--theme-splitter-color)",
+    };
+  } else {
+    style = { width: "100%", height: "100%", borderRight: "1px solid var(--theme-splitter-color)" };
+  }
+
+  return <div style={style}>{sidepanel}</div>;
 }
 
 const connector = connect((state: UIState) => ({
+  narrowMode: selectors.getNarrowMode(state),
   selectedPrimaryPanel: selectors.getSelectedPrimaryPanel(state),
 }));
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/Views/NonDevView.tsx
+++ b/src/ui/components/Views/NonDevView.tsx
@@ -73,35 +73,12 @@ function NonDevView({ updateTimelineDimensions, narrowMode }: PropsFromRedux) {
 
   return (
     <div className="horizontal-panels">
-      <div
-        className="flex flex-row overflow-hidden h-full"
-        style={{ borderRight: "1px solid var(--theme-splitter-color)" }}
-      >
+      <div className="flex flex-row h-full">
         <Toolbar />
         <SidePanel />
       </div>
       {viewer}
     </div>
-  );
-
-  return (
-    <SplitBox
-      style={{ width: "100%", overflow: "hidden" }}
-      splitterSize={1}
-      initialSize={prefs.nonDevSidePanelWidth as string}
-      minSize="20%"
-      onMove={handleMove}
-      maxSize="80%"
-      vert={true}
-      startPanel={
-        <div className="horizontal-panels">
-          <Toolbar />
-          <SidePanel />
-        </div>
-      }
-      endPanel={viewer}
-      endPanelControl={false}
-    />
   );
 }
 


### PR DESCRIPTION
Fix #2979.

This PR sets the `<SidePanel />` component to a fixed 400px width.

Regular (Dev View) 
![image](https://user-images.githubusercontent.com/15959269/126537304-fdc64165-4b84-4912-bcb8-ab3800ec2e92.png)

Regular (Dev View + Narrow)
![image](https://user-images.githubusercontent.com/15959269/126537441-66b4e7fa-7bc2-4c69-b545-3ae2f4d8bdcc.png)

Regular (Non Dev View)
![image](https://user-images.githubusercontent.com/15959269/126537353-eff6912e-2a3e-4070-958e-e8221a198ee2.png)

Regular (Non Dev View + Narrow)
![image](https://user-images.githubusercontent.com/15959269/126537399-015eb209-ae66-430d-97ed-ae2b663b6f13.png)

Node (Dev view)
![image](https://user-images.githubusercontent.com/15959269/126537119-db3e6982-9981-41d2-bb2a-ce1a87900219.png)

Node (Dev view + Narrow)
![image](https://user-images.githubusercontent.com/15959269/126537264-05382721-449e-4f57-9c08-bcf3478d3d93.png)
