### PR TITLE
Fix double seek when clicking on a comment marker in the timeline

### DIFF
--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -118,12 +118,12 @@ class Timeline extends Component<PropsFromRedux> {
     const {
       hoverTime,
       seek,
-      hoveredItem,
+      hoveredComment,
       clearPendingComment,
       setTimelineToTime,
       setTimelineState,
     } = this.props;
-    const hoveringOverMarker = hoveredItem?.target === "timeline";
+    const hoveringOverMarker = !!hoveredComment;
     const mouseTime = this.getMouseTime(e);
 
     if (hoverTime != null && !hoveringOverMarker) {
@@ -376,6 +376,7 @@ const connector = connect(
     hoveredLineNumberLocation: selectors.getHoveredLineNumberLocation(state),
     pointsForHoveredLineNumber: selectors.getPointsForHoveredLineNumber(state),
     hoveredItem: selectors.getHoveredItem(state),
+    hoveredComment: selectors.getHoveredComment(state),
     clickEvents: selectors.getEventsForType(state, "mousedown"),
     videoUrl: selectors.getVideoUrl(state),
   }),


### PR DESCRIPTION
While looking at #3379 I noticed that a click on a comment marker in the timeline generates two calls to `seek()` (one from the `Timeline` component and one from the `CommentMarker` component). The reason is that the check if the mouse is hovering over a marker was outdated, so I fixed it.