### PR TITLE
Standardize buttons

### DIFF
--- a/src/ui/components/Dashboard/DashboardViewerHeader.tsx
+++ b/src/ui/components/Dashboard/DashboardViewerHeader.tsx
@@ -3,7 +3,7 @@ import "./DashboardViewerHeader.css";
 import BatchActionDropdown from "./BatchActionDropdown";
 import "./DashboardViewerHeader.css";
 import { RecordingId } from "@recordreplay/protocol";
-import { PrimaryButton } from "../shared/Button";
+import { SecondaryButton } from "../shared/Button";
 
 type HeaderActionsProps = Pick<
   DashboardViewerHeaderProps,
@@ -21,9 +21,9 @@ function HeaderActions({
       {editing ? (
         <BatchActionDropdown setSelectedIds={setSelectedIds} selectedIds={selectedIds} />
       ) : null}
-      <PrimaryButton size="xl" color="blue" onClick={toggleEditing}>
+      <SecondaryButton color="blue" onClick={toggleEditing}>
         {editing ? "Done" : "Edit"}
-      </PrimaryButton>
+      </SecondaryButton>
     </div>
   );
 }

--- a/src/ui/components/TOSScreen.tsx
+++ b/src/ui/components/TOSScreen.tsx
@@ -58,7 +58,7 @@ export default function TOSScreen() {
             </a>{" "}
             which outline how we treat the personal information we collect as you use our services.
           </div>
-          <PrimaryButton color="blue" size="2xl" onClick={handleAccept}>
+          <PrimaryButton color="blue" onClick={handleAccept}>
             I’ve read and accept the terms of service
           </PrimaryButton>
         </div>

--- a/src/ui/components/shared/Button.tsx
+++ b/src/ui/components/shared/Button.tsx
@@ -2,9 +2,9 @@ import classNames from "classnames";
 import React from "react";
 
 type ButtonSizes = "sm" | "md" | "lg" | "xl" | "2xl";
-type ButtonStyles = "primary" | "secondary" | "white";
+type ButtonStyles = "primary" | "secondary" | "disabled";
 type ColorScale = 50 | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
-type Colors = "gray" | "blue" | "red" | "yellow" | "green" | "indigo" | "purple" | "pink";
+type Colors = "gray" | "blue" | "red" | "yellow" | "green" | "indigo" | "purple" | "pink" | "white";
 
 const STANDARD_CLASSES = {
   sm:
@@ -18,7 +18,7 @@ const STANDARD_CLASSES = {
     "inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md",
 };
 
-function getColorCode(color: any, num: ColorScale) {
+function getColorCode(color: Colors, num: ColorScale) {
   // We convert blue-600 and blue-700 to primaryAccent and primaryAccentHover
   if (color === "blue") {
     if (num === 600) {
@@ -31,26 +31,29 @@ function getColorCode(color: any, num: ColorScale) {
   return `${color}-${num}`;
 }
 
-function getTextClass(color: any) {
+function getTextClass(color: Colors) {
   if (color === "white") {
     return "text-white";
   }
 
-  return `text-${color}-700`;
+  return `text-${getColorCode(color, 700)}`;
 }
 
-function getColorClasses(color: any, style: ButtonStyles) {
+function getColorClasses(color: Colors, style: ButtonStyles) {
   let textStyle, bgStyle;
 
   if (style === "primary") {
     textStyle = getTextClass("white");
-    bgStyle = `bg-${getColorCode(color, 600)} hover:bg-${getColorCode(color, 700)}`;
+    bgStyle = `bg-primaryAccent hover:bg-${getColorCode(color, 700)}`;
   } else if (style === "secondary") {
     textStyle = getTextClass(color);
-    bgStyle = `bg-${getColorCode(color, 100)} hover:bg-${getColorCode(color, 200)}`;
+    bgStyle = `bg-white border-${getColorCode(color, 600)} hover:border-${getColorCode(
+      color,
+      700
+    )}`;
   } else {
     textStyle = getTextClass("gray");
-    bgStyle = `bg-white hover:bg-gray-50`;
+    bgStyle = `bg-gray-300`;
   }
 
   return `${textStyle} ${bgStyle}`;
@@ -63,8 +66,8 @@ function Button({
   color,
   className,
   onClick = () => {},
-  disabled = false,
 }: ButtonProps & {
+  size: ButtonSizes;
   style: ButtonStyles;
 }) {
   const standardClasses = STANDARD_CLASSES[size];
@@ -74,7 +77,7 @@ function Button({
   return (
     <button
       onClick={onClick}
-      disabled={disabled}
+      disabled={style === "disabled"}
       className={classNames(standardClasses, colorClasses, focusClasses, className)}
     >
       {children}
@@ -83,14 +86,18 @@ function Button({
 }
 
 interface ButtonProps {
-  size: ButtonSizes;
-  color: any;
+  color: Colors;
   children?: React.ReactNode;
   className?: string;
   onClick?: () => void;
-  disabled?: boolean;
 }
 
-export const PrimaryButton = (props: ButtonProps) => <Button {...props} style="primary" />;
-export const SecondaryButton = (props: ButtonProps) => <Button {...props} style="secondary" />;
-export const WhiteButton = (props: ButtonProps) => <Button {...props} style="white" />;
+export const PrimaryButton = (props: ButtonProps) => (
+  <Button {...props} size="2xl" style="primary" />
+);
+export const SecondaryButton = (props: ButtonProps) => (
+  <Button {...props} size="2xl" style="secondary" />
+);
+export const DisabledButton = (props: ButtonProps) => (
+  <Button {...props} size="2xl" style="disabled" className="cursor-default" />
+);

--- a/src/ui/components/shared/FirstReplayModal/FirstReplayModal.tsx
+++ b/src/ui/components/shared/FirstReplayModal/FirstReplayModal.tsx
@@ -46,7 +46,7 @@ function FirstReplayModal({ hideModal }: PropsFromRedux) {
               {` button to start recording.`}
             </div>
             <UrlCopy url={FIRST_REPLAY_TARGET} />
-            <PrimaryButton color="blue" size="2xl" onClick={handleOpen}>
+            <PrimaryButton color="blue" onClick={handleOpen}>
               {`Open this website in a new tab`}
             </PrimaryButton>
           </div>


### PR DESCRIPTION
Fix #3150. 

We're trying to standardize the UI components that we use. To that end, we're limiting buttons to (mostly) 3 variations:
1) PrimaryButton (blue background, white text): Go-to button
2) SecondaryButton (white background, blue text, blue border): For cases where we want to emphasize a secondary action or not make an action too prominent.
3) DisabledButton (medium gray background, dark gray text): For when a button is not to be clicked.