### PR TITLE
Fix the stepping-04 e2e test

### DIFF
--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -322,7 +322,7 @@ async function waitForScopeValue(name, value) {
 async function toggleBlackboxSelectedSource() {
   const { getSelectedSource } = dbgSelectors;
   const blackboxed = getSelectedSource().isBlackBoxed;
-  await clickElement(".black-box");
+  dbg.actions.toggleBlackBox(getContext(), getSelectedSource());
   await waitUntil(() => getSelectedSource().isBlackBoxed != blackboxed);
   await ThreadFront.waitForInvalidateCommandsToFinish();
 }


### PR DESCRIPTION
stepping-04 tests blackboxing sources and used the button in the editor's footer to toggle blackboxing. That button was removed so we now toggle blackboxing using the redux action directly.