### PR TITLE
Add UI for managing API keys in settings

### DIFF
--- a/src/ui/components/Dashboard/DashboardViewer.tsx
+++ b/src/ui/components/Dashboard/DashboardViewer.tsx
@@ -123,7 +123,7 @@ export default function DashboardViewer({ recordings }: { recordings: Recording[
             <TextInput
               placeholder="Search..."
               value={searchString}
-              onChange={e => setSearchString(e.target.value)}
+              onChange={e => setSearchString((e.target as HTMLInputElement).value)}
             />
           </>
         }

--- a/src/ui/components/shared/Forms/TextInput.tsx
+++ b/src/ui/components/shared/Forms/TextInput.tsx
@@ -1,24 +1,13 @@
-import React, { ChangeEvent } from "react";
+import React from "react";
 
-export default function TextInput({
-  placeholder,
-  value,
-  onChange,
-  id,
-}: {
-  placeholder?: string;
-  value: string;
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
-  id?: string;
-}) {
+export default function TextInput(
+  props: Omit<React.HTMLProps<HTMLInputElement>, "type" | "className">
+) {
   return (
     <input
+      {...props}
       type="text"
-      id={id}
-      onChange={onChange}
-      value={value}
       className="focus:ring-primaryAccent focus:primaryAccentHover block w-full text-lg border px-3 py-2 border-textFieldBorder rounded-md"
-      placeholder={placeholder}
     />
   );
 }

--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -5,15 +5,22 @@ import * as selectors from "ui/reducers/app";
 import { UIState } from "ui/state";
 import "./MaterialIcon.css";
 
-type MaterialIconProps = PropsFromRedux & {
-  children: string;
-  highlighted?: boolean;
-  className?: string;
-};
+type MaterialIconProps = PropsFromRedux &
+  React.HTMLProps<HTMLDivElement> & {
+    children: string;
+    highlighted?: boolean;
+  };
 
-function MaterialIcon({ children, fontLoading, highlighted, className }: MaterialIconProps) {
+function MaterialIcon({
+  children,
+  fontLoading,
+  highlighted,
+  className,
+  ...rest
+}: MaterialIconProps) {
   return (
     <div
+      {...rest}
       className={classnames(
         "material-icons",
         className,

--- a/src/ui/components/shared/SettingsModal/ReplayInvitations.tsx
+++ b/src/ui/components/shared/SettingsModal/ReplayInvitations.tsx
@@ -62,7 +62,7 @@ export default function ReplayInvitations() {
           <TextInput
             placeholder="Email Address"
             value={inputValue}
-            onChange={e => setInputValue(e.target.value)}
+            onChange={e => setInputValue((e.target as HTMLInputElement).value)}
           />
           <button
             type="submit"

--- a/src/ui/components/shared/SettingsModal/SettingsBody.css
+++ b/src/ui/components/shared/SettingsModal/SettingsBody.css
@@ -1,8 +1,9 @@
 .settings-modal main {
   padding: 36px;
-  flex-grow: 1;
+  flex: 1;
   display: flex;
   flex-direction: column;
+  width: 0;
 }
 
 .settings-modal main > :not(:first-child) {

--- a/src/ui/components/shared/SettingsModal/SettingsBodyItem.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBodyItem.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction } from "react";
-import { UserSettings } from "ui/types";
+import { ApiKey, UserSettings } from "ui/types";
 import { SettingItem } from "./types";
 import hooks from "ui/hooks";
 import { SelectMenu } from "ui/components/shared/Forms";
@@ -64,7 +64,7 @@ function Input({
   setShowRefresh,
 }: {
   item: SettingItem;
-  value: boolean | string | null;
+  value: boolean | string | ApiKey[] | null;
   setShowRefresh: Dispatch<SetStateAction<boolean>>;
 }) {
   if (item.type == "checkbox") {

--- a/src/ui/components/shared/SettingsModal/SettingsModal.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsModal.tsx
@@ -25,6 +25,11 @@ const settings: Settings = [
     items: [],
   },
   {
+    title: "API Keys",
+    icon: "vpn_key",
+    items: [],
+  },
+  {
     title: "Experimental",
     icon: "biotech",
     items: [

--- a/src/ui/graphql/settings.ts
+++ b/src/ui/graphql/settings.ts
@@ -3,6 +3,12 @@ import { gql } from "@apollo/client";
 export const GET_USER_SETTINGS = gql`
   query GetUserSettings {
     viewer {
+      apiKeys {
+        id
+        createdAt
+        label
+        scopes
+      }
       settings {
         showElements
         showReact
@@ -12,6 +18,26 @@ export const GET_USER_SETTINGS = gql`
       defaultWorkspace {
         id
       }
+    }
+  }
+`;
+
+export const ADD_USER_API_KEY = gql`
+  mutation CreateUserAPIKey($label: String!, $scopes: [String!]!) {
+    createUserAPIKey(input: { label: $label, scopes: $scopes }) {
+      key {
+        id
+        label
+      }
+      keyValue
+    }
+  }
+`;
+
+export const DELETE_USER_API_KEY = gql`
+  mutation DeleteUserAPIKey($id: ID!) {
+    deleteUserAPIKey(input: { id: $id }) {
+      success
     }
   }
 `;

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -4,9 +4,10 @@ import { isTest } from "ui/utils/environment";
 import { SettingItemKey } from "ui/components/shared/SettingsModal/types";
 import useAuth0 from "ui/utils/useAuth0";
 import type { UserSettings } from "../types";
-import { GET_USER_SETTINGS } from "ui/graphql/settings";
+import { ADD_USER_API_KEY, DELETE_USER_API_KEY, GET_USER_SETTINGS } from "ui/graphql/settings";
 
 const emptySettings: UserSettings = {
+  apiKeys: [],
   showElements: false,
   showReact: false,
   enableTeams: true,
@@ -15,6 +16,7 @@ const emptySettings: UserSettings = {
 };
 
 const testSettings: UserSettings = {
+  apiKeys: [],
   showElements: true,
   showReact: true,
   enableTeams: true,
@@ -63,6 +65,7 @@ function convertUserSettings(data: any): UserSettings {
 
   const settings = data.viewer.settings;
   return {
+    apiKeys: data.viewer.apiKeys,
     showElements: settings.showElements,
     showReact: settings.showReact,
     enableTeams: settings.enableTeams,
@@ -109,4 +112,20 @@ export function useUpdateDefaultWorkspace() {
   }
 
   return updateUserSetting;
+}
+
+export function useAddUserApiKey() {
+  const [addUserApiKey, { loading, error }] = useMutation(ADD_USER_API_KEY, {
+    refetchQueries: ["GetUserSettings"],
+  });
+
+  return { addUserApiKey, loading, error };
+}
+
+export function useDeleteUserApiKey() {
+  const [deleteUserApiKey, { loading, error }] = useMutation(DELETE_USER_API_KEY, {
+    refetchQueries: ["GetUserSettings"],
+  });
+
+  return { deleteUserApiKey, loading, error };
 }

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -30,7 +30,13 @@ export type ModalType =
   | "browser-launch"
   | "first-replay";
 export type WorkspaceId = string;
-export type SettingsTabTitle = "Experimental" | "Invitations" | "Support" | "Personal" | "Legal";
+export type SettingsTabTitle =
+  | "Experimental"
+  | "Invitations"
+  | "Support"
+  | "Personal"
+  | "Legal"
+  | "API Keys";
 
 export interface ExpectedError {
   message: string;

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -6,11 +6,24 @@ export interface User {
 }
 
 export interface UserSettings {
+  apiKeys: ApiKey[];
   showElements: boolean;
   showReact: boolean;
   enableTeams: boolean;
   enableRepaint: boolean;
   defaultWorkspaceId: null | string;
+}
+
+export interface ApiKey {
+  id: string;
+  createdAt: string;
+  label: string;
+  scopes: string[];
+}
+
+export interface ApiKeyResponse {
+  key: ApiKey;
+  keyValue: string;
 }
 
 export interface Recording {


### PR DESCRIPTION
## Feature

* Adds ability for user to create and delete API keys from their settings modal

The following replay walks through the UX: https://app.replay.io/?id=a1fb8df4-95e0-48f5-be71-ab98577a9d81