### PR TITLE
Display navigation and keyboard events in the events sidepanel

### DIFF
--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -21,7 +21,6 @@ import { selectors } from "ui/reducers";
 import { isRepaintEnabled } from "./enable-repaint";
 
 const { features } = require("ui/utils/prefs");
-import groupBy from "lodash/groupBy";
 
 export const screenshotCache = new ScreenshotCache();
 const repaintedScreenshots: Map<string, ScreenShot> = new Map();
@@ -136,31 +135,6 @@ function onMouseEvents(events: MouseEvent[], store: UIStore) {
   store.dispatch(actions.setEventsForType(gMouseClickEvents, "mousedown"));
 }
 
-function onKeyboardEvents(events: KeyboardEvent[], store: UIStore) {
-  events.forEach(entry => {
-    insertEntrySorted(gKeyboardEvents, entry);
-  });
-
-  const keyboardEvents = groupBy(events, event => event.kind);
-
-  Object.keys(keyboardEvents).map(event => {
-    store.dispatch(actions.setEventsForType(keyboardEvents[event], event));
-  });
-}
-
-function onNavigationEvents(events: NavigationEvent[], store: UIStore) {
-  events.forEach(entry => {
-    insertEntrySorted(gNavigationEvents, entry);
-  });
-
-  store.dispatch(
-    actions.setEventsForType(
-      gNavigationEvents.map(e => ({ ...e, kind: "navigation" })),
-      "navigation"
-    )
-  );
-}
-
 class VideoPlayer {
   store: UIStore | null = null;
   video: HTMLVideoElement | null = null;
@@ -241,12 +215,6 @@ export function setupGraphics(store: UIStore) {
 
     client.Session.findMouseEvents({}, sessionId);
     client.Session.addMouseEventsListener(({ events }) => onMouseEvents(events, store));
-
-    client.Session.findKeyboardEvents({}, sessionId);
-    client.Session.addKeyboardEventsListener(({ events }) => onKeyboardEvents(events, store));
-
-    client.Session.findNavigationEvents({}, sessionId);
-    client.Session.addNavigationEventsListener(({ events }) => onNavigationEvents(events, store));
 
     if (features.videoPlayback) {
       client.Graphics.getPlaybackVideo({}, sessionId);

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -1,13 +1,16 @@
 import { Action } from "redux";
 import { UIStore, UIThunkAction } from ".";
 import {
-  RecordingId,
   SessionId,
   unprocessedRegions,
   PointDescription,
   Location,
   MouseEvent,
   loadedRegions,
+  KeyboardEvent,
+  MouseEventKind,
+  KeyboardEventKind,
+  NavigationEvent,
 } from "@recordreplay/protocol";
 import { ThreadFront } from "protocol/thread";
 import * as selectors from "ui/reducers/app";
@@ -15,12 +18,12 @@ import {
   PanelName,
   PrimaryPanelName,
   ViewMode,
-  Event,
   ModalType,
   UploadInfo,
   Canvas,
   WorkspaceId,
   SettingsTabTitle,
+  EventKind,
 } from "ui/state/app";
 import { RecordingTarget } from "protocol/thread/thread";
 import { Workspace } from "ui/types";
@@ -56,8 +59,8 @@ export type SetAnalysisErrorAction = Action<"set_analysis_error"> & {
   condition: string;
 };
 export type SetEventsForType = Action<"set_events"> & {
-  events: MouseEvent[];
-  eventType: Event;
+  events: (MouseEvent | KeyboardEvent | NavigationEvent)[];
+  eventType: EventKind;
 };
 export type SetViewMode = Action<"set_view_mode"> & { viewMode: ViewMode };
 export type SetHoveredLineNumberLocation = Action<"set_hovered_line_number_location"> & {
@@ -246,7 +249,10 @@ export function setAnalysisError(location: Location, condition = ""): SetAnalysi
   };
 }
 
-export function setEventsForType(events: MouseEvent[], eventType: Event): SetEventsForType {
+export function setEventsForType(
+  events: (MouseEvent | KeyboardEvent | NavigationEvent)[],
+  eventType: EventKind
+): SetEventsForType {
   return {
     type: "set_events",
     eventType,

--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -31,7 +31,7 @@ function Event({
     icon = "ads_click";
   } else if (event.kind?.includes("navigation")) {
     const ev = event as NavigationEvent;
-    text = `Navigation (${ev.url})`;
+    text = `Navigation ${ev.url}`;
     icon = "place";
   } else {
     icon = "keyboard";
@@ -46,7 +46,7 @@ function Event({
       eventText = `Key Press`;
     }
 
-    text = `${eventText} (${ev.key})`;
+    text = `${eventText} ${ev.key}`;
   }
 
   return (

--- a/src/ui/components/Timeline/EventMarker.tsx
+++ b/src/ui/components/Timeline/EventMarker.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
-import { RecordingEvent } from "ui/state/timeline";
-import { actions } from "ui/actions";
 import { selectors } from "ui/reducers";
 import { UIState } from "ui/state";
+import { ReplayEvent } from "ui/state/app";
 import Marker from "./Marker";
 
 function EventMarker({
@@ -35,7 +34,7 @@ const connector = connect((state: UIState) => ({
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
 type EventMarkerProps = PropsFromRedux & {
-  event: RecordingEvent;
+  event: ReplayEvent;
   isPrimaryHighlighted: boolean;
 };
 

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -1,4 +1,4 @@
-import { AppState, PanelName, ViewMode } from "ui/state/app";
+import { AppState, EventKind, PanelName, ReplayEvent, ViewMode } from "ui/state/app";
 import { AppActions } from "ui/actions/app";
 import { UIState } from "ui/state";
 import { SessionActions } from "ui/actions/session";
@@ -251,6 +251,19 @@ export const getPointsForHoveredLineNumber = (state: UIState) => {
 const NO_EVENTS: MouseEvent[] = [];
 export const getEventsForType = (state: UIState, type: string) =>
   state.app.events[type] || NO_EVENTS;
+export const getFlatEvents = (state: UIState) => {
+  let events: ReplayEvent[] = [];
+
+  Object.keys(state.app.events).map(
+    (eventKind: EventKind) => (events = [...events, ...state.app.events[eventKind]])
+  );
+
+  const sortedEvents = events.sort((a: ReplayEvent, b: ReplayEvent) =>
+    BigInt(a.point) < BigInt(b.point) ? -1 : BigInt(a.point) > BigInt(b.point) ? 1 : 0
+  );
+
+  return sortedEvents;
+};
 export const getIsNodePickerActive = (state: UIState) => state.app.isNodePickerActive;
 export const getCanvas = (state: UIState) => state.app.canvas;
 export const getVideoUrl = (state: UIState) => state.app.videoUrl;

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -6,6 +6,7 @@ import { prefs } from "../utils/prefs";
 import { Location } from "@recordreplay/protocol";
 import { getLocationAndConditionKey } from "devtools/client/debugger/src/utils/breakpoint";
 import { isSameTimeStampedPointRange } from "ui/utils/timeline";
+import { compareBigInt } from "ui/utils/helpers";
 
 function initialAppState(): AppState {
   return {
@@ -259,7 +260,7 @@ export const getFlatEvents = (state: UIState) => {
   );
 
   const sortedEvents = events.sort((a: ReplayEvent, b: ReplayEvent) =>
-    BigInt(a.point) < BigInt(b.point) ? -1 : BigInt(a.point) > BigInt(b.point) ? 1 : 0
+    compareBigInt(BigInt(a.point), BigInt(b.point))
   );
 
   return sortedEvents;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -5,6 +5,10 @@ import {
   Location,
   MouseEvent,
   loadedRegions,
+  KeyboardEvent,
+  NavigationEvent,
+  KeyboardEventKind,
+  MouseEventKind,
 } from "@recordreplay/protocol";
 import type { RecordingTarget } from "protocol/thread/thread";
 import { Workspace } from "ui/types";
@@ -94,10 +98,12 @@ export interface AnalysisPoints {
 }
 
 interface Events {
-  [key: string]: MouseEvent[];
+  [key: string]: ReplayEvent[];
 }
 
-export type Event = "mousedown";
+export type ReplayEvent = MouseEvent | KeyboardEvent | NavigationEvent;
+
+export type EventKind = MouseEventKind | KeyboardEventKind | string;
 
 export interface Canvas {
   gDevicePixelRatio: number;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -43,11 +43,3 @@ interface HoveredLocation extends Location {
   line: number;
   column: number;
 }
-
-export interface RecordingEvent {
-  clientX: number;
-  clientY: number;
-  kind: MouseEventKind;
-  point: string;
-  time: number;
-}

--- a/src/ui/utils/helpers.ts
+++ b/src/ui/utils/helpers.ts
@@ -7,3 +7,7 @@ export function validateUUID(uuid: string) {
   const re = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/;
   return re.test(uuid);
 }
+
+export function compareBigInt(point1: BigInt, point2: BigInt) {
+  return point1 < point2 ? -1 : point1 > point2 ? 1 : 0;
+}


### PR DESCRIPTION
Fix #3294.

Follow up items:
- This shows three keyboard events (key down/press/up), which gets repetitive. We should collapse them and just show once key press event. #3317
- This tacks metadata (e.g. the key that was pressed, the URL navigated to) immediately after the event name (e.g. `Key Press Enter`, `Navigation www.replay.io`. We should find a better way to display the metadata — maybe as a secondary line. #3318
- Add the element being clicked as metadata to a click event, e.g. `Mouse Click button.my-button`. #3319
- Add heuristics for collapsing keyboard events that should be together. Instead of having `Key Press H` and `Key Press I`, there should be some logic that realizes that perhaps the user was typing something and it should be presented as `Typed HI`. #3320