### PR TITLE
Fix viewer toolbox styling

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -11,6 +11,9 @@ import { UIState } from "ui/state";
 import { PrimaryPanelName } from "ui/state/app";
 import { isDemo } from "ui/utils/environment";
 
+// TODO [ryanjduffy]: Refactor shared styling more completely
+import "./Toolbox.css";
+
 function IndexingLoader({
   progressPercentage,
   viewMode,


### PR DESCRIPTION
The Viewer toolbar is reusing global classes from the toolbox but not directly importing the CSS. After the change to split the viewer and devtools into separate bundles, the CSS isn't available until the devtools is loaded once.

Importing the CSS directly resolves this though further work to more properly manage these global classes would be great!

Fixed #3180