### PR TITLE
Add team API Key UI

### DIFF
--- a/src/ui/components/shared/APIKeys.tsx
+++ b/src/ui/components/shared/APIKeys.tsx
@@ -1,0 +1,212 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { ApiKey, ApiKeyResponse, ApiKeyScope } from "ui/types";
+
+import TextInput from "./Forms/TextInput";
+import MaterialIcon from "./MaterialIcon";
+
+const scopeLabels: Record<ApiKeyScope, string> = {
+  "admin:all": "Create recordings",
+  "write:sourcemap": "Upload source maps",
+};
+
+function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void }) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (copied) {
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [copied, setCopied]);
+
+  return (
+    <>
+      <div className="flex items-center justify-between space-x-4">
+        <div className="flex-auto w-0">
+          <div className="flex items-center px-3 h-12 w-full border border-textFieldBorder rounded-md bg-blue-100">
+            <input
+              readOnly
+              value={keyValue}
+              className="bg-blue-100 flex-auto truncate focus:outline-none"
+              onFocus={ev => ev.target.setSelectionRange(0, keyValue.length)}
+            />
+            {copied ? (
+              <div className="mx-3 text-primaryAccent">Copied!</div>
+            ) : (
+              <MaterialIcon
+                className="material-icons mx-3 w-7 h-7 text-primaryAccent"
+                onClick={() => navigator.clipboard.writeText(keyValue!).then(() => setCopied(true))}
+              >
+                assignment_outline
+              </MaterialIcon>
+            )}
+          </div>
+        </div>
+        <button
+          className="inline-flex items-center px-3 py-2 h-12 border border-transparent leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:bg-primaryAccentHover"
+          onClick={onDone}
+        >
+          Done
+        </button>
+      </div>
+      <div className="flex items-center p-3 border border-textFieldBorder rounded-md bg-red-100">
+        Make sure to copy your API key now. You won{"'"}t be able to see it again!
+      </div>
+    </>
+  );
+}
+
+function ApiKeyList({ apiKeys, onDelete }: { apiKeys: ApiKey[]; onDelete: (id: string) => void }) {
+  if (apiKeys.length === 0) return null;
+
+  return (
+    <section className="flex-auto flex flex-col">
+      <h3 className="text-base uppercase font-semibold">API Keys</h3>
+      <div className="flex-auto overflow-auto h-0">
+        {apiKeys.map(apiKey => (
+          <div className="flex flex-row items-center py-2" key={apiKey.id}>
+            <span className="flex-auto">{apiKey.label}</span>
+            <button
+              className="inline-flex items-center p-3 text-sm shadow-sm leading-4 rounded-md bg-gray-100 text-red-500 hover:text-red-700 focus:outline-none focus:text-red-700"
+              onClick={() => {
+                const message =
+                  "This action will permanently delete this API key. \n\nAre you sure you want to proceed?";
+
+                if (window.confirm(message)) {
+                  onDelete(apiKey.id);
+                }
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function APIKeys({
+  apiKeys,
+  description,
+  error,
+  loading,
+  addKey,
+  deleteKey,
+  scopes = [],
+}: {
+  apiKeys: ApiKey[];
+  scopes?: ApiKeyScope[];
+  description: string;
+  error: any;
+  loading: boolean;
+  addKey: (label: string, scopes?: ApiKeyScope[]) => Promise<ApiKeyResponse>;
+  deleteKey: (id: string) => void;
+}) {
+  const labelRef = useRef<HTMLInputElement>(null);
+  const [keyValue, setKeyValue] = useState<string>();
+  const [selectedScopes, selectScopes] = useState<ApiKeyScope[]>(scopes);
+  const [label, setLabel] = useState<string>("");
+
+  const canSubmit = label && !loading && selectedScopes.length > 0;
+  const sortedKeys = useMemo(
+    () =>
+      [...apiKeys].sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      ),
+    [apiKeys]
+  );
+
+  // focus the input on mount (when the ref is valued) and when returning to the
+  // form (when keyValue changes)
+  useEffect(() => {
+    labelRef.current?.focus();
+  }, [labelRef.current, keyValue]);
+
+  return (
+    <div className="space-y-8 flex flex-col flex-auto h-0">
+      <label className="setting-item">
+        <div className="description">{description}</div>
+      </label>
+      {error ? (
+        <div>Unable to add an API key at this time. Please try again later.</div>
+      ) : keyValue ? (
+        <NewApiKey keyValue={keyValue} onDone={() => setKeyValue(undefined)} />
+      ) : (
+        <>
+          <section className="space-y-3">
+            <h3 className="text-base uppercase font-semibold">Create new API Key</h3>
+            <form
+              className="space-y-4"
+              onSubmit={ev => {
+                canSubmit &&
+                  addKey(label, selectedScopes).then(resp => {
+                    selectScopes(scopes);
+                    setKeyValue(resp.keyValue);
+                    setLabel("");
+                  });
+
+                ev.preventDefault();
+              }}
+            >
+              <fieldset className="w-full space-x-2 flex flex-row">
+                <TextInput
+                  disabled={loading}
+                  placeholder="API Key Label"
+                  onChange={e => setLabel((e.target as HTMLInputElement).value)}
+                  ref={labelRef}
+                  value={label}
+                />
+                <button
+                  type="submit"
+                  disabled={!canSubmit}
+                  className={`inline-flex items-center px-3 py-2 border border-transparent leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent focus:outline-none ${
+                    canSubmit
+                      ? "hover:bg-primaryAccentHover focus:bg-primaryAccentHover"
+                      : "opacity-60"
+                  }`}
+                >
+                  Add
+                </button>
+              </fieldset>
+              {scopes && scopes.length > 1 ? (
+                <fieldset className="w-full">
+                  <h4 className="text-sm uppercase font-semibold">Permissions</h4>
+                  {scopes.map(scope => (
+                    <label key={scope} className="inline-block space-x-2 mx-2">
+                      <input
+                        type="checkbox"
+                        onChange={e =>
+                          selectScopes(current => {
+                            if ((e.target as HTMLInputElement).checked) {
+                              return [...current, scope];
+                            } else {
+                              return current.filter(s => s !== scope);
+                            }
+                          })
+                        }
+                        checked={selectedScopes.includes(scope)}
+                      />
+                      <span>{scopeLabels[scope]}</span>
+                    </label>
+                  ))}
+                  {selectedScopes.length === 0 ? (
+                    <div className="mt-3 flex items-center p-3 border border-textFieldBorder rounded-md bg-red-100">
+                      At least one permission must be selected.
+                    </div>
+                  ) : null}
+                </fieldset>
+              ) : null}
+            </form>
+          </section>
+          <ApiKeyList
+            apiKeys={sortedKeys}
+            onDelete={id => {
+              deleteKey(id);
+              labelRef.current?.focus();
+            }}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/shared/Forms/TextInput.tsx
+++ b/src/ui/components/shared/Forms/TextInput.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 
-export default function TextInput(
-  props: Omit<React.HTMLProps<HTMLInputElement>, "type" | "className">
-) {
+export default React.forwardRef<
+  HTMLInputElement,
+  Omit<React.HTMLProps<HTMLInputElement>, "type" | "className">
+>(function TextInput(props, ref) {
   return (
     <input
       {...props}
+      ref={ref}
       type="text"
       className="focus:ring-primaryAccent focus:primaryAccentHover block w-full text-lg border px-3 py-2 border-textFieldBorder rounded-md"
     />
   );
-}
+});

--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -16,6 +16,7 @@ function MaterialIcon({
   fontLoading,
   highlighted,
   className,
+  dispatch, // unused
   ...rest
 }: MaterialIconProps) {
   return (

--- a/src/ui/components/shared/SettingsModal/SettingsBody.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBody.tsx
@@ -9,6 +9,7 @@ import useAuth0 from "ui/utils/useAuth0";
 import hooks from "ui/hooks";
 import TextInput from "../Forms/TextInput";
 import MaterialIcon from "../MaterialIcon";
+import APIKeys from "../APIKeys";
 
 interface SettingsBodyProps {
   selectedSetting: Setting;
@@ -111,123 +112,24 @@ function Legal() {
   );
 }
 
-function APIKeys({ apiKeys }: { apiKeys: ApiKey[] }) {
-  const [keyValue, setKeyValue] = useState<string>();
-  const [label, setLabel] = useState<string>("");
-  const [copied, setCopied] = useState(false);
+function UserAPIKeys({ apiKeys }: { apiKeys: ApiKey[] }) {
   const { addUserApiKey, loading: addLoading, error: addError } = hooks.useAddUserApiKey();
-  const {
-    deleteUserApiKey,
-    loading: deleteLoading,
-    error: deleteError,
-  } = hooks.useDeleteUserApiKey();
-
-  useEffect(() => {
-    if (copied) {
-      setTimeout(() => setCopied(false), 2000);
-    }
-  }, [copied, setCopied]);
-
-  const sortedKeys = useMemo(
-    () =>
-      [...apiKeys].sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      ),
-    [apiKeys]
-  );
+  const { deleteUserApiKey } = hooks.useDeleteUserApiKey();
 
   return (
-    <div className="space-y-8 flex flex-col flex-auto h-0">
-      <label className="setting-item">
-        <div className="description">
-          API Keys allow you to upload recordings programmatically from your automated tests or from
-          your continuous integration environment.
-        </div>
-      </label>
-      {addError ? (
-        <div>Unable to add an API key at this time. Please try again later.</div>
-      ) : keyValue ? (
-        <>
-          <div className="flex items-center justify-between space-x-4">
-            <div className="flex flex-auto items-center px-3 h-12 border border-textFieldBorder rounded-md bg-blue-100">
-              <span>{keyValue}</span>
-              {copied ? (
-                <div className="mx-3 text-primaryAccent">Copied!</div>
-              ) : (
-                <MaterialIcon
-                  className="material-icons mx-3 w-7 h-7 text-primaryAccent"
-                  onClick={() =>
-                    navigator.clipboard.writeText(keyValue!).then(() => setCopied(true))
-                  }
-                >
-                  assignment_outline
-                </MaterialIcon>
-              )}
-            </div>
-            <button
-              className="inline-flex items-center px-3 py-2 h-12 border border-transparent leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:bg-primaryAccentHover"
-              onClick={() => setKeyValue(undefined)}
-            >
-              Done
-            </button>
-          </div>
-          <div className="flex items-center px-3 h-12 border border-textFieldBorder rounded-md bg-red-100">
-            Make sure to copy your API key now. You won{"'"}t be able to see it again!
-          </div>
-        </>
-      ) : (
-        <>
-          <form
-            onSubmit={ev => {
-              label &&
-                addUserApiKey({ variables: { label: label, scopes: ["create:recording"] } }).then(
-                  resp => {
-                    setKeyValue(resp.data.createUserAPIKey.keyValue);
-                    setLabel("");
-                  }
-                );
-
-              ev.preventDefault();
-            }}
-            className="space-x-2"
-          >
-            <TextInput
-              disabled={addLoading}
-              placeholder="API Key Label"
-              onChange={e => setLabel((e.target as HTMLInputElement).value)}
-              value={label}
-            />
-            <button
-              type="submit"
-              disabled={addLoading}
-              className="inline-flex items-center px-3 py-2 border border-transparent leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:bg-primaryAccentHover"
-            >
-              Add
-            </button>
-          </form>
-          <div className="flex-auto overflow-auto">
-            {sortedKeys.map(apiKey => (
-              <div className="flex flex-row items-center py-2" key={apiKey.id}>
-                <span className="flex-auto">{apiKey.label}</span>
-                <button
-                  className="inline-flex items-center p-3 text-sm shadow-sm leading-4 rounded-md bg-gray-100 text-red-500 hover:text-red-700 focus:outline-none focus:text-red-700"
-                  onClick={() => {
-                    const message =
-                      "This action will permanently delete this API key. \n\nAre you sure you want to proceed?";
-
-                    if (window.confirm(message)) {
-                      deleteUserApiKey({ variables: { id: apiKey.id } });
-                    }
-                  }}
-                >
-                  Delete
-                </button>
-              </div>
-            ))}
-          </div>
-        </>
-      )}
-    </div>
+    <APIKeys
+      apiKeys={apiKeys}
+      description="API Keys allow you to upload recordings programmatically from your automated tests or from your continuous integration environment."
+      loading={addLoading}
+      error={addError}
+      addKey={(label, scopes) =>
+        addUserApiKey({ variables: { label: label, scopes } }).then(
+          resp => resp.data.createUserAPIKey
+        )
+      }
+      deleteKey={id => deleteUserApiKey({ variables: { id } })}
+      scopes={["admin:all"]}
+    />
   );
 }
 
@@ -284,7 +186,7 @@ export default function SettingsBody({ selectedSetting, userSettings }: Settings
     return (
       <SettingsBodyWrapper>
         <SettingsHeader>{title}</SettingsHeader>
-        <APIKeys apiKeys={userSettings.apiKeys} />
+        <UserAPIKeys apiKeys={userSettings.apiKeys} />
       </SettingsBodyWrapper>
     );
   }

--- a/src/ui/components/shared/SettingsModal/SettingsBodyItem.css
+++ b/src/ui/components/shared/SettingsModal/SettingsBodyItem.css
@@ -1,0 +1,19 @@
+.settings-modal main > ul > li {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.settings-modal main > ul > li .setting-item {
+  flex-grow: 1
+}
+
+.settings-modal main > ul > li .setting-item .label {
+  font-size: 16px;
+}
+
+.settings-modal main > ul > li .setting-item .description {
+  font-size: 14px;
+  max-width: 80%;
+  color: var(--theme-comment)
+}

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceAPIKeys.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceAPIKeys.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import hooks from "ui/hooks";
+
+import APIKeys from "../APIKeys";
+
+export default function WorkspaceAPIKeys({ workspaceId }: { workspaceId: string }) {
+  const {
+    addWorkspaceApiKey,
+    loading: addLoading,
+    error: addError,
+  } = hooks.useAddWorkspaceApiKey();
+  const { deleteWorkspaceApiKey } = hooks.useDeleteWorkspaceApiKey();
+  const { data } = hooks.useGetWorkspaceApiKeys(workspaceId);
+
+  if (!data) return null;
+
+  return (
+    <APIKeys
+      apiKeys={data.node.apiKeys}
+      description="API Keys allow you to upload recordings programmatically from your automated tests or from your continuous integration environment or upload source maps for sites that do not publish their source maps."
+      loading={addLoading}
+      error={addError}
+      addKey={(label, scopes) =>
+        addWorkspaceApiKey({
+          variables: { label, scopes, workspaceId },
+        }).then(resp => resp.data.createWorkspaceAPIKey)
+      }
+      scopes={["admin:all", "write:sourcemap"]}
+      deleteKey={id => deleteWorkspaceApiKey({ variables: { id } })}
+    />
+  );
+}

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -11,6 +11,7 @@ import { validateEmail } from "ui/utils/helpers";
 import { TextInput } from "../Forms";
 import MaterialIcon from "../MaterialIcon";
 import InvitationLink from "../NewWorkspaceModal/InvitationLink";
+import WorkspaceAPIKeys from "./WorkspaceAPIKeys";
 import WorkspaceMember, { NonRegisteredWorkspaceMember } from "./WorkspaceMember";
 
 function ModalButton({
@@ -104,6 +105,7 @@ function WorkspaceForm({ workspaceId, members }: WorkspaceFormProps) {
 }
 
 function WorkspaceSettingsModal(props: PropsFromRedux) {
+  const [selectedTab, setSelectedTab] = useState<string>();
   const { members } = hooks.useGetWorkspaceMembers(props.workspaceId!);
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
   const deleteWorkspace = hooks.useDeleteWorkspace();
@@ -131,35 +133,50 @@ function WorkspaceSettingsModal(props: PropsFromRedux) {
         style={{ width: "520px", height: "600px" }}
       >
         <div className="space-y-12 flex flex-col flex-grow overflow-hidden">
-          <h2 className="font-bold text-3xl ">{`Team settings`}</h2>
-          <div className="flex flex-col flex-grow space-y-4 overflow-hidden">
-            <div className="text-xl">{`Manage members here so that everyone who belongs to this team can see each other's replays.`}</div>
-            <WorkspaceForm {...{ ...props, members }} />
-            <div className=" text-sm uppercase font-semibold">{`Members`}</div>
-            <div className="overflow-auto flex-grow">
-              <div className="workspace-members-container flex flex-col space-y-2">
-                <div className="flex flex-col space-y-2">
-                  {members ? <WorkspaceMembers members={members} /> : null}
+          {selectedTab === "api-keys" && props.workspaceId ? (
+            <>
+              <h2 className="font-bold text-3xl ">Team API Keys</h2>
+              <WorkspaceAPIKeys workspaceId={props.workspaceId} />
+            </>
+          ) : (
+            <>
+              <h2 className="font-bold text-3xl ">Team settings</h2>
+              <div className="flex flex-col flex-grow space-y-4 overflow-hidden">
+                <div className="text-xl">{`Manage members here so that everyone who belongs to this team can see each other's replays.`}</div>
+                <WorkspaceForm {...{ ...props, members }} />
+                <div className=" text-sm uppercase font-semibold">{`Members`}</div>
+                <div className="overflow-auto flex-grow">
+                  <div className="workspace-members-container flex flex-col space-y-2">
+                    <div className="flex flex-col space-y-2">
+                      {members ? <WorkspaceMembers members={members} /> : null}
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-            <InvitationLink workspaceId={props.workspaceId!} />
-            <div className="flex flex-col space-y-4">
-              <div className=" text-sm uppercase font-semibold">{`Danger Zone`}</div>
-              <div className="border border-red-300 flex flex-row justify-between rounded-lg p-2">
-                <div className="flex flex-col">
-                  <div className="font-semibold">Delete this team</div>
-                  <div className="">{`This cannot be reversed.`}</div>
+                <InvitationLink workspaceId={props.workspaceId!} />
+                <div className="flex flex-col space-y-4">
+                  <div className=" text-sm uppercase font-semibold">{`Danger Zone`}</div>
+                  <div className="border border-red-300 flex flex-row justify-between rounded-lg p-2">
+                    <div className="flex flex-col">
+                      <div className="font-semibold">Delete this team</div>
+                      <div className="">{`This cannot be reversed.`}</div>
+                    </div>
+                    <button
+                      onClick={handleDeleteTeam}
+                      className="max-w-max items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-red-600 hover:bg-red-700"
+                    >
+                      Delete this team
+                    </button>
+                  </div>
                 </div>
                 <button
-                  onClick={handleDeleteTeam}
-                  className="max-w-max items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-red-600 hover:bg-red-700"
+                  className="text-primaryAccent hover:underline self-start"
+                  onClick={() => setSelectedTab("api-keys")}
                 >
-                  Delete this team
+                  API Keys
                 </button>
               </div>
-            </div>
-          </div>
+            </>
+          )}
         </div>
         <button className="absolute top-4 right-4" onClick={props.hideModal}>
           <div>

--- a/src/ui/graphql/settings.ts
+++ b/src/ui/graphql/settings.ts
@@ -41,3 +41,38 @@ export const DELETE_USER_API_KEY = gql`
     }
   }
 `;
+
+export const GET_WORKSPACE_API_KEYS = gql`
+  query GetWorkspaceApiKeys($workspaceId: ID!) {
+    node(id: $workspaceId) {
+      ... on Workspace {
+        apiKeys {
+          id
+          createdAt
+          label
+          scopes
+        }
+      }
+    }
+  }
+`;
+
+export const ADD_WORKSPACE_API_KEY = gql`
+  mutation CreateWorkspaceAPIKey($workspaceId: ID!, $label: String!, $scopes: [String!]!) {
+    createWorkspaceAPIKey(input: { workspaceId: $workspaceId, label: $label, scopes: $scopes }) {
+      key {
+        id
+        label
+      }
+      keyValue
+    }
+  }
+`;
+
+export const DELETE_WORKSPACE_API_KEY = gql`
+  mutation DeleteWorkspaceAPIKey($id: ID!) {
+    deleteWorkspaceAPIKey(input: { id: $id }) {
+      success
+    }
+  }
+`;

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -3,8 +3,15 @@ import { query } from "ui/utils/apolloClient";
 import { isTest } from "ui/utils/environment";
 import { SettingItemKey } from "ui/components/shared/SettingsModal/types";
 import useAuth0 from "ui/utils/useAuth0";
-import type { UserSettings } from "../types";
-import { ADD_USER_API_KEY, DELETE_USER_API_KEY, GET_USER_SETTINGS } from "ui/graphql/settings";
+import type { UserSettings, Workspace } from "../types";
+import {
+  ADD_USER_API_KEY,
+  ADD_WORKSPACE_API_KEY,
+  DELETE_USER_API_KEY,
+  DELETE_WORKSPACE_API_KEY,
+  GET_USER_SETTINGS,
+  GET_WORKSPACE_API_KEYS,
+} from "ui/graphql/settings";
 
 const emptySettings: UserSettings = {
   apiKeys: [],
@@ -128,4 +135,31 @@ export function useDeleteUserApiKey() {
   });
 
   return { deleteUserApiKey, loading, error };
+}
+
+export function useGetWorkspaceApiKeys(workspaceId: string) {
+  const { data, loading, error } = useQuery<{ node: Pick<Required<Workspace>, "apiKeys"> }>(
+    GET_WORKSPACE_API_KEYS,
+    {
+      variables: { workspaceId },
+    }
+  );
+
+  return { data, loading, error };
+}
+
+export function useAddWorkspaceApiKey() {
+  const [addWorkspaceApiKey, { loading, error }] = useMutation(ADD_WORKSPACE_API_KEY, {
+    refetchQueries: ["GetWorkspaceApiKeys"],
+  });
+
+  return { addWorkspaceApiKey, loading, error };
+}
+
+export function useDeleteWorkspaceApiKey() {
+  const [deleteWorkspaceApiKey, { loading, error }] = useMutation(DELETE_WORKSPACE_API_KEY, {
+    refetchQueries: ["GetWorkspaceApiKeys"],
+  });
+
+  return { deleteWorkspaceApiKey, loading, error };
 }

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -14,11 +14,13 @@ export interface UserSettings {
   defaultWorkspaceId: null | string;
 }
 
+export type ApiKeyScope = "admin:all" | "write:sourcemap";
+
 export interface ApiKey {
   id: string;
   createdAt: string;
   label: string;
-  scopes: string[];
+  scopes: ApiKeyScope[];
 }
 
 export interface ApiKeyResponse {
@@ -54,6 +56,7 @@ export interface Workspace {
   isDomainLimitedCode: boolean;
   recordingCount?: number;
   members?: User[];
+  apiKeys?: ApiKey[];
 }
 
 export interface WorkspaceUser {


### PR DESCRIPTION
## Feature

Adds UI to team settings to create workspace API keys

https://app.replay.io/?id=b9e95bdd-b1b2-4663-9b40-91ceced9d12d

## Changes

* Refactors the `APIKeys` component out of the user settings view and into a shared component reused by both team and user settings
* Adds support for selecting `scopes` if more than one scope is supported. For user keys, this is suppressed. For team keys, at least one scope must be selected (and both are selected by default).
* Adds simple link to the bottom of team settings to switch to the API keys view

![image](https://user-images.githubusercontent.com/788456/126831671-5f51f950-1f01-4ec7-9d01-4c90c78b4979.png)