### PR TITLE
Show the replay updated error message when switching to the dev view fails because an import fails

### DIFF
--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -8,6 +8,7 @@ import PropTypes from "prop-types";
 import { connect } from "../utils/connect";
 import { features } from "../utils/prefs";
 import actions from "../actions";
+import { setUnexpectedError } from "ui/actions/session";
 import A11yIntention from "./A11yIntention";
 import { ShortcutsModal } from "./ShortcutsModal";
 
@@ -46,6 +47,7 @@ import QuickOpenModal from "./QuickOpenModal";
 import SidePanel from "ui/components/SidePanel";
 import { waitForEditor } from "../utils/editor/create-editor";
 import { isDemo } from "ui/utils/environment";
+import { ReplayUpdatedError } from "ui/components/ErrorBoundary";
 
 class Debugger extends Component {
   onLayoutChange;
@@ -256,8 +258,12 @@ function DebuggerLoader(props) {
 
   useEffect(() => {
     (async () => {
-      await waitForEditor();
-      setLoading(false);
+      try {
+        await waitForEditor();
+        setLoading(false);
+      } catch {
+        props.setUnexpectedError(ReplayUpdatedError);
+      }
     })();
   }, []);
 
@@ -280,4 +286,5 @@ export default connect(mapStateToProps, {
   openQuickOpen: actions.openQuickOpen,
   closeQuickOpen: actions.closeQuickOpen,
   refreshCodeMirror: actions.refreshCodeMirror,
+  setUnexpectedError,
 })(DebuggerLoader);

--- a/src/ui/components/ErrorBoundary.tsx
+++ b/src/ui/components/ErrorBoundary.tsx
@@ -1,19 +1,22 @@
 import React, { Component, ReactNode } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { UIState } from "ui/state";
+import { UnexpectedError } from "ui/state/app";
 import { getUnexpectedError } from "ui/reducers/app";
 import { setUnexpectedError } from "ui/actions/session";
 import BlankScreen from "./shared/BlankScreen";
+
+export const ReplayUpdatedError: UnexpectedError = {
+  message: "Replay updated",
+  content: "Replay was updated since you opened it. Please refresh the page.",
+  action: "refresh",
+};
 
 class ErrorBoundary extends Component<PropsFromRedux & { children: ReactNode }> {
   componentDidCatch(error: any, errorInfo: any) {
     const { setUnexpectedError } = this.props;
     if (error.name === "ChunkLoadError") {
-      setUnexpectedError({
-        message: "Replay updated",
-        content: "Replay was updated since you opened it. Please refresh the page.",
-        action: "refresh",
-      });
+      setUnexpectedError(ReplayUpdatedError);
     } else {
       setUnexpectedError({
         message: "Unexpected error",


### PR DESCRIPTION
We recently saw an issue where an import failed (when the user switched to the dev view) but the "Replay updated" error modal wasn't shown. The reason was that not all errors are caught by our `ErrorBoundary` component.
This PR fixes the issue in one place, but there are probably other places where the same issue can occur.