### PR TITLE
Make the remaining onboarding flows visually consistent

### DIFF
--- a/src/ui/components/Account/Library.tsx
+++ b/src/ui/components/Account/Library.tsx
@@ -16,6 +16,7 @@ import {
   isTeamLeaderInvite,
   isTeamMemberInvite,
   hasTeamInvitationCode,
+  removeUrlParameters,
 } from "ui/utils/environment";
 import LaunchButton from "../shared/LaunchButton";
 import { setExpectedError } from "ui/actions/session";
@@ -71,7 +72,7 @@ function LibraryLoader(props: PropsFromRedux) {
     // This allows the server enough time to refresh the pending workspaces
     // with the new team before we render the Library.
     setTimeout(() => {
-      window.history.pushState({}, document.title, window.location.pathname);
+      removeUrlParameters();
       setRenderLibrary(true);
     }, 1000);
   }

--- a/src/ui/components/Account/index.tsx
+++ b/src/ui/components/Account/index.tsx
@@ -9,14 +9,14 @@ import Library from "./Library";
 import "./Account.css";
 import "../Header/Header.css";
 import "devtools/client/debugger/src/components/shared/AccessibleImage.css";
-import BlankScreen from "../shared/BlankScreen";
-import Modal from "../shared/NewModal";
 import { PrimaryLgButton } from "../shared/Button";
 import {
-  ModalHeader,
-  ReplayLogo,
-} from "../shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal";
-const Circles = require("ui/components/shared/Circles").default;
+  OnboardingActions,
+  OnboardingBody,
+  OnboardingContent,
+  OnboardingHeader,
+  OnboardingModalContainer,
+} from "../shared/Onboarding/index";
 
 function WelcomePage() {
   const { loginWithRedirect } = useAuth0();
@@ -38,27 +38,19 @@ function WelcomePage() {
 
   if (isTeamLeaderInvite()) {
     return (
-      <>
-        <BlankScreen className="fixed" background="white" />
-        <Circles randomNumber={Math.random()} />
-        <Modal options={{ maskTransparency: "transparent" }} blurMask={false}>
-          <div
-            className="p-12 text-4xl space-y-16 relative flex flex-col items-center"
-            style={{ width: "800px" }}
-          >
-            <ReplayLogo />
-            <ModalHeader>👋 Welcome</ModalHeader>
-            <div className="text-center">
-              {"Welcome to Replay - the new way to record, replay, and debug web applications!"}
-            </div>
-            <div className="space-x-4 pt-16">
-              <PrimaryLgButton color="blue" onClick={onLogin}>
-                Sign in
-              </PrimaryLgButton>
-            </div>
-          </div>
-        </Modal>
-      </>
+      <OnboardingModalContainer>
+        <OnboardingContent>
+          <OnboardingHeader>👋 Welcome</OnboardingHeader>
+          <OnboardingBody>
+            {"Welcome to Replay - the new way to record, replay, and debug web applications!"}
+          </OnboardingBody>
+          <OnboardingActions>
+            <PrimaryLgButton color="blue" onClick={onLogin}>
+              Sign in
+            </PrimaryLgButton>
+          </OnboardingActions>
+        </OnboardingContent>
+      </OnboardingModalContainer>
     );
   }
 

--- a/src/ui/components/shared/Circles.js
+++ b/src/ui/components/shared/Circles.js
@@ -90,5 +90,5 @@ export default function Circles({ randomNumber }) {
     [<Circle label="smallTopCenter" key={1} />, <Circle label="bigBottomRight" key={2} />],
   ];
 
-  return <div>HI{circles[Math.floor(randomNumber * 5)]}</div>;
+  return <div>{circles[Math.floor(randomNumber * 5)]}</div>;
 }

--- a/src/ui/components/shared/FirstReplayModal/FirstReplayModal.tsx
+++ b/src/ui/components/shared/FirstReplayModal/FirstReplayModal.tsx
@@ -1,20 +1,23 @@
-import classNames from "classnames";
-import React, { Dispatch, SetStateAction, useState } from "react";
+import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
-import BlankScreen from "../BlankScreen";
-import { PrimaryButton } from "../Button";
-import Modal from "../NewModal";
+import { PrimaryLgButton } from "../Button";
+import { TextInputCopy } from "../NewWorkspaceModal/InvitationLink";
+import {
+  OnboardingBody,
+  OnboardingActions,
+  OnboardingHeader,
+  OnboardingModalContainer,
+  OnboardingContent,
+} from "../Onboarding/index";
 import { UrlCopy } from "../SharingModal/ReplayLink";
 
 const FIRST_REPLAY_TARGET = "https://replay.io/demo";
 
 const RecordIcon = () => (
-  <span className="bg-primaryAccent text-white rounded-xl px-2 py-0.5 uppercase text-base">
-    ⦿ REC
-  </span>
+  <span className="bg-primaryAccent text-white rounded-lg px-2 py-1 uppercase text-lg">⦿ REC</span>
 );
 
 function FirstReplayModal({ hideModal }: PropsFromRedux) {
@@ -31,28 +34,22 @@ function FirstReplayModal({ hideModal }: PropsFromRedux) {
   };
 
   return (
-    <>
-      <BlankScreen className="fixed" />
-      <Modal options={{ maskTransparency: "transparent" }}>
-        <div
-          className="p-12 bg-white rounded-lg shadow-xl text-xl space-y-8 relative flex flex-col justify-between"
-          style={{ width: "520px" }}
-        >
-          <div className="space-y-12">
-            <h2 className="font-bold text-3xl ">Create your first Replay</h2>
-            <div className="text-gray-500">
-              {`We've put together a demo to show you how Replay works. Once it's opened in a new tab, press the record `}
-              <RecordIcon />
-              {` button to start recording.`}
-            </div>
-            <UrlCopy url={FIRST_REPLAY_TARGET} />
-            <PrimaryButton color="blue" onClick={handleOpen}>
-              {`Open this website in a new tab`}
-            </PrimaryButton>
-          </div>
-        </div>
-      </Modal>
-    </>
+    <OnboardingModalContainer>
+      <OnboardingContent>
+        <OnboardingHeader>Create your first Replay</OnboardingHeader>
+        <OnboardingBody>
+          {`We've put together a demo to show you how Replay works. Once it's opened in a new tab, press the record `}
+          <RecordIcon />
+          {` button to start recording.`}
+        </OnboardingBody>
+        <TextInputCopy text={FIRST_REPLAY_TARGET} isLarge={true} isCenter={true} />
+        <OnboardingActions>
+          <PrimaryLgButton color="blue" onClick={handleOpen}>
+            {`Open this website in a new tab`}
+          </PrimaryLgButton>
+        </OnboardingActions>
+      </OnboardingContent>
+    </OnboardingModalContainer>
   );
 }
 

--- a/src/ui/components/shared/NewModal.tsx
+++ b/src/ui/components/shared/NewModal.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import { truncate } from "lodash";
 import React from "react";
 
 export default function Modal({

--- a/src/ui/components/shared/NewWorkspaceModal/InvitationLink.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/InvitationLink.tsx
@@ -3,13 +3,20 @@ import React, { useRef, useState } from "react";
 import hooks from "ui/hooks";
 import { Workspace } from "ui/types";
 
-function InvitationURL({ code, isLarge }: { code: string; isLarge: boolean }) {
+export function TextInputCopy({
+  text,
+  isLarge = false,
+  isCenter = false,
+}: {
+  text: string;
+  isLarge?: boolean;
+  isCenter?: boolean;
+}) {
   const [showCopied, setShowCopied] = useState(false);
   const timeoutKey = useRef<NodeJS.Timeout | null>(null);
-  const displayedText = `https://app.replay.io/?invitationcode=${code}`;
 
   const onClick = () => {
-    navigator.clipboard.writeText(displayedText);
+    navigator.clipboard.writeText(text);
 
     if (timeoutKey.current) {
       clearTimeout(timeoutKey.current);
@@ -20,20 +27,21 @@ function InvitationURL({ code, isLarge }: { code: string; isLarge: boolean }) {
   };
 
   return (
-    <div className="relative flex flex-col items-center">
+    <div className="relative flex flex-col items-center w-full">
       <input
         className={classNames(
           isLarge ? "text-2xl" : "text-lg",
+          isCenter ? "text-center" : "",
           "focus:ring-primaryAccent focus:border-primaryAccent block w-full border px-3 py-2 border-textFieldBorder rounded-md"
         )}
         type="text"
-        value={displayedText}
+        value={text}
         onKeyPress={e => e.preventDefault()}
         onChange={e => e.preventDefault()}
         onClick={onClick}
       />
       {showCopied ? (
-        <div className="absolute bottom-full p-2 bg-black bg-opacity-90 text-white shadow-2xl rounded-lg mb-2">
+        <div className="absolute bottom-full p-2 bg-black bg-opacity-90 text-white shadow-2xl rounded-lg mb-2 text-lg">
           Copied
         </div>
       ) : null}
@@ -95,13 +103,14 @@ export default function InvitationLink({
     return null;
   }
 
+  const inputText = loading
+    ? "Loading URL"
+    : `https://app.replay.io/?invitationcode=${workspace.invitationCode}`;
+
   return (
     <div className="flex flex-col space-y-4 w-full">
       <div className=" text-sm uppercase font-bold">{`Invite via link`}</div>
-      <InvitationURL
-        code={workspace ? workspace.invitationCode : "Loading URL"}
-        isLarge={isLarge}
-      />
+      <TextInputCopy text={inputText} isLarge={isLarge} />
       {showDomainCheck ? <InvationDomainCheck workspace={workspace} /> : null}
     </div>
   );

--- a/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -11,6 +11,7 @@ import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
 import hooks from "ui/hooks";
 import { Workspace, WorkspaceUser } from "ui/types";
+import { removeUrlParameters } from "ui/utils/environment";
 import { validateEmail } from "ui/utils/helpers";
 import { TextInput } from "../Forms";
 import Modal from "../NewModal";
@@ -141,7 +142,7 @@ function SlideBody1({ hideModal, setNewWorkspace, setCurrent, total, current }: 
     setInputValue(e.target.value);
   };
   const onSkip = () => {
-    window.history.pushState({}, document.title, window.location.pathname);
+    removeUrlParameters();
     hideModal();
   };
   const handleSave = () => createNewWorkspace({ variables: { name: inputValue, userId } });
@@ -240,7 +241,7 @@ function SlideBody3({ setWorkspaceId, hideModal, newWorkspace }: SlideBody3Props
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
 
   const onClick = () => {
-    window.history.pushState({}, document.title, window.location.pathname);
+    removeUrlParameters();
 
     setWorkspaceId(newWorkspace.id);
     updateDefaultWorkspace({ variables: { workspaceId: newWorkspace.id } });

--- a/src/ui/components/shared/Onboarding/DownloadPage.tsx
+++ b/src/ui/components/shared/Onboarding/DownloadPage.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { DisabledLgButton, PrimaryLgButton, SecondaryLgButton } from "../Button";
+import { OnboardingActions, OnboardingBody, OnboardingHeader } from "../Onboarding/index";
+import { trackEvent } from "ui/utils/telemetry";
+
+function DownloadButtonContent({ text, imgUrl }: { text: string; imgUrl: string }) {
+  return (
+    <div
+      className="flex flex-row items-center w-full justify-between"
+      style={{ minWidth: "120px" }}
+    >
+      <span>{text}</span>
+      <img className="w-8 h-8" src={imgUrl} />
+    </div>
+  );
+}
+
+function DownloadButtons({ onNext }: { onNext: () => void }) {
+  const startDownload = (url: string) => {
+    window.open(url, "_blank");
+    onNext();
+  };
+  const handleMac = () => {
+    trackEvent("downloaded-mac");
+    startDownload("https://replay.io/downloads/replay.dmg");
+  };
+  const handleLinux = () => {
+    trackEvent("downloaded-linux");
+    startDownload("https://replay.io/downloads/linux-replay.tar.bz2");
+  };
+  const handleWindows = () => {
+    trackEvent("downloaded-windows");
+  };
+
+  return (
+    <div className="py-4 flex flex-row w-full space-x-4 justify-center">
+      <PrimaryLgButton color="blue" onClick={handleMac}>
+        <DownloadButtonContent text="Mac" imgUrl="/images/icon-apple.svg" />
+      </PrimaryLgButton>
+      <PrimaryLgButton color="blue" onClick={handleLinux}>
+        <DownloadButtonContent text="Linux" imgUrl="/images/icon-linux.svg" />
+      </PrimaryLgButton>
+      <div title="Coming soon" onClick={handleWindows}>
+        <DisabledLgButton>
+          <DownloadButtonContent text="Windows" imgUrl="/images/icon-windows.svg" />
+        </DisabledLgButton>
+      </div>
+    </div>
+  );
+}
+
+export function DownloadPage({
+  onNext,
+  onSkipToLibrary,
+}: {
+  onNext: () => void;
+  onSkipToLibrary: () => void;
+}) {
+  return (
+    <>
+      <OnboardingHeader>Download Replay</OnboardingHeader>
+      <OnboardingBody>
+        Record your first replay with the Replay browser, or go directly to your team’s library
+      </OnboardingBody>
+      <DownloadButtons onNext={onNext} />
+      <OnboardingActions>
+        <SecondaryLgButton color="blue" onClick={onSkipToLibrary}>
+          Skip for now
+        </SecondaryLgButton>
+      </OnboardingActions>
+    </>
+  );
+}

--- a/src/ui/components/shared/Onboarding/DownloadingPage.tsx
+++ b/src/ui/components/shared/Onboarding/DownloadingPage.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { PrimaryLgButton } from "../Button";
+import { OnboardingActions, OnboardingBody, OnboardingHeader } from "../Onboarding/index";
+
+export function DownloadingPage({ onFinished }: { onFinished: () => void }) {
+  return (
+    <>
+      <OnboardingHeader>Downloading Replay ...</OnboardingHeader>
+      <OnboardingBody>
+        {`Once the download is finished, install and open the Replay browser. We'll see you there!`}
+      </OnboardingBody>
+      <OnboardingActions>
+        <PrimaryLgButton color="blue" onClick={onFinished}>
+          Take me to my library
+        </PrimaryLgButton>
+      </OnboardingActions>
+    </>
+  );
+}

--- a/src/ui/components/shared/Onboarding/index.tsx
+++ b/src/ui/components/shared/Onboarding/index.tsx
@@ -1,0 +1,130 @@
+import classNames from "classnames";
+import React, { Dispatch, MouseEventHandler, SetStateAction, useEffect, useState } from "react";
+import { actions } from "ui/actions";
+import BlankScreen from "../BlankScreen";
+import { PrimaryLgButton } from "../Button";
+const Circles = require("ui/components/shared/Circles.js").default;
+import Modal from "../NewModal";
+
+export function OnboardingContent({
+  children,
+}: {
+  children: React.ReactChild | React.ReactChild[];
+}) {
+  return (
+    <div
+      className="p-12 text-4xl space-y-16 relative flex flex-col items-center"
+      style={{ width: "800px" }}
+    >
+      <ReplayLogo />
+      {children}
+    </div>
+  );
+}
+
+export function OnboardingHeader({ children }: { children: string }) {
+  return <div className="text-7xl font-semibold">{children}</div>;
+}
+
+export function OnboardingBody({
+  children,
+}: {
+  children: string | React.ReactChild | React.ReactChild[];
+}) {
+  return <div className="text-center">{children}</div>;
+}
+
+export function OnboardingActions({
+  children,
+}: {
+  children: string | React.ReactChild | React.ReactChild[];
+}) {
+  return <div className="space-x-4 pt-16">{children}</div>;
+}
+
+export function NextButton({
+  current,
+  text,
+  setCurrent,
+  onNext,
+  allowNext,
+}: {
+  current: number;
+  text?: string;
+  setCurrent: Dispatch<SetStateAction<number>>;
+  hideModal: typeof actions.hideModal;
+  onNext: () => void;
+  allowNext: boolean;
+}) {
+  const [nextClicked, setNextClicked] = useState<boolean>(false);
+
+  const onClick = () => {
+    if (onNext) {
+      onNext();
+    }
+    setNextClicked(true);
+  };
+
+  useEffect(() => {
+    // Only navigate to the next slide the work that eventually turns
+    // allowNext to true is finished. This allows us to do mutations
+    // in between navigations.
+    if (allowNext && nextClicked) {
+      setCurrent(current + 1);
+    }
+  }, [allowNext, nextClicked]);
+
+  const inferLoading = nextClicked && !allowNext;
+  const buttonText = inferLoading ? "Loading" : text || "Next";
+
+  return (
+    <PrimaryLgButton color="blue" onClick={onClick}>
+      {buttonText}
+    </PrimaryLgButton>
+  );
+}
+
+export function OnboardingButton({
+  children,
+  onClick = () => {},
+  className,
+  disabled = false,
+}: {
+  children: React.ReactElement | string;
+  className?: string;
+  onClick?: MouseEventHandler;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={classNames(
+        className,
+        "max-w-max items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function OnboardingModalContainer({
+  children,
+  randomNumber = 0,
+}: {
+  children: React.ReactElement;
+  randomNumber?: number;
+}) {
+  return (
+    <div className="w-full h-full grid fixed bg-white">
+      <Circles randomNumber={randomNumber} />
+      <Modal options={{ maskTransparency: "transparent" }} blurMask={false}>
+        {children}
+      </Modal>
+    </div>
+  );
+}
+
+export const ReplayLogo = () => <img className="w-24 h-24" src="/images/logo.svg" />;

--- a/src/ui/components/shared/OnboardingModal/TeamMemberOnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/TeamMemberOnboardingModal.tsx
@@ -5,7 +5,7 @@ import * as actions from "ui/actions/app";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
 import { PendingWorkspaceInvitation } from "ui/types";
-import { isTeamMemberInvite } from "ui/utils/environment";
+import { isTeamMemberInvite, removeUrlParameters } from "ui/utils/environment";
 import BlankScreen from "../BlankScreen";
 import Modal, { ModalContent } from "../NewModal";
 import Spinner from "../Spinner";
@@ -153,13 +153,13 @@ function TeamMemberOnboardingModal({
     // or they're trying to skip when they accepted an invitation and should be
     // nudged to open that team.
     if (isFinished && !actions.includes("accept")) {
-      window.history.pushState({}, document.title, window.location.pathname);
+      removeUrlParameters();
       hideModal();
       return;
     }
 
     if (window.confirm(`Are you sure you want to skip this step?`)) {
-      window.history.pushState({}, document.title, window.location.pathname);
+      removeUrlParameters();
       hideModal();
     }
   };
@@ -182,7 +182,7 @@ function TeamMemberOnboardingModal({
 
       // Remove any URL parameters. This applies when a user clicks on a team invite
       // link from their email.
-      window.history.pushState({}, document.title, window.location.pathname);
+      removeUrlParameters();
 
       return;
     }

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
@@ -1,114 +1,28 @@
-import classNames from "classnames";
-import React, {
-  ChangeEvent,
-  Dispatch,
-  MouseEventHandler,
-  SetStateAction,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
 import hooks from "ui/hooks";
 import { Workspace, WorkspaceUser } from "ui/types";
 import { validateEmail } from "ui/utils/helpers";
-import BlankScreen from "../BlankScreen";
-import { DisabledLgButton, PrimaryLgButton, SecondaryLgButton } from "../Button";
+import { PrimaryLgButton, SecondaryLgButton } from "../Button";
 import { TextInput } from "../Forms";
-import Modal from "../NewModal";
+import {
+  OnboardingActions,
+  OnboardingBody,
+  OnboardingButton,
+  OnboardingContent,
+  OnboardingHeader,
+  NextButton,
+  OnboardingModalContainer,
+} from "../Onboarding/index";
 import InvitationLink from "../NewWorkspaceModal/InvitationLink";
 import { WorkspaceMembers } from "../WorkspaceSettingsModal/WorkspaceSettingsModal";
 import { trackEvent } from "ui/utils/telemetry";
-const Circles = require("../Circles").default;
+import { removeUrlParameters } from "ui/utils/environment";
+import { DownloadPage } from "../Onboarding/DownloadPage";
+import { DownloadingPage } from "../Onboarding/DownloadingPage";
 
 const DOWNLOAD_PAGE_INDEX = 4;
-
-export const ReplayLogo = () => <img className="w-24 h-24" src="/images/logo.svg" />;
-
-function DownloadButtonContent({ text, imgUrl }: { text: string; imgUrl: string }) {
-  return (
-    <div
-      className="flex flex-row items-center w-full justify-between"
-      style={{ minWidth: "120px" }}
-    >
-      <span>{text}</span>
-      <img className="w-8 h-8" src={imgUrl} />
-    </div>
-  );
-}
-
-function ModalButton({
-  children,
-  onClick = () => {},
-  className,
-  disabled = false,
-}: {
-  children: React.ReactElement | string;
-  className?: string;
-  onClick?: MouseEventHandler;
-  disabled?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={classNames(
-        className,
-        "max-w-max items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
-      )}
-    >
-      {children}
-    </button>
-  );
-}
-
-export function ModalHeader({ children }: { children: string }) {
-  return <div className="text-7xl font-semibold">{children}</div>;
-}
-
-function NextButton({
-  current,
-  text,
-  setCurrent,
-  onNext,
-  allowNext,
-}: {
-  current: number;
-  text?: string;
-  setCurrent: Dispatch<SetStateAction<number>>;
-  hideModal: typeof actions.hideModal;
-  onNext: () => void;
-  allowNext: boolean;
-}) {
-  const [nextClicked, setNextClicked] = useState<boolean>(false);
-
-  const onClick = () => {
-    if (onNext) {
-      onNext();
-    }
-    setNextClicked(true);
-  };
-
-  useEffect(() => {
-    // Only navigate to the next slide the work that eventually turns
-    // allowNext to true is finished. This allows us to do mutations
-    // in between navigations.
-    if (allowNext && nextClicked) {
-      setCurrent(current + 1);
-    }
-  }, [allowNext, nextClicked]);
-
-  const inferLoading = nextClicked && !allowNext;
-  const buttonText = inferLoading ? "Loading" : text || "Next";
-
-  return (
-    <PrimaryLgButton color="blue" onClick={onClick}>
-      {buttonText}
-    </PrimaryLgButton>
-  );
-}
 
 type SlideBodyProps = PropsFromRedux & {
   onNext: () => void;
@@ -124,20 +38,19 @@ type SlideBodyProps = PropsFromRedux & {
 function IntroPage({ onSkipToDownload, onNext }: SlideBodyProps) {
   return (
     <>
-      <ReplayLogo />
-      <ModalHeader>Set up your team</ModalHeader>
-      <div className="text-center">
+      <OnboardingHeader>Set up your team</OnboardingHeader>
+      <OnboardingBody>
         Replay teams are the easiest way to collaborate on bug reports, pull requests, and technical
         questions
-      </div>
-      <div className="space-x-4 pt-16">
+      </OnboardingBody>
+      <OnboardingActions>
         <PrimaryLgButton color="blue" onClick={onNext}>
           Create a team
         </PrimaryLgButton>
         <SecondaryLgButton color="blue" onClick={() => onSkipToDownload("intro-page")}>
           Skip for now
         </SecondaryLgButton>
-      </div>
+      </OnboardingActions>
     </>
   );
 }
@@ -175,10 +88,10 @@ function TeamNamePage({
 
   return (
     <>
-      <ReplayLogo /> <ModalHeader>Your team name</ModalHeader>
-      <div className="text-center">
+      <OnboardingHeader>Your team name</OnboardingHeader>
+      <OnboardingBody>
         We recommend keeping it simple and using your company or project name
-      </div>
+      </OnboardingBody>
       <div className="py-4 flex flex-col w-full">
         <TextInput
           placeholder="Team name"
@@ -188,12 +101,12 @@ function TeamNamePage({
           center={true}
         />
       </div>
-      <div className="space-x-4 pt-16">
+      <OnboardingActions>
         <NextButton onNext={handleSave} {...{ current, setCurrent, hideModal, allowNext }} />
         <SecondaryLgButton color="blue" onClick={() => onSkipToDownload("team-name-page")}>
           Skip for now
         </SecondaryLgButton>
-      </div>
+      </OnboardingActions>
     </>
   );
 }
@@ -249,11 +162,11 @@ function TeamMemberInvitationPage({
 
   return (
     <>
-      <ReplayLogo /> <ModalHeader>Invite your team members</ModalHeader>
-      <div className="text-center">
+      <OnboardingHeader>Invite your team members</OnboardingHeader>
+      <OnboardingBody>
         Replay is for your whole team. Invite anyone who you would like to be able to record and
         discuss replays with
-      </div>
+      </OnboardingBody>
       <div className="text-2xl w-full space-y-4">
         <form className="flex flex-col w-full space-y-4 text-2xl" onSubmit={handleAddMember}>
           <div className="text-sm uppercase font-bold">{`Invite via email`}</div>
@@ -264,9 +177,9 @@ function TeamMemberInvitationPage({
               onChange={onChange}
               textSize={"lg"}
             />
-            <ModalButton onClick={handleAddMember} disabled={isLoading}>
+            <OnboardingButton onClick={handleAddMember} disabled={isLoading}>
               {isLoading ? "Loading" : "Invite"}
-            </ModalButton>
+            </OnboardingButton>
           </div>
           {errorMessage ? <div>{errorMessage}</div> : null}
         </form>
@@ -277,77 +190,18 @@ function TeamMemberInvitationPage({
         ) : null}
         <InvitationLink workspaceId={newWorkspace!.id} showDomainCheck={false} isLarge={true} />
       </div>
-      <div className="space-x-4 pt-16">
+      <OnboardingActions>
         <PrimaryLgButton color="blue" onClick={() => onSkipToDownload()}>
           Next
         </PrimaryLgButton>
-      </div>
+      </OnboardingActions>
     </>
   );
 }
 
-function DownloadPage({ onFinished, onNext, onSkipToLibrary }: SlideBodyProps) {
-  const startDownload = (url: string) => {
-    window.open(url, "_blank");
-    onNext();
-  };
-  const handleMac = () => {
-    trackEvent("downloaded-mac");
-    startDownload("https://replay.io/downloads/replay.dmg");
-  };
-  const handleLinux = () => {
-    trackEvent("downloaded-linux");
-    startDownload("https://replay.io/downloads/linux-replay.tar.bz2");
-  };
-  const handleWindows = () => {
-    trackEvent("downloaded-windows");
-  };
-
-  return (
-    <>
-      <ReplayLogo /> <ModalHeader>Download Replay</ModalHeader>
-      <div className="text-center">
-        Record your first replay with the Replay browser, or go directly to your team’s library
-      </div>
-      <div className="py-4 flex flex-row w-full space-x-4 justify-center">
-        <PrimaryLgButton color="blue" onClick={handleMac}>
-          <DownloadButtonContent text="Mac" imgUrl="/images/icon-apple.svg" />
-        </PrimaryLgButton>
-        <PrimaryLgButton color="blue" onClick={handleLinux}>
-          <DownloadButtonContent text="Linux" imgUrl="/images/icon-linux.svg" />
-        </PrimaryLgButton>
-        <div title="Coming soon" onClick={handleWindows}>
-          <DisabledLgButton>
-            <DownloadButtonContent text="Windows" imgUrl="/images/icon-windows.svg" />
-          </DisabledLgButton>
-        </div>
-      </div>
-      <div className="space-x-4 pt-16">
-        <SecondaryLgButton color="blue" onClick={onSkipToLibrary}>
-          Skip for now
-        </SecondaryLgButton>
-      </div>
-    </>
-  );
-}
-
-function DownloadingPage({ onFinished }: SlideBodyProps) {
-  return (
-    <>
-      <ReplayLogo />
-      <ModalHeader>Downloading Replay ...</ModalHeader>
-      <div className="text-center">
-        {`Once the download is finished, install and open the Replay browser. We'll see you there!`}
-      </div>
-      <div className="space-x-4 pt-16">
-        <PrimaryLgButton color="blue" onClick={onFinished}>
-          Take me to my library
-        </PrimaryLgButton>
-      </div>
-    </>
-  );
-}
-
+// This modal is used whenever a user is invited to Replay via the Replay invitations
+// tab in the settings panel. This should guide them through 1) creating a team, and/or
+// 2) downloading the Replay browser.
 function OnboardingModal(props: PropsFromRedux) {
   const [current, setCurrent] = useState<number>(1);
   const [randomNumber, setRandomNumber] = useState<number>(Math.random());
@@ -369,12 +223,12 @@ function OnboardingModal(props: PropsFromRedux) {
     setRandomNumber(Math.random());
   };
   const onSkipToLibrary = () => {
-    window.history.pushState({}, document.title, window.location.pathname);
+    removeUrlParameters();
     trackEvent("skipped-replay-download");
     props.hideModal();
   };
   const onFinished = () => {
-    window.history.pushState({}, document.title, window.location.pathname);
+    removeUrlParameters();
     trackEvent("finished-onboarding");
     props.hideModal();
   };
@@ -399,24 +253,15 @@ function OnboardingModal(props: PropsFromRedux) {
   } else if (current === 3) {
     slide = <TeamMemberInvitationPage {...newProps} />;
   } else if (current === DOWNLOAD_PAGE_INDEX) {
-    slide = <DownloadPage {...newProps} />;
+    slide = <DownloadPage {...{ onNext, onSkipToLibrary }} />;
   } else {
-    slide = <DownloadingPage {...newProps} />;
+    slide = <DownloadingPage {...{ onFinished }} />;
   }
 
   return (
-    <>
-      <BlankScreen className="fixed" background="white" />
-      <Circles randomNumber={randomNumber} />
-      <Modal options={{ maskTransparency: "transparent" }} blurMask={false}>
-        <div
-          className="p-12 text-4xl space-y-16 relative flex flex-col items-center"
-          style={{ width: "800px" }}
-        >
-          {slide}
-        </div>
-      </Modal>
-    </>
+    <OnboardingModalContainer {...{ randomNumber }}>
+      <OnboardingContent>{slide}</OnboardingContent>
+    </OnboardingModalContainer>
   );
 }
 

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -116,3 +116,7 @@ export function getPausePointParams() {
 
   return null;
 }
+
+export function removeUrlParameters() {
+  window.history.pushState({}, document.title, window.location.pathname);
+}


### PR DESCRIPTION
Fixes #3292.

This patch makes our onboarding flows visually consistent, by following the lead from #3262.

## Replay onboarding (Workspace invitation flow):

<details>
<summary><strong>Screenshots</strong></summary>
<img src="https://user-images.githubusercontent.com/15959269/130501834-233a9ea8-143f-41b5-a3c8-29a753154bd7.png" />
<img src="https://user-images.githubusercontent.com/15959269/130501886-3045b660-9a35-4c8f-8c40-ce50952365c5.png" />
<img src="https://user-images.githubusercontent.com/15959269/130501912-0e4b8d76-38e8-4661-86b4-59863ed32e36.png" />
</details>

- This shows up when a user signs up for Replay as a result of being invited to a workspace.
- The user would have received an e-mail from us, and a register link. Clicking on that link would direct them to register for Replay, and then show this flow.
- This auto-accepts the corresponding workspace invitation as soon as the user registers.

## Replay onboarding (Replay invitation flow):

<details>
<summary><strong>Screenshots</strong></summary>
<img src="https://user-images.githubusercontent.com/15959269/130502010-6296d2d4-c354-456b-827a-65641ae9a86e.png" />
<img src="https://user-images.githubusercontent.com/15959269/130502037-15375283-0d12-42bf-b438-9e1583a62043.png" />
<img src="https://user-images.githubusercontent.com/15959269/130502076-6fc8a95b-3eec-4783-aabb-046f849a77bd.png" />
<img src="https://user-images.githubusercontent.com/15959269/130502104-6eab6c6b-f285-4194-854b-8b0d1fea78c1.png" />
<img src="https://user-images.githubusercontent.com/15959269/130502124-af7084ca-957a-4640-b58c-76b67c0b4277.png" />
</details>

- This shows up when a user signs up for Replay as a result of being invited to Replay.
- The user would have received an e-mail from us, and a register link. Clicking on that link would direct them to register for Replay, and then show this flow.
- This also applies when users are invited as part of our cohorts.

## First Replay onboarding:

<details>
<summary><strong>Screenshots</strong></summary>
<img src="https://user-images.githubusercontent.com/15959269/130504141-1e600aeb-0322-4109-968b-42f1531c432c.png" />
</details>

- This shows up when a user logs into their account on the Replay browser for the first time.