### PR TITLE
Add a button to allow users to go back to their library in the case of an access error

### DIFF
--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -80,7 +80,7 @@ function LibraryButton() {
         "w-full inline-flex items-center justify-center px-24 py-3 border border-transparent text-2xl font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
       )}
     >
-      Okay
+      Back to Library
     </button>
   );
 }

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -786,6 +786,7 @@ export function useHasExpectedError(recordingId: RecordingId): ExpectedError | u
       message: "You don't have permission to view this replay",
       content:
         "Sorry, you can't access this Replay. If you were given this URL, make sure you were invited.",
+      action: "library",
     };
   }
 


### PR DESCRIPTION
Fix #3358.

Added it in the error modal itself instead of the top left since it's the fastest way to get something in.

![image](https://user-images.githubusercontent.com/15959269/131334466-8edddede-73c0-468f-bb01-757c39b8fb60.png)
