### PR TITLE
Allow seeking to unloaded regions

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -253,11 +253,7 @@ export function seek(
   hasFrames: boolean,
   pauseId?: PauseId
 ): UIThunkAction<boolean> {
-  return ({ getState, dispatch }) => {
-    if (!selectors.isRegionLoaded(getState(), time)) {
-      return false;
-    }
-
+  return ({ dispatch }) => {
     const pause = pauseId !== undefined ? Pause.getById(pauseId) : undefined;
 
     updateUrl({ point, time, hasFrames });


### PR DESCRIPTION
Fixes #3162 

This allows users to seek to unloaded locations

before: https://app.replay.io/?id=37b65c20-6a3a-46ce-b8ee-bbbbbc3ca46d&point=25961484298513924218237035376279794&time=11843.80976560729&hasFrames=true
after: https://app.replay.io/?id=b35659de-86e0-40d7-8f3c-aeaa6d7a8a56
