### PR TITLE
Fix debugger panels overflowing

### DIFF
--- a/src/devtools/client/debugger/src/components/App.css
+++ b/src/devtools/client/debugger/src/components/App.css
@@ -10,8 +10,8 @@ button {
 
 .split-box .debugger {
   display: flex;
-  flex: 1;
-  height: 100%;
+  flex: 1 1 auto;
+  width: 0;
 }
 
 #toolbox-content-debugger .tree-indent {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/SecondaryPanes.css
@@ -27,6 +27,7 @@
 
 .secondary-panes-wrapper {
   width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }
@@ -34,6 +35,12 @@
 .secondary-panes .accordion {
   flex: 1 0 auto;
   margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.secondary-panes .accordion li {
+  display: contents;
 }
 
 .secondary-panes-wrapper .accordion li:last-child ._content {


### PR DESCRIPTION
Fixes #3187 by fixing the flex box sizing (because it's notoriously onery)

Repro for part 2:
* Open a replay with multiple sources
* Open several sources from the explorer such that one of the tabs is clipped on the right
* Select the overflowing source from the explorer