### PR TITLE
Fix React warning message

### DIFF
--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -5,28 +5,29 @@ import * as selectors from "ui/reducers/app";
 import { UIState } from "ui/state";
 import "./MaterialIcon.css";
 
-type MaterialIconProps = PropsFromRedux &
-  React.HTMLProps<HTMLDivElement> & {
-    children: string;
-    highlighted?: boolean;
-  };
+type MaterialIconProps = PropsFromRedux & {
+  children: string;
+  highlighted?: boolean;
+  className?: string;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+};
 
 function MaterialIcon({
   children,
   fontLoading,
   highlighted,
   className,
-  ...rest
+  onClick,
 }: MaterialIconProps) {
   return (
     <div
-      {...rest}
       className={classnames(
         "material-icons",
         className,
         highlighted ? "text-primaryAccent" : "text-gray-800",
         { invisible: fontLoading }
       )}
+      onClick={onClick}
     >
       {children}
     </div>


### PR DESCRIPTION
The `connect()` method of `react-redux` adds the `dispatch()` function to the component's props, which `<div>` doesn't expect, so in development mode, React warns about this prop.