### PR TITLE
Keep devtools loading screens from flickering

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,9 +33,10 @@ const BrowserLaunch = React.lazy(() => import("views/browser/launch"));
 const BrowserNewTab = React.lazy(() => import("views/browser/new-tab"));
 const BrowserWelcome = React.lazy(() => import("views/browser/welcome"));
 const AppRouter = React.lazy(() => import("views/app"));
+const BlankScreen = require("ui/components/shared/BlankScreen").default;
 
 ReactDOM.render(
-  <React.Suspense fallback={<div>Loading</div>}>
+  <React.Suspense fallback={<BlankScreen background="white" />}>
     <Router>
       <Switch>
         <Route exact path="/browser/error" component={BrowserError} />

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -13,14 +13,11 @@ import OnboardingModal from "./shared/OnboardingModal/index";
 import { isDeployPreview, isTest, hasLoadingParam } from "ui/utils/environment";
 import * as selectors from "ui/reducers/app";
 import * as actions from "ui/actions/app";
-import ResizeObserverPolyfill from "resize-observer-polyfill";
-import LogRocket from "ui/utils/logrocket";
 import { setTelemetryContext } from "ui/utils/telemetry";
 import { setUserInBrowserPrefs, setAccessTokenInBrowserPrefs } from "ui/utils/browser";
 import { UIState } from "ui/state";
 import { ModalType, UnexpectedError } from "ui/state/app";
 import { useGetUserInfo } from "ui/hooks/users";
-import { useGetRecording } from "ui/hooks/recordings";
 import useToken from "ui/utils/useToken";
 
 import "./App.css";
@@ -93,18 +90,10 @@ function useCheckForApolloError() {
   return null;
 }
 
-function App({
-  theme,
-  recordingId,
-  modal,
-  setFontLoading,
-  setUnexpectedError,
-  children,
-}: AppProps) {
+function App({ theme, modal, setFontLoading, setUnexpectedError, children }: AppProps) {
   const auth = useAuth0();
   const userInfo = useGetUserInfo();
   const { isAuthenticated } = useAuth0();
-  const recordingInfo = useGetRecording(recordingId);
   const apolloError = useCheckForApolloError();
   const tokenInfo = useToken();
 
@@ -144,12 +133,6 @@ function App({
     setUserInBrowserPrefs(auth.user);
   }, [auth.user]);
 
-  useEffect(() => {
-    if (!recordingInfo.loading && !userInfo.loading && recordingInfo.recording) {
-      LogRocket.createSession(recordingInfo.recording, userInfo, auth);
-    }
-  }, [auth, userInfo, recordingInfo]);
-
   if (apolloError) {
     return <BlankScreen />;
   }
@@ -159,7 +142,7 @@ function App({
   }
 
   if (!isDeployPreview() && (auth.isLoading || userInfo.loading)) {
-    return <BlankScreen />;
+    return <BlankScreen background="white" />;
   }
 
   if (!isTest() && isAuthenticated && userInfo.acceptedTOSVersion !== LATEST_TOS_VERSION) {

--- a/src/views/app.tsx
+++ b/src/views/app.tsx
@@ -93,7 +93,7 @@ const AppRouting = () => (
       <IntercomProvider appId={"k7f741xx"}>
         <Provider store={window.store}>
           <App>
-            <React.Suspense fallback={<div>Loading</div>}>
+            <React.Suspense fallback={<BlankScreen background="white" />}>
               <ConnectedPageSwitch />
             </React.Suspense>
           </App>


### PR DESCRIPTION
Fix #3190.

Right now when you open a Replay, there's a mix of white screens/blue screens/spinners/loading bars that show up before DevTools finally loads up. 

This makes it so that when we open a recording, it goes:
```
white screen -> spinner -> loading bar (scanning) -> devtools
```

There's a cleaner way to do this but this cleans this up right now and we can do a follow up.

Before:
https://app.replay.io/?id=a4cbbc7d-4434-48bf-a442-659d5fa3ff71
After:
https://app.replay.io/?id=fee081e4-19c8-4d2b-8152-b32067149e21
