### PR TITLE
Check that the user's TOS version exists before comparing

### DIFF
--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -77,7 +77,12 @@ function App({ theme, modal, children }: AppProps) {
     return <LoadingScreen />;
   }
 
-  if (!isTest() && auth.isAuthenticated && userInfo.acceptedTOSVersion !== LATEST_TOS_VERSION) {
+  if (
+    !isTest() &&
+    auth.isAuthenticated &&
+    userInfo.acceptedTOSVersion &&
+    userInfo.acceptedTOSVersion !== LATEST_TOS_VERSION
+  ) {
     return <TOSScreen />;
   }
 


### PR DESCRIPTION
Right now, it's possible for a request to finish loading but because of a failure, return undefined values.

When this happens, we get an undefined `userInfo.acceptedTOSVersion`. This leads to a mismatch between the TOS version and the latest TOS version, which then pops open the TOS modal.

This adds a guard to make sure that the `acceptedTOSVersion` is not undefined.