### PR TITLE
Only use debugger shortcuts when the debugger is focused (#3448)

### DIFF
--- a/src/devtools/client/debugger/src/components/ProjectSearch.js
+++ b/src/devtools/client/debugger/src/components/ProjectSearch.js
@@ -53,15 +53,14 @@ export class ProjectSearch extends Component {
   }
 
   componentDidMount() {
-    const { shortcuts } = this.context;
-
-    shortcuts.on("CmdOrCtrl+Shift+F", this.toggleProjectTextSearch);
+    const { globalShortcuts, shortcuts } = this.context;
+    globalShortcuts.on("CmdOrCtrl+Shift+F", this.toggleProjectTextSearch);
     shortcuts.on("Enter", this.onEnterPress);
   }
 
   componentWillUnmount() {
-    const { shortcuts } = this.context;
-    shortcuts.off("CmdOrCtrl+Shift+F", this.toggleProjectTextSearch);
+    const { globalShortcuts, shortcuts } = this.context;
+    globalShortcuts.off("CmdOrCtrl+Shift+F", this.toggleProjectTextSearch);
     shortcuts.off("Enter", this.onEnterPress);
   }
 
@@ -264,6 +263,7 @@ export class ProjectSearch extends Component {
   }
 }
 ProjectSearch.contextTypes = {
+  globalShortcuts: PropTypes.object,
   shortcuts: PropTypes.object,
 };
 


### PR DESCRIPTION
The `KeyShortcuts` implementation used in the debugger expects the DOM node that it should attach to as a constructor argument. At the same time, the `KeyShortcuts` instance is shared with the child components, so it needs to exist before the debugger is rendered. To solve this chicken-and-egg problem, I pulled the outermost DOM node from the `Debugger` component to the `DebuggerLoader` component and pass it to `Debugger` as a prop.