### PR TITLE
Enable limited markdown support for comments (#3370)

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import classNames from "classnames";
+import Markdown from "react-markdown";
 import { UIState } from "ui/state";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
@@ -53,7 +54,9 @@ function CommentItem({
           </div>
         </div>
       </div>
-      <div className="space-y-4 px-3 pt-3 pb-3 text-xs">{comment.content}</div>
+      <div className="space-y-4 px-3 pt-3 pb-3 text-xs">
+        <Markdown>{comment.content}</Markdown>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This PR only enables the markdown-to-html conversion, but most markdown features don't work yet because of the css reset by tailwind. For example, `# Header` is converted to `<h1>Header</h1>`, but tailwind resets the default styling for `<h1>`, so this looks like regular text.