### PR TITLE
Refactor handling of multiple identical sources (#3065)

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/setFramePositions.js
+++ b/src/devtools/client/debugger/src/actions/pause/setFramePositions.js
@@ -20,9 +20,7 @@ export function setFramePositions() {
     const { sourceId: protocolSourceId } = await ThreadFront.getPreferredLocation(
       positions[0].frame
     );
-    const source = getSourceByActorId(getState(), protocolSourceId);
-    const sourceId = source?.id;
-    const sourceUrl = source?.url;
+    const sourceId = getSourceByActorId(getState(), protocolSourceId)?.id;
 
     if (!sourceId) {
       return;
@@ -31,7 +29,7 @@ export function setFramePositions() {
     const locations = await Promise.all(
       positions.map(async ({ frame }) => {
         const { line, column } = await ThreadFront.getPreferredLocation(frame);
-        return { line, column, sourceId, sourceUrl };
+        return { line, column, sourceId };
       })
     );
 

--- a/src/devtools/client/debugger/src/actions/sources/newSources.js
+++ b/src/devtools/client/debugger/src/actions/sources/newSources.js
@@ -80,12 +80,6 @@ function checkPendingBreakpoints(cx, sourceId) {
       return;
     }
 
-    await ThreadFront.ensureAllSources();
-    const pickedSourceId = ThreadFront.pickCorrespondingSourceId(sourceId, source.url);
-    if (sourceId !== pickedSourceId) {
-      return;
-    }
-
     for (const bp of pendingBreakpoints) {
       const line = bp.location.line;
       dispatch({ type: "SET_REQUESTED_BREAKPOINT", location: { sourceId, line } });

--- a/src/devtools/client/debugger/src/actions/sources/select.js
+++ b/src/devtools/client/debugger/src/actions/sources/select.js
@@ -88,7 +88,7 @@ export function selectSource(cx, sourceId, options = {}) {
  * @memberof actions/sources
  * @static
  */
-export function selectLocation(cx, initialLocation, { keepContext = true } = {}) {
+export function selectLocation(cx, location, { keepContext = true } = {}) {
   return async ({ dispatch, getState, client }) => {
     const currentSource = getSelectedSource(getState());
 
@@ -98,16 +98,11 @@ export function selectLocation(cx, initialLocation, { keepContext = true } = {})
       return;
     }
 
-    const initialSource = getSource(getState(), initialLocation.sourceId);
-    if (!initialSource) {
+    const source = getSource(getState(), location.sourceId);
+    if (!source) {
       // If there is no source we deselect the current selected source
       return dispatch(clearSelectedLocation(cx));
     }
-
-    await ThreadFront.ensureAllSources();
-    const sourceId = ThreadFront.pickCorrespondingSourceId(initialSource.id, initialSource.url);
-    const source = getSource(getState(), sourceId);
-    const location = { ...initialLocation, sourceId };
 
     const activeSearch = getActiveSearch(getState());
     if (activeSearch && activeSearch !== "file") {

--- a/src/devtools/client/debugger/src/client/create.js
+++ b/src/devtools/client/debugger/src/client/create.js
@@ -20,10 +20,8 @@ export async function createFrame(frame, index = 0, asyncIndex = 0) {
   }
 
   const { sourceId, line, column } = await ThreadFront.getPreferredLocation(frame.location);
-  const sourceUrl = await ThreadFront.getSourceURL(sourceId);
   const location = {
     sourceId: clientCommands.getSourceForActor(sourceId),
-    sourceUrl,
     line,
     column,
   };
@@ -31,10 +29,8 @@ export async function createFrame(frame, index = 0, asyncIndex = 0) {
   let alternateLocation;
   const alternate = await ThreadFront.getAlternateLocation(frame.location);
   if (alternate) {
-    const alternateSourceUrl = await ThreadFront.getSourceURL(alternate.sourceId);
     alternateLocation = {
       sourceId: clientCommands.getSourceForActor(alternate.sourceId),
-      sourceUrl: alternateSourceUrl,
       line: alternate.line,
       column: alternate.column,
     };

--- a/src/devtools/client/debugger/src/selectors/debugLine.ts
+++ b/src/devtools/client/debugger/src/selectors/debugLine.ts
@@ -1,4 +1,3 @@
-import { ThreadFront } from "protocol/thread";
 import { UIState } from "ui/state";
 import { getVisibleSelectedFrame, getSourceWithContent, getPausePreviewLocation } from ".";
 import { hasDocument } from "../utils/editor";
@@ -10,9 +9,6 @@ export function getDebugLineLocation(state: UIState) {
   if (!location) {
     return undefined;
   }
-  // this is bad design: a redux selector should only use redux state, but here we use
-  // the state stored in ThreadFront. This will be fixed in #3065.
-  location.sourceId = ThreadFront.pickCorrespondingSourceId(location.sourceId, location.sourceUrl);
   const source = getSourceWithContent(state, location.sourceId);
   if (source && source.content && hasDocument(location.sourceId)) {
     return location;

--- a/src/devtools/client/inspector/markup/markup.js
+++ b/src/devtools/client/inspector/markup/markup.js
@@ -82,6 +82,7 @@ class MarkupView {
   async loadNewDocument() {
     this.isLoadingPostponed = false;
 
+    await ThreadFront.ensureAllSources();
     ThreadFront.ensureCurrentPause();
     const pause = ThreadFront.currentPause;
     if (this.selection.nodeFront && this.selection.nodeFront.pause !== pause) {

--- a/src/devtools/client/webconsole/actions/input.js
+++ b/src/devtools/client/webconsole/actions/input.js
@@ -29,6 +29,7 @@ function evaluateExpression(expression) {
     }
 
     const { asyncIndex, frameId } = toolbox.getPanel("debugger").getFrameId();
+    await ThreadFront.ensureAllSources();
     const pause = ThreadFront.pauseForAsyncIndex(asyncIndex);
     assert(pause);
 

--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -223,6 +223,7 @@ export function setupGraphics(store: UIStore) {
       return;
     }
 
+    await ThreadFront.ensureAllSources();
     ThreadFront.ensureCurrentPause();
     const pause = ThreadFront.currentPause;
     assert(pause);

--- a/src/protocol/thread/pause.ts
+++ b/src/protocol/thread/pause.ts
@@ -196,6 +196,8 @@ export class Pause {
   private _updateDataFronts({ frames, scopes, objects }: PauseData) {
     (frames || []).forEach(frame => {
       (frame as WiredFrame).this = new ValueFront(this, frame.this);
+      ThreadFront.updateMappedLocation(frame.location);
+      ThreadFront.updateMappedLocation(frame.functionLocation);
     });
 
     (scopes || []).forEach(scope => {
@@ -265,6 +267,8 @@ export class Pause {
           this,
           prototypeId ? { object: prototypeId } : { value: null }
         );
+
+        ThreadFront.updateMappedLocation(object.preview.functionLocation);
       }
 
       this.objects.get(object.objectId)!.preview = object.preview as WiredObjectPreview;
@@ -484,6 +488,9 @@ export class Pause {
       const { steps } = await this.sendMessage(client.Pause.getFrameSteps, {
         frameId,
       });
+      for (const step of steps) {
+        ThreadFront.updateMappedLocation(step.frame);
+      }
       this.frameSteps.set(frameId, steps);
     }
     return this.frameSteps.get(frameId)!;

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -461,6 +461,7 @@ async function executeInConsole(value) {
   await window.jsterm.editorWaiter;
   window.jsterm.setValue(value);
   window.jsterm.execute();
+  await new Promise(resolve => setTimeout(resolve, 1));
 }
 
 function waitForFrameTimeline(width) {
@@ -766,6 +767,7 @@ const testCommands = {
   checkHighlighterVisible,
   checkHighlighterShape,
   getRecordingTarget,
+  waitForSource,
   waitForSourceCount,
 };
 

--- a/test/scripts/breakpoints-07.js
+++ b/test/scripts/breakpoints-07.js
@@ -5,8 +5,7 @@
     console.log(`# Test that breakpoints work across navigations.`);
     await Test.start();
 
-    // this source is loaded twice, wait until the server has sent us both instances
-    await Test.waitForSourceCount("bundle_input.js", 2);
+    await Test.waitForSource("bundle_input.js");
 
     Test.app.actions.openQuickOpen();
     Test.app.actions.setQuickOpenQuery("bundle");


### PR DESCRIPTION
Recordings can contain multiple identical sources (usually because the user navigated while recording), but in our frontend we want to show only one of the identical sources.
In the past, we fixed this as "close to the UI" as possible (see #2628, #2784, #2812, #3012), with this PR we do it as "far away from the UI" as possible instead - the advantage is that only the code in `src/protocol` needs to know about this issue now.
- when all sources are loaded, `ThreadFront.groupSourceIds()` will identify identical sources and store them in `ThreadFront.correspondingSourceIds`
- when messages containing `SourceId`s are received from the backend, each `SourceId` is replaced with the first `SourceId` from the set of corresponding `SourceId`s
- breakpoints and logpoints are set for all identical sources
- `Pause.create()` and `Pause.instantiate()` now should only be called after all sources are loaded: these methods call `Pause.addData()`, which may need to replace some `SourceId`s. Since these methods are synchronous (and some of their callers are synchronous), they can't wait for the sources to be loaded, so the caller needs to ensure that somehow.