### PR TITLE
Dynamic nature images in our loading screen

### DIFF
--- a/src/ui/components/shared/BlankScreen.tsx
+++ b/src/ui/components/shared/BlankScreen.tsx
@@ -25,7 +25,7 @@ export default function BlankScreen({
   return (
     <main
       className={`w-full h-full grid ${className}`}
-      style={{ background: backgroundStyle, padding: "5px", backgroundSize: "cover" }}
+      style={{ background: backgroundStyle, backgroundSize: "cover" }}
     >
       {children}
     </main>

--- a/src/ui/components/shared/BlankScreen.tsx
+++ b/src/ui/components/shared/BlankScreen.tsx
@@ -6,6 +6,7 @@ import Spinner from "./Spinner";
 const BACKGROUNDS = {
   white: "white",
   "blue-gradient": "linear-gradient(to bottom right, #68DCFC, #4689F8)",
+  graphic: "url('https://source.unsplash.com/random/800×800/?nature')",
 };
 
 export default function BlankScreen({
@@ -22,7 +23,10 @@ export default function BlankScreen({
     background && BACKGROUNDS[background] ? BACKGROUNDS[background] : BACKGROUNDS["blue-gradient"];
 
   return (
-    <main className={`w-full h-full grid ${className}`} style={{ background: backgroundStyle }}>
+    <main
+      className={`w-full h-full grid ${className}`}
+      style={{ background: backgroundStyle, padding: "5px", backgroundSize: "cover" }}
+    >
       {children}
     </main>
   );
@@ -89,11 +93,11 @@ export function BlankProgressScreen({
   }, [displayedProgress]);
 
   return (
-    <BlankScreen background="white">
+    <BlankScreen background="graphic">
       <div className="m-auto">
-        <div className="flex flex-col items-center space-y-4">
+        <div className="flex flex-col items-center space-y-4 bg-white opacity-90 rounded-md p-8">
           <div className="text-xl">Preparing Replay</div>
-          <div className="w-96 relative h-2 bg-gray-200 rounded-lg overflow-hidden">
+          <div className="w-40 relative h-1 bg-gray-200 rounded-lg overflow-hidden">
             <div
               className="absolute t-0 h-full bg-primaryAccent"
               style={{ width: `${displayedProgress}%`, transitionDuration: "200ms" }}


### PR DESCRIPTION
Current loading screen:
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/9154902/126933428-07f26b89-1a1a-4579-bd9b-2e87865f51c0.png">

Proposed loading screen that loads a random nature photo from unsplash:
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/9154902/126933456-06bf777b-885b-45e1-80ad-6598556612f4.png">
<img width="1144" alt="image" src="https://user-images.githubusercontent.com/9154902/126933467-e2f147d2-dc7a-4250-8dc4-9f7045ed2f54.png">
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/9154902/126933481-afb208bb-6f68-4a16-8bbf-d6772da937aa.png">
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/9154902/126933497-0aadf948-7c9e-43a8-9065-449af31e3768.png">

We can add other items later -- branding, Replay details, etc. But in the meantime, I think this is a much nicer experience than our current white screen.
