### PR TITLE
Refactor the routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install
 npm start
 ```
 
-Once you see `Compiled succesfully` in your terminal, open your browser and go to [this link](http://localhost:8080/view?id=79f0cacd-727b-456d-8970-dbb4866ce6c7).
+Once you see `Compiled succesfully` in your terminal, open your browser and go to [this link](http://localhost:8080/recording/79f0cacd-727b-456d-8970-dbb4866ce6c7).
 
 **You just successfully opened your first Replay recording!** That recording uses your locally running copy of Replay DevTools to debug our test recording.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,7 @@ npm install
 npm start
 ```
 
-Once you see `Compiled succesfully` in your terminal, open your browser and go to [this link](http://localhost:8080/view?id=79f0cacd-727b-456d-8970-dbb4866ce6c7).
+Once you see `Compiled succesfully` in your terminal, open your browser and go to [this link](http://localhost:8080/recording/79f0cacd-727b-456d-8970-dbb4866ce6c7).
 
 ## Maintainers
 

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary.tsx
@@ -5,7 +5,6 @@ import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { selectors } from "ui/reducers";
-import { getRecordingId } from "ui/reducers/app";
 import { UIState } from "ui/state";
 import { isDemo } from "ui/utils/environment";
 const { getExecutionPoint } = require("devtools/client/debugger/src/reducers/pause");
@@ -21,7 +20,6 @@ type PanelSummaryProps = PropsFromRedux & {
 
 function PanelSummary({
   breakpoint,
-  recordingId,
   toggleEditingOn,
   setInputToFocus,
   createFrameComment,
@@ -147,7 +145,6 @@ function PanelSummary({
 const connector = connect(
   (state: UIState, { breakpoint }: { breakpoint: any }) => ({
     executionPoint: getExecutionPoint(state),
-    recordingId: getRecordingId(state),
     currentTime: selectors.getCurrentTime(state),
     analysisPoints: selectors.getAnalysisPointsForLocation(
       state,

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -25,7 +25,6 @@ import {
 import { RecordingTarget } from "protocol/thread/thread";
 import { Workspace } from "ui/types";
 
-export type SetupAppAction = Action<"setup_app"> & { recordingId: RecordingId };
 export type SetRecordingDurationAction = Action<"set_recording_duration"> & { duration: number };
 export type LoadingAction = Action<"loading"> & { loading: number };
 export type IndexingAction = Action<"indexing"> & { indexing: number };
@@ -88,7 +87,6 @@ export type SetShowVideoPanelAction = Action<"set_show_video_panel"> & {
 };
 
 export type AppActions =
-  | SetupAppAction
   | SetRecordingDurationAction
   | LoadingAction
   | IndexingAction
@@ -118,9 +116,7 @@ export type AppActions =
   | SetShowVideoPanelAction
   | SetAwaitingSourcemapsAction;
 
-export function setupApp(recordingId: RecordingId, store: UIStore) {
-  store.dispatch({ type: "setup_app", recordingId });
-
+export function setupApp(store: UIStore) {
   ThreadFront.waitForSession().then(sessionId =>
     store.dispatch({ type: "set_session_id", sessionId })
   );

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -8,7 +8,7 @@ import * as actions from "ui/actions/app";
 import * as selectors from "ui/reducers/app";
 import { ThreadFront } from "protocol/thread";
 import { prefs } from "ui/utils/prefs";
-import { getTest, isTest, isDevelopment } from "ui/utils/environment";
+import { getTest, isTest, isDevelopment, getRecordingId } from "ui/utils/environment";
 import { sendTelemetryEvent } from "ui/utils/telemetry";
 
 import { ExpectedError, UnexpectedError } from "ui/state/app";
@@ -110,7 +110,7 @@ export function setExpectedError(error: ExpectedError): UIThunkAction {
     sendTelemetryEvent("DevtoolsExpectedError", {
       message: error.message,
       action: error.action,
-      recordingId: selectors.getRecordingId(state),
+      recordingId: getRecordingId(),
       sessionId: selectors.getSessionId(state),
       environment: isDevelopment() ? "dev" : "prod",
     });
@@ -125,7 +125,7 @@ export function setUnexpectedError(error: UnexpectedError): UIThunkAction {
 
     sendTelemetryEvent("DevtoolsUnexpectedError", {
       ...error,
-      recordingId: selectors.getRecordingId(state),
+      recordingId: getRecordingId(),
       sessionId: selectors.getSessionId(state),
       environment: isDevelopment() ? "dev" : "prod",
     });

--- a/src/ui/components/Account/index.tsx
+++ b/src/ui/components/Account/index.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect } from "react";
+import { useHistory } from "react-router-dom";
 import useAuth0 from "ui/utils/useAuth0";
 import { setUserInBrowserPrefs } from "../../utils/browser";
 import { isTeamMemberInvite } from "ui/utils/environment";
+import { createReplayURL } from "views/app";
 import Library from "./Library";
 
 import "./Account.css";
@@ -55,6 +57,18 @@ function WelcomePage() {
 
 export default function Account() {
   const { isAuthenticated } = useAuth0();
+  const history = useHistory();
+  const searchParams = new URLSearchParams(window.location.search);
+
+  useEffect(() => {
+    if (searchParams.get("id")) {
+      history.replace(createReplayURL(searchParams));
+    }
+  }, []);
+
+  if (searchParams.get("id")) {
+    return null;
+  }
 
   if (!isAuthenticated) {
     return <WelcomePage />;

--- a/src/ui/components/Account/index.tsx
+++ b/src/ui/components/Account/index.tsx
@@ -13,7 +13,11 @@ import "devtools/client/debugger/src/components/shared/AccessibleImage.css";
 function WelcomePage() {
   const { loginWithRedirect } = useAuth0();
   const forceOpenAuth = new URLSearchParams(window.location.search).get("signin");
-  const onLogin = () => loginWithRedirect({ appState: { returnTo: window.location.href } });
+  const onLogin = () =>
+    loginWithRedirect({
+      redirectUri: window.location.origin,
+      appState: { returnTo: window.location.href },
+    });
 
   if (forceOpenAuth) {
     onLogin();

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -182,7 +182,6 @@ function App({
 const connector = connect(
   (state: UIState) => ({
     theme: selectors.getTheme(state),
-    recordingId: selectors.getRecordingId(state),
     modal: selectors.getModal(state),
     sessionId: selectors.getSessionId(state),
   }),

--- a/src/ui/components/Comments/TranscriptComments/CommentActions.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentActions.tsx
@@ -6,15 +6,14 @@ import { actions } from "ui/actions";
 import hooks from "ui/hooks";
 import "./CommentActions.css";
 import { DotsHorizontalIcon } from "@heroicons/react/solid";
-import { UIState } from "ui/state";
-import { getRecordingId } from "ui/reducers/app";
 
 type CommentActionsProps = PropsFromRedux & {
   comment: Comment | Reply;
   isRoot: boolean;
 };
 
-function CommentActions({ comment, editItem, isRoot, recordingId }: CommentActionsProps) {
+function CommentActions({ comment, editItem, isRoot }: CommentActionsProps) {
+  const recordingId = hooks.useGetRecordingId();
   const { userId } = hooks.useGetUserId();
   const deleteComment = hooks.useDeleteComment();
   const deleteCommentReply = hooks.useDeleteCommentReply();
@@ -76,7 +75,7 @@ function CommentActions({ comment, editItem, isRoot, recordingId }: CommentActio
   );
 }
 
-const connector = connect((state: UIState) => ({ recordingId: getRecordingId(state) }), {
+const connector = connect(null, {
   editItem: actions.editItem,
 });
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -1,11 +1,9 @@
 import React, { useMemo, useState } from "react";
-import useAuth0 from "ui/utils/useAuth0";
 import { connect, ConnectedProps } from "react-redux";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
 import { UIState } from "ui/state";
 import hooks from "ui/hooks";
-import CommentTool from "ui/components/shared/CommentTool";
 import {
   Comment,
   PendingEditComment,
@@ -24,12 +22,8 @@ type CommentEditorProps = PropsFromRedux & {
   handleSubmit: (inputValue: string) => void;
 };
 
-function CommentEditor({
-  comment,
-  handleSubmit,
-  clearPendingComment,
-  recordingId,
-}: CommentEditorProps) {
+function CommentEditor({ comment, handleSubmit, clearPendingComment }: CommentEditorProps) {
+  const recordingId = hooks.useGetRecordingId();
   const { collaborators, recording, loading } = hooks.useGetOwnersAndCollaborators(recordingId!);
   const [api, setApi] = useState<DraftJSAPI>();
   const [submitEnabled, setSubmitEnabled] = useState<boolean>(false);
@@ -96,7 +90,6 @@ function CommentEditor({
 
 const connector = connect(
   (state: UIState) => ({
-    recordingId: selectors.getRecordingId(state),
     pendingComment: selectors.getPendingComment(state),
   }),
   {

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
-import { selectors } from "ui/reducers";
 import hooks from "ui/hooks";
 import { actions } from "ui/actions";
-import { UIState } from "ui/state";
 import { PendingNewComment, PendingNewReply } from "ui/state/comments";
 import CommentEditor from "./CommentEditor";
 
@@ -12,12 +10,8 @@ interface NewCommentEditorProps extends PropsFromRedux {
   type: "new_reply" | "new_comment";
 }
 
-function NewCommentEditor({
-  comment,
-  type,
-  clearPendingComment,
-  recordingId,
-}: NewCommentEditorProps) {
+function NewCommentEditor({ comment, type, clearPendingComment }: NewCommentEditorProps) {
+  const recordingId = hooks.useGetRecordingId();
   const addComment = hooks.useAddComment();
   const addCommentReply = hooks.useAddCommentReply();
 
@@ -79,11 +73,8 @@ function NewCommentEditor({
   return <CommentEditor {...{ comment, handleSubmit }} />;
 }
 
-const connector = connect(
-  (state: UIState) => ({
-    recordingId: selectors.getRecordingId(state),
-  }),
-  { clearPendingComment: actions.clearPendingComment }
-);
+const connector = connect(null, {
+  clearPendingComment: actions.clearPendingComment,
+});
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(NewCommentEditor);

--- a/src/ui/components/Comments/VideoComments/CommentsOverlay.tsx
+++ b/src/ui/components/Comments/VideoComments/CommentsOverlay.tsx
@@ -38,10 +38,10 @@ function findComment({
 function CommentsOverlay({
   pendingComment,
   canvas,
-  recordingId,
   currentTime,
   children,
 }: PropsFromRedux & { children: React.ReactNode }) {
+  const recordingId = hooks.useGetRecordingId();
   const { comments: hasuraComments } = hooks.useGetComments(recordingId);
 
   if (!canvas) {
@@ -71,15 +71,11 @@ function CommentsOverlay({
   );
 }
 
-const connector = connect(
-  (state: UIState) => ({
-    currentTime: selectors.getCurrentTime(state),
-    pendingComment: selectors.getPendingComment(state),
-    recordingId: selectors.getRecordingId(state)!,
-    canvas: selectors.getCanvas(state),
-  }),
-  null
-);
+const connector = connect((state: UIState) => ({
+  currentTime: selectors.getCurrentTime(state),
+  pendingComment: selectors.getPendingComment(state),
+  canvas: selectors.getCanvas(state),
+}));
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 export default connector(CommentsOverlay);

--- a/src/ui/components/Comments/VideoComments/VideoComment.tsx
+++ b/src/ui/components/Comments/VideoComments/VideoComment.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { selectors } from "ui/reducers";
 import classnames from "classnames";
 import { actions } from "ui/actions";
@@ -64,7 +64,6 @@ const connector = connect(
     currentTime: selectors.getCurrentTime(state),
     hoverTime: selectors.getHoverTime(state),
     pendingComment: selectors.getPendingComment(state),
-    recordingId: selectors.getRecordingId(state),
     canvas: selectors.getCanvas(state),
     hoveredComment: selectors.getHoveredComment(state),
   }),

--- a/src/ui/components/Comments/index.tsx
+++ b/src/ui/components/Comments/index.tsx
@@ -10,7 +10,8 @@ import "./Comments.css";
 import { UIState } from "ui/state";
 import { Comment, PendingComment } from "ui/state/comments";
 
-function Comments({ recordingId, pendingComment, hoveredItem }: PropsFromRedux) {
+function Comments({ pendingComment, hoveredItem }: PropsFromRedux) {
+  const recordingId = hooks.useGetRecordingId();
   const { comments: hasuraComments, loading, error } = hooks.useGetComments(recordingId);
 
   // Don't render anything if the comments are loading. For now, we fail silently
@@ -52,7 +53,6 @@ function Comments({ recordingId, pendingComment, hoveredItem }: PropsFromRedux) 
 
 const connector = connect((state: UIState) => ({
   playback: selectors.getPlayback(state),
-  recordingId: selectors.getRecordingId(state)!,
   pendingComment: selectors.getPendingComment(state),
   hoveredItem: selectors.getHoveredItem(state),
 }));

--- a/src/ui/components/Dashboard/RecordingItem/RecordingItem.tsx
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingItem.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
 import hooks from "ui/hooks";
 import RecordingListItem from "./RecordingListItem";
 import RecordingItemDropdown from "./RecordingItemDropdown";
@@ -19,6 +20,7 @@ export default function RecordingItem({
   removeSelectedId,
   editing,
 }: RecordingItemProps) {
+  const history = useHistory();
   const [editingTitle, setEditingTitle] = useState(false);
   const [isPrivate, setIsPrivate] = useState(data.private);
   const updateIsPrivate = hooks.useUpdateIsPrivate();
@@ -28,17 +30,17 @@ export default function RecordingItem({
     updateIsPrivate({ variables: { recordingId: data.id, isPrivate: !isPrivate } });
   };
   const onNavigate: React.MouseEventHandler = event => {
-    let url = `/?id=${data.id}`;
+    let url = `/recording/${data.id}`;
     const isTesting = new URL(window.location.href).searchParams.get("e2etest");
 
     if (isTesting) {
-      url += `&e2etest=true`;
+      url += `?e2etest=true`;
     }
 
     if (event.metaKey) {
       return window.open(url);
     }
-    window.location.href = url;
+    history.push(url);
   };
 
   const Panel = (

--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.tsx
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.tsx
@@ -19,7 +19,7 @@ function getDurationString(durationMs: number) {
 
 function CopyLinkButton({ recordingId }: { recordingId: RecordingId }) {
   const [clicked, setClicked] = useState(false);
-  const linkUrl = `${window.location.origin}/?id=${recordingId}`;
+  const linkUrl = `${window.location.origin}/recording/${recordingId}`;
 
   const handleCopyClick: React.MouseEventHandler = e => {
     e.stopPropagation();

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -22,12 +22,12 @@ function _DevTools({
   loading,
   uploading,
   awaitingSourcemaps,
-  recordingId,
   setExpectedError,
   selectedPanel,
   viewMode,
   setRecordingWorkspace,
 }: PropsFromRedux) {
+  const recordingId = hooks.useGetRecordingId();
   const [finishedLoading, setFinishedLoading] = useState(false);
   const { recording, loading: recordingQueryLoading } = hooks.useGetRecording(recordingId);
   const auth = useAuth0();
@@ -105,7 +105,6 @@ function _DevTools({
 
 const connector = connect(
   (state: UIState) => ({
-    recordingId: selectors.getRecordingId(state)!,
     loading: selectors.getLoading(state),
     uploading: selectors.getUploading(state),
     selectedPanel: selectors.getSelectedPanel(state),

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -27,7 +27,7 @@ function _DevTools({
   selectedPanel,
   viewMode,
   setRecordingWorkspace,
-}: DevToolsProps) {
+}: PropsFromRedux) {
   const [finishedLoading, setFinishedLoading] = useState(false);
   const { recording, loading: recordingQueryLoading } = hooks.useGetRecording(recordingId);
   const auth = useAuth0();
@@ -105,6 +105,7 @@ function _DevTools({
 
 const connector = connect(
   (state: UIState) => ({
+    recordingId: selectors.getRecordingId(state)!,
     loading: selectors.getLoading(state),
     uploading: selectors.getUploading(state),
     selectedPanel: selectors.getSelectedPanel(state),
@@ -116,19 +117,12 @@ const connector = connect(
     setRecordingWorkspace: actions.setRecordingWorkspace,
   }
 );
-type DevToolsProps = ConnectedProps<typeof connector> & {
-  recordingId: string;
-};
+type PropsFromRedux = ConnectedProps<typeof connector>;
 const ConnectedDevTools = connector(_DevTools);
-
-// Todo: This is a short term fix. Fix how we initialize the devtools app
-// so that we can assume that the recording ID is already in the store.
-const url = new URL(window.location.href);
-const recordingId = url.searchParams.get("id")!;
 
 const DevTools = () => (
   <WaitForReduxSlice slice="messages">
-    <ConnectedDevTools recordingId={recordingId} />
+    <ConnectedDevTools />
   </WaitForReduxSlice>
 );
 

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -35,10 +35,8 @@ function Avatars({ recordingId }: { recordingId: RecordingId | null }) {
   );
 }
 
-function Links({
-  recordingId,
-  recordingTarget,
-}: Pick<PropsFromRedux, "recordingId" | "recordingTarget">) {
+function Links({ recordingTarget }: Pick<PropsFromRedux, "recordingTarget">) {
+  const recordingId = hooks.useGetRecordingId();
   const { isAuthenticated } = useAuth0();
   const isOwner = hooks.useIsOwner(recordingId || "00000000-0000-0000-0000-000000000000");
   const isCollaborator =
@@ -108,8 +106,9 @@ function HeaderTitle({
   );
 }
 
-function Header({ recordingId, sessionId, recordingTarget }: PropsFromRedux) {
+function Header({ recordingTarget }: PropsFromRedux) {
   const { isAuthenticated } = useAuth0();
+  const recordingId = hooks.useGetRecordingId();
   const { recording, loading } = hooks.useGetRecording(recordingId);
   const backIcon = <div className="img arrowhead-right" style={{ transform: "rotate(180deg)" }} />;
   const dashboardUrl = window.location.origin;
@@ -144,13 +143,12 @@ function Header({ recordingId, sessionId, recordingTarget }: PropsFromRedux) {
           <div className="title">Recordings</div>
         )}
       </div>
-      <Links recordingId={recordingId} recordingTarget={recordingTarget} />
+      <Links recordingTarget={recordingTarget} />
     </div>
   );
 }
 
 const connector = connect((state: UIState) => ({
-  recordingId: selectors.getRecordingId(state),
   sessionId: selectors.getSessionId(state),
   recordingTarget: selectors.getRecordingTarget(state),
 }));

--- a/src/ui/components/Header/ShareButton.tsx
+++ b/src/ui/components/Header/ShareButton.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
-import * as selectors from "ui/reducers/app";
-import { UIState } from "ui/state";
+import { useGetRecordingId } from "ui/hooks/recordings";
 
-function ShareButton({ setModal, recordingId }: PropsFromRedux) {
+function ShareButton({ setModal }: PropsFromRedux) {
+  const recordingId = useGetRecordingId();
   const onClick = () => setModal("sharing", { recordingId: recordingId! });
 
   return (
@@ -18,7 +18,7 @@ function ShareButton({ setModal, recordingId }: PropsFromRedux) {
   );
 }
 
-const connector = connect((state: UIState) => ({ recordingId: selectors.getRecordingId(state) }), {
+const connector = connect(null, {
   setModal: actions.setModal,
 });
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/Header/ShareDropdown.tsx
+++ b/src/ui/components/Header/ShareDropdown.tsx
@@ -13,7 +13,7 @@ function CopyUrl({ recordingId }: { recordingId: RecordingId }) {
   const [copyClicked, setCopyClicked] = useState(false);
 
   const handleCopyClick = () => {
-    navigator.clipboard.writeText(`https://app.replay.io/?id=${recordingId}`);
+    navigator.clipboard.writeText(`https://app.replay.io/recording/${recordingId}`);
     setCopyClicked(true);
     setTimeout(() => setCopyClicked(false), 2000);
   };
@@ -32,7 +32,7 @@ function CopyUrl({ recordingId }: { recordingId: RecordingId }) {
     <div className="row link">
       <input
         type="text"
-        value={`https://app.replay.io/?id=${recordingId}`}
+        value={`https://app.replay.io/recording/${recordingId}`}
         onKeyPress={e => e.preventDefault()}
         onChange={e => e.preventDefault()}
       />

--- a/src/ui/components/Header/ShareDropdown.tsx
+++ b/src/ui/components/Header/ShareDropdown.tsx
@@ -1,15 +1,18 @@
 import React, { useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { useGetUserInfo } from "ui/hooks/users";
-import { useIsOwner, useGetRecording, useToggleIsPrivate } from "ui/hooks/recordings";
-import * as selectors from "ui/reducers/app";
+import {
+  useIsOwner,
+  useGetRecording,
+  useToggleIsPrivate,
+  useGetRecordingId,
+} from "ui/hooks/recordings";
 import * as actions from "ui/actions/app";
 import Dropdown from "ui/components/shared/Dropdown";
 import "./ShareDropdown.css";
-import { RecordingId } from "@recordreplay/protocol";
-import { UIState } from "ui/state";
 
-function CopyUrl({ recordingId }: { recordingId: RecordingId }) {
+function CopyUrl() {
+  const recordingId = useGetRecordingId();
   const [copyClicked, setCopyClicked] = useState(false);
 
   const handleCopyClick = () => {
@@ -94,9 +97,9 @@ function PrivacyNote({ isPrivate, isOwner }: { isPrivate: boolean; isOwner: bool
 
 function Collaborators({
   setExpanded,
-  recordingId,
   setModal,
 }: PropsFromRedux & { setExpanded(expanded: boolean): void }) {
+  const recordingId = useGetRecordingId();
   const { id } = useGetUserInfo();
   if (!id) {
     return null;
@@ -122,12 +125,12 @@ function Collaborators({
 }
 
 interface OwnerSettingsProps {
-  recordingId: RecordingId;
   isPrivate: boolean;
   isOwner: boolean;
 }
 
-function OwnerSettings({ recordingId, isPrivate, isOwner }: OwnerSettingsProps) {
+function OwnerSettings({ isPrivate, isOwner }: OwnerSettingsProps) {
+  const recordingId = useGetRecordingId();
   const updateIsPrivate = useToggleIsPrivate(recordingId, isPrivate);
 
   if (!isOwner) {
@@ -141,7 +144,8 @@ function OwnerSettings({ recordingId, isPrivate, isOwner }: OwnerSettingsProps) 
   );
 }
 
-function ShareDropdown({ recordingId, setModal }: PropsFromRedux) {
+function ShareDropdown({ setModal }: PropsFromRedux) {
+  const recordingId = useGetRecordingId();
   const [expanded, setExpanded] = useState(false);
   const isOwner = useIsOwner(recordingId);
   const { recording } = useGetRecording(recordingId);
@@ -157,23 +161,18 @@ function ShareDropdown({ recordingId, setModal }: PropsFromRedux) {
         setExpanded={setExpanded}
         expanded={expanded}
       >
-        <CopyUrl recordingId={recordingId} />
-        <OwnerSettings recordingId={recordingId} isPrivate={isPrivate} isOwner={isOwner} />
+        <CopyUrl />
+        <OwnerSettings isPrivate={isPrivate} isOwner={isOwner} />
         <PrivacyNote isPrivate={isPrivate} isOwner={isOwner} />
-        <Collaborators recordingId={recordingId} setExpanded={setExpanded} setModal={setModal} />
+        <Collaborators setExpanded={setExpanded} setModal={setModal} />
       </Dropdown>
     </div>
   );
 }
 
-const connector = connect(
-  (state: UIState) => ({
-    recordingId: selectors.getRecordingId(state)!,
-  }),
-  {
-    setModal: actions.setModal,
-  }
-);
+const connector = connect(null, {
+  setModal: actions.setModal,
+});
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 export default connector(ShareDropdown);

--- a/src/ui/components/Header/UserOptions.tsx
+++ b/src/ui/components/Header/UserOptions.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
-import * as selectors from "ui/reducers/app";
 import hooks from "ui/hooks";
 import LoginButton from "ui/components/LoginButton";
 import Dropdown from "ui/components/shared/Dropdown";
@@ -9,14 +8,14 @@ import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { isDeployPreview } from "ui/utils/environment";
 import useAuth0 from "ui/utils/useAuth0";
 import "./UserOptions.css";
-import { UIState } from "ui/state";
 import { features } from "ui/utils/prefs";
 
 interface UserOptionsProps extends PropsFromRedux {
   noBrowserItem?: boolean;
 }
 
-function UserOptions({ recordingId, setModal, noBrowserItem }: UserOptionsProps) {
+function UserOptions({ setModal, noBrowserItem }: UserOptionsProps) {
+  const recordingId = hooks.useGetRecordingId();
   const [expanded, setExpanded] = useState(false);
   const { isAuthenticated } = useAuth0();
 
@@ -99,7 +98,7 @@ function UserOptions({ recordingId, setModal, noBrowserItem }: UserOptionsProps)
   );
 }
 
-const connector = connect((state: UIState) => ({ recordingId: selectors.getRecordingId(state)! }), {
+const connector = connect(null, {
   setModal: actions.setModal,
 });
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/Header/ViewToggle.tsx
+++ b/src/ui/components/Header/ViewToggle.tsx
@@ -47,12 +47,8 @@ function Handle({ text, mode, localViewMode, handleToggle, motion }: HandleProps
   );
 }
 
-function ViewToggle({
-  viewMode,
-  recordingId,
-  setViewMode,
-  setSelectedPrimaryPanel,
-}: PropsFromRedux) {
+function ViewToggle({ viewMode, setViewMode, setSelectedPrimaryPanel }: PropsFromRedux) {
+  const recordingId = hooks.useGetRecordingId();
   const { recording, loading } = hooks.useGetRecording(recordingId);
   const { userId } = hooks.useGetUserId();
   const isAuthor = userId && userId == recording?.userId;
@@ -118,7 +114,6 @@ function ViewToggle({
 const connector = connect(
   (state: UIState) => ({
     viewMode: getViewMode(state),
-    recordingId: selectors.getRecordingId(state),
   }),
   {
     setViewMode,

--- a/src/ui/components/LoginButton.tsx
+++ b/src/ui/components/LoginButton.tsx
@@ -17,7 +17,12 @@ const LoginButton = () => {
 
   return (
     <button
-      onClick={() => loginWithRedirect({ appState: { returnTo: window.location.href } })}
+      onClick={() =>
+        loginWithRedirect({
+          redirectUri: window.location.origin,
+          appState: { returnTo: window.location.href },
+        })
+      }
       type="button"
       className="inline-flex items-center px-6 py-2 text-xl rounded-lg bg-primaryAccent hover:bg-primaryAccentHover text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent mr-0 sharebutton"
     >

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -11,9 +11,10 @@ import useAuth0 from "ui/utils/useAuth0";
 import useDraftJS from "ui/components/Comments/TranscriptComments/CommentEditor/use-draftjs";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 
-function Transcript({ recordingId, pendingComment }: PropsFromRedux) {
-  const { comments } = hooks.useGetComments(recordingId!);
-  const { recording, loading } = hooks.useGetRecording(recordingId!);
+function Transcript({ pendingComment }: PropsFromRedux) {
+  const recordingId = hooks.useGetRecordingId();
+  const { comments } = hooks.useGetComments(recordingId);
+  const { recording, loading } = hooks.useGetRecording(recordingId);
   const { userId } = hooks.useGetUserId();
   const load = useDraftJS();
   const isAuthor = userId && userId == recording?.userId;
@@ -69,7 +70,6 @@ function Transcript({ recordingId, pendingComment }: PropsFromRedux) {
   );
 }
 const connector = connect((state: UIState) => ({
-  recordingId: selectors.getRecordingId(state),
   pendingComment: selectors.getPendingComment(state),
 }));
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -8,9 +8,7 @@ import Modal from "ui/components/shared/NewModal";
 import { Recording, UserSettings, Workspace } from "ui/types";
 import { BlankLoadingScreen } from "../shared/BlankScreen";
 import MaterialIcon from "../shared/MaterialIcon";
-
-const url = new URL(window.location.href);
-const recordingId = url.searchParams.get("id");
+import { useGetRecordingId } from "ui/hooks/recordings";
 
 type UploadScreenProps = { recording: Recording; userSettings: UserSettings };
 type Status = "saving" | "deleting" | "deleted" | null;
@@ -242,6 +240,7 @@ function SharingPreview({
 }
 
 export default function UploadScreen({ recording, userSettings }: UploadScreenProps) {
+  const recordingId = useGetRecordingId();
   const [showSharingSettings, setShowSharingSettings] = useState(false);
   // This is pre-loaded in the parent component.
   const { screenData, loading: loading1 } = hooks.useGetRecordingPhoto(recordingId!);

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -20,7 +20,6 @@ function CommentLoader({ recordingId }: { recordingId: string }) {
 }
 
 function Video({
-  recordingId,
   currentTime,
   playback,
   isNodePickerActive,
@@ -30,6 +29,7 @@ function Video({
   videoUrl,
 }: PropsFromRedux) {
   const { isAuthenticated } = useAuth0();
+  const recordingId = hooks.useGetRecordingId();
   const isPaused = !playback;
   const isNodeTarget = recordingTarget == "node";
 
@@ -78,7 +78,6 @@ const connector = connect(
     currentTime: selectors.getCurrentTime(state),
     playback: selectors.getPlayback(state),
     recordingTarget: selectors.getRecordingTarget(state),
-    recordingId: selectors.getRecordingId(state)!,
     videoUrl: selectors.getVideoUrl(state),
   }),
   {

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -48,7 +48,10 @@ function SignInButton() {
   const { loginWithRedirect } = useAuth0();
 
   const onClick = () => {
-    loginWithRedirect({ appState: { returnTo: window.location.href } });
+    loginWithRedirect({
+      redirectUri: window.location.origin,
+      appState: { returnTo: window.location.href },
+    });
   };
 
   return (

--- a/src/ui/components/shared/LaunchButton.tsx
+++ b/src/ui/components/shared/LaunchButton.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
-import * as selectors from "ui/reducers/app";
-import { UIState } from "ui/state";
 import { features } from "ui/utils/prefs";
 
-function ShareButton({ setModal, recordingId }: PropsFromRedux) {
+function ShareButton({ setModal }: PropsFromRedux) {
   const onClick = () => setModal("browser-launch");
 
   if (window.__IS_RECORD_REPLAY_RUNTIME__ || !features.launchBrowser) return null;
@@ -23,7 +21,7 @@ function ShareButton({ setModal, recordingId }: PropsFromRedux) {
   );
 }
 
-const connector = connect((state: UIState) => ({ recordingId: selectors.getRecordingId(state) }), {
+const connector = connect(null, {
   setModal: actions.setModal,
 });
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/shared/LoginModal.tsx
+++ b/src/ui/components/shared/LoginModal.tsx
@@ -8,7 +8,10 @@ function LoginModal() {
   const { loginWithRedirect } = useAuth0();
 
   const onClick: React.MouseEventHandler = e => {
-    loginWithRedirect({ appState: { returnTo: window.location.href } });
+    loginWithRedirect({
+      redirectUri: window.location.origin,
+      appState: { returnTo: window.location.href },
+    });
   };
 
   return (

--- a/src/ui/components/shared/SharingModal/ReplayLink.tsx
+++ b/src/ui/components/shared/SharingModal/ReplayLink.tsx
@@ -36,5 +36,5 @@ export function UrlCopy({ url }: { url: string }) {
 }
 
 export default function ReplayLink({ recordingId }: { recordingId: RecordingId }) {
-  return <UrlCopy url={`https://app.replay.io/?id=${recordingId}`} />;
+  return <UrlCopy url={`https://app.replay.io/recording/${recordingId}`} />;
 }

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -1,3 +1,4 @@
+import { useParams } from "react-router-dom";
 import { RecordingId } from "@recordreplay/protocol";
 import { ApolloError, gql, useQuery, useMutation } from "@apollo/client";
 import { query, extractGraphQLError } from "ui/utils/apolloClient";
@@ -95,6 +96,11 @@ const GET_MY_RECORDINGS = gql`
     }
   }
 `;
+
+export function useGetRecordingId() {
+  const { recordingId } = useParams<{ recordingId: string }>();
+  return recordingId;
+}
 
 /**
  * Returns true if the recording is accessible and initialized, false if it is

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -6,11 +6,9 @@ import { prefs } from "../utils/prefs";
 import { Location } from "@recordreplay/protocol";
 import { getLocationAndConditionKey } from "devtools/client/debugger/src/utils/breakpoint";
 import { isSameTimeStampedPointRange } from "ui/utils/timeline";
-import { isDemo } from "ui/utils/environment";
 
 function initialAppState(): AppState {
   return {
-    recordingId: null,
     expectedError: null,
     unexpectedError: null,
     theme: "theme-light",
@@ -49,10 +47,6 @@ export default function update(
   action: AppActions | SessionActions
 ): AppState {
   switch (action.type) {
-    case "setup_app": {
-      return { ...state, recordingId: action.recordingId };
-    }
-
     case "set_recording_duration": {
       return { ...state, recordingDuration: action.duration };
     }
@@ -234,7 +228,6 @@ export const getLoading = (state: UIState) => state.app.loading;
 export const getLoadedRegions = (state: UIState) => state.app.loadedRegions;
 export const getUploading = (state: UIState) => state.app.uploading;
 export const getAwaitingSourcemaps = (state: UIState) => state.app.awaitingSourcemaps;
-export const getRecordingId = (state: UIState) => state.app.recordingId;
 export const getSessionId = (state: UIState) => state.app.sessionId;
 export const getExpectedError = (state: UIState) => state.app.expectedError;
 export const getUnexpectedError = (state: UIState) => state.app.unexpectedError;

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -105,7 +105,7 @@ const dispatch = url.searchParams.get("dispatch") || undefined;
   initSocket(store, dispatch);
   createSession(store, recordingId);
 
-  setupApp(recordingId, store);
+  setupApp(store);
   setupTimeline(recordingId, store);
   setupEventListeners(recordingId, store);
   setupGraphics(store);

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -35,6 +35,7 @@ const {
 import { DevToolsToolbox } from "ui/utils/devtools-toolbox";
 import { asyncStore } from "ui/utils/prefs";
 import { getUserSettings } from "ui/hooks/settings";
+import { getRecordingId } from "ui/utils/environment";
 const { LocalizationHelper } = require("devtools/shared/l10n");
 const { setupDemo } = require("ui/utils/demo");
 
@@ -56,10 +57,12 @@ declare global {
 }
 
 const url = new URL(window.location.href);
-const recordingId = url.searchParams.get("id")!;
+const recordingId = getRecordingId();
 const dispatch = url.searchParams.get("dispatch") || undefined;
 
 (async () => {
+  if (!recordingId) return;
+
   window.gToolbox = new DevToolsToolbox();
 
   window.L10N = new LocalizationHelper("devtools/client/locales/debugger.properties");

--- a/src/ui/setup/helpers.ts
+++ b/src/ui/setup/helpers.ts
@@ -1,4 +1,5 @@
 import { UIStore } from "ui/actions";
+import { getRecordingId } from "ui/utils/environment";
 import { prefs, features } from "ui/utils/prefs";
 
 declare global {
@@ -16,6 +17,8 @@ declare global {
 }
 
 export function setupAppHelper(store: UIStore) {
+  const recordingId = getRecordingId();
+
   window.app = {
     store,
     prefs,
@@ -24,21 +27,17 @@ export function setupAppHelper(store: UIStore) {
     dumpPrefs: () =>
       JSON.stringify({ features: features.toJSON(), prefs: prefs.toJSON() }, null, 2),
     local: () => {
-      const params = new URLSearchParams(document.location.search.substring(1));
-
-      if (params.get("id")) {
-        window.location.href = `http://localhost:8080/index.html?id=${params.get("id")}`;
+      if (recordingId) {
+        window.location.href = `http://localhost:8080/recording/${recordingId}`;
       } else {
-        window.location.href = "http://localhost:8080/index.html";
+        window.location.href = "http://localhost:8080/";
       }
     },
     prod: () => {
-      const params = new URLSearchParams(document.location.search.substring(1));
-
-      if (params.get("id")) {
-        window.location.href = `http://app.replay.io/?id=${params.get("id")}`;
+      if (recordingId) {
+        window.location.href = `https://app.replay.io/recording/${recordingId}`;
       } else {
-        window.location.href = "http://app.replay.io/";
+        window.location.href = "https://app.replay.io/";
       }
     },
   };

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -14,10 +14,9 @@ declare global {
 }
 
 const url = new URL(window.location.href);
-const recordingId = url.searchParams.get("id");
 
 export function bootstrapApp() {
-  setupTelemetry({ recordingId });
+  setupTelemetry();
 
   setupDOMHelpers();
 

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -57,7 +57,6 @@ export interface UploadInfo {
 }
 
 export interface AppState {
-  recordingId: RecordingId | null;
   sessionId: SessionId | null;
   theme: string;
   splitConsoleOpen: boolean;

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -1,4 +1,5 @@
 import { MockedResponse } from "@apollo/client/testing";
+import { matchPath } from "react-router-dom";
 
 export interface MockEnvironment {
   graphqlMocks: MockedResponse[];
@@ -92,6 +93,11 @@ export function isDeployPreview() {
 // such as sourcemaps to load
 export function hasLoadingParam() {
   return url.searchParams.get("loading") != null;
+}
+
+export function getRecordingId() {
+  return matchPath<{ recordingId: string }>(window.location.pathname, "/recording/:recordingId")
+    ?.params.recordingId;
 }
 
 export function getPausePointParams() {

--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/react";
 import { Integrations } from "@sentry/tracing";
 import { skipTelemetry } from "./environment";
 
-export function setupTelemetry(context: Record<string, any>) {
+export function setupTelemetry() {
   const ignoreList = ["Current thread has paused or resumed", "Current thread has changed"];
   mixpanel.init("ffaeda9ef8fb976a520ca3a65bba5014");
 
@@ -28,10 +28,11 @@ export function setupTelemetry(context: Record<string, any>) {
       return event;
     },
   });
+}
 
-  mixpanel.register({ recordingId: context.recordingId });
-
-  Sentry.setContext("recording", { ...context, url: window.location.href });
+export function registerRecording(recordingId: string) {
+  mixpanel.register({ recordingId });
+  Sentry.setContext("recording", { recordingId, url: window.location.href });
 }
 
 type TelemetryUser = {

--- a/src/views/app.tsx
+++ b/src/views/app.tsx
@@ -1,92 +1,19 @@
-import React, { useEffect } from "react";
-import { connect, ConnectedProps, Provider } from "react-redux";
+import React from "react";
+import { Provider } from "react-redux";
 import { IntercomProvider } from "react-use-intercom";
-import { isTest } from "ui/utils/environment";
-import { validateUUID } from "ui/utils/helpers";
-import { bootIntercom } from "ui/utils/intercom";
 import tokenManager from "ui/utils/tokenManager";
-import useAuth0 from "ui/utils/useAuth0";
 import { ApolloWrapper } from "ui/utils/apolloClient";
-import { setWorkspaceId } from "ui/actions/app";
-import { setExpectedError } from "ui/actions/session";
-import { useGetUserSettings } from "ui/hooks/settings";
-import { useIsRecordingInitialized, useGetRecordingOwnerUserId } from "ui/hooks/recordings";
 import BlankScreen from "ui/components/shared/BlankScreen";
 import ErrorBoundary from "ui/components/ErrorBoundary";
 import App from "ui/components/App";
 import { bootstrapApp } from "ui/setup";
 import "image/image.css";
+import { Route, Switch } from "react-router-dom";
 
-const url = new URL(window.location.href);
-const recordingId = url.searchParams.get("id");
-
-const Upload = React.lazy(() => import("views/upload"));
+const Recording = React.lazy(() => import("./recording"));
 const Account = React.lazy(() => import("ui/components/Account"));
-const DevTools = React.lazy(() => import("ui/components/DevTools"));
 
 bootstrapApp();
-
-function PageSwitch({ setExpectedError, setWorkspaceId }: PropsFromRedux) {
-  const { isAuthenticated, user } = useAuth0();
-  const { userSettings, loading: settingsLoading } = useGetUserSettings();
-  const {
-    initialized: recordingInitialized,
-    loading: initializedLoading,
-    graphQLError,
-  } = useIsRecordingInitialized(recordingId);
-  const { userId: ownerId, loading: ownerIdLoading } = useGetRecordingOwnerUserId(recordingId);
-
-  useEffect(() => {
-    if (userSettings) {
-      setWorkspaceId(userSettings.defaultWorkspaceId);
-    }
-  }, [userSettings]);
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      bootIntercom({ email: user.email });
-    }
-  }, [isAuthenticated]);
-
-  useEffect(() => {
-    if (recordingId) {
-      if (!validateUUID(recordingId)) {
-        return setExpectedError({
-          message: "Invalid ID",
-          content: `"${recordingId}" is not a valid recording ID`,
-        });
-      }
-      if (graphQLError) {
-        return setExpectedError({ message: "Error", content: graphQLError });
-      }
-    }
-  }, [graphQLError]);
-
-  if (initializedLoading || ownerIdLoading || settingsLoading) {
-    return null;
-  }
-
-  if (recordingId) {
-    if (!validateUUID(recordingId) || graphQLError) {
-      return <BlankScreen />;
-    }
-
-    // Add a check to make sure the recording has an associated user ID.
-    // We skip the upload step if there's no associated user ID, which
-    // is the case for CI test recordings.
-    if (recordingInitialized === false && !isTest() && ownerId) {
-      return <Upload />;
-    } else {
-      return <DevTools />;
-    }
-  } else {
-    return <Account />;
-  }
-}
-
-const connector = connect(null, { setExpectedError, setWorkspaceId });
-type PropsFromRedux = ConnectedProps<typeof connector>;
-const ConnectedPageSwitch = connector(PageSwitch);
 
 const AppRouting = () => (
   <tokenManager.Auth0Provider>
@@ -96,7 +23,10 @@ const AppRouting = () => (
           <App>
             <ErrorBoundary>
               <React.Suspense fallback={<BlankScreen background="white" />}>
-                <ConnectedPageSwitch />
+                <Switch>
+                  <Route path="/recording/:recordingId" component={Recording} />
+                  <Route exact path="/" component={Account} />
+                </Switch>
               </React.Suspense>
             </ErrorBoundary>
           </App>

--- a/src/views/app.tsx
+++ b/src/views/app.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { Route, Switch, useHistory } from "react-router-dom";
 import { Provider } from "react-redux";
 import { IntercomProvider } from "react-use-intercom";
 import tokenManager from "ui/utils/tokenManager";
@@ -8,7 +9,6 @@ import ErrorBoundary from "ui/components/ErrorBoundary";
 import App from "ui/components/App";
 import { bootstrapApp } from "ui/setup";
 import "image/image.css";
-import { Route, Switch } from "react-router-dom";
 
 const Recording = React.lazy(() => import("./recording"));
 const Account = React.lazy(() => import("ui/components/Account"));
@@ -26,6 +26,7 @@ const AppRouting = () => (
                 <Switch>
                   <Route path="/recording/:recordingId" component={Recording} />
                   <Route exact path="/" component={Account} />
+                  <Route exact path="/view" component={ViewRedirect} />
                 </Switch>
               </React.Suspense>
             </ErrorBoundary>
@@ -35,5 +36,31 @@ const AppRouting = () => (
     </ApolloWrapper>
   </tokenManager.Auth0Provider>
 );
+
+// This component replaces a legacy /view route with its current equivalent
+function ViewRedirect() {
+  const history = useHistory();
+  const currentParams = new URLSearchParams(window.location.search);
+  useEffect(() => {
+    history.replace(createReplayURL(currentParams));
+  });
+  return null;
+}
+
+/**
+ * Create a (host relative) URL with the given parameters. Used for replacing
+ * legacy routes with their current equivalents.
+ */
+export function createReplayURL(currentParams: URLSearchParams) {
+  const recordingId = currentParams.get("id");
+  const path = recordingId ? `/recording/${recordingId}` : "/";
+  const newParams = new URLSearchParams();
+  currentParams.forEach((value, key) => {
+    if (key !== "id") {
+      newParams.set(key, value);
+    }
+  });
+  return `${path}?${newParams.toString()}`;
+}
 
 export default AppRouting;

--- a/src/views/recording.tsx
+++ b/src/views/recording.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { isTest } from "ui/utils/environment";
+import { validateUUID } from "ui/utils/helpers";
+import { setExpectedError } from "ui/actions/session";
+import {
+  useIsRecordingInitialized,
+  useGetRecordingOwnerUserId,
+  useGetRecordingId,
+} from "ui/hooks/recordings";
+import BlankScreen from "ui/components/shared/BlankScreen";
+import { registerRecording } from "ui/utils/telemetry";
+import Upload from "views/upload";
+import DevTools from "ui/components/DevTools";
+
+function Recording({ setExpectedError }: PropsFromRedux) {
+  const recordingId = useGetRecordingId();
+  const {
+    initialized: recordingInitialized,
+    loading: initializedLoading,
+    graphQLError,
+  } = useIsRecordingInitialized(recordingId);
+  const { userId: ownerId, loading: ownerIdLoading } = useGetRecordingOwnerUserId(recordingId);
+
+  useEffect(() => {
+    if (!validateUUID(recordingId)) {
+      return setExpectedError({
+        message: "Invalid ID",
+        content: `"${recordingId}" is not a valid recording ID`,
+      });
+    }
+    if (graphQLError) {
+      return setExpectedError({ message: "Error", content: graphQLError });
+    }
+  }, [graphQLError]);
+
+  useEffect(() => {
+    registerRecording(recordingId);
+  }, [recordingId]);
+
+  if (initializedLoading || ownerIdLoading || !validateUUID(recordingId) || graphQLError) {
+    return <BlankScreen />;
+  }
+
+  // Add a check to make sure the recording has an associated user ID.
+  // We skip the upload step if there's no associated user ID, which
+  // is the case for CI test recordings.
+  if (recordingInitialized === false && !isTest() && ownerId) {
+    return <Upload />;
+  } else {
+    return <DevTools />;
+  }
+}
+
+const connector = connect(null, { setExpectedError });
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default connector(Recording);

--- a/src/views/upload.tsx
+++ b/src/views/upload.tsx
@@ -1,15 +1,13 @@
 import React, { useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { setExpectedError } from "ui/actions/session";
-import { useGetRecording, useHasExpectedError } from "ui/hooks/recordings";
+import { useGetRecording, useGetRecordingId, useHasExpectedError } from "ui/hooks/recordings";
 import { useGetUserSettings } from "ui/hooks/settings";
 import { BlankLoadingScreen } from "ui/components/shared/BlankScreen";
 import UploadScreen from "ui/components/UploadScreen";
 
-const url = new URL(window.location.href);
-const recordingId = url.searchParams.get("id")!;
-
 function _UploadScreenWrapper({ setExpectedError }: PropsFromRedux) {
+  const recordingId = useGetRecordingId();
   const expectedError = useHasExpectedError(recordingId);
   const { recording } = useGetRecording(recordingId);
   // Make sure to get the user's settings before showing the upload screen.

--- a/test/header.js
+++ b/test/header.js
@@ -64,7 +64,7 @@ async function waitForViewRecording() {
     dump(`TestHarnessWaitForViewRecording\n`);
 
     // This is the server used for hosting the devtools in run.js. This is cheesy...
-    if (await waitForLoad("localhost:8080/view?id=")) {
+    if (await waitForLoad("localhost:8080/recording/")) {
       break;
     }
   }

--- a/test/mock/run.js
+++ b/test/mock/run.js
@@ -45,7 +45,7 @@ async function main() {
       if (recordings.length) {
         const recordingId = await uploadRecording(recordings[recordings.length - 1].id);
         if (recordingId) {
-          url = `https://app.replay.io?id=${recordingId}`;
+          url = `https://app.replay.io/recording/${recordingId}`;
         }
       }
       // Log an error which github will recognize.

--- a/test/mock/src/runTest.ts
+++ b/test/mock/src/runTest.ts
@@ -110,10 +110,11 @@ export const runTest = wrapped(async cbk => {
 });
 
 export function devtoolsURL({ id }: { id: string }) {
-  let url = "http://localhost:8080/view?mock=1";
+  let url = "http://localhost:8080/";
   if (id) {
-    url += `&id=${id}`;
+    url += `recording/${id}/`;
   }
+  url += "?mock=1";
   return url;
 }
 

--- a/test/run.js
+++ b/test/run.js
@@ -202,7 +202,7 @@ async function runTest(test, example, target) {
     RECORD_REPLAY_DONT_PROCESS_RECORDINGS: true,
     RECORD_REPLAY_TEST_URL:
       exampleRecordingId
-        ? `http://localhost:8080/view?id=${exampleRecordingId}&test=${test}&dispatch=${dispatchServer}`
+        ? `http://localhost:8080/recording/${exampleRecordingId}?test=${test}&dispatch=${dispatchServer}`
         : `http://localhost:8080/test/examples/${example}`,
     // If we need to record the example we have to use the target dispatch server.
     // If we already have the example, use the default dispatch server. When running in CI
@@ -261,7 +261,7 @@ async function runTestViewer(path, local, timeout, env) {
 
   function processOutput(data) {
     const match = /CreateRecording (.*?) (.*)/.exec(data.toString());
-    if (match && match[2].startsWith("http://localhost:8080/view")) {
+    if (match && match[2].startsWith("http://localhost:8080/recording")) {
       recordingId = match[1];
 
       if (env.RECORD_REPLAY_SERVER == DefaultDispatchServer) {
@@ -313,11 +313,11 @@ async function runTestViewer(path, local, timeout, env) {
     // Log an error which github will recognize.
     let msg = `::error ::Failure ${local}`;
     if (recordingId) {
-      msg += ` https://app.replay.io/?id=${recordingId}`;
+      msg += ` https://app.replay.io/recording/${recordingId}`;
     }
     const nodeRecordingId = maybeGetBackendNodeRecordingId();
     if (nodeRecordingId) {
-      msg += ` node https://app.replay.io/?id=${nodeRecordingId}`;
+      msg += ` node https://app.replay.io/recording/${nodeRecordingId}`;
     }
     spawnChecked("echo", [msg], { stdio: "inherit" });
   }


### PR DESCRIPTION
@ryanjduffy This is essentially your PR (#3191) with a few fixes and the following changes:
- I changed the routes for recordings to be `/recording/:recordingId` (as suggested [here](https://github.com/RecordReplay/devtools/pull/3191#discussion_r683796893))
- when clicking on a recording in the library, the app no longer needs to reload (see the changes in `RecordingItem.tsx`)