### PR TITLE
Split out app bundle from browser pages

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1,0 +1,32 @@
+/* NOTE: this is added to protect against React DevTools */
+html {
+  font-size: 12px !important;
+}
+
+html, body {
+  height: 100vh;
+  width: 100vw;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+#app {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  align-items: stretch;
+  height: 100%;
+  width: 100%;
+  font-family: system-ui, Arial, sans-serif;
+  color: var(--theme-body-color);
+  --light-grey: #969696;
+  --dark-grey: #696969;
+  --light-blue: #61cdff;
+  --dark-blue: #2d7eff;
+  --faint-red: rgba(255, 0, 0, 0.5);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 require("tailwindcss/tailwind.css");
+require("./base.css");
 
 const url = new URL(window.location.href);
 const test = url.searchParams.get("test");
@@ -24,10 +25,27 @@ if (test && !url.searchParams.get("navigated")) {
 require("ui/utils/whatwg-url-fix");
 const React = require("react");
 const ReactDOM = require("react-dom");
-const { bootstrapApp } = require("ui/setup");
-const AppRouting = require("views/routing").default;
-require("image/image.css");
+const { BrowserRouter: Router, Route, Switch } = require("react-router-dom");
 
-bootstrapApp();
+const BrowserError = React.lazy(() => import("views/browser/error"));
+const BrowserImport = React.lazy(() => import("views/browser/import-settings"));
+const BrowserLaunch = React.lazy(() => import("views/browser/launch"));
+const BrowserNewTab = React.lazy(() => import("views/browser/new-tab"));
+const BrowserWelcome = React.lazy(() => import("views/browser/welcome"));
+const AppRouter = React.lazy(() => import("views/app"));
 
-ReactDOM.render(<AppRouting />, document.querySelector("#app"));
+ReactDOM.render(
+  <React.Suspense fallback={<div>Loading</div>}>
+    <Router>
+      <Switch>
+        <Route exact path="/browser/error" component={BrowserError} />
+        <Route exact path="/browser/import-settings" component={BrowserImport} />
+        <Route exact path="/browser/launch" component={BrowserLaunch} />
+        <Route exact path="/browser/new-tab" component={BrowserNewTab} />
+        <Route exact path="/browser/welcome" component={BrowserWelcome} />
+        <Route component={AppRouter} />
+      </Switch>
+    </Router>
+  </React.Suspense>,
+  document.querySelector("#app")
+);

--- a/src/ui/components/Account/Library.tsx
+++ b/src/ui/components/Account/Library.tsx
@@ -28,7 +28,8 @@ function Header({
   currentWorkspaceId: string | null;
   setModal: (modal: ModalType) => void;
 }) {
-  const onSettingsClick = () => {
+  const onSettingsClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
     setModal("workspace-settings");
   };
 

--- a/src/ui/components/App.css
+++ b/src/ui/components/App.css
@@ -1,36 +1,3 @@
-#app {
-  display: flex;
-  position: relative;
-  flex-direction: column;
-  align-items: stretch;
-  height: 100%;
-  width: 100%;
-  font-family: system-ui, Arial, sans-serif;
-  color: var(--theme-body-color);
-  --light-grey: #969696;
-  --dark-grey: #696969;
-  --light-blue: #61cdff;
-  --dark-blue: #2d7eff;
-  --faint-red: rgba(255, 0, 0, 0.5);
-}
-
-/* NOTE: this is added to protect against React DevTools */
-html {
-  font-size: 12px !important;
-}
-
-html, body {
-  height: 100vh;
-  width: 100vw;
-  margin: 0;
-  padding: 0;
-  overflow: hidden;
-}
-
-* {
-  box-sizing: border-box;
-}
-
 #video {
   height: 100%;
   position: relative;

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -23,7 +23,7 @@ import { useGetUserInfo } from "ui/hooks/users";
 import { useGetRecording } from "ui/hooks/recordings";
 import useToken from "ui/utils/useToken";
 
-import "styles.css";
+import "./App.css";
 import UploadingScreen from "./UploadingScreen";
 import TeamMemberOnboardingModal from "./shared/OnboardingModal/TeamMemberOnboardingModal";
 import TeamLeaderOnboardingModal from "./shared/TeamLeaderOnboardingModal";

--- a/src/ui/components/Dashboard/Navigation/NewWorkspaceButton.tsx
+++ b/src/ui/components/Dashboard/Navigation/NewWorkspaceButton.tsx
@@ -8,7 +8,8 @@ import classnames from "classnames";
 type NewWorkspaceButtonProps = PropsFromRedux & {};
 
 function NewWorkspaceButton({ setModal }: NewWorkspaceButtonProps) {
-  const onClick = () => {
+  const onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
     setModal("new-workspace");
   };
 

--- a/src/ui/components/Dashboard/Navigation/WorkspaceItem.tsx
+++ b/src/ui/components/Dashboard/Navigation/WorkspaceItem.tsx
@@ -16,7 +16,8 @@ type WorkspaceItemProps = PropsFromRedux & {
 function WorkspaceItem({ workspace, currentWorkspaceId, setWorkspaceId }: WorkspaceItemProps) {
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
 
-  const onClick = () => {
+  const onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
     setWorkspaceId(workspace.id);
     updateDefaultWorkspace({
       variables: { workspaceId: workspace.id },

--- a/src/views/app.tsx
+++ b/src/views/app.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react";
 import { connect, ConnectedProps, Provider } from "react-redux";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { IntercomProvider } from "react-use-intercom";
 import { isTest } from "ui/utils/environment";
 import { validateUUID } from "ui/utils/helpers";
@@ -14,18 +13,17 @@ import { useGetUserSettings } from "ui/hooks/settings";
 import { useIsRecordingInitialized, useGetRecordingOwnerUserId } from "ui/hooks/recordings";
 import BlankScreen from "ui/components/shared/BlankScreen";
 import App from "ui/components/App";
+import { bootstrapApp } from "ui/setup";
+import "image/image.css";
 
 const url = new URL(window.location.href);
 const recordingId = url.searchParams.get("id");
 
-const BrowserError = React.lazy(() => import("views/browser/error"));
-const BrowserImport = React.lazy(() => import("views/browser/import-settings"));
-const BrowserLaunch = React.lazy(() => import("views/browser/launch"));
-const BrowserNewTab = React.lazy(() => import("views/browser/new-tab"));
-const BrowserWelcome = React.lazy(() => import("views/browser/welcome"));
 const Upload = React.lazy(() => import("views/upload"));
 const Account = React.lazy(() => import("ui/components/Account"));
 const DevTools = React.lazy(() => import("ui/components/DevTools"));
+
+bootstrapApp();
 
 function PageSwitch({ setExpectedError, setWorkspaceId }: PropsFromRedux) {
   const { isAuthenticated, user } = useAuth0();
@@ -90,32 +88,19 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 const ConnectedPageSwitch = connector(PageSwitch);
 
 const AppRouting = () => (
-  <React.Suspense fallback={<div>Loading</div>}>
-    <Router>
-      <Switch>
-        <Route exact path="/browser/error" component={BrowserError} />
-        <Route exact path="/browser/import-settings" component={BrowserImport} />
-        <Route exact path="/browser/launch" component={BrowserLaunch} />
-        <Route exact path="/browser/new-tab" component={BrowserNewTab} />
-        <Route exact path="/browser/welcome" component={BrowserWelcome} />
-        <Route>
-          <tokenManager.Auth0Provider>
-            <ApolloWrapper>
-              <IntercomProvider appId={"k7f741xx"}>
-                <Provider store={window.store}>
-                  <App>
-                    <React.Suspense fallback={<div>Loading</div>}>
-                      <ConnectedPageSwitch />
-                    </React.Suspense>
-                  </App>
-                </Provider>
-              </IntercomProvider>
-            </ApolloWrapper>
-          </tokenManager.Auth0Provider>
-        </Route>
-      </Switch>
-    </Router>
-  </React.Suspense>
+  <tokenManager.Auth0Provider>
+    <ApolloWrapper>
+      <IntercomProvider appId={"k7f741xx"}>
+        <Provider store={window.store}>
+          <App>
+            <React.Suspense fallback={<div>Loading</div>}>
+              <ConnectedPageSwitch />
+            </React.Suspense>
+          </App>
+        </Provider>
+      </IntercomProvider>
+    </ApolloWrapper>
+  </tokenManager.Auth0Provider>
 );
 
 export default AppRouting;


### PR DESCRIPTION
## Summary

This continues the work started in #3098 to further split the app bundle from the browser pages to reduce the load on these "standalone" pages. In particular, this lightens the work required for `/browser/new-tab` so it can launch as quickly as possible from devtools.

## Changes

* Move the routing code back up to `main.js` and lazy load each of the views from there
* Refactors out the common view styling from `app.css` into `base.css` and import that from `main.js` so each view has the same base font size and html/body sizing
* Moves the remaining styles from `/styles.css` to `ui/components/App.css` so it can be alongside the component that imports it.