### PR TITLE
Mixpanel events

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/index.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/index.js
@@ -33,6 +33,7 @@ import { actions } from "ui/actions";
 import { selectors } from "ui/reducers";
 import remapLocations from "./remapLocations";
 import { getFilename } from "devtools/client/debugger/src/utils/source";
+import { trackEvent } from "ui/utils/telemetry";
 
 // this will need to be changed so that addCLientBreakpoint is removed
 
@@ -223,6 +224,8 @@ export function addBreakpointAtLine(cx, line, shouldLog = false, disabled = fals
       return;
     }
 
+    trackEvent("add breakpoint");
+
     const breakpointLocation = {
       sourceId: source.id,
       sourceUrl: source.url,
@@ -233,9 +236,8 @@ export function addBreakpointAtLine(cx, line, shouldLog = false, disabled = fals
     const options = {
       logValue: getLogValue(source, state, breakpointLocation),
     };
-    const shouldTrack = true;
 
-    return dispatch(addBreakpoint(cx, breakpointLocation, options, disabled, shouldTrack));
+    return dispatch(addBreakpoint(cx, breakpointLocation, options, disabled));
   };
 }
 
@@ -258,9 +260,10 @@ export function addBreakpointAtColumn(cx, location) {
     const options = {
       logValue: getLogValue(source, state, location),
     };
-    const shouldTrack = true;
 
-    return dispatch(addBreakpoint(cx, breakpointLocation, options, false, shouldTrack));
+    trackEvent("add column breakpoint");
+
+    return dispatch(addBreakpoint(cx, breakpointLocation, options, false));
   };
 }
 

--- a/src/devtools/client/debugger/src/actions/pause/paused.js
+++ b/src/devtools/client/debugger/src/actions/pause/paused.js
@@ -8,6 +8,7 @@ import { getSelectedFrame, getThreadContext, getSelectedLocation } from "../../s
 import { selectLocation } from "../sources";
 import { fetchScopes } from "./fetchScopes";
 import { setFramePositions } from "./setFramePositions";
+import { trackEvent } from "ui/utils/telemetry";
 
 // How many times to fetch an async set of parent frames.
 const MaxAsyncFrames = 5;
@@ -49,6 +50,7 @@ function fetchAsyncFrames(cx) {
 export function paused({ executionPoint, time }) {
   return async function ({ dispatch, getState }) {
     dispatch({ type: "PAUSED", executionPoint, time });
+    trackEvent("paused");
 
     // Get a context capturing the newly paused and selected thread.
     const cx = getThreadContext(getState());

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -8,7 +8,6 @@ import classnames from "classnames";
 import PanelEditor from "./PanelEditor";
 import BreakpointNavigation from "devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation";
 import Widget from "./Widget";
-import MaterialIcon from "ui/components/shared/MaterialIcon";
 
 import "./Panel.css";
 import { connect } from "react-redux";

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -17,6 +17,7 @@ const CollapseButton = require("devtools/client/webconsole/components/Output/Col
 const MessageRepeat = require("devtools/client/webconsole/components/Output/MessageRepeat");
 const PropTypes = require("prop-types");
 const SmartTrace = require("devtools/client/shared/components/SmartTrace");
+const { trackEvent } = require("ui/utils/telemetry");
 
 class Message extends Component {
   static get propTypes() {
@@ -169,6 +170,7 @@ class Message extends Component {
 
     let overlayType, label, onClick;
     let onRewindClick = () => {
+      trackEvent("console seek");
       dispatch(
         actions.seek(executionPoint, executionPointTime, executionPointHasFrames, message.pauseId)
       );

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -24,6 +24,7 @@ import {
 } from "ui/state/app";
 import { RecordingTarget } from "protocol/thread/thread";
 import { Workspace } from "ui/types";
+import { trackEvent } from "ui/utils/telemetry";
 
 export type SetRecordingDurationAction = Action<"set_recording_duration"> & { duration: number };
 export type LoadingAction = Action<"loading"> & { loading: number };
@@ -254,6 +255,7 @@ export function setEventsForType(events: MouseEvent[], eventType: Event): SetEve
 }
 
 export function setViewMode(viewMode: ViewMode): SetViewMode {
+  trackEvent(viewMode == "dev" ? "visit devtools" : "visit viewer");
   return { type: "set_view_mode", viewMode };
 }
 

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -9,6 +9,8 @@ import { Recording, UserSettings, Workspace } from "ui/types";
 import { BlankLoadingScreen } from "../shared/BlankScreen";
 import MaterialIcon from "../shared/MaterialIcon";
 import { useGetRecordingId } from "ui/hooks/recordings";
+import { trackEvent } from "ui/utils/telemetry";
+const { isDemoReplay } = require("ui/utils/demo");
 
 type UploadScreenProps = { recording: Recording; userSettings: UserSettings };
 type Status = "saving" | "deleting" | "deleted" | null;
@@ -278,6 +280,8 @@ export default function UploadScreen({ recording, userSettings }: UploadScreenPr
 
     setStatus("saving");
     const workspaceId = selectedWorkspaceId == "" ? null : selectedWorkspaceId;
+
+    trackEvent(isDemoReplay(recording) ? "create demo replay" : "create replay");
 
     await initializeRecording({
       variables: { recordingId, title: inputValue, workspaceId },

--- a/src/ui/hooks/comments/useAddComment.tsx
+++ b/src/ui/hooks/comments/useAddComment.tsx
@@ -4,6 +4,7 @@ import useAuth0 from "ui/utils/useAuth0";
 import { CommentPosition, PendingNewComment } from "ui/state/comments";
 import { GET_USER_ID } from "ui/graphql/users";
 import { GET_COMMENTS } from "ui/graphql/comments";
+import { trackEvent } from "ui/utils/telemetry";
 
 interface NewCommentVariable extends Omit<PendingNewComment, "content"> {
   content: string;
@@ -32,6 +33,8 @@ export default function useAddComment() {
 
   return (comment: NewCommentVariable, recordingId: RecordingId) => {
     const temporaryId = new Date().toISOString();
+    trackEvent("create comment");
+
     addComment({
       variables: { input: comment },
       optimisticResponse: {

--- a/src/ui/utils/demo.js
+++ b/src/ui/utils/demo.js
@@ -25,3 +25,7 @@ export async function setupDemo() {
   root.style.setProperty("--editor-header-height", "0px");
   root.style.setProperty("--editor-footer-height", "0px");
 }
+
+export function isDemoReplay(recording) {
+  return recording?.title == "Your first replay";
+}

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -31,6 +31,7 @@ pref("devtools.maxHitsDisplayed", 500);
 pref("devtools.maxHitsEditable", 200);
 pref("devtools.libraryFilterTime", "all");
 pref("devtools.libraryFilterAssociation", "all");
+pref("devtools.logTelemetryEvent", false);
 
 // app features
 pref("devtools.features.comments", true);
@@ -63,6 +64,7 @@ export const prefs = new PrefsHelper("devtools", {
   maxHitsEditable: ["Int", "maxHitsEditable"],
   libraryFilterTime: ["String", "libraryFilterTime"],
   libraryFilterAssociation: ["String", "libraryFilterAssociation"],
+  logTelemetryEvent: ["Bool", "logTelemetryEvent"],
 });
 
 export const features = new PrefsHelper("devtools.features", {


### PR DESCRIPTION
This PR adds a new `trackEvent` API that uses mixpanel to setup our user funnel 

1. new replay
2. visit devtools
3. seek in the console to a point in time
4. add a breakpoint
5. add a comment
6. edit breakpoint

Here's a [replay](https://app.replay.io/recording/a3a376d5-881f-4559-afbf-230025ba0fb3?point=10060075164575555887329213690151644&time=5337.298172607201&hasFrames=true
) where I walk through the funnel

The nice thing is we can confirm that the mixpanel context is set as well