### PR TITLE
Remove react devtools icon

### DIFF
--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -70,7 +70,7 @@ function PanelButtons({
           })}
           onClick={() => onClick("react-components")}
         >
-          <div className="label">⚛️ React</div>
+          <div className="label">React</div>
         </button>
       )}
     </div>


### PR DESCRIPTION
The react devtools icon is a sore thumb for a couple of reasons:

1. it's the only panel with an icon
2. the icon is very different than all the others

<img width="446" alt="Screen Shot 2021-09-03 at 8 24 24 AM" src="https://user-images.githubusercontent.com/254562/132004681-a497b333-1f96-431a-a4b3-3c1eb2219602.png">

