### PR TITLE
Don't reload the app after login

### DIFF
--- a/src/ui/components/Account/index.tsx
+++ b/src/ui/components/Account/index.tsx
@@ -23,7 +23,7 @@ function WelcomePage() {
   const forceOpenAuth = new URLSearchParams(window.location.search).get("signin");
   const onLogin = () =>
     loginWithRedirect({
-      appState: { returnTo: window.location.href },
+      appState: { returnTo: window.location.pathname + window.location.search },
     });
 
   if (forceOpenAuth) {

--- a/src/ui/components/LoginButton.tsx
+++ b/src/ui/components/LoginButton.tsx
@@ -19,7 +19,7 @@ const LoginButton = () => {
     <button
       onClick={() =>
         loginWithRedirect({
-          appState: { returnTo: window.location.href },
+          appState: { returnTo: window.location.pathname + window.location.search },
         })
       }
       type="button"

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -49,7 +49,7 @@ function SignInButton() {
 
   const onClick = () => {
     loginWithRedirect({
-      appState: { returnTo: window.location.href },
+      appState: { returnTo: window.location.pathname + window.location.search },
     });
   };
 

--- a/src/ui/components/shared/LoginModal.tsx
+++ b/src/ui/components/shared/LoginModal.tsx
@@ -9,7 +9,7 @@ function LoginModal() {
 
   const onClick: React.MouseEventHandler = e => {
     loginWithRedirect({
-      appState: { returnTo: window.location.href },
+      appState: { returnTo: window.location.pathname + window.location.search },
     });
   };
 

--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -48,9 +48,7 @@ class TokenManager {
 
     const onRedirectCallback = (appState: AppState) => {
       if (appState?.returnTo) {
-        window.location.href = appState.returnTo;
-      } else {
-        history.push(window.location.pathname);
+        history.replace(appState.returnTo);
       }
     };
 


### PR DESCRIPTION
Reloading the app after login caused the loading screen to flicker and added an unnecessary delay.