### PR TITLE
Add email address validation when inviting an email to Replay

### DIFF
--- a/src/ui/components/shared/SettingsModal/ReplayInvitations.tsx
+++ b/src/ui/components/shared/SettingsModal/ReplayInvitations.tsx
@@ -2,11 +2,14 @@ import React, { useState } from "react";
 import hooks from "ui/hooks";
 import "./ReplayInvitations.css";
 import { TextInput } from "ui/components/shared/Forms";
+import { validateEmail } from "ui/utils/helpers";
+import { Invitation } from "ui/hooks/invitations";
 
 const USE_AVAILABLE_INVITATIONS = false;
 
 export default function ReplayInvitations() {
   const [inputValue, setInputValue] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const { invitations, loading: inviteLoading } = hooks.useGetInvitations();
   let {
     availableInvitations,
@@ -16,6 +19,19 @@ export default function ReplayInvitations() {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+
+    const isInvalidEmail = !validateEmail(inputValue);
+    const isAlreadyInvited = invitations && invitations.some(i => i.invitedEmail === inputValue);
+
+    if (isInvalidEmail) {
+      setErrorMessage("Invalid email address");
+      return;
+    } else if (isAlreadyInvited) {
+      setErrorMessage("Address has already been invited");
+      return;
+    }
+
+    setErrorMessage(null);
     setInputValue("");
     addInvitation({ variables: { email: inputValue } });
   };
@@ -58,30 +74,38 @@ export default function ReplayInvitations() {
         </div>
       </label>
       {(!USE_AVAILABLE_INVITATIONS || availableInvitations > 0) && (
-        <form onSubmit={onSubmit} className="space-x-2">
-          <TextInput
-            placeholder="Email Address"
-            value={inputValue}
-            onChange={e => setInputValue((e.target as HTMLInputElement).value)}
-          />
-          <button
-            type="submit"
-            value="Invite"
-            className="inline-flex items-center px-3 py-2 border border-transparent text-lg leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:bg-primaryAccentHover"
-          >
-            Invite
-          </button>
-        </form>
+        <div className="flex flex-col w-full">
+          <form onSubmit={onSubmit} className="space-x-2">
+            <TextInput
+              placeholder="Email Address"
+              value={inputValue}
+              onChange={e => setInputValue((e.target as HTMLInputElement).value)}
+            />
+            <button
+              type="submit"
+              value="Invite"
+              className="inline-flex items-center px-3 py-2 border border-transparent text-lg leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:bg-primaryAccentHover"
+            >
+              Invite
+            </button>
+          </form>
+          {errorMessage ? <div className="text-red-500 text-sm">{errorMessage}</div> : null}
+        </div>
       )}
       <div className="invitations-list">
-        {invitations!.map((invite, i) => (
-          <div className="invitations" key={i}>
-            <div className={`material-icons ${invite.pending || "finished"}`}>
-              {invite.pending ? "pending" : "check_circle"}
+        {invitations!
+          .sort(
+            (a: Invitation, b: Invitation) =>
+              new Date(b.createdAt!).getTime() - new Date(a.createdAt!).getTime()
+          )
+          .map((invite, i) => (
+            <div className="invitations" key={i}>
+              <div className={`material-icons ${invite.pending || "finished"}`}>
+                {invite.pending ? "pending" : "check_circle"}
+              </div>
+              <div>{invite.invitedEmail}</div>
             </div>
-            <div>{invite.invitedEmail}</div>
-          </div>
-        ))}
+          ))}
       </div>
     </li>
   );


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/backend/issues/2696

This adds some email address validation before inviting a user to Replay. Specifically this checks for a valid email address and that the e-mail address hasn't already been invited by the same user before.

This also sorts the invitations reverse-chronologically so that the newest invitations are displayed up top instead of being buried in the overflow.