### PR TITLE
Add custom single invite modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/uuid": "^8.3.1",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
+    "@webpack-cli/serve": "^1.5.1",
     "autoprefixer": "^10.2.5",
     "babel-loader": "^8.2.2",
     "copy-webpack-plugin": "^9.0.1",

--- a/src/ui/components/Account/Library.tsx
+++ b/src/ui/components/Account/Library.tsx
@@ -137,7 +137,13 @@ function Library({
     if (isTeamLeaderInvite()) {
       setModal("team-leader-onboarding");
     } else if (pendingWorkspaces?.length) {
-      setModal("team-member-onboarding");
+      // Show the single invite modal to users who have just signed up for Replay
+      // because they were invited to a team.
+      if (pendingWorkspaces.length === 1 && workspaces.length === 0) {
+        setModal("single-invite");
+      } else {
+        setModal("team-member-onboarding");
+      }
     }
 
     const showFirstReplayTutorial =

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -32,6 +32,7 @@ import BlankScreen from "./shared/BlankScreen";
 import { setUnexpectedError } from "ui/actions/session";
 import FirstReplayModal from "./shared/FirstReplayModal";
 import TOSScreen, { LATEST_TOS_VERSION } from "./TOSScreen";
+import SingleInviteModal from "./shared/OnboardingModal/SingleInviteModal";
 var FontFaceObserver = require("fontfaceobserver");
 
 function AppModal({ modal }: { modal: ModalType }) {
@@ -56,6 +57,9 @@ function AppModal({ modal }: { modal: ModalType }) {
     }
     case "team-member-onboarding": {
       return <TeamMemberOnboardingModal />;
+    }
+    case "single-invite": {
+      return <SingleInviteModal />;
     }
     case "team-leader-onboarding": {
       return <TeamLeaderOnboardingModal />;

--- a/src/ui/components/shared/Button.tsx
+++ b/src/ui/components/shared/Button.tsx
@@ -67,6 +67,7 @@ function Button({
   className,
   onClick = () => {},
 }: ButtonProps & {
+  color: Colors;
   size: ButtonSizes;
   style: ButtonStyles;
 }) {
@@ -86,18 +87,17 @@ function Button({
 }
 
 interface ButtonProps {
-  color: Colors;
   children?: React.ReactNode;
   className?: string;
   onClick?: () => void;
 }
 
-export const PrimaryButton = (props: ButtonProps) => (
+export const PrimaryButton = (props: ButtonProps & { color: Colors }) => (
   <Button {...props} size="2xl" style="primary" />
 );
-export const SecondaryButton = (props: ButtonProps) => (
+export const SecondaryButton = (props: ButtonProps & { color: Colors }) => (
   <Button {...props} size="2xl" style="secondary" />
 );
 export const DisabledButton = (props: ButtonProps) => (
-  <Button {...props} size="2xl" style="disabled" className="cursor-default" />
+  <Button {...props} size="2xl" style="disabled" className="cursor-default" color="gray" />
 );

--- a/src/ui/components/shared/NewModal.tsx
+++ b/src/ui/components/shared/NewModal.tsx
@@ -37,3 +37,14 @@ export default function Modal({
     </div>
   );
 }
+
+export function ModalContent({ children }: { children: React.ReactChild | React.ReactChild[] }) {
+  return (
+    <div
+      className="p-12 bg-white rounded-lg shadow-xl text-xl relative justify-between"
+      style={{ width: "520px" }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
@@ -1,0 +1,182 @@
+import React, { useState } from "react";
+import { useEffect } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import * as actions from "ui/actions/app";
+import hooks from "ui/hooks";
+import { PendingWorkspaceInvitation } from "ui/types";
+import BlankScreen from "../BlankScreen";
+import { DisabledButton, PrimaryButton, SecondaryButton } from "../Button";
+import Modal, { ModalContent } from "../NewModal";
+import Spinner from "../Spinner";
+
+function ModalLoader() {
+  return (
+    <>
+      <BlankScreen className="fixed" />
+      <Modal options={{ maskTransparency: "translucent" }}>
+        <div className="p-12 bg-white rounded-lg shadow-xl text-xl relative flex">
+          <Spinner className="animate-spin h-6 w-6 text-gray-500" />
+        </div>
+      </Modal>
+    </>
+  );
+}
+
+function SingleInviteModalLoader(props: PropsFromRedux) {
+  const [workspace, setWorkspace] = useState<null | PendingWorkspaceInvitation>(null);
+  const { pendingWorkspaces, loading } = hooks.useGetPendingWorkspaces();
+
+  useEffect(() => {
+    if (!loading && pendingWorkspaces && !workspace) {
+      setWorkspace(pendingWorkspaces[0]);
+    }
+  }, [pendingWorkspaces]);
+
+  if (!workspace) {
+    return <ModalLoader />;
+  }
+
+  return <AutoAccept {...{ ...props, workspace }} />;
+}
+
+function AutoAccept(props: SingleInviteModalProps) {
+  const { setWorkspaceId, workspace } = props;
+  const [accepted, setAccepted] = useState(false);
+
+  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
+  const acceptPendingInvitation = hooks.useAcceptPendingInvitation(() => {
+    updateDefaultWorkspace({ variables: { workspaceId: workspace.id } });
+    setWorkspaceId(workspace.id);
+    setAccepted(true);
+  });
+
+  useEffect(() => {
+    acceptPendingInvitation({ variables: { workspaceId: workspace.id } });
+  }, []);
+
+  if (!accepted) {
+    return <ModalLoader />;
+  }
+
+  return <SingleInviteModal {...props} />;
+}
+
+function InitialScreen({
+  onSkip,
+  onDownload,
+  name,
+  inviterEmail,
+}: {
+  onSkip: () => void;
+  onDownload: () => void;
+  name: string | null;
+  inviterEmail: string | null;
+}) {
+  return (
+    <ModalContent>
+      <div className="space-y-12 flex flex-col">
+        <h2 className="font-bold text-3xl ">{`Welcome to Replay`}</h2>
+        <div className="text-gray-500">
+          {`You've been added to the team `}
+          <strong>{name}</strong>
+          {` by `}
+          <strong>{inviterEmail}</strong>
+          {`. Would you like to go that team, or download Replay?`}
+        </div>
+        <div className="space-x-4">
+          <SecondaryButton color="blue" onClick={onSkip}>
+            {`Go to ${name}`}
+          </SecondaryButton>
+          <PrimaryButton color="blue" onClick={onDownload}>
+            {`Download Replay`}
+          </PrimaryButton>
+        </div>
+      </div>
+    </ModalContent>
+  );
+}
+
+function DownloadScreen({ onDownloading }: { onDownloading: () => void }) {
+  const handleMac = () => {
+    onDownloading();
+    window.open("https://replay.io/downloads/replay.dmg", "_blank");
+  };
+  const handleLinux = () => {
+    onDownloading();
+    window.open("https://replay.io/downloads/linux-replay.tar.bz2", "_blank");
+  };
+
+  return (
+    <ModalContent>
+      <div className="space-y-12 flex flex-col">
+        <h2 className="font-bold text-3xl ">{`Get the Replay browser`}</h2>
+        <div className="text-gray-500">{`To start recording replays, you have to first download the Replay browser. Please select your operating system below.`}</div>
+        <div className="space-x-4 flex flex-row">
+          <PrimaryButton color="blue" onClick={handleMac}>
+            Mac
+          </PrimaryButton>
+          <PrimaryButton color="blue" onClick={handleLinux}>
+            Linux
+          </PrimaryButton>
+          <DisabledButton>Windows</DisabledButton>
+        </div>
+      </div>
+    </ModalContent>
+  );
+}
+
+function DownloadingScreen({ hideModal }: { hideModal: () => void }) {
+  return (
+    <ModalContent>
+      <div className="space-y-12 flex flex-col">
+        <h2 className="font-bold text-3xl ">{`Hang tight!`}</h2>
+        <div className="text-gray-500">{`Replay is downloading now. Please check your download folder.`}</div>
+        <div className="space-x-4 flex flex-row">
+          <PrimaryButton color="blue" onClick={hideModal}>
+            Got it
+          </PrimaryButton>
+        </div>
+      </div>
+    </ModalContent>
+  );
+}
+
+type SingleInviteModalProps = PropsFromRedux & {
+  workspace: PendingWorkspaceInvitation;
+};
+
+function SingleInviteModal({ hideModal, workspace }: SingleInviteModalProps) {
+  const [showDownload, setShowDownload] = useState(false);
+  const [showDownloading, setShowDownloading] = useState(false);
+  const { name, inviterEmail } = workspace;
+
+  const onSkip = () => hideModal();
+  const onDownload = () => setShowDownload(true);
+  const onDownloading = () => setShowDownloading(true);
+
+  let content;
+
+  if (showDownloading) {
+    content = <DownloadingScreen {...{ hideModal }} />;
+  } else if (showDownload) {
+    content = <DownloadScreen {...{ onDownloading }} />;
+  } else {
+    content = <InitialScreen {...{ onSkip, onDownload, name, inviterEmail }} />;
+  }
+
+  return (
+    <>
+      <BlankScreen className="fixed" />
+      <Modal onMaskClick={hideModal} options={{ maskTransparency: "transparent" }}>
+        {content}
+      </Modal>
+    </>
+  );
+}
+
+const connector = connect(() => ({}), {
+  hideModal: actions.hideModal,
+  setWorkspaceId: actions.setWorkspaceId,
+});
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(SingleInviteModalLoader);

--- a/src/ui/components/shared/OnboardingModal/TeamMemberOnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/TeamMemberOnboardingModal.tsx
@@ -7,7 +7,7 @@ import { Nag } from "ui/hooks/users";
 import { PendingWorkspaceInvitation } from "ui/types";
 import { isTeamMemberInvite } from "ui/utils/environment";
 import BlankScreen from "../BlankScreen";
-import Modal from "../NewModal";
+import Modal, { ModalContent } from "../NewModal";
 import Spinner from "../Spinner";
 
 type Status = "pending" | "loading" | "loaded" | "declined";
@@ -200,10 +200,7 @@ function TeamMemberOnboardingModal({
         onMaskClick={onSkip}
         options={{ maskTransparency: isTeamMemberInvite() ? "transparent" : "translucent" }}
       >
-        <div
-          className="p-12 bg-white rounded-lg shadow-xl text-xl space-y-8 relative flex flex-col justify-between"
-          style={{ width: "520px" }}
-        >
+        <ModalContent>
           <div className="space-y-8 flex flex-col">
             <h2 className="font-bold text-3xl ">{headerText}</h2>
             {displayedWorkspaces.map(workspace => (
@@ -223,7 +220,7 @@ function TeamMemberOnboardingModal({
               </button>
             ) : null}
           </div>
-        </div>
+        </ModalContent>
       </Modal>
     </>
   );

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -26,6 +26,7 @@ export type ModalType =
   | "workspace-settings"
   | "onboarding"
   | "team-member-onboarding"
+  | "single-invite"
   | "team-leader-onboarding"
   | "browser-launch"
   | "first-replay";


### PR DESCRIPTION
Fix #3046.

We have an existing generic modal for when a user opens the library and there is an outstanding replay invite. We use the same modal for when a non-existing user is invited to Replay via team invite. 

This PR creates a new onboarding flow for that user. It automatically accepts the team invitation, sets that team as the default team, leads to a screen that shows the replay download links, and brings the user to that team once the modal is closed.

Demo: https://share.descript.com/view/PXVH2fYpho2