### PR TITLE
Add role selection to team settings ui

### DIFF
--- a/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -217,7 +217,7 @@ function SlideBody2({ hideModal, setCurrent, newWorkspace, total, current }: Sli
           {errorMessage ? <div>{errorMessage}</div> : null}
         </form>
         <div className="overflow-auto flex-grow">
-          {!loading && sortedMembers ? <WorkspaceMembers members={sortedMembers} /> : null}
+          {!loading && sortedMembers ? <WorkspaceMembers members={sortedMembers} isAdmin /> : null}
         </div>
         <InvitationLink workspaceId={newWorkspace!.id} />
       </SlideContent>

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
@@ -272,7 +272,7 @@ function TeamMemberInvitationPage({
         </form>
         {!loading && sortedMembers ? (
           <div className="overflow-auto w-full text-2xl " style={{ height: "180px" }}>
-            <WorkspaceMembers members={sortedMembers} />
+            <WorkspaceMembers members={sortedMembers} isAdmin />
           </div>
         ) : null}
         <InvitationLink workspaceId={newWorkspace!.id} showDomainCheck={false} isLarge={true} />

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.css
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.css
@@ -16,22 +16,9 @@
   padding: 0px;
   color: var(--theme-toolbar-color);
   background: inherit;
-}
-
-.permissions-dropdown-item {
   line-height: 20px;
   font-size: 14px;
   padding: 4px 8px 4px 8px;
-}
-
-.permissions-dropdown-item:first-child {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-}
-
-.permissions-dropdown-item:last-child {
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
 }
 
 .permissions-dropdown-item:hover {

--- a/src/ui/graphql/settings.ts
+++ b/src/ui/graphql/settings.ts
@@ -76,3 +76,11 @@ export const DELETE_WORKSPACE_API_KEY = gql`
     }
   }
 `;
+
+export const UPDATE_WORKSPACE_MEMBER_ROLE = gql`
+  mutation UpdateWorkspaceMemberRole($id: ID!, $roles: [String!]!) {
+    updateWorkspaceMemberRole(input: { id: $id, roles: $roles }) {
+      success
+    }
+  }
+`;

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -3,7 +3,7 @@ import { query } from "ui/utils/apolloClient";
 import { isTest } from "ui/utils/environment";
 import { SettingItemKey } from "ui/components/shared/SettingsModal/types";
 import useAuth0 from "ui/utils/useAuth0";
-import type { UserSettings, Workspace } from "../types";
+import type { UserSettings, Workspace, WorkspaceUserRole } from "../types";
 import {
   ADD_USER_API_KEY,
   ADD_WORKSPACE_API_KEY,
@@ -11,6 +11,7 @@ import {
   DELETE_WORKSPACE_API_KEY,
   GET_USER_SETTINGS,
   GET_WORKSPACE_API_KEYS,
+  UPDATE_WORKSPACE_MEMBER_ROLE,
 } from "ui/graphql/settings";
 
 const emptySettings: UserSettings = {
@@ -162,4 +163,15 @@ export function useDeleteWorkspaceApiKey() {
   });
 
   return { deleteWorkspaceApiKey, loading, error };
+}
+
+export function useUpdateWorkspaceMemberRole() {
+  const [updateWorkspaceMemberRole, { loading, error }] = useMutation<
+    any,
+    { id: string; roles: WorkspaceUserRole[] }
+  >(UPDATE_WORKSPACE_MEMBER_ROLE, {
+    refetchQueries: ["GetWorkspaceMembers"],
+  });
+
+  return { updateWorkspaceMemberRole, loading, error };
 }

--- a/src/ui/hooks/workspaces_user.ts
+++ b/src/ui/hooks/workspaces_user.ts
@@ -14,12 +14,14 @@ export function useGetWorkspaceMembers(workspaceId: string) {
                   ... on WorkspacePendingEmailMember {
                     __typename
                     id
+                    roles
                     email
                     createdAt
                   }
                   ... on WorkspacePendingUserMember {
                     __typename
                     id
+                    roles
                     user {
                       id
                       name
@@ -29,6 +31,7 @@ export function useGetWorkspaceMembers(workspaceId: string) {
                   ... on WorkspaceUserMember {
                     __typename
                     id
+                    roles
                     user {
                       id
                       name
@@ -60,6 +63,7 @@ export function useGetWorkspaceMembers(workspaceId: string) {
           pending: true,
           email: node.email,
           createdAt: node.createdAt,
+          roles: node.roles,
         };
       } else {
         return {
@@ -67,6 +71,7 @@ export function useGetWorkspaceMembers(workspaceId: string) {
           userId: node.user.id,
           pending: node.__typename === "WorkspacePendingUserMember",
           user: node.user,
+          roles: node.roles,
         };
       }
     });
@@ -82,8 +87,8 @@ export function useInviteNewWorkspaceMember(onCompleted: () => void) {
 
   const [inviteNewWorkspaceMember] = useMutation(
     gql`
-      mutation InviteNewWorkspaceMember($email: String!, $workspaceId: ID!) {
-        addWorkspaceMember(input: { email: $email, workspaceId: $workspaceId }) {
+      mutation InviteNewWorkspaceMember($email: String!, $workspaceId: ID!, $roles: [String!]) {
+        addWorkspaceMember(input: { email: $email, workspaceId: $workspaceId, roles: $roles }) {
           success
         }
       }

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -59,6 +59,8 @@ export interface Workspace {
   apiKeys?: ApiKey[];
 }
 
+export type WorkspaceUserRole = "viewer" | "debugger" | "admin";
+
 export interface WorkspaceUser {
   membershipId: string;
   pending: boolean;
@@ -66,4 +68,5 @@ export interface WorkspaceUser {
   user?: User;
   userId?: string;
   createdAt?: string;
+  roles?: WorkspaceUserRole[];
 }


### PR DESCRIPTION
## Summary

* Adds role ("User", "Developer", "Admin") selection to team members UI
* Defaults new members to "Developer" for now
* Removes "Danger Zone" and invite domain checkbox for non-admin users

https://user-images.githubusercontent.com/788456/130270281-0d905556-7a94-4d77-af32-b61604b271ac.mp4

## Follow Up Work

* We need to add a dropdown to the invite button to allow the user to select the role at invite time. They can immediately change it below but this would be a good usability improvement (and is already included in the wireframes)
* The dropdown in the member list is left aligned with the text and, as a result, jumps a bit when the text changes when changing roles. It should be right aligned and stay anchored below the arrow.
* Maybe API Keys should be restricted to the "Developer" role or greater?