### PR TITLE
Restoring the size 16 font

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1,7 +1,4 @@
 /* NOTE: this is added to protect against React DevTools */
-html {
-  font-size: 12px !important;
-}
 
 html,
 body {

--- a/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
@@ -30,7 +30,7 @@ function StaticTooltip({
   }
 
   return ReactDOM.createPortal(
-    <div className={`static-tooltip ${className}`} style={style}>
+    <div className={`static-tooltip text-sm ${className}`} style={style}>
       {children}
     </div>,
     targetNode

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoint.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoint.css
@@ -6,11 +6,6 @@
   overflow-x: auto;
 }
 
-.empty-state-content {
-  padding: 8px;
-  white-space: pre-wrap;
-}
-
 .breakpoints-list *:focus:not(:focus-visible) {
   outline: none;
   background: inherit;

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/index.js
@@ -46,7 +46,7 @@ class Breakpoints extends Component {
 
     if (!breakpointSources.length) {
       return (
-        <div className="empty-state-content">
+        <div className="p-2 whitespace-pre-wrap text-sm">
           There is nothing here yet. Try adding a breakpoint in a source file.
         </div>
       );

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/EventListeners.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/EventListeners.js
@@ -182,7 +182,7 @@ class EventListeners extends Component {
     );
 
     return (
-      <div className="flex flex-col space-y-2">
+      <div className="flex flex-col space-y-1.5">
         {commonCategories.length
           ? this.renderCategoriesSection("Common Events", commonCategories)
           : null}
@@ -209,7 +209,7 @@ class EventListeners extends Component {
 
     return (
       <div className="flex flex-col space-y-1">
-        <div className="text-lg font-medium">{label}</div>
+        <div className="text-sm font-medium">{label}</div>
         <ul className="event-listeners-list">{content}</ul>
       </div>
     );

--- a/src/devtools/client/debugger/src/components/shared/Dropdown.css
+++ b/src/devtools/client/debugger/src/components/shared/Dropdown.css
@@ -104,8 +104,6 @@
 .dropdown-panel .menu-item {
   padding: 4px 8px;
   color: var(--theme-body-color);
-  line-height: 1.75rem;
-  font-size: 1.1rem;
 }
 
 .dropdown-panel .menu-item:hover {

--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -11,7 +11,7 @@
     * Workaround: specify font-size on root, on form inputs, and whenever
     * we're using the `font` shorthand. */
   font: message-box;
-  font-size: var(--theme-body-font-size);
+  font-size: var(--root-font-size);
 
   --tab-line-hover-color: rgba(0, 0, 0, 0.2);
   --tab-line-selected-color: var(--blue-50);

--- a/src/devtools/client/themes/tooltips.css
+++ b/src/devtools/client/themes/tooltips.css
@@ -116,6 +116,7 @@ strong {
 }
 
 .tooltip-container {
+  font-size: var(--devtools-base-font-size);
   display: none;
   position: fixed;
   z-index: 9999;
@@ -398,6 +399,7 @@ strong {
 }
 
 .tooltip-container[type="doorhanger"] .menuitem > .command {
+  font-size: var(--devtools-base-font-size);
   display: flex;
   align-items: baseline;
   margin: 0;
@@ -458,8 +460,7 @@ strong {
   flex: 1;
   font: menu;
   white-space: nowrap;
-  font-size: 1.2rem;
-  line-height: 1.6rem;
+  font-size: 0.825rem;
 }
 
 .tooltip-container[type="doorhanger"] .checkbox-container .menuitem > .command > .label {

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -13,6 +13,8 @@
   --theme-textbox-box-shadow: rgba(97, 181, 255, 0.75);
 
   /* Text sizes */
+  --root-font-size: 16px;
+  --devtools-base-font-size: 12px;
   --theme-body-font-size: 11px;
   --theme-code-font-size: 11px;
   --theme-code-line-height: calc(15 / 11);

--- a/src/devtools/client/webconsole/components/FilterBar/Events.js
+++ b/src/devtools/client/webconsole/components/FilterBar/Events.js
@@ -17,7 +17,7 @@ export function Events() {
   );
 
   return (
-    <div className="event-breakpoints">
+    <div className="event-breakpoints text-xs">
       <Dropdown
         buttonContent={buttonContent}
         setExpanded={setExpanded}

--- a/src/devtools/client/webconsole/components/FilterBar/FilterBar.js
+++ b/src/devtools/client/webconsole/components/FilterBar/FilterBar.js
@@ -233,7 +233,7 @@ class FilterBar extends Component {
 
     return dom.div(
       {
-        className: `webconsole-filteringbar-wrapper ${displayMode}`,
+        className: `webconsole-filteringbar-wrapper text-xs ${displayMode}`,
         "aria-live": "off",
         ref: node => {
           this.wrapperNode = node;

--- a/src/ui/components/Account/Library.tsx
+++ b/src/ui/components/Account/Library.tsx
@@ -39,14 +39,14 @@ function Header({
 
   return (
     <div id="header">
-      <div className="header-left space-x-0">
+      <div className="header-left">
         {currentWorkspaceId == null ? null : (
           <a
             href="#"
             onClick={onSettingsClick}
-            className="flex flex-row ml-4 items-center text-gray-400 hover:text-gray-800"
+            className="flex flex-row ml-3 items-center text-gray-400 hover:text-gray-800"
           >
-            <CogIcon className="h-8 w-8" />
+            <CogIcon className="h-6 w-6" />
           </a>
         )}
 

--- a/src/ui/components/Account/index.tsx
+++ b/src/ui/components/Account/index.tsx
@@ -58,15 +58,15 @@ function WelcomePage() {
       className="w-full h-full grid"
       style={{ background: "linear-gradient(to bottom right, #68DCFC, #4689F8)" }}
     >
-      <section className="max-w-lg w-full m-auto bg-white shadow-lg rounded-lg overflow-hidden">
-        <div className="p-16 h-84 space-y-12">
-          <div className="space-y-4 place-content-center">
-            <img className="w-16 h-16 mx-auto" src="/images/logo.svg" />
+      <section className="max-w-sm w-full m-auto bg-white shadow-lg rounded-lg overflow-hidden">
+        <div className="p-12 space-y-9">
+          <div className="space-y-3 place-content-center">
+            <img className="w-12 h-12 mx-auto" src="/images/logo.svg" />
           </div>
           {isTeamMemberInvite() ? (
-            <div className="text-center space-y-2">
-              <div className="font-bold text-2xl">Almost there!</div>
-              <div className="font-medium text-xl">
+            <div className="text-center space-y-1.5">
+              <div className="font-bold text-xl">Almost there!</div>
+              <div className="font-medium text-lg">
                 In order to join your team, we first need you to sign in.
               </div>
             </div>
@@ -74,7 +74,7 @@ function WelcomePage() {
           <a
             href="#"
             onClick={onLogin}
-            className="w-full inline-flex items-center justify-center px-5 py-3 border border-transparent text-2xl font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
+            className="w-full inline-flex items-center justify-center px-3.5 py-2 border border-transparent text-lg font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
           >
             Sign in to Replay
           </a>

--- a/src/ui/components/Comments/TranscriptComments/CommentActions.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentActions.tsx
@@ -50,21 +50,23 @@ function CommentActions({ comment, editItem, isRoot }: CommentActionsProps) {
   return (
     <div className="comment-actions" onClick={e => e.stopPropagation()}>
       <PortalDropdown
-        buttonContent={<DotsHorizontalIcon className="w-5 h-5 opacity-0 group-hover:opacity-100" />}
+        buttonContent={
+          <DotsHorizontalIcon className="w-3.5 h-3.5 opacity-0 group-hover:opacity-100" />
+        }
         setExpanded={setExpanded}
         expanded={expanded}
         buttonStyle=""
         position="bottom-right"
       >
         <div
-          className="comments-dropdown-item edit-comment text-lg"
+          className="comments-dropdown-item edit-comment text-xs"
           title="Edit Comment"
           onClick={editComment}
         >
           Edit comment
         </div>
         <div
-          className="comments-dropdown-item delete-comment text-lg"
+          className="comments-dropdown-item delete-comment text-xs"
           title="Delete Comment"
           onClick={handleDelete}
         >

--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -36,27 +36,27 @@ function CommentItem({
 
   return (
     <div>
-      <div className="space-y-6 px-4 pt-4">
-        <div className="flex space-x-3 items-center">
+      <div className="space-y-4 px-3 pt-3">
+        <div className="flex space-x-2.5 items-center">
           <img
-            className="h-10 w-10 rounded-full"
+            className="h-8 w-8 rounded-full"
             src={comment.user.picture}
             alt={comment.user.name}
           />
-          <div className="flex-1 overflow-hidden">
+          <div className="flex-1 overflow-hidden text-xs">
             <div className="flex items-center justify-between">
-              <h3 className="text-md font-medium overflow-hidden overflow-ellipsis whitespace-pre">
+              <h3 className="font-medium overflow-hidden overflow-ellipsis whitespace-pre">
                 {comment.user.name}
               </h3>
               <CommentActions comment={comment} isRoot={"replies" in comment} />
             </div>
-            <p className="text-md text-gray-500 overflow-hidden overflow-ellipsis whitespace-pre">
+            <p className="text-gray-500 overflow-hidden overflow-ellipsis whitespace-pre">
               {relativeDate}
             </p>
           </div>
         </div>
       </div>
-      <div className="space-y-6 px-4 pt-4 pb-4 text-md">{comment.content}</div>
+      <div className="space-y-4 px-3 pt-3 pb-3 text-xs">{comment.content}</div>
     </div>
   );
 }

--- a/src/ui/components/Comments/TranscriptComments/CommentCardFooter.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCardFooter.tsx
@@ -56,7 +56,7 @@ function NewReply({
 
 function CommentCardFooter({ comment, pendingComment, onReply }: CommentCardFooterProps) {
   const replyPrompt = (
-    <div className="border-t border-gray-200 px-4 py-4 text-lg text-gray-400" onClick={onReply}>
+    <div className="border-t border-gray-200 px-3 py-3 text-gray-400" onClick={onReply}>
       Write a reply...
     </div>
   );

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -50,8 +50,8 @@ function CommentEditor({ comment, handleSubmit, clearPendingComment }: CommentEd
   };
 
   return (
-    <div className="comment-input-container p-2" onClick={e => e.stopPropagation()}>
-      <div className="comment-input text-lg">
+    <div className="comment-input-container text-sm p-1.5" onClick={e => e.stopPropagation()}>
+      <div className="comment-input text-xs">
         <DraftJSEditor
           handleCancel={handleCancel}
           handleSubmit={handleSubmit}
@@ -65,9 +65,7 @@ function CommentEditor({ comment, handleSubmit, clearPendingComment }: CommentEd
       <div className="flex justify-end space-x-2">
         <button
           onClick={clearPendingComment}
-          className={classNames(
-            "justify-center py-2 px-4 text-lg font-medium text-black underline"
-          )}
+          className={classNames("justify-center py-1.5 px-3 font-medium text-black underline")}
         >
           Cancel
         </button>
@@ -75,7 +73,7 @@ function CommentEditor({ comment, handleSubmit, clearPendingComment }: CommentEd
           onClick={onSubmit}
           disabled={!submitEnabled}
           className={classNames(
-            "justify-center py-2 px-4 rounded-md shadow-sm text-lg font-medium",
+            "justify-center py-1.5 px-3 rounded-md shadow-sm font-medium",
             submitEnabled
               ? "bg-primaryAccent text-white hover:bg-primaryAccentHover"
               : "text-white bg-gray-300"

--- a/src/ui/components/Comments/TranscriptComments/CommentSource.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentSource.tsx
@@ -23,11 +23,11 @@ function CommentSource({ comment, createLabels }: CommentSourceProps) {
   }, []);
 
   return (
-    <div className="space-y-6 p-4 rounded-xl rounded-b-none border-b border-gray-200">
-      <div className="text-lg font-medium flex flex-col">
+    <div className="space-y-5 p-3 rounded-xl rounded-b-none border-b border-gray-200">
+      <div className="font-medium flex flex-col">
         <div className="font-semibold">{labels.primary}</div>
         <div
-          className="cm-s-mozilla font-mono overflow-hidden whitespace-pre text-base"
+          className="cm-s-mozilla font-mono overflow-hidden whitespace-pre text-xs"
           dangerouslySetInnerHTML={{ __html: labels.secondary || "" }}
         />
       </div>

--- a/src/ui/components/Comments/VideoComments/VideoComment.tsx
+++ b/src/ui/components/Comments/VideoComments/VideoComment.tsx
@@ -53,7 +53,7 @@ function VideoComment({
           onMouseLeave={() => setHoveredComment(null)}
           style={{ width: `${MARKER_DIAMETER}px`, height: `${MARKER_DIAMETER}px` }}
         />
-        <ChatAltIcon className="w-5 h-5 absolute text-white pointer-events-none	" />
+        <ChatAltIcon className="w-3.5 h-3.5 absolute text-white pointer-events-none	" />
       </div>
     </div>
   );

--- a/src/ui/components/Dashboard/Dashboard.css
+++ b/src/ui/components/Dashboard/Dashboard.css
@@ -9,7 +9,6 @@ main.dashboard {
 
 .dashboard-viewer {
   width: 100%;
-  font-size: 14px;
   display: flex;
   flex-direction: column;
   overflow: auto;

--- a/src/ui/components/Dashboard/DashboardViewer.tsx
+++ b/src/ui/components/Dashboard/DashboardViewer.tsx
@@ -90,7 +90,7 @@ export default function DashboardViewer({ recordings }: { recordings: Recording[
   );
 
   return (
-    <div className={classnames("dashboard-viewer flex-grow", { editing })}>
+    <div className={classnames("dashboard-viewer text-sm flex-grow", { editing })}>
       <DashboardViewerHeader
         selectedIds={selectedIds}
         setSelectedIds={setSelectedIds}
@@ -107,7 +107,7 @@ export default function DashboardViewer({ recordings }: { recordings: Recording[
                 { id: "collaborator", name: "Replays shared with me" },
                 { id: "author", name: "Replays I've authored" },
               ]}
-              className="w-72"
+              className="w-56"
             />
             <SelectMenu
               selected={timeFilter}
@@ -118,7 +118,7 @@ export default function DashboardViewer({ recordings }: { recordings: Recording[
                 { id: "week", name: "This week" },
                 { id: "day", name: "Today" },
               ]}
-              className="w-48"
+              className="w-36"
             />
             <TextInput
               placeholder="Search..."

--- a/src/ui/components/Dashboard/DashboardViewerContent.tsx
+++ b/src/ui/components/Dashboard/DashboardViewerContent.tsx
@@ -20,7 +20,7 @@ function DownloadLinks() {
 
   if (clicked) {
     return (
-      <div className="flex flex-col space-y-8" style={{ maxWidth: "32rem" }}>
+      <div className="flex flex-col space-y-6" style={{ maxWidth: "24rem" }}>
         <div>Download started.</div>
         <div>{`Once the download is finished, open the Replay Browser installer to install Replay`}</div>
       </div>
@@ -28,13 +28,13 @@ function DownloadLinks() {
   }
 
   return (
-    <div className="flex flex-col space-y-8" style={{ maxWidth: "32rem" }}>
+    <div className="flex flex-col space-y-6 text-sm" style={{ maxWidth: "24rem" }}>
       <div>{`There's nothing here yet. To create your first replay, you first need to download the Replay Browser`}</div>
-      <div className="grid gap-4 grid-cols-2">
+      <div className="grid gap-3 grid-cols-2">
         <a
           href="https://replay.io/downloads/replay.dmg"
           className={
-            "w-full text-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
+            "w-full text-center px-3 py-1.5 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
           }
           onClick={() => setClicked(true)}
         >
@@ -43,7 +43,7 @@ function DownloadLinks() {
         <a
           href="https://replay.io/downloads/linux-replay.tar.bz2"
           className={
-            "w-full text-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
+            "w-full text-center px-3 py-1.5 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
           }
           onClick={() => setClicked(true)}
         >
@@ -88,8 +88,8 @@ export default function DashboardViewerContent({
     }
 
     return (
-      <section className="dashboard-viewer-content grid items-center justify-center">
-        <span className="text-xl text-gray-500">{errorText}</span>
+      <section className="dashboard-viewer-content grid items-center justify-center text-sm">
+        <span className="text-gray-500">{errorText}</span>
       </section>
     );
   }
@@ -180,7 +180,7 @@ function DashboardViewerContentHeader({
   };
 
   return (
-    <tr>
+    <tr className="text-xs">
       <th>
         <input
           type="checkbox"

--- a/src/ui/components/Dashboard/DashboardViewerHeader.tsx
+++ b/src/ui/components/Dashboard/DashboardViewerHeader.tsx
@@ -51,7 +51,7 @@ export default function DashboardViewerHeader({
         editing={editing}
         toggleEditing={toggleEditing}
       />
-      <div className="flex flex-row space-x-8 items-center">{filters}</div>
+      <div className="flex flex-row space-x-6 items-center">{filters}</div>
     </header>
   );
 }

--- a/src/ui/components/Dashboard/Navigation/Invitations.tsx
+++ b/src/ui/components/Dashboard/Navigation/Invitations.tsx
@@ -19,12 +19,12 @@ function InvitationCard({
     <div
       className={classNames(
         borderStyles,
-        "relative rounded-lg border bg-white px-6 py-2 shadow-sm flex space-x-3 focus-within:ring-2 focus-within:ring-offset-2"
+        "relative rounded-lg border bg-white px-4 py-1.5 shadow-sm flex space-x-2.5 focus-within:ring-2 focus-within:ring-offset-2"
       )}
     >
       <div className="flex-1 min-w-0 select-none">
-        <p className="text-lg font-medium ">{teamName}</p>
-        <div className="text-lg truncate space-x-2">{actions}</div>
+        <p className="text-base font-medium ">{teamName}</p>
+        <div className="text-base truncate space-x-1.5">{actions}</div>
       </div>
     </div>
   );
@@ -145,9 +145,9 @@ function Invitations({ setWorkspaceId }: PropsFromRedux) {
   };
 
   return (
-    <div className="workspace-invites flex flex-col space-y-4 p-8 items-start">
+    <div className="workspace-invites flex flex-col space-y-3 p-6 items-start">
       <h2 className="font-medium uppercase tracking-wide">{`PENDING INVITATIONS`}</h2>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
         {displayedWorkspaces.map(workspace =>
           acceptedInvitations.includes(workspace) ? (
             <AcceptedInvitation

--- a/src/ui/components/Dashboard/Navigation/NewWorkspaceButton.tsx
+++ b/src/ui/components/Dashboard/Navigation/NewWorkspaceButton.tsx
@@ -19,13 +19,13 @@ function NewWorkspaceButton({ setModal }: NewWorkspaceButtonProps) {
         <a
           href="#"
           className={classnames(
-            "flex flex-row px-4 py-2 text-md cursor-pointer space-x-3 items-center",
+            "flex flex-row px-3 py-1.5 text-md cursor-pointer space-x-2.5 items-center",
             active ? "bg-gray-100 " : ""
           )}
           onClick={onClick}
         >
-          <PlusIcon className="w-6 h-6" />
-          <div className="text-lg">Create a new team</div>
+          <PlusIcon className="w-5 h-5" />
+          <div>Create a new team</div>
         </a>
       )}
     </Menu.Item>

--- a/src/ui/components/Dashboard/Navigation/WorkspaceDropdown.tsx
+++ b/src/ui/components/Dashboard/Navigation/WorkspaceDropdown.tsx
@@ -32,7 +32,7 @@ export default function WorkspaceDropdown({
           >
             <Menu.Items
               static
-              className="origin-top-right absolute left-0 z-10 mt-2 w-72 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 divide-y divide-gray-100 focus:outline-none select-none"
+              className="origin-top-right absolute left-0 z-10 mt-1.5 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 divide-y divide-gray-100 focus:outline-none select-none text-sm overflow-hidden"
             >
               <div className="py-1">
                 {workspaces.map((workspace, i) => (

--- a/src/ui/components/Dashboard/Navigation/WorkspaceDropdownButton.tsx
+++ b/src/ui/components/Dashboard/Navigation/WorkspaceDropdownButton.tsx
@@ -35,9 +35,9 @@ function WorkspaceDropdownButton({ workspaces, currentWorkspaceId }: WorkspaceDr
   }
 
   return (
-    <Menu.Button className="inline-flex items-center justify-center w-full rounded-md px-0 mx-2 py-2 text-2xl font-medium  hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-primaryAccent">
+    <Menu.Button className="inline-flex items-center justify-center w-full rounded-md px-0 mx-1.5 py-1.5 text-lg font-medium  hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-primaryAccent">
       <Redacted>{title}</Redacted>
-      <ChevronDownIcon className="-mr-1 ml-2 h-6 w-6" aria-hidden="true" />
+      <ChevronDownIcon className="-mr-1 ml-1.5 h-5 w-5" aria-hidden="true" />
     </Menu.Button>
   );
 }

--- a/src/ui/components/Dashboard/Navigation/WorkspaceItem.tsx
+++ b/src/ui/components/Dashboard/Navigation/WorkspaceItem.tsx
@@ -28,9 +28,9 @@ function WorkspaceItem({ workspace, currentWorkspaceId, setWorkspaceId }: Worksp
   let icon: ReactElement;
 
   if (workspace.id == null) {
-    icon = <UserIcon className="w-6 h-6 flex-shrink-0" />;
+    icon = <UserIcon className="w-5 h-5 flex-shrink-0" />;
   } else {
-    icon = <UserGroupIcon className="w-6 h-6 flex-shrink-0" />;
+    icon = <UserGroupIcon className="w-5 h-5 flex-shrink-0" />;
   }
 
   return (
@@ -39,7 +39,7 @@ function WorkspaceItem({ workspace, currentWorkspaceId, setWorkspaceId }: Worksp
         <a
           href="#"
           className={classnames(
-            "flex flex-row px-4 py-2 text-md cursor-pointer space-x-3 text-lg items-center",
+            "flex flex-row px-3 py-1.5 text-md cursor-pointer space-x-2.5 text-sm items-center",
             active ? "bg-gray-100 " : "",
             currentWorkspaceId == workspace.id ? "font-semibold" : ""
           )}

--- a/src/ui/components/Dashboard/RecordingItem/RecordingItemDropdown.tsx
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingItemDropdown.tsx
@@ -64,7 +64,7 @@ const DropdownPanel = ({
   };
 
   return (
-    <div className="dropdown-panel">
+    <div className="dropdown-panel text-sm">
       {!editingTitle ? (
         <div className="menu-item" onClick={() => setEditingTitle(true)}>
           Edit title

--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.css
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.css
@@ -47,7 +47,6 @@
 
 .recording-list thead.dashboard-viewer-content-header {
   display: contents;
-  font-size: 1rem;
   font-weight: 700;
   color: var(--theme-text-color-inactive);
 }

--- a/src/ui/components/Dashboard/RecordingItem/RecordingListItem.tsx
+++ b/src/ui/components/Dashboard/RecordingItem/RecordingListItem.tsx
@@ -214,7 +214,7 @@ export default function RecordingListItem({
       <td>
         {data.comments.length ? (
           <div className="flex flex-row space-x-1 items-center">
-            <ChatAltIcon className="w-6 h-6 text-gray-500" />
+            <ChatAltIcon className="w-5 h-5 text-gray-500" />
             <span>{data.comments.length}</span>
           </div>
         ) : null}

--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -59,11 +59,11 @@ function Event({
       onClick={() => onSeek(event.point, event.time)}
       title={title}
       className={classNames(
-        "flex flex-row items-center justify-between p-4 rounded-lg hover:bg-gray-100 focus:outline-none",
+        "flex flex-row items-center justify-between p-3 rounded-lg hover:bg-gray-100 focus:outline-none",
         isPaused ? "text-primaryAccent" : ""
       )}
     >
-      <div className="flex flex-row space-x-2 items-center overflow-hidden">
+      <div className="flex flex-row space-x-1.5 items-center overflow-hidden">
         <MaterialIcon highlighted={isPaused}>{icon}</MaterialIcon>
         <div
           className={classNames(
@@ -89,7 +89,7 @@ function EventsLoaderItem({ category, isLoading }: { category: string; isLoading
           className="flex flex-col items-center justify-center"
           style={{ minHeight: "22px", minWidth: "22px" }}
         >
-          <Spinner className="animate-spin h-6 w-6" />
+          <Spinner className="animate-spin h-5 w-5" />
         </div>
       ) : (
         <MaterialIcon>done</MaterialIcon>
@@ -105,7 +105,7 @@ function EventsLoader({
   eventCategoriesLoading: { [key: string]: boolean };
 }) {
   return (
-    <div className="space-y-4 flex flex-col w-full p-4 bg-gray-100 rounded-lg">
+    <div className="space-y-3 flex flex-col w-full p-3 bg-gray-100 rounded-md">
       <strong>Loading events:</strong>
       <div className="flex flex-col w-full space-y-1">
         {Object.keys(eventCategoriesLoading).map(category => {
@@ -140,7 +140,7 @@ function Events({
         <div className="right-sidebar-toolbar-item">Events</div>
       </div>
       <div className="flex-grow overflow-auto overflow-x-hidden flex flex-column items-center bg-white h-full">
-        <div className="flex flex-col p-2 self-stretch space-y-2 w-full">
+        <div className="flex flex-col p-1.5 self-stretch space-y-1.5 w-full text-xs">
           {progressPercentage < 100 ? <EventsLoader {...{ eventCategoriesLoading }} /> : null}
           {events.map((e, i) => (
             <Event key={i} onSeek={onSeek} event={e} {...{ currentTime, executionPoint }} />

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -93,7 +93,7 @@ function HeaderTitle({
 
   return (
     <span
-      className="input focus:ring-primaryAccent ml-2 focus:border-blue-500 text-2xl p-1 bg-transparent border-black whitespace-pre overflow-hidden overflow-ellipsis"
+      className="input focus:ring-primaryAccent ml-2 focus:border-blue-500 text-lg p-0.5 bg-transparent border-black whitespace-pre overflow-hidden overflow-ellipsis"
       role="textbox"
       spellCheck="false"
       contentEditable

--- a/src/ui/components/Header/ShareButton.tsx
+++ b/src/ui/components/Header/ShareButton.tsx
@@ -11,7 +11,7 @@ function ShareButton({ setModal }: PropsFromRedux) {
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center px-6 py-2 border-2 border-bg-blue-100 text-xl rounded-xl text-black-700 bg-white hover:bg-blue-100 hover:border-blue-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent h-11 mr-0 sharebutton"
+      className="inline-flex items-center px-4 py-1.5 border-2 border-bg-blue-100 rounded-lg text-black-700 bg-white hover:bg-blue-100 hover:border-blue-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent h-8 mr-0 sharebutton"
     >
       Share
     </button>

--- a/src/ui/components/Header/ShareDropdown.tsx
+++ b/src/ui/components/Header/ShareDropdown.tsx
@@ -76,7 +76,7 @@ function PrivacyNote({ isPrivate, isOwner }: { isPrivate: boolean; isOwner: bool
 
   return (
     <div className={`row privacy-note ${isPrivate ? "is-private" : "is-public"}`}>
-      <div style={{ width: "67px" }} />
+      <div style={{ width: "52px" }} />
       <div className="label">
         <div className="label-title">Note</div>
         <div className="label-description">

--- a/src/ui/components/Header/ViewToggle.css
+++ b/src/ui/components/Header/ViewToggle.css
@@ -26,7 +26,6 @@
 }
 
 .view-toggle .text {
-  font-size: 15px;
   min-width: 145px;
   text-align: center;
   padding: 3px 36px;

--- a/src/ui/components/LoginButton.tsx
+++ b/src/ui/components/LoginButton.tsx
@@ -23,7 +23,7 @@ const LoginButton = () => {
         })
       }
       type="button"
-      className="inline-flex items-center px-6 py-2 text-xl rounded-lg bg-primaryAccent hover:bg-primaryAccentHover text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent mr-0 sharebutton"
+      className="inline-flex items-center px-4 py-1.5 text-xl rounded-lg bg-primaryAccent hover:bg-primaryAccentHover text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent mr-0 sharebutton"
     >
       Sign In
     </button>

--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -28,7 +28,6 @@
 }
 
 .secondary-toolbox-header button {
-  font-size: 15px;
   padding: 8px 12px;
   cursor: pointer;
   transition: color 200ms;

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -45,7 +45,7 @@ function PanelButtons({
   };
 
   return (
-    <div className="flex flex-row items-center overflow-hidden">
+    <div className="flex flex-row items-center overflow-hidden text-sm">
       {showElements && !isNode && <NodePicker />}
       <button
         className={classnames("console-panel-button", { expanded: selectedPanel === "console" })}
@@ -127,7 +127,7 @@ function SecondaryToolbox({
           </button>
         </header>
       )}
-      <div className="secondary-toolbox-content">
+      <div className="secondary-toolbox-content text-xs">
         {selectedPanel === "console" ? <ConsolePanel /> : null}
         {selectedPanel === "inspector" ? <InspectorPanel /> : null}
         {showReact && selectedPanel === "react-components" ? <ReactDevtoolsPanel /> : null}

--- a/src/ui/components/SkeletonLoader.tsx
+++ b/src/ui/components/SkeletonLoader.tsx
@@ -16,7 +16,6 @@ type SkeletonProps = PropsFromRedux & {
 function SkeletonLoader({ setFinishedLoading, progress = 1, content, viewMode }: SkeletonProps) {
   const [displayedProgress, setDisplayedProgress] = useState(0);
   const key = useRef<any>(null);
-  const backgroundColor = `hsl(0, 0%, 98%)`;
 
   useEffect(() => {
     return () => clearTimeout(key.current);

--- a/src/ui/components/TOSScreen.tsx
+++ b/src/ui/components/TOSScreen.tsx
@@ -16,11 +16,11 @@ export default function TOSScreen() {
       <BlankScreen background="white" />
       <Modal options={{ maskTransparency: "transparent" }}>
         <div
-          className="p-12 bg-white rounded-lg shadow-2xl text-xl space-y-8 relative flex flex-col items-center"
+          className="p-9 bg-white rounded-lg shadow-xl text-xl space-y-6 relative flex flex-col items-center"
           style={{ width: "520px" }}
         >
           <div className="space-y-4 place-content-center">
-            <img className="w-16 h-16 mx-auto" src="/images/logo.svg" />
+            <img className="w-12 h-12 mx-auto" src="/images/logo.svg" />
           </div>
           <div className="font-bold text-2xl">Terms of Use</div>
           <div>
@@ -36,7 +36,7 @@ export default function TOSScreen() {
             help define Replay’s relationship with you as you interact with our services. This
             includes:
           </div>
-          <ul className="list-disc pl-8 space-y-2">
+          <ul className="list-disc pl-6 space-y-1.5">
             <li>
               <span className="font-medium">What you can expect from us</span>, which describes how
               we provide and develop our services

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -42,7 +42,7 @@ function IndexingLoader({
   }
 
   return (
-    <div className="w-8 h-8" title={`Indexing (${progressPercentage.toFixed()}%)`}>
+    <div className="w-6 h-6" title={`Indexing (${progressPercentage.toFixed()}%)`}>
       <CircularProgressbar
         value={progressPercentage}
         strokeWidth={10}
@@ -76,7 +76,7 @@ function Toolbar({
   }
 
   return (
-    <div className="toolbox-toolbar-container flex flex-col items-center justify-between p-2 pb-8">
+    <div className="toolbox-toolbar-container flex flex-col items-center justify-between p-1.5 pb-6">
       <div id="toolbox-toolbar">
         <div
           className={classnames("toolbar-panel-button comments", {

--- a/src/ui/components/Toolbox.tsx
+++ b/src/ui/components/Toolbox.tsx
@@ -7,7 +7,7 @@ export default function Toolbox() {
   return (
     <div id="toolbox">
       <div className="toolbox-top-panels">
-        <div className="toolbox-panel" id="toolbox-content-debugger">
+        <div className="toolbox-panel text-xs" id="toolbox-content-debugger">
           <DebuggerApp />
         </div>
       </div>

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -45,7 +45,7 @@ function Transcript({ pendingComment }: PropsFromRedux) {
       <div className="right-sidebar-toolbar">
         <div className="right-sidebar-toolbar-item comments">Comments</div>
       </div>
-      <div className="transcript-list flex-grow overflow-auto overflow-x-hidden flex flex-col items-center bg-white h-full">
+      <div className="transcript-list flex-grow overflow-auto overflow-x-hidden flex flex-col items-center bg-white h-full text-sm">
         {displayedComments.length > 0 ? (
           <div className="p-3 overflow-auto w-full flex-grow space-y-3">
             {sortBy(displayedComments, ["time"]).map(comment => {
@@ -53,7 +53,7 @@ function Transcript({ pendingComment }: PropsFromRedux) {
             })}
           </div>
         ) : (
-          <div className="transcript-list p-4 self-stretch space-y-4 text-lg text-gray-500 onboarding-text">
+          <div className="transcript-list p-3 self-stretch space-y-3 text-base text-gray-500 onboarding-text">
             <MaterialIcon className="forum large-icon">forum</MaterialIcon>
             <h2>{isAuthenticated ? "Start a conversation" : "Sign in to get started"}</h2>
 

--- a/src/ui/components/UploadScreen/PrivacyToggle.tsx
+++ b/src/ui/components/UploadScreen/PrivacyToggle.tsx
@@ -9,7 +9,7 @@ export default function PrivacyToggle({
   setIsPublic: Dispatch<SetStateAction<boolean>>;
 }) {
   return (
-    <div className="flex flex-row space-x-4 items-center">
+    <div className="flex flex-row space-x-3 items-center">
       <input
         type="checkbox"
         checked={isPublic}

--- a/src/ui/components/UploadScreen/ReplayTitle.tsx
+++ b/src/ui/components/UploadScreen/ReplayTitle.tsx
@@ -14,7 +14,7 @@ export default function ReplayTitle({
 
   return (
     <div>
-      <label htmlFor="replay-title" className="block text-sm uppercase font-semibold ">
+      <label htmlFor="replay-title" className="block text-xs uppercase font-semibold ">
         Title
       </label>
       <div className="mt-1">

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -32,11 +32,11 @@ function DeletedScreen({ url }: { url: string }) {
     >
       <Modal>
         <div
-          className="p-12 bg-white rounded-lg shadow-xl text-lg space-y-12 relative flex flex-col justify-between"
-          style={{ width: "400px" }}
+          className="p-9 bg-white rounded-md shadow-xl text-base space-y-9 relative flex flex-col justify-between"
+          style={{ width: "300px" }}
         >
-          <h2 className="font-bold text-3xl ">{`Redirecting...`}</h2>
-          <div className="text-gray-500 space-y-6 text-xl">
+          <h2 className="font-bold text-2xl ">{`Redirecting...`}</h2>
+          <div className="text-gray-500 space-y-5 text-lg">
             <div>{`Sit tight! We'll take you back to the library in a few seconds.`}</div>
           </div>
           <div className="space-y-1">
@@ -44,7 +44,7 @@ function DeletedScreen({ url }: { url: string }) {
               type="button"
               onClick={navigateToUrl}
               className={classNames(
-                "inline-flex items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccentHover justify-center",
+                "inline-flex items-center px-3 py-1.5 border border-transparent text-base font-medium rounded shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccentHover justify-center",
                 "text-white bg-primaryAccent hover:bg-primaryAccentHover"
               )}
             >
@@ -76,13 +76,13 @@ function Actions({ onDiscard, status }: { onDiscard: () => void; status: Status 
   const isDeleting = status === "deleting";
 
   return (
-    <div className="grid grid-cols-2 gap-4">
+    <div className="grid grid-cols-2 gap-4 text-sm">
       <button
         type="button"
         onClick={onDiscard}
         disabled={isSaving || isDeleting}
         className={classNames(
-          "inline-flex items-center px-4 py-2 border border-textFieldBorder text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent justify-center",
+          "inline-flex items-center px-4 py-2 border border-textFieldBorder font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent justify-center",
           "text-gray-500 hover:bg-gray-100 hover:"
         )}
       >
@@ -93,7 +93,7 @@ function Actions({ onDiscard, status }: { onDiscard: () => void; status: Status 
         disabled={isSaving || isDeleting}
         value={isSaving ? `Uploading…` : `Save & Upload`}
         className={classNames(
-          "inline-flex items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccentHover justify-center cursor-pointer",
+          "inline-flex items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccentHover justify-center cursor-pointer",
           "text-white bg-primaryAccent hover:bg-primaryAccentHover"
         )}
       ></input>
@@ -104,19 +104,19 @@ function Actions({ onDiscard, status }: { onDiscard: () => void; status: Status 
 function ReplayPreview({ recording, screenData }: { recording: Recording; screenData: string }) {
   return (
     <div className="space-y-1">
-      <div className="block text-sm uppercase font-semibold ">Preview</div>
+      <div className="block text-xs uppercase font-semibold ">Preview</div>
       <div
-        className="relative bg-gray-100 border border-gray-200 rounded-lg"
+        className="relative bg-gray-100 border border-gray-200 rounded-lg text-xs"
         style={{ height: "200px" }}
       >
         <img src={screenData} className="h-full m-auto" />
         <div
           style={{ maxWidth: "50%" }}
-          className="bg-gray-700 text-white bottom-4 left-4 rounded-lg px-3 py-0.5 absolute text-base select-none"
+          className="bg-gray-700 text-white bottom-4 left-4 rounded-lg px-3 py-0.5 absolute select-none"
         >
           <div className="whitespace-pre overflow-hidden overflow-ellipsis">{recording.url}</div>
         </div>
-        <div className="bg-gray-700 text-white bottom-4 right-4 rounded-lg px-3 py-0.5 absolute text-base select-none">
+        <div className="bg-gray-700 text-white bottom-4 right-4 rounded-lg px-3 py-0.5 absolute select-none">
           {getFormattedTime(recording!.duration)}
         </div>
       </div>
@@ -158,13 +158,13 @@ export function SharingSettings({
   return (
     <>
       <div className="">
-        <label className="block text-sm uppercase font-semibold ">Team</label>
+        <label className="block text-sm uppercase font-semibold">Team</label>
         {workspaces.length ? (
           <TeamSelect {...{ workspaces, handleWorkspaceSelect, selectedWorkspaceId }} />
         ) : null}
       </div>
-      <div className="text-lg space-y-2">
-        <label className="block text-sm uppercase font-semibold ">Privacy</label>
+      <div className="space-y-2 text-sm">
+        <label className="block text-xs uppercase font-semibold">Privacy</label>
         <div className="space-y-1">
           <div className="space-x-2 items-center">
             <input
@@ -231,7 +231,7 @@ function SharingPreview({
   }
 
   return (
-    <div className="flex flex-row items-center space-x-4">
+    <div className="flex flex-row items-center space-x-4 text-sm">
       <span className="material-icons">{icon}</span>
       <div className="flex flex-col flex-grow overflow-hidden">
         <div className="overflow-hidden overflow-ellipsis whitespace-pre">{text}</div>
@@ -317,7 +317,7 @@ export default function UploadScreen({ recording, userSettings }: UploadScreenPr
           className="p-12 bg-white rounded-lg shadow-xl text-lg space-y-12 relative flex flex-col justify-between"
           style={{ width: "520px" }}
         >
-          <h2 className="font-bold text-3xl ">Save and Upload</h2>
+          <h2 className="font-bold text-2xl ">Save and Upload</h2>
           <form className="space-y-6" onSubmit={e => onSubmit(e)}>
             <ReplayTitle inputValue={inputValue} setInputValue={setInputValue} />
             <ReplayPreview recording={recording} screenData={screenData!} />

--- a/src/ui/components/WelcomeBanner.tsx
+++ b/src/ui/components/WelcomeBanner.tsx
@@ -15,7 +15,7 @@ export default function WelcomeBanner({
     <div className="w-full h-full flex justify-center items-center">
       <div className="relative overflow-hidden text-center">
         {title || em ? (
-          <h1 className="text-6xl font-bold text-gray-800">
+          <h1 className="text-5xl font-bold text-gray-800">
             {title}{" "}
             <div className="inline-block relative">
               {em}
@@ -55,7 +55,7 @@ export default function WelcomeBanner({
           </h1>
         ) : null}
         {subtitle ? (
-          <h2 style={{ width: "660px" }} className="text-2xl mt-8 text-gray-600">
+          <h2 style={{ width: "660px" }} className="text-xl mt-6 text-gray-600">
             {subtitle}
           </h2>
         ) : null}

--- a/src/ui/components/shared/APIKeys.tsx
+++ b/src/ui/components/shared/APIKeys.tsx
@@ -20,9 +20,9 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
 
   return (
     <>
-      <div className="flex items-center justify-between space-x-4">
+      <div className="flex items-center justify-between space-x-3">
         <div className="flex-auto w-0">
-          <div className="flex items-center px-3 h-12 w-full border border-textFieldBorder rounded-md bg-blue-100">
+          <div className="flex items-center px-2.5 h-9 w-full border border-textFieldBorder rounded-md bg-blue-100">
             <input
               readOnly
               value={keyValue}
@@ -33,7 +33,7 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
               <div className="mx-3 text-primaryAccent">Copied!</div>
             ) : (
               <MaterialIcon
-                className="material-icons mx-3 w-7 h-7 text-primaryAccent"
+                className="material-icons mx-2.5 w-5 h-5 text-primaryAccent"
                 onClick={() => navigator.clipboard.writeText(keyValue!).then(() => setCopied(true))}
               >
                 assignment_outline
@@ -42,13 +42,13 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
           </div>
         </div>
         <button
-          className="inline-flex items-center px-3 py-2 h-12 border border-transparent leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:bg-primaryAccentHover"
+          className="inline-flex items-center px-2.5 py-1.5 h-9 border border-transparent leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:bg-primaryAccentHover"
           onClick={onDone}
         >
           Done
         </button>
       </div>
-      <div className="flex items-center p-3 border border-textFieldBorder rounded-md bg-red-100">
+      <div className="flex items-center p-2.5 border border-textFieldBorder rounded-md bg-red-100">
         Make sure to copy your API key now. You won{"'"}t be able to see it again!
       </div>
     </>
@@ -63,10 +63,10 @@ function ApiKeyList({ apiKeys, onDelete }: { apiKeys: ApiKey[]; onDelete: (id: s
       <h3 className="text-base uppercase font-semibold">API Keys</h3>
       <div className="flex-auto overflow-auto h-0">
         {apiKeys.map(apiKey => (
-          <div className="flex flex-row items-center py-2" key={apiKey.id}>
+          <div className="flex flex-row items-center py-1.5" key={apiKey.id}>
             <span className="flex-auto">{apiKey.label}</span>
             <button
-              className="inline-flex items-center p-3 text-sm shadow-sm leading-4 rounded-md bg-gray-100 text-red-500 hover:text-red-700 focus:outline-none focus:text-red-700"
+              className="inline-flex items-center p-2.5 text-sm shadow-sm leading-4 rounded-md bg-gray-100 text-red-500 hover:text-red-700 focus:outline-none focus:text-red-700"
               onClick={() => {
                 const message =
                   "This action will permanently delete this API key. \n\nAre you sure you want to proceed?";
@@ -133,10 +133,10 @@ export default function APIKeys({
         <NewApiKey keyValue={keyValue} onDone={() => setKeyValue(undefined)} />
       ) : (
         <>
-          <section className="space-y-3">
-            <h3 className="text-base uppercase font-semibold">Create new API Key</h3>
+          <section className="space-y-2.5 text-sm">
+            <h3 className="uppercase font-semibold text-xs">Create new API Key</h3>
             <form
-              className="space-y-4"
+              className="space-y-3"
               onSubmit={ev => {
                 canSubmit &&
                   addKey(label, selectedScopes).then(resp => {
@@ -148,7 +148,7 @@ export default function APIKeys({
                 ev.preventDefault();
               }}
             >
-              <fieldset className="w-full space-x-2 flex flex-row">
+              <fieldset className="w-full space-x-1.5 flex flex-row">
                 <TextInput
                   disabled={loading}
                   placeholder="API Key Label"
@@ -159,7 +159,7 @@ export default function APIKeys({
                 <button
                   type="submit"
                   disabled={!canSubmit}
-                  className={`inline-flex items-center px-3 py-2 border border-transparent leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent focus:outline-none ${
+                  className={`inline-flex items-center px-2.5 py-1.5 border border-transparent leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent focus:outline-none ${
                     canSubmit
                       ? "hover:bg-primaryAccentHover focus:bg-primaryAccentHover"
                       : "opacity-60"
@@ -172,7 +172,7 @@ export default function APIKeys({
                 <fieldset className="w-full">
                   <h4 className="text-sm uppercase font-semibold">Permissions</h4>
                   {scopes.map(scope => (
-                    <label key={scope} className="inline-block space-x-2 mx-2">
+                    <label key={scope} className="inline-block space-x-1.5 mx-1.5">
                       <input
                         type="checkbox"
                         onChange={e =>
@@ -190,7 +190,7 @@ export default function APIKeys({
                     </label>
                   ))}
                   {selectedScopes.length === 0 ? (
-                    <div className="mt-3 flex items-center p-3 border border-textFieldBorder rounded-md bg-red-100">
+                    <div className="mt-2.5 flex items-center p-2.5 border border-textFieldBorder rounded-md bg-red-100">
                       At least one permission must be selected.
                     </div>
                   ) : null}

--- a/src/ui/components/shared/BlankScreen.tsx
+++ b/src/ui/components/shared/BlankScreen.tsx
@@ -52,12 +52,12 @@ export function BlankLoadingScreen({
     <BlankScreen background={background}>
       <div className="m-auto">
         <div
-          className={classNames("flex flex-col items-center space-y-4  opacity-90 rounded-md p-8", {
+          className={classNames("flex flex-col items-center space-y-3 opacity-90 rounded-md p-6", {
             "bg-white": background == "white",
           })}
         >
           <div
-            className={classNames("text-xl", {
+            className={classNames("text-lg", {
               invisible: !statusMessage,
               "text-white": background === "blue-gradient",
             })}
@@ -65,7 +65,7 @@ export function BlankLoadingScreen({
             {statusMessage || defaultStatusMessage}
           </div>
           <Spinner
-            className={classNames("animate-spin -ml-1 mr-3 h-8 w-8", {
+            className={classNames("animate-spin -ml-1 mr-2.5 h-6 w-6", {
               "text-white": background === "blue-gradient",
             })}
           />
@@ -80,8 +80,8 @@ export function BlankProgressScreen({ progress }: { progress: number }) {
   return (
     <BlankScreen background="white">
       <div className="m-auto">
-        <div className="flex flex-col items-center space-y-4">
-          <div className="text-xl">Preparing replay</div>
+        <div className="flex flex-col items-center space-y-3">
+          <div className="text-lg">Preparing replay</div>
           <div className="w-40 relative h-1 bg-gray-200 rounded-lg overflow-hidden">
             <div
               className="absolute t-0 h-full bg-primaryAccent"

--- a/src/ui/components/shared/Button.tsx
+++ b/src/ui/components/shared/Button.tsx
@@ -46,7 +46,7 @@ function getColorClasses(color: Colors, style: ButtonStyles) {
 
   if (style === "primary") {
     textStyle = getTextClass("white");
-    bgStyle = `bg-primaryAccent hover:bg-${getColorCode(color, 700)}`;
+    bgStyle = `bg-${getColorCode(color, 600)} hover:bg-${getColorCode(color, 700)}`;
   } else if (style === "secondary") {
     textStyle = getTextClass(color);
     bgStyle = `bg-white border-${getColorCode(color, 600)} hover:border-${getColorCode(
@@ -61,7 +61,7 @@ function getColorClasses(color: Colors, style: ButtonStyles) {
   return `${textStyle} ${bgStyle}`;
 }
 
-function Button({
+export function Button({
   size,
   children,
   style,
@@ -95,21 +95,21 @@ interface ButtonProps {
 }
 
 export const PrimaryLgButton = (props: ButtonProps & { color: Colors }) => (
-  <Button {...props} size="3xl" style="primary" />
+  <Button {...props} size="2xl" style="primary" />
 );
 export const SecondaryLgButton = (props: ButtonProps & { color: Colors }) => (
-  <Button {...props} size="3xl" style="secondary" />
+  <Button {...props} size="2xl" style="secondary" />
 );
 export const DisabledLgButton = (props: ButtonProps) => (
-  <Button {...props} size="3xl" style="disabled" className="cursor-default" color="gray" />
+  <Button {...props} size="2xl" style="disabled" className="cursor-default" color="gray" />
 );
 
 export const PrimaryButton = (props: ButtonProps & { color: Colors }) => (
-  <Button {...props} size="2xl" style="primary" />
+  <Button {...props} size="md" style="primary" />
 );
 export const SecondaryButton = (props: ButtonProps & { color: Colors }) => (
-  <Button {...props} size="2xl" style="secondary" />
+  <Button {...props} size="md" style="secondary" />
 );
 export const DisabledButton = (props: ButtonProps) => (
-  <Button {...props} size="2xl" style="disabled" className="cursor-default" color="gray" />
+  <Button {...props} size="md" style="disabled" className="cursor-default" color="gray" />
 );

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -150,7 +150,7 @@ function CommentTool({
     <div style={parentStyle} className="absolute">
       <div
         className={classNames(
-          "px-3 py-1 absolute text-base text-white rounded-2xl w-max space-x-2 flex items-center bg-black bg-opacity-70",
+          "px-2.5 py-1 absolute text-base text-white rounded-2xl w-max space-x-1.5 flex items-center bg-black bg-opacity-70",
           !captionNode.current ? "invisible" : ""
         )}
         style={childStyle}

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -36,7 +36,7 @@ function RefreshButton() {
       onClick={onClick}
       disabled={clicked}
       className={classNames(
-        "w-full inline-flex items-center justify-center px-24 py-3 border border-transparent text-2xl font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
+        "w-full inline-flex items-center justify-center px-16 py-2.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
       )}
     >
       {clicked ? `Refreshing...` : `Refresh`}
@@ -58,7 +58,7 @@ function SignInButton() {
       type="button"
       onClick={onClick}
       className={classNames(
-        "w-full inline-flex items-center justify-center px-24 py-3 border border-transparent text-2xl font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
+        "w-full inline-flex items-center justify-center px-16 py-2.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
       )}
     >
       Sign in to Replay
@@ -76,7 +76,7 @@ function LibraryButton() {
       type="button"
       onClick={onClick}
       className={classNames(
-        "w-full inline-flex items-center justify-center px-24 py-3 border border-transparent text-2xl font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
+        "w-full inline-flex items-center justify-center px-16 py-2.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
       )}
     >
       Back to Library
@@ -102,14 +102,14 @@ function Error({ error }: { error: ExpectedError | UnexpectedError }) {
   const { action, message, content } = error;
 
   return (
-    <section className="max-w-2xl w-full m-auto bg-white shadow-lg rounded-lg overflow-hidden">
-      <div className="p-16 h-84 space-y-12 items-center flex flex-col">
+    <section className="max-w-lg w-full m-auto bg-white shadow-lg rounded-lg overflow-hidden text-base">
+      <div className="p-12 h-64 space-y-12 items-center flex flex-col">
         <div className="space-y-4 place-content-center">
-          <img className="w-16 h-16 mx-auto" src="/images/logo.svg" />
+          <img className="w-12 h-12 mx-auto" src="/images/logo.svg" />
         </div>
-        <div className="text-center space-y-4">
-          {message ? <div className="font-bold text-2xl">{message}</div> : null}
-          {content ? <div className="text-xl text-gray-500">{content}</div> : null}
+        <div className="text-center space-y-3">
+          {message ? <div className="font-bold text-lg">{message}</div> : null}
+          {content ? <div className="text-gray-500">{content}</div> : null}
         </div>
         {action ? <ActionButton action={action} /> : null}
       </div>

--- a/src/ui/components/shared/Forms/SelectMenu.tsx
+++ b/src/ui/components/shared/Forms/SelectMenu.tsx
@@ -15,7 +15,7 @@ function Option({ name, id }: { name: string; id: string | null }) {
       className={({ active }) =>
         classnames(
           active ? "text-white bg-primaryAccent" : "",
-          "cursor-default select-none relative py-2 pl-3 pr-9"
+          "cursor-default select-none relative py-1.5 pl-2.5 pr-7"
         )
       }
       value={id}
@@ -31,10 +31,10 @@ function Option({ name, id }: { name: string; id: string | null }) {
             <span
               className={classnames(
                 active ? "text-white" : "text-primaryAccent",
-                "absolute inset-y-0 right-0 flex items-center pr-4"
+                "absolute inset-y-0 right-0 flex items-center pr-3"
               )}
             >
-              <CheckIcon className="h-5 w-5" aria-hidden="true" />
+              <CheckIcon className="h-4 w-4" aria-hidden="true" />
             </span>
           ) : null}
         </>
@@ -59,20 +59,16 @@ export default function SelectMenu({
   const selectedName = options.find(option => option.id === selected)!.name;
 
   return (
-    <div>
+    <div className="text-sm">
       <Listbox value={selected} onChange={setSelected}>
         {({ open }) => (
           <>
-            {label ? (
-              <Listbox.Label className="block text-md font-medium ">
-                label
-              </Listbox.Label>
-            ) : null}
-            <div className={`mt-1 relative z-10 ${className}`}>
-              <Listbox.Button className="bg-white relative w-full border border-textFieldBorder rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-primaryAccent focus:border-primaryAccentHover text-lg">
+            {label ? <Listbox.Label className="block font-medium ">label</Listbox.Label> : null}
+            <div className={`relative z-10 ${className}`}>
+              <Listbox.Button className="bg-white relative w-full border border-textFieldBorder rounded-md shadow-sm pl-2.5 pr-8 py-1.5 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-primaryAccent focus:border-primaryAccentHover">
                 <span className="block truncate">{selectedName}</span>
-                <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                  <SelectorIcon className="h-5 w-5 text-textFieldBorder" aria-hidden="true" />
+                <span className="absolute inset-y-0 right-0 flex items-center pr-1.5 pointer-events-none">
+                  <SelectorIcon className="h-4 w-4 text-textFieldBorder" aria-hidden="true" />
                 </span>
               </Listbox.Button>
               <Transition
@@ -84,7 +80,7 @@ export default function SelectMenu({
               >
                 <Listbox.Options
                   static
-                  className="absolute mt-1 w-full bg-white shadow-lg max-h-60 rounded-md py-1 ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none text-lg"
+                  className="absolute mt-1 w-full bg-white shadow-lg max-h-48 rounded-md py-1 ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none"
                 >
                   {options.map(({ name, id }) => (
                     <Option name={name} id={id} key={id} />

--- a/src/ui/components/shared/Forms/TextInput.tsx
+++ b/src/ui/components/shared/Forms/TextInput.tsx
@@ -16,9 +16,9 @@ export default React.forwardRef<
       ref={ref}
       type="text"
       className={classNames(
-        textSize === "xl" ? "text-4xl" : textSize === "lg" ? "text-2xl" : "text-lg",
+        textSize === "xl" ? "text-2xl" : textSize === "lg" ? "text-base" : "text-sm",
         center ? "text-center" : "",
-        "focus:ring-primaryAccent focus:primaryAccentHover block w-full border px-3 py-2 border-textFieldBorder rounded-md"
+        "focus:ring-primaryAccent focus:primaryAccentHover block w-full border px-2.5 py-1.5 border-textFieldBorder rounded-md"
       )}
     />
   );

--- a/src/ui/components/shared/Forms/Toggle.tsx
+++ b/src/ui/components/shared/Forms/Toggle.tsx
@@ -15,14 +15,14 @@ export default function Toggle({
       onChange={setEnabled}
       className={classnames(
         enabled ? "bg-green-600" : "bg-gray-200",
-        "relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
+        "relative inline-flex flex-shrink-0 h-4 w-8 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
       )}
     >
       <span
         aria-hidden="true"
         className={classnames(
           enabled ? "translate-x-5" : "translate-x-0",
-          "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200"
+          "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200"
         )}
       />
     </Switch>

--- a/src/ui/components/shared/IconWithTooltip.tsx
+++ b/src/ui/components/shared/IconWithTooltip.tsx
@@ -22,7 +22,7 @@ export default function IconWithTooltip({ icon, content, handleClick }: IconWith
   };
 
   return (
-    <div className="icon-with-tooltip">
+    <div className="icon-with-tooltip text-sm">
       <button onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} onClick={handleClick}>
         {icon}
       </button>

--- a/src/ui/components/shared/LaunchBrowserModal.tsx
+++ b/src/ui/components/shared/LaunchBrowserModal.tsx
@@ -16,19 +16,19 @@ function LaunchBrowser({
   }, [path]);
 
   return (
-    <section className="max-w-2xl w-full m-auto bg-white shadow-lg rounded-lg overflow-hidden relative">
-      <div className="p-16 h-84 space-y-12 items-center flex flex-col">
-        <div className="space-y-4 place-content-center">
-          <img className="w-16 h-16 mx-auto" src="/images/logo.svg" />
+    <section className="max-w-xl w-full m-auto bg-white shadow-lg rounded-lg overflow-hidden relative text-sm">
+      <div className="p-12 space-y-9 items-center flex flex-col">
+        <div className="space-y-3 place-content-center">
+          <img className="w-12 h-12 mx-auto" src="/images/logo.svg" />
         </div>
-        <div className="text-center space-y-4">
-          <div className="font-bold text-2xl">Launching Replay ...</div>
-          <div className="text-xl text-gray-500 space-y-8">
+        <div className="text-center space-y-3">
+          <div className="font-bold text-lg">Launching Replay ...</div>
+          <div className="text-gray-500 space-y-6">
             <p>
               Click <strong>Open Replay</strong> in the dialog shown by your browser
             </p>
             {children}
-            <p className="text-sm">
+            <p className="text-xs">
               Don&apos;t have Replay installed? <a href="https://replay.io/welcome">Download Now</a>
             </p>
           </div>

--- a/src/ui/components/shared/LaunchButton.tsx
+++ b/src/ui/components/shared/LaunchButton.tsx
@@ -14,7 +14,7 @@ function ShareButton({ setModal }: PropsFromRedux) {
       onClick={onClick}
       // This height matches the height of the icon button + border
       style={{ height: 26 }}
-      className="inline-flex items-center px-6 rounded-lg text-white bg-primaryAccent hover:bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white box-content mr-2"
+      className="inline-flex items-center px-4 text-xs rounded-lg text-white bg-primaryAccent hover:bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white box-content mr-2"
     >
       Launch Replay
     </button>

--- a/src/ui/components/shared/LoginModal.tsx
+++ b/src/ui/components/shared/LoginModal.tsx
@@ -16,19 +16,19 @@ function LoginModal() {
   return (
     <div className="login-modal">
       <Modal showClose={false}>
-        <div className="px-8 py-4 space-y-6">
+        <div className="px-6 py-3 space-y-5">
           <div className="place-content-center">
-            <img className="w-16 h-16 mx-auto" src="/images/logo.svg" />
+            <img className="w-12 h-12 mx-auto" src="/images/logo.svg" />
           </div>
-          <div className="text-center space-y-2">
-            <div className="font-bold text-2xl">Sign in required</div>
-            <div className="text-xl">You need to be signed in to leave a comment</div>
+          <div className="text-center space-y-1.5">
+            <div className="font-bold text-xl">Sign in required</div>
+            <div className="text-lg">You need to be signed in to leave a comment</div>
           </div>
           <div className="flex items-center flex-col">
             <button
               type="button"
               onClick={onClick}
-              className="inline-flex items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
+              className="inline-flex items-center px-3 py-1.5 border border-transparent text-lg font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
             >
               Sign In
             </button>

--- a/src/ui/components/shared/Modal.tsx
+++ b/src/ui/components/shared/Modal.tsx
@@ -13,7 +13,7 @@ function Modal({ hideModal, children, showClose = true }: ModalProps) {
   return (
     <div className="modal-container">
       <div className="modal-mask" onClick={hideModal} />
-      <div className="modal-content">
+      <div className="modal-content text-sm">
         {showClose && (
           <button className="modal-close" onClick={hideModal}>
             <div className="img close" />

--- a/src/ui/components/shared/NewModal.tsx
+++ b/src/ui/components/shared/NewModal.tsx
@@ -41,7 +41,7 @@ export default function Modal({
 export function ModalContent({ children }: { children: React.ReactChild | React.ReactChild[] }) {
   return (
     <div
-      className="p-12 bg-white rounded-lg shadow-xl text-xl relative justify-between"
+      className="p-9 bg-white rounded-lg shadow-xl text-lg relative justify-between"
       style={{ width: "520px" }}
     >
       {children}

--- a/src/ui/components/shared/NewWorkspaceModal/InvitationLink.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/InvitationLink.tsx
@@ -30,9 +30,9 @@ export function TextInputCopy({
     <div className="relative flex flex-col items-center w-full">
       <input
         className={classNames(
-          isLarge ? "text-2xl" : "text-lg",
+          isLarge ? "text-xl" : "text-sm",
           isCenter ? "text-center" : "",
-          "focus:ring-primaryAccent focus:border-primaryAccent block w-full border px-3 py-2 border-textFieldBorder rounded-md"
+          "focus:ring-primaryAccent focus:border-primaryAccent block w-full border px-2.5 py-1.5 border-textFieldBorder rounded-md"
         )}
         type="text"
         value={text}
@@ -41,7 +41,7 @@ export function TextInputCopy({
         onClick={onClick}
       />
       {showCopied ? (
-        <div className="absolute bottom-full p-2 bg-black bg-opacity-90 text-white shadow-2xl rounded-lg mb-2 text-lg">
+        <div className="absolute bottom-full p-1.5 bg-black bg-opacity-90 text-white shadow-2xl rounded-lg mb-1.5 text-base">
           Copied
         </div>
       ) : null}
@@ -73,7 +73,7 @@ function InvationDomainCheck({ workspace }: { workspace: Workspace }) {
   );
 
   return (
-    <div className="space-x-4 flex flex-row items-center px-2">
+    <div className="space-x-3 flex flex-row items-center px-1.5">
       <input
         id="domain-limited"
         className="outline-none focus:outline-none"
@@ -108,8 +108,8 @@ export default function InvitationLink({
     : `https://app.replay.io/?invitationcode=${workspace.invitationCode}`;
 
   return (
-    <div className="flex flex-col space-y-4 w-full">
-      <div className=" text-sm uppercase font-bold">{`Invite via link`}</div>
+    <div className="flex flex-col space-y-3 w-full">
+      <div className="text-xs uppercase font-bold">{`Invite via link`}</div>
       <TextInputCopy text={inputText} isLarge={isLarge} />
       {showDomainCheck ? <InvationDomainCheck workspace={workspace} /> : null}
     </div>

--- a/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -34,7 +34,7 @@ function ModalButton({
       onClick={onClick}
       disabled={disabled}
       className={
-        "max-w-max items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
+        "max-w-max items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
       }
     >
       {children}
@@ -50,9 +50,9 @@ function SlideContent({
   children: React.ReactElement | (React.ReactElement | null)[];
 }) {
   return (
-    <div className="space-y-12 flex flex-col flex-grow overflow-hidden">
-      <h2 className="font-bold text-3xl ">{headerText}</h2>
-      <div className="text-gray-500 flex flex-col flex-grow space-y-4 overflow-hidden">
+    <div className="space-y-9 flex flex-col flex-grow overflow-hidden">
+      <h2 className="text-2xl ">{headerText}</h2>
+      <div className="text-gray-500 flex flex-col flex-grow space-y-3 overflow-hidden">
         {children}
       </div>
     </div>
@@ -65,7 +65,7 @@ function DisabledNextButton() {
       disabled={true}
       type="button"
       className={classNames(
-        "items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none",
+        "items-center px-3 py-1.5 border border-transparent font-medium rounded-md shadow-sm focus:outline-none",
         "text-gray-600 bg-gray-300"
       )}
     >
@@ -115,7 +115,7 @@ function NextButton({
       disabled={current == total}
       type="button"
       className={classNames(
-        "items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent",
+        "items-center px-3 py-1.5 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent",
         {
           "text-white bg-primaryAccent hover:bg-primaryAccentHover": current < total,
         }
@@ -176,9 +176,9 @@ function SlideBody1({ hideModal, setNewWorkspace, setCurrent, total, current }: 
   return (
     <>
       <SlideContent headerText="Team name">
-        <div className="text-xl">{`Please name your team`}</div>
+        <div>{`Please name your team`}</div>
         {/* <form onSubmit={handleSave} className="flex flex-col space-y-4"> */}
-        <div className="py-4 flex flex-col">
+        <div className="py-3 flex flex-col">
           <TextInput value={inputValue} onChange={onChange} />
           {inputError ? <div className="text-red-500">{inputError}</div> : null}
         </div>
@@ -241,9 +241,9 @@ function SlideBody2({ hideModal, setCurrent, newWorkspace, total, current }: Sli
   return (
     <>
       <SlideContent headerText="Your team members">
-        <div className="text-xl">{`Next, we need to add your team members to your team.`}</div>
+        <div>{`Next, we need to add your team members to your team.`}</div>
         <form className="flex flex-col" onSubmit={handleAddMember}>
-          <div className="flex-grow flex flex-row space-x-4">
+          <div className="flex-grow flex flex-row space-x-3">
             <TextInput placeholder="Email address" value={inputValue} onChange={onChange} />
             <ModalButton onClick={handleAddMember} disabled={isLoading}>
               {isLoading ? "Loading" : "Invite"}
@@ -285,13 +285,13 @@ function SlideBody3({ setWorkspaceId, hideModal, newWorkspace }: SlideBody3Props
   return (
     <>
       <SlideContent headerText="Team setup complete">
-        <div className="text-xl">{`Your new team is ready.`}</div>
+        <div>{`Your new team is ready.`}</div>
       </SlideContent>
       <div className="grid">
         <button
           onClick={onClick}
           className={classNames(
-            "items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent",
+            "items-center px-3 py-1.5 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent",
             "text-white bg-primaryAccent hover:bg-primaryAccentHover"
           )}
         >
@@ -330,7 +330,7 @@ function OnboardingModal(props: PropsFromRedux) {
     <>
       <Modal options={{ maskTransparency: "translucent" }} onMaskClick={props.hideModal}>
         <div
-          className="p-12 bg-white rounded-lg shadow-xl text-xl space-y-8 relative flex flex-col justify-between"
+          className="p-9 bg-white rounded-lg shadow-xl text-sm space-y-6 relative flex flex-col justify-between"
           style={{ width: "520px", height }}
         >
           {slide}

--- a/src/ui/components/shared/Onboarding/DownloadPage.tsx
+++ b/src/ui/components/shared/Onboarding/DownloadPage.tsx
@@ -10,7 +10,7 @@ function DownloadButtonContent({ text, imgUrl }: { text: string; imgUrl: string 
       style={{ minWidth: "120px" }}
     >
       <span>{text}</span>
-      <img className="w-8 h-8" src={imgUrl} />
+      <img className="w-6 h-6" src={imgUrl} />
     </div>
   );
 }
@@ -33,7 +33,7 @@ function DownloadButtons({ onNext }: { onNext: () => void }) {
   };
 
   return (
-    <div className="py-4 flex flex-row w-full space-x-4 justify-center">
+    <div className="py-3 flex flex-row w-full space-x-3 justify-center">
       <PrimaryLgButton color="blue" onClick={handleMac}>
         <DownloadButtonContent text="Mac" imgUrl="/images/icon-apple.svg" />
       </PrimaryLgButton>

--- a/src/ui/components/shared/Onboarding/index.tsx
+++ b/src/ui/components/shared/Onboarding/index.tsx
@@ -13,7 +13,7 @@ export function OnboardingContent({
 }) {
   return (
     <div
-      className="p-12 text-4xl space-y-16 relative flex flex-col items-center"
+      className="p-9 text-2xl space-y-12 relative flex flex-col items-center"
       style={{ width: "800px" }}
     >
       <ReplayLogo />
@@ -23,7 +23,7 @@ export function OnboardingContent({
 }
 
 export function OnboardingHeader({ children }: { children: string }) {
-  return <div className="text-7xl font-semibold">{children}</div>;
+  return <div className="text-5xl font-semibold">{children}</div>;
 }
 
 export function OnboardingBody({
@@ -39,7 +39,7 @@ export function OnboardingActions({
 }: {
   children: string | React.ReactChild | React.ReactChild[];
 }) {
-  return <div className="space-x-4 pt-16">{children}</div>;
+  return <div className="space-x-3 pt-12">{children}</div>;
 }
 
 export function NextButton({
@@ -102,7 +102,7 @@ export function OnboardingButton({
       disabled={disabled}
       className={classNames(
         className,
-        "max-w-max items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
+        "max-w-max items-center px-3 py-1.5 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
       )}
     >
       {children}
@@ -127,4 +127,4 @@ export function OnboardingModalContainer({
   );
 }
 
-export const ReplayLogo = () => <img className="w-24 h-24" src="/images/logo.svg" />;
+export const ReplayLogo = () => <img className="w-16 h-16" src="/images/logo.svg" />;

--- a/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
@@ -10,10 +10,10 @@ const slides = [
     header: "Welcome to Replay! 👋",
     content: (
       <>
-        <div className="text-xl pb-8">{`We're glad you're here! This is how to get started:`}</div>
-        <li className="text-xl pb-2">{`In the Replay browser, open a website in a new tab`}</li>
-        <li className="text-xl pb-2">{`Press the blue record button to record, press again to stop`}</li>
-        <li className="text-xl pb-2">{`And with that, you'll have recorded your first replay :)`}</li>
+        <div className="text-lg pb-6">{`We're glad you're here! This is how to get started:`}</div>
+        <li className="text-lg pb-1.5">{`In the Replay browser, open a website in a new tab`}</li>
+        <li className="text-lg pb-1.5">{`Press the blue record button to record, press again to stop`}</li>
+        <li className="text-lg pb-1.5">{`And with that, you'll have recorded your first replay :)`}</li>
       </>
     ),
   },
@@ -27,8 +27,8 @@ function SlideContent({
   children: React.ReactElement | React.ReactElement[];
 }) {
   return (
-    <div className="space-y-12">
-      <h2 className="font-bold text-3xl ">{headerText}</h2>
+    <div className="space-y-9">
+      <h2 className="font-bold text-2xl ">{headerText}</h2>
       <div className="text-gray-500">{children}</div>
     </div>
   );
@@ -57,7 +57,7 @@ function Navigation({
   };
 
   return (
-    <div className="text-lg items-right">
+    <div className="text-base items-right">
       {/* <div className="flex flex-row items-center space-x-2">
         <input
           type="checkbox"
@@ -73,7 +73,7 @@ function Navigation({
         <button
           onClick={onSkipOrDone}
           type="button"
-          className="float-right inline-flex items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
+          className="float-right inline-flex items-center px-3 py-1.5 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
         >
           {current == total ? "Got it!" : "Skip"}
         </button>
@@ -90,7 +90,7 @@ function OnboardingModal({ hideModal }: PropsFromRedux) {
   return (
     <Modal options={{ maskTransparency: "translucent" }}>
       <div
-        className="p-12 bg-white rounded-lg shadow-xl text-xl space-y-8 relative flex flex-col justify-between"
+        className="p-9 bg-white rounded-lg shadow-xl text-lg space-y-6 relative flex flex-col justify-between"
         style={{ width: "520px" }}
       >
         <SlideContent headerText={header}>{content}</SlideContent>
@@ -101,7 +101,7 @@ function OnboardingModal({ hideModal }: PropsFromRedux) {
           hideModal={hideModal}
         />
         <div
-          className="h-2 bg-white absolute bottom-0 left-0 rounded-md"
+          className="h-1.5 bg-white absolute bottom-0 left-0 rounded-md"
           style={{ width: `${(current / slides.length) * 100}%` }}
         />
       </div>

--- a/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
@@ -22,7 +22,7 @@ function ModalLoader() {
   return (
     <OnboardingModalContainer>
       <OnboardingContent>
-        <Spinner className="animate-spin h-6 w-6 text-gray-500" />
+        <Spinner className="animate-spin h-4 w-4 text-gray-500" />
       </OnboardingContent>
     </OnboardingModalContainer>
   );

--- a/src/ui/components/shared/OnboardingModal/TeamMemberOnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/TeamMemberOnboardingModal.tsx
@@ -19,8 +19,8 @@ function TeamMemberOnboardingModalLoader({ hideModal, setWorkspaceId }: PropsFro
   if (loading || !pendingWorkspaces) {
     return (
       <Modal options={{ maskTransparency: "translucent" }}>
-        <div className="p-12 bg-white rounded-lg shadow-xl text-xl relative flex">
-          <Spinner className="animate-spin h-6 w-6 text-gray-500" />
+        <div className="p-9 bg-white rounded-lg shadow-xl text-lg relative flex">
+          <Spinner className="animate-spin h-4 w-4 text-gray-500" />
         </div>
       </Modal>
     );
@@ -68,12 +68,12 @@ function TeamMemberInvitation({
     callToAction = <div className="select-none">Declined</div>;
   } else if (status == "pending") {
     callToAction = (
-      <div className="space-y-2 flex flex-col items-center">
-        <div className="space-x-4 flex flex-row">
+      <div className="space-y-1.5 flex flex-col items-center">
+        <div className="space-x-3 flex flex-row">
           <button
             onClick={onAccept}
             type="button"
-            className="inline-flex items-center px-4 py-2 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
+            className="inline-flex items-center px-3 py-1.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
           >
             Accept
           </button>
@@ -81,7 +81,7 @@ function TeamMemberInvitation({
             <button
               onClick={onDecline}
               type="button"
-              className="inline-flex items-center px-4 py-2 border border-transparent font-medium rounded-md bg-gray-200 hover:bg-gray-300"
+              className="inline-flex items-center px-3 py-1.5 border border-transparent font-medium rounded-md bg-gray-200 hover:bg-gray-300"
             >
               Decline
             </button>
@@ -91,23 +91,23 @@ function TeamMemberInvitation({
     );
   } else if (status == "loading") {
     callToAction = (
-      <div className="space-y-2 flex flex-col items-center">
+      <div className="space-y-1.5 flex flex-col items-center">
         <button
           disabled
           type="button"
-          className="inline-flex items-center px-4 py-2 border border-transparent font-medium rounded-md text-white bg-primaryAccent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
+          className="inline-flex items-center px-3 py-1.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
         >
-          <Spinner className="animate-spin h-6 w-6 text-white" />
+          <Spinner className="animate-spin h-4 w-4 text-white" />
         </button>
       </div>
     );
   } else {
     callToAction = (
-      <div className="space-y-2 flex flex-col items-center">
+      <div className="space-y-1.5 flex flex-col items-center">
         <button
           onClick={() => onGo(workspaceTarget.id)}
           type="button"
-          className="inline-flex items-center px-4 py-2 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
+          className="inline-flex items-center px-3 py-1.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
         >
           {`Open`}
         </button>
@@ -116,9 +116,9 @@ function TeamMemberInvitation({
   }
 
   return (
-    <div className="flex flex-row items-center justify-between space-x-8">
+    <div className="flex flex-row items-center justify-between space-x-6">
       <div className="flex flex-col text-gray-500 overflow-hidden">
-        <h2 className="text-2xl font-semibold  whitespace-pre overflow-ellipsis overflow-hidden">{`${workspaceTarget.name} team`}</h2>
+        <h2 className="text-xl font-semibold  whitespace-pre overflow-ellipsis overflow-hidden">{`${workspaceTarget.name} team`}</h2>
         <div className="overflow-hidden whitespace-pre overflow-ellipsis">{`${workspaceTarget.recordingCount} replays`}</div>
         <div className="overflow-hidden whitespace-pre overflow-ellipsis">
           {workspaceTarget.inviterEmail
@@ -201,8 +201,8 @@ function TeamMemberOnboardingModal({
         options={{ maskTransparency: isTeamMemberInvite() ? "transparent" : "translucent" }}
       >
         <ModalContent>
-          <div className="space-y-8 flex flex-col">
-            <h2 className="font-bold text-3xl ">{headerText}</h2>
+          <div className="space-y-6 flex flex-col">
+            <h2 className="font-bold text-2xl ">{headerText}</h2>
             {displayedWorkspaces.map(workspace => (
               <TeamMemberInvitation
                 {...{ hideModal, onGo, workspace, onAction }}
@@ -212,7 +212,7 @@ function TeamMemberOnboardingModal({
             {isFinished && !actions.includes("accept") ? (
               <button
                 className={classNames(
-                  "py-2 font-medium rounded-md bg-primaryAccent hover:bg-primaryAccentHover text-white"
+                  "py-1.5 font-medium rounded-md bg-primaryAccent hover:bg-primaryAccentHover text-white"
                 )}
                 onClick={onSkip}
               >

--- a/src/ui/components/shared/SettingsModal/SettingsBody.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBody.tsx
@@ -17,15 +17,15 @@ interface SettingsBodyProps<
 }
 
 function SettingsBodyWrapper({ children }: { children: (React.ReactChild | null)[] }) {
-  return <main className="text-lg">{children}</main>;
+  return <main className="text-sm">{children}</main>;
 }
 
 export function SettingsHeader({ children }: { children: React.ReactChild }) {
-  return <h1 className="text-3xl">{children}</h1>;
+  return <h1 className="text-2xl">{children}</h1>;
 }
 
 export function SettingsBodyHeader({ children }: { children: React.ReactChild }) {
-  return <h2 className="text-2xl">{children}</h2>;
+  return <h2 className="text-lg">{children}</h2>;
 }
 
 export default function SettingsBody<

--- a/src/ui/components/shared/SettingsModal/SettingsBodyItem.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBodyItem.tsx
@@ -24,7 +24,7 @@ function Checkbox<K>({ item, value, onChange }: InputProps<K, boolean>) {
   };
 
   if (item.comingSoon) {
-    return <span className="italic  text-gray-500">Coming Soon...</span>;
+    return <span className="italic text-gray-500">Coming Soon...</span>;
   }
 
   return <input type="checkbox" id={String(key)} checked={value} onChange={toggleSetting} />;
@@ -34,7 +34,7 @@ function Dropdown<K>({ value }: InputProps<K>) {
   const onChange = () => {};
 
   return (
-    <div className="w-64">
+    <div className="w-48">
       <SelectMenu selected={value} setSelected={onChange} options={[]} />
     </div>
   );
@@ -53,7 +53,7 @@ export default function SettingsBodyItem<K>({ item, values, onChange }: Settings
 
   return (
     <li className="flex flex-row items-center">
-      <label className="space-y-2 pr-48 flex-grow cursor-pointer" htmlFor={String(key)}>
+      <label className="space-y-1.5 pr-36 flex-grow cursor-pointer" htmlFor={String(key)}>
         <SettingsBodyHeader>{label}</SettingsBodyHeader>
         {description && <div>{description}</div>}
       </label>

--- a/src/ui/components/shared/SharingModal/Collaborators.tsx
+++ b/src/ui/components/shared/SharingModal/Collaborators.tsx
@@ -16,7 +16,7 @@ export default function Collaborators({ recordingId }: CollaboratorsProps) {
   }
 
   return (
-    <section className="flex flex-col w-full space-y-2">
+    <section className="flex flex-col w-full space-y-1.5">
       <EmailForm recordingId={recordingId} />
       <CollaboratorsList {...{ recording, collaborators }} />
     </section>

--- a/src/ui/components/shared/SharingModal/EmailForm.tsx
+++ b/src/ui/components/shared/SharingModal/EmailForm.tsx
@@ -19,30 +19,30 @@ function AutocompleteAction({
   if (status === "loading") {
     return (
       <button
-        className="inline-flex items-center px-3 py-2 space-x-2 border border-transparent font-medium rounded-md focus:outline-none text-white bg-primaryAccent"
+        className="inline-flex items-center px-2.5 py-1.5 space-x-1.5 border border-transparent font-medium rounded-md focus:outline-none text-white bg-primaryAccent"
         disabled
       >
-        <Spinner className="animate-spin h-6 w-6 text-white" />
+        <Spinner className="animate-spin h-4 w-4 text-white" />
         <span>Inviting</span>
       </button>
     );
   } else if (status === "completed") {
     return (
       <button
-        className="inline-flex items-center px-3 py-2 space-x-1 border border-transparent font-medium rounded-md focus:outline-none text-white bg-green-600"
+        className="inline-flex items-center px-2.5 py-1.5 space-x-1 border border-transparent font-medium rounded-md focus:outline-none text-white bg-green-600"
         disabled
       >
-        <CheckCircleIcon className="h-6 w-6 text-white" />
+        <CheckCircleIcon className="h-4 w-4 text-white" />
         <span>Invited</span>
       </button>
     );
   } else if (status === "error") {
     return (
       <button
-        className="inline-flex items-center px-3 py-2 space-x-1 border border-transparent font-medium rounded-md focus:outline-none text-white bg-red-600"
+        className="inline-flex items-center px-2.5 py-1.5 space-x-1 border border-transparent font-medium rounded-md focus:outline-none text-white bg-red-600"
         disabled
       >
-        <ExclamationCircleIcon className="h-6 w-6 text-white" />
+        <ExclamationCircleIcon className="h-4 w-4 text-white" />
         <span>Unknown User</span>
       </button>
     );
@@ -50,10 +50,10 @@ function AutocompleteAction({
 
   return (
     <button
-      className="inline-flex items-center px-3 py-2 space-x-1 border border-transparent font-medium rounded-md focus:outline-none text-white bg-primaryAccent hover:bg-primaryAccentHover"
+      className="inline-flex items-center px-2.5 py-1.5 space-x-1 border border-transparent font-medium rounded-md focus:outline-none text-white bg-primaryAccent hover:bg-primaryAccentHover"
       onClick={handleSubmit}
     >
-      <PaperAirplaneIcon className="h-6 w-6 text-white transform rotate-90" />
+      <PaperAirplaneIcon className="h-4 w-4 text-white transform rotate-90" />
       <span>Add</span>
     </button>
   );

--- a/src/ui/components/shared/SharingModal/ReplayLink.tsx
+++ b/src/ui/components/shared/SharingModal/ReplayLink.tsx
@@ -27,7 +27,7 @@ export function UrlCopy({ url }: { url: string }) {
         onClick={onClick}
       />
       {showCopied ? (
-        <div className="absolute bottom-full p-2 bg-black bg-opacity-900 text-white shadow-2xl rounded-lg mb-2">
+        <div className="absolute bottom-full p-1.5 bg-black bg-opacity-900 text-white shadow-2xl rounded-lg mb-1.5">
           Copied to Clipboard
         </div>
       ) : null}

--- a/src/ui/components/shared/SharingModal/SharedWith.tsx
+++ b/src/ui/components/shared/SharingModal/SharedWith.tsx
@@ -23,9 +23,9 @@ export function SharedWith(props: SharedWithProps) {
   const [isEditing, setIsEditing] = useState(false);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <div className="w-full flex flex-row justify-between items-center">
-        <h2 className="text-2xl">Shared with</h2>
+        <h2 className="text-xl">Shared with</h2>
         {isEditing ? (
           <PrimaryButton color="blue" onClick={() => setIsEditing(false)}>
             Done
@@ -66,14 +66,14 @@ function SharedWithForm({
   };
 
   return (
-    <div className="w-full justify-between flex flex-col space-y-4">
+    <div className="w-full justify-between flex flex-col space-y-3">
       {workspaces.length ? (
-        <div className="w-full space-y-2">
+        <div className="w-full space-y-1.5">
           <div className="text-sm uppercase font-bold">{`Team`}</div>
           <TeamSelect {...{ workspaces, handleWorkspaceSelect, selectedWorkspaceId }} />
         </div>
       ) : null}
-      <div className="w-full space-y-2">
+      <div className="w-full space-y-1.5">
         <div className="text-sm uppercase font-bold">{`People`}</div>
         <Collaborators {...{ recordingId }} />
       </div>
@@ -97,8 +97,8 @@ function getCollaboratorsSummary(workspace: Workspace, collaboratorCount: number
   }
 
   if (sharees.length === 0) {
-    return <div className="pr-8">This is not currently shared with anybody</div>;
+    return <div className="pr-6">This is not currently shared with anybody</div>;
   }
 
-  return <div className="pr-8">Shared with {commaListOfThings(sharees)}</div>;
+  return <div className="pr-6">Shared with {commaListOfThings(sharees)}</div>;
 }

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -60,17 +60,17 @@ function SharingModal({
   return (
     <Modal options={{ maskTransparency: "translucent" }} onMaskClick={hideModal}>
       <div
-        className="sharing-modal p-12 space-y-8 relative flex flex-col bg-white text-lg rounded-lg"
+        className="sharing-modal p-12 space-y-8 relative flex flex-col bg-white rounded-lg text-sm"
         style={{ width: "600px" }}
       >
-        <h1 className="text-3xl">Sharing</h1>
+        <h1 className="text-2xl">Sharing</h1>
         <section className="space-y-8">
           <SharedWith
             defaultWorkspaceId={userSettings?.defaultWorkspaceId || null}
             {...{ workspaces, recordingId, collaborators }}
           />
           <div className="space-y-4">
-            <h2 className="text-2xl">Get Link</h2>
+            <h2 className="text-xl">Get Link</h2>
             <ReplayLink recordingId={recordingId} />
             <div className="flex flex-row items-center">
               {isPrivate ? (

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
@@ -107,7 +107,7 @@ function TeamNamePage({
       <OnboardingBody>
         We recommend keeping it simple and using your company or project name
       </OnboardingBody>
-      <div className="py-4 flex flex-col w-full">
+      <div className="py-3 flex flex-col w-full">
         <TextInput
           placeholder="Team name"
           value={inputValue}
@@ -183,10 +183,10 @@ function TeamMemberInvitationPage({
         Replay is for your whole team. Invite anyone who you would like to be able to record and
         discuss replays with
       </OnboardingBody>
-      <div className="text-2xl w-full space-y-4">
-        <form className="flex flex-col w-full space-y-4 text-2xl" onSubmit={handleAddMember}>
+      <div className="text-xl w-full space-y-3">
+        <form className="flex flex-col w-full space-y-3 text-xl" onSubmit={handleAddMember}>
           <div className="text-sm uppercase font-bold">{`Invite via email`}</div>
-          <div className="flex-grow flex flex-row space-x-4">
+          <div className="flex-grow flex flex-row space-x-3">
             <TextInput
               placeholder="Email address"
               value={inputValue}
@@ -200,7 +200,7 @@ function TeamMemberInvitationPage({
           {errorMessage ? <div>{errorMessage}</div> : null}
         </form>
         {!loading && sortedMembers ? (
-          <div className="overflow-auto w-full text-2xl " style={{ maxHeight: "180px" }}>
+          <div className="overflow-auto w-full text-xl " style={{ maxHeight: "180px" }}>
             <WorkspaceMembers members={sortedMembers} isAdmin />
           </div>
         ) : null}

--- a/src/ui/components/shared/UserSettingsModal/ReplayInvitations.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ReplayInvitations.tsx
@@ -11,8 +11,10 @@ export default function ReplayInvitations() {
   const [inputValue, setInputValue] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const { invitations, loading: inviteLoading } = hooks.useGetInvitations();
-  let { availableInvitations, loading: availableInvitationsLoading } =
-    hooks.useGetAvailableInvitations();
+  let {
+    availableInvitations,
+    loading: availableInvitationsLoading,
+  } = hooks.useGetAvailableInvitations();
   const addInvitation = hooks.useAddInvitation();
 
   const onSubmit = (e: React.FormEvent) => {
@@ -74,7 +76,7 @@ export default function ReplayInvitations() {
         </label>
         {(!USE_AVAILABLE_INVITATIONS || availableInvitations > 0) && (
           <div className="flex flex-col w-full">
-            <form onSubmit={onSubmit} className="space-x-2 flex flex-row">
+            <form onSubmit={onSubmit} className="space-x-1.5 flex flex-row">
               <TextInput
                 placeholder="Email Address"
                 value={inputValue}
@@ -83,12 +85,12 @@ export default function ReplayInvitations() {
               <button
                 type="submit"
                 value="Invite"
-                className="inline-flex items-center px-3 py-2 border border-transparent text-lg leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:bg-primaryAccentHover"
+                className="inline-flex items-center px-2.5 py-1.5 border border-transparent leading-4 font-medium rounded-md shadow-sm text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:bg-primaryAccentHover"
               >
                 Invite
               </button>
             </form>
-            {errorMessage ? <div className="text-red-500 text-sm">{errorMessage}</div> : null}
+            {errorMessage ? <div className="text-red-500 text-xs">{errorMessage}</div> : null}
           </div>
         )}
         <div className="invitations-list">

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -23,7 +23,7 @@ function Support() {
   return (
     <ul>
       <li className="flex flex-row items-center">
-        <label className="space-y-2 pr-48 flex-grow">
+        <label className="space-y-1.5 pr-36 flex-grow">
           <SettingsBodyHeader>Join us on Discord</SettingsBodyHeader>
           <div className="description">
             Come chat with us on our{" "}
@@ -34,7 +34,7 @@ function Support() {
         </label>
       </li>
       <li className="flex flex-row items-center">
-        <label className="space-y-2 pr-48 flex-grow">
+        <label className="space-y-1.5 pr-36 flex-grow">
           <SettingsBodyHeader>Send us an email</SettingsBodyHeader>
           <div className="description">
             You can also send an email at <a href="mailto:support@replay.io">support@replay.io</a>.
@@ -52,18 +52,18 @@ function Personal() {
   const { name, picture, email } = user!;
 
   return (
-    <div className="space-y-16">
-      <div className="flex flex-row space-x-4 items-center">
-        <img src={picture} className="rounded-full w-16" />
+    <div className="space-y-12">
+      <div className="flex flex-row space-x-3 items-center">
+        <img src={picture} className="rounded-full w-12" />
         <div>
-          <div className="text-xl">{name}</div>
+          <div className="text-base">{name}</div>
           <div className="text-gray-500">{email}</div>
         </div>
       </div>
       <div>
         <button
           onClick={() => handleIntercomLogout(logout)}
-          className="max-w-max items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
+          className="max-w-max items-center px-3 py-1.5 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
         >
           Log Out
         </button>
@@ -74,9 +74,9 @@ function Personal() {
 
 function Legal() {
   return (
-    <div className="space-y-16 pr-48">
-      <div className="space-y-4">
-        <div className="space-y-2">
+    <div className="space-y-12 pr-36">
+      <div className="space-y-3">
+        <div className="space-y-1.5">
           <SettingsBodyHeader>
             <a
               className="underline"
@@ -89,7 +89,7 @@ function Legal() {
           </SettingsBodyHeader>
           <div>{`The Terms of Use help define Replay's relationship with you as you interact with our services.`}</div>
         </div>
-        <div className="space-y-2">
+        <div className="space-y-1.5">
           <SettingsBodyHeader>
             <a
               className="underline"

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
@@ -147,9 +147,9 @@ export function NonRegisteredWorkspaceMember({
   };
 
   return (
-    <li className="flex flex-row items-center space-x-2">
+    <li className="flex flex-row items-center space-x-1.5">
       <div className="grid justify-center items-center" style={{ width: "28px", height: "28px" }}>
-        <MaterialIcon className="text-3xl">mail_outline</MaterialIcon>
+        <MaterialIcon>mail_outline</MaterialIcon>
       </div>
       <Redacted className="flex-grow">{member.email}</Redacted>
       <PortalDropdown
@@ -244,7 +244,7 @@ function WorkspaceMember({
   canLeave = false,
 }: WorkspaceMemberProps) {
   return (
-    <li className="flex flex-row items-center space-x-2">
+    <li className="flex flex-row items-center space-x-1.5">
       <img
         src={member.user!.picture}
         className="rounded-full"

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -17,6 +17,7 @@ import { Settings } from "../SettingsModal/types";
 import WorkspaceAPIKeys from "./WorkspaceAPIKeys";
 import WorkspaceSubscription from "./WorkspaceSubscription";
 import WorkspaceMember, { NonRegisteredWorkspaceMember } from "./WorkspaceMember";
+import { Button } from "../Button";
 
 function ModalButton({
   children,
@@ -36,7 +37,7 @@ function ModalButton({
       disabled={disabled}
       className={classNames(
         className,
-        "max-w-max items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
+        "max-w-max items-center px-3 py-1.5 border border-transparent text-base font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
       )}
     >
       {children}
@@ -59,7 +60,7 @@ export function WorkspaceMembers({
   const canAdminLeave = canLeave && members.filter(a => a.roles?.includes("admin")).length > 1;
 
   return (
-    <ul className="flex flex-col space-y-3">
+    <ul className="flex flex-col space-y-2.5">
       {sortedMembers.map(member =>
         member.email ? (
           <NonRegisteredWorkspaceMember
@@ -117,13 +118,13 @@ function WorkspaceForm({ workspaceId, members }: WorkspaceFormProps) {
 
   return (
     <form className="flex flex-col" onSubmit={handleAddMember}>
-      <div className="flex-grow flex flex-row space-x-4">
+      <div className="flex-grow flex flex-row space-x-3">
         <TextInput placeholder="Email address" value={inputValue} onChange={onChange} />
         <ModalButton onClick={handleAddMember} disabled={isLoading}>
           {isLoading ? "Loading" : "Invite"}
         </ModalButton>
       </div>
-      {errorMessage ? <div className="text-red-500 text-sm">{errorMessage}</div> : null}
+      {errorMessage ? <div className="text-red-500 text-xs">{errorMessage}</div> : null}
     </form>
   );
 }
@@ -148,13 +149,13 @@ const settings: Settings<
       const { members } = hooks.useGetWorkspaceMembers(workspaceId);
 
       return (
-        <div className="flex flex-col flex-grow space-y-4 overflow-hidden">
-          <div className="text-xl">{`Manage members here so that everyone who belongs to this team can see each other's replays.`}</div>
+        <div className="flex flex-col flex-grow space-y-3 overflow-hidden">
+          <div>{`Manage members here so that everyone who belongs to this team can see each other's replays.`}</div>
           <WorkspaceForm {...rest} workspaceId={workspaceId} members={members} />
-          <div className=" text-sm uppercase font-semibold">{`Members`}</div>
+          <div className="text-xs uppercase font-semibold">{`Members`}</div>
           <div className="overflow-auto flex-grow">
-            <div className="workspace-members-container flex flex-col space-y-2">
-              <div className="flex flex-col space-y-2">
+            <div className="workspace-members-container flex flex-col space-y-1.5">
+              <div className="flex flex-col space-y-1.5">
                 {members ? <WorkspaceMembers members={members} isAdmin={isAdmin} /> : null}
               </div>
             </div>
@@ -198,19 +199,16 @@ const settings: Settings<
       };
 
       return (
-        <div className="flex flex-col space-y-4">
-          <div className=" text-sm uppercase font-semibold">{`Danger Zone`}</div>
-          <div className="border border-red-300 flex flex-row justify-between rounded-lg p-2">
+        <div className="flex flex-col space-y-3">
+          <div className=" text-xs uppercase font-semibold">{`Danger Zone`}</div>
+          <div className="border border-red-300 flex flex-row justify-between rounded-lg p-1.5">
             <div className="flex flex-col">
               <div className="font-semibold">Delete this team</div>
               <div className="">{`This cannot be reversed.`}</div>
             </div>
-            <button
-              onClick={handleDeleteTeam}
-              className="max-w-max items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-red-600 hover:bg-red-700"
-            >
+            <Button color="red" onClick={handleDeleteTeam} size="md" style="primary">
               Delete this team
-            </button>
+            </Button>
           </div>
         </div>
       );

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSubscription.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSubscription.tsx
@@ -13,14 +13,14 @@ function PlanDetails({
 }) {
   return (
     <section className="rounded-lg border border-blue-600 overflow-hidden">
-      <header className="bg-blue-200 p-4 border-b border-blue-600 flex flex-row">
-        <MaterialIcon className="mr-4 text-2xl">group</MaterialIcon>
-        <h3 className="text-2xl font-semibold">{title}</h3>
+      <header className="bg-blue-200 p-3 border-b border-blue-600 flex flex-row">
+        <MaterialIcon className="mr-3 text-2xl">group</MaterialIcon>
+        <h3 className="text-xl font-semibold">{title}</h3>
       </header>
-      <div className="p-4">
+      <div className="p-3">
         {description ? <p>{description}</p> : null}
         {features && features.length > 0 ? (
-          <ul className="list-disc pl-8">
+          <ul className="list-disc pl-6">
             {features.map((f, i) => (
               <li key={i}>{f}</li>
             ))}
@@ -67,8 +67,8 @@ export default function WorkspaceSubscription({ workspaceId }: { workspaceId: st
       {data?.node.subscription ? (
         <>
           {data.node.subscription.status === "trialing" ? (
-            <div className="p-4 bg-yellow-100 rounded-lg border border-yellow-600 flex flex-row items-center">
-              <MaterialIcon className="mr-4">access_time</MaterialIcon>
+            <div className="p-3 bg-yellow-100 rounded-lg border border-yellow-600 flex flex-row items-center">
+              <MaterialIcon className="mr-3">access_time</MaterialIcon>
               Trial ends&nbsp;
               <strong>
                 {new Intl.DateTimeFormat("en", {


### PR DESCRIPTION
This removes the root font styling (16) from the app. This way, components using tailwind UI will look the same between the app and the marketing website.

The intention is to remove the root font style while keeping everything looking the same. This was possible in most places, but in some other places we had to either round up/down because of tailwind's styles. 

Checked the following to make sure they were consistent:
- sidepanels, e.g. comments, events, pause info, breakpoints
- editor, e.g. codemirror, tabs, footer, context menus
- console, e.g. filters, event dropdown, jsterm, filter dropdown
- elements, react
- team leader onboarding flow (cohorts), team member onboarding flow
- user settings, team settings
- new team modal
- errors
- login page
- library
- launch replay flow
- first replay flow
- upload screen