### PR TITLE
Remove excess vertical space from sidebar height

### DIFF
--- a/src/ui/components/Toolbox.css
+++ b/src/ui/components/Toolbox.css
@@ -44,7 +44,6 @@
   float: left;
   display: flex;
   cursor: default;
-  line-height: 35px;
   color: var(--theme-toolbar-color);
   align-items: center;
   border-radius: 4px;


### PR DESCRIPTION
Fix #3125.

Before:

![image](https://user-images.githubusercontent.com/15959269/126998884-5da9b54a-1a78-47f6-9b5f-82dbd6114390.png)

After:

![image](https://user-images.githubusercontent.com/15959269/126998821-56c48974-8ab7-49f1-988e-c209ce3c3cb6.png)