### PR TITLE
We should only show Column Breakpoints when enabled

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoint.js
+++ b/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoint.js
@@ -9,10 +9,8 @@ import { connect } from "../../utils/connect";
 import actions from "../../actions";
 
 import { getDocument } from "../../utils/editor";
-// import Panel from "../Breakpoints/Panel/index";
 import Panel from "./Breakpoints/Panel/index";
-
-// eslint-disable-next-line max-len
+import { features } from "ui/utils/prefs";
 
 const breakpointButton = document.createElement("button");
 breakpointButton.innerHTML =
@@ -46,6 +44,10 @@ class ColumnBreakpoint extends Component {
 
   addColumnBreakpoint = nextProps => {
     const { columnBreakpoint, source } = nextProps || this.props;
+
+    if (!features.columnBreakpoints) {
+      return null;
+    }
 
     const sourceId = source.id;
     const doc = getDocument(sourceId);

--- a/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoints.js
+++ b/src/devtools/client/debugger/src/components/Editor/ColumnBreakpoints.js
@@ -14,8 +14,6 @@ import { getLocationKey } from "../../utils/breakpoint";
 // eslint-disable-next-line max-len
 
 class ColumnBreakpoints extends Component {
-  props;
-
   render() {
     const { cx, editor, columnBreakpoints, selectedSource } = this.props;
 

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -50,6 +50,7 @@ pref("devtools.features.videoPlayback", false);
 pref("devtools.features.launchBrowser", true);
 pref("devtools.features.termsOfService", false);
 pref("devtools.features.eventCount", true);
+pref("devtools.features.columnBreakpoints", false);
 
 export const prefs = new PrefsHelper("devtools", {
   splitConsole: ["Bool", "split-console"],
@@ -86,6 +87,7 @@ export const features = new PrefsHelper("devtools.features", {
   launchBrowser: ["Bool", "launchBrowser"],
   termsOfService: ["Bool", "termsOfService"],
   eventCount: ["Bool", "eventCount"],
+  columnBreakpoints: ["Bool", "columnBreakpoints"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {


### PR DESCRIPTION
We're in a funny spot now where we only show the first column breakpoint per line which defeats the purpose

This PR does 2 things
1. it adds cbs behind a feature flag
2. it hides the cb marker if the flag is off

CBs disabled
https://app.replay.io/recording/ddf434b5-39b9-49cd-b4f5-8c6575b65443

CBs enabled
https://app.replay.io/recording/ecfea184-23cc-46b5-b63b-2cd2585e10cc