### PR TITLE
Make load-region test unload most of the recording.

### DIFF
--- a/test/scripts/region_loading-01.js
+++ b/test/scripts/region_loading-01.js
@@ -5,7 +5,8 @@ Test.describe(
     const { assert } = Test;
 
     const loadTimerange = [0, 5000];
-    const unloadTimerange = [0, loadTimerange[1] / 2];
+    // Unload 90% of the recording.
+    const unloadTimerange = [0, (loadTimerange[1] * 0.9)|0];
     const totalMessageCount = 50;
 
     await Test.selectSource("doc_rr_region_loading.html");


### PR DESCRIPTION
The region loading E2E test has been failing intermittently.  I can't replicate locally.  Main reason for test failure is that after "unloadRegions" is called, we expect at least one logpoint message to go away (compared to the fully loaded recording), and that's not happening (all logpoints are being reported).

This may be due to the details of checkpoint selection.  This patch increases the span of the unloaded region in the test to try to protect against variances in checkpoint selection affecting the test outcome.