### PR TITLE
Add subscription to add team flow behind a feature flag

### DIFF
--- a/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -13,6 +13,7 @@ import hooks from "ui/hooks";
 import { Workspace, WorkspaceUser } from "ui/types";
 import { removeUrlParameters } from "ui/utils/environment";
 import { validateEmail } from "ui/utils/helpers";
+import { features } from "ui/utils/prefs";
 import { TextInput } from "../Forms";
 import Modal from "../NewModal";
 import { WorkspaceMembers } from "../WorkspaceSettingsModal/WorkspaceSettingsModal";
@@ -145,7 +146,13 @@ function SlideBody1({ hideModal, setNewWorkspace, setCurrent, total, current }: 
     removeUrlParameters();
     hideModal();
   };
-  const handleSave = () => createNewWorkspace({ variables: { name: inputValue, userId } });
+  const handleSave = () =>
+    createNewWorkspace({
+      variables: {
+        name: inputValue,
+        planKey: features.teamSubscription ? "test-beta-v1" : undefined,
+      },
+    });
 
   return (
     <>

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
@@ -21,6 +21,7 @@ import { trackEvent } from "ui/utils/telemetry";
 import { removeUrlParameters } from "ui/utils/environment";
 import { DownloadPage } from "../Onboarding/DownloadPage";
 import { DownloadingPage } from "../Onboarding/DownloadingPage";
+import { features } from "ui/utils/prefs";
 
 const DOWNLOAD_PAGE_INDEX = 4;
 
@@ -82,7 +83,12 @@ function TeamNamePage({
     setInputValue(e.target.value);
   };
   const handleSave = () => {
-    createNewWorkspace({ variables: { name: inputValue, userId } });
+    createNewWorkspace({
+      variables: {
+        name: inputValue,
+        planKey: features.teamSubscription ? "test-beta-v1" : undefined,
+      },
+    });
     trackEvent("created-team");
   };
 

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -6,6 +6,7 @@ import Modal from "ui/components/shared/NewModal";
 import hooks from "ui/hooks";
 import * as selectors from "ui/reducers/app";
 import { UIState } from "ui/state";
+import { features } from "ui/utils/prefs";
 import { WorkspaceUser } from "ui/types";
 import { validateEmail } from "ui/utils/helpers";
 import { TextInput } from "../Forms";
@@ -14,6 +15,7 @@ import InvitationLink from "../NewWorkspaceModal/InvitationLink";
 import SettingsModal from "../SettingsModal";
 import { Settings } from "../SettingsModal/types";
 import WorkspaceAPIKeys from "./WorkspaceAPIKeys";
+import WorkspaceSubscription from "./WorkspaceSubscription";
 import WorkspaceMember, { NonRegisteredWorkspaceMember } from "./WorkspaceMember";
 
 function ModalButton({
@@ -154,13 +156,11 @@ const settings: Settings<
       );
     },
   },
-  // {
-  //   title: "Billing",
-  //   icon: "payment",
-  //   component: function Billing() {
-  //     return <div>Billing to come</div>;
-  //   },
-  // },
+  {
+    title: "Billing",
+    icon: "payment",
+    component: WorkspaceSubscription,
+  },
   {
     title: "API Keys",
     icon: "vpn_key",
@@ -217,10 +217,19 @@ function WorkspaceSettingsModal({ workspaceId, ...rest }: PropsFromRedux) {
   if (!workspaceId) return null;
 
   const isAdmin = members?.find(m => m.userId === localUserId)?.roles?.includes("admin") || false;
+  const hiddenTabs: SettingsTabTitle[] = [];
+
+  if (!isAdmin) {
+    hiddenTabs.push("Delete Team");
+  }
+
+  if (!features.teamSubscription) {
+    hiddenTabs.push("Billing");
+  }
 
   return (
     <SettingsModal
-      hiddenTabs={!isAdmin ? ["Delete Team"] : undefined}
+      hiddenTabs={hiddenTabs}
       defaultSelectedTab="Team Members"
       panelProps={{ isAdmin, workspaceId, ...rest }}
       settings={settings}

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSubscription.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSubscription.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import hooks from "ui/hooks";
+import MaterialIcon from "../MaterialIcon";
+
+function PlanDetails({
+  title,
+  description,
+  features,
+}: {
+  title: string;
+  description?: string;
+  features?: string[];
+}) {
+  return (
+    <section className="rounded-lg border border-blue-600 overflow-hidden">
+      <header className="bg-blue-200 p-4 border-b border-blue-600 flex flex-row">
+        <MaterialIcon className="mr-4 text-2xl">group</MaterialIcon>
+        <h3 className="text-2xl font-semibold">{title}</h3>
+      </header>
+      <div className="p-4">
+        {description ? <p>{description}</p> : null}
+        {features && features.length > 0 ? (
+          <ul className="list-disc pl-8">
+            {features.map((f, i) => (
+              <li key={i}>{f}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function getPlanDetails(key: string) {
+  if (key === "test-beta-v1" || key === "beta-v1") {
+    return (
+      <PlanDetails
+        title="Beta Plan"
+        description="As a thank you for being a beta user, you have full access for a limited time to Replay including recording, debugging, and collaborating with your team."
+      />
+    );
+  }
+
+  if (key === "test-team-v1" || key === "team-v1") {
+    return (
+      <PlanDetails
+        title="Team Plan"
+        features={[
+          "Unlimited recordings",
+          "Team Library to easily share recordings",
+          "Programmatic recording upload with personal and team API keys",
+        ]}
+      />
+    );
+  }
+
+  return null;
+}
+
+export default function WorkspaceSubscription({ workspaceId }: { workspaceId: string }) {
+  const { data, loading } = hooks.useGetWorkspaceSubscription(workspaceId);
+
+  if (loading) return null;
+
+  return (
+    <section className="space-y-8">
+      {data?.node.subscription ? (
+        <>
+          {data.node.subscription.status === "trialing" ? (
+            <div className="p-4 bg-yellow-100 rounded-lg border border-yellow-600 flex flex-row items-center">
+              <MaterialIcon className="mr-4">access_time</MaterialIcon>
+              Trial ends&nbsp;
+              <strong>
+                {new Intl.DateTimeFormat("en", {
+                  year: "numeric",
+                  month: "numeric",
+                  day: "numeric",
+                }).format(new Date(data.node.subscription.trialEnds!))}
+              </strong>
+            </div>
+          ) : null}
+          {getPlanDetails(data.node.subscription.plan.key)}
+        </>
+      ) : (
+        <p>This team does not have an active subscription</p>
+      )}
+    </section>
+  );
+}

--- a/src/ui/graphql/settings.ts
+++ b/src/ui/graphql/settings.ts
@@ -84,3 +84,23 @@ export const UPDATE_WORKSPACE_MEMBER_ROLE = gql`
     }
   }
 `;
+
+export const GET_WORKSPACE_SUBSCRIPTION = gql`
+  query GetWorkspaceSubscription($workspaceId: ID!) {
+    node(id: $workspaceId) {
+      ... on Workspace {
+        subscription {
+          id
+          createdAt
+          effectiveFrom
+          effectiveUntil
+          status
+          trialEnds
+          plan {
+            key
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -12,6 +12,7 @@ import {
   GET_USER_SETTINGS,
   GET_WORKSPACE_API_KEYS,
   UPDATE_WORKSPACE_MEMBER_ROLE,
+  GET_WORKSPACE_SUBSCRIPTION,
 } from "ui/graphql/settings";
 
 const emptySettings: UserSettings = {
@@ -174,4 +175,15 @@ export function useUpdateWorkspaceMemberRole() {
   });
 
   return { updateWorkspaceMemberRole, loading, error };
+}
+
+export function useGetWorkspaceSubscription(workspaceId: string) {
+  const { data, loading, error } = useQuery<{ node: Pick<Required<Workspace>, "subscription"> }>(
+    GET_WORKSPACE_SUBSCRIPTION,
+    {
+      variables: { workspaceId },
+    }
+  );
+
+  return { data, loading, error };
 }

--- a/src/ui/hooks/workspaces.ts
+++ b/src/ui/hooks/workspaces.ts
@@ -4,10 +4,10 @@ import { PendingWorkspaceInvitation, Workspace } from "ui/types";
 const NO_WORKSPACES: Workspace[] = [];
 
 export function useCreateNewWorkspace(onCompleted: (data: any) => void) {
-  const [createNewWorkspace, { error }] = useMutation(
+  const [createNewWorkspace, { error }] = useMutation<any, { name: string; planKey?: string }>(
     gql`
-      mutation CreateNewWorkspace($name: String!) {
-        createWorkspace(input: { name: $name }) {
+      mutation CreateNewWorkspace($name: String!, $planKey: String) {
+        createWorkspace(input: { name: $name, planKey: $planKey }) {
           success
           workspace {
             id

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -28,6 +28,23 @@ export interface ApiKeyResponse {
   keyValue: string;
 }
 
+export interface Subscription {
+  id: string;
+  createdAt: string;
+  seatCount: number;
+  effectiveFrom?: string;
+  effectiveTo?: string;
+  createdBy: User;
+  status: string;
+  trialEnds: string | null;
+  plan: {
+    id: string;
+    name: string;
+    key: string;
+    createdAt: string;
+  };
+}
+
 export interface Recording {
   id: string;
   url: string;
@@ -57,6 +74,7 @@ export interface Workspace {
   recordingCount?: number;
   members?: User[];
   apiKeys?: ApiKey[];
+  subscription?: Subscription;
 }
 
 export type WorkspaceUserRole = "viewer" | "debugger" | "admin";

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -49,6 +49,7 @@ pref("devtools.features.videoPlayback", false);
 pref("devtools.features.launchBrowser", true);
 pref("devtools.features.termsOfService", false);
 pref("devtools.features.eventCount", true);
+pref("devtools.features.teamSubscription", false);
 
 export const prefs = new PrefsHelper("devtools", {
   splitConsole: ["Bool", "split-console"],
@@ -84,6 +85,7 @@ export const features = new PrefsHelper("devtools.features", {
   launchBrowser: ["Bool", "launchBrowser"],
   termsOfService: ["Bool", "termsOfService"],
   eventCount: ["Bool", "eventCount"],
+  teamSubscription: ["Bool", "teamSubscription"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {


### PR DESCRIPTION
A greatly simplified implementation of adding subscription support for teams behind the `teamSubscription` feature flag.

* Adds `plan` variable to `createWorkspace` mutation which is conditionally passed based on the feature flag. When passed, the backend will create the subscription. Further, once the subscription is created, adding and removing members will trigger subscription updates from the backend.
* Adds a placeholder pane for the team settings (the link for it is also behind the feature flag) that displays the subscription key if the team has a subscription.
* Adds a new hook to query the subscription state for the settings pane.

![image](https://user-images.githubusercontent.com/788456/130704093-fe4d9a96-4c2b-409c-af65-668a1c2b2302.png)
