### PR TITLE
Change the language in the download page

### DIFF
--- a/src/ui/components/shared/Onboarding/DownloadPage.tsx
+++ b/src/ui/components/shared/Onboarding/DownloadPage.tsx
@@ -60,7 +60,7 @@ export function DownloadPage({
     <>
       <OnboardingHeader>Download Replay</OnboardingHeader>
       <OnboardingBody>
-        Record your first replay with the Replay browser, or go directly to your team’s library
+        Record your first replay with the Replay browser, or go directly to your library
       </OnboardingBody>
       <DownloadButtons onNext={onNext} />
       <OnboardingActions>


### PR DESCRIPTION
Fix #3387.

This changes the copy from "your team's library" to just "your library". This makes sure that the copy makes sense whether or not the user created/skipped creating a team.