### PR TITLE
Add UI feature guards for team users

### DIFF
--- a/src/devtools/client/debugger/src/components/App.css
+++ b/src/devtools/client/debugger/src/components/App.css
@@ -27,6 +27,7 @@ button {
   background-color: var(--theme-body-background);
   height: 100%;
   overflow: hidden;
+  z-index: 10; /* ensure tooltips are above other panes */
 }
 
 .editor-container {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -75,8 +75,6 @@
   text-overflow: ellipsis;
   padding: 5px;
   width: 100%;
-  margin-right: 10px;
-  cursor: text;
 }
 
 span.expression {

--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -1088,3 +1088,13 @@ a.learn-more-link.webconsole-learn-more-link {
   font-size: 1rem;
   color: white;
 }
+
+.webconsole-app .message.paywall > .icon::before {
+  content: "lock";
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* tailwind text-gray-500 */
+  color: rgba(107, 114, 128);
+}

--- a/src/devtools/client/webconsole/components/Output/MessageContainer.js
+++ b/src/devtools/client/webconsole/components/Output/MessageContainer.js
@@ -12,6 +12,10 @@ const { MESSAGE_SOURCE, MESSAGE_TYPE } = require("devtools/client/webconsole/con
 
 const componentMap = new Map([
   [
+    "PaywallMessage",
+    require("devtools/client/webconsole/components/Output/message-types/PaywallMessage"),
+  ],
+  [
     "ConsoleApiCall",
     require("devtools/client/webconsole/components/Output/message-types/ConsoleApiCall"),
   ],
@@ -83,7 +87,9 @@ function getMessageComponent(message) {
 
   switch (message.source) {
     case MESSAGE_SOURCE.CONSOLE_API:
-      return componentMap.get("ConsoleApiCall");
+      return message.paywall
+        ? componentMap.get("PaywallMessage")
+        : componentMap.get("ConsoleApiCall");
     case MESSAGE_SOURCE.JAVASCRIPT:
       switch (message.type) {
         case MESSAGE_TYPE.COMMAND:

--- a/src/devtools/client/webconsole/components/Output/MessageIcon.js
+++ b/src/devtools/client/webconsole/components/Output/MessageIcon.js
@@ -29,6 +29,8 @@ function getIconElement(level, onRewindClick, type) {
 
   if (type === "logPoint") {
     classnames.push("logpoint");
+  } else if (type === "paywall") {
+    classnames.push("material-icons");
   }
 
   {

--- a/src/devtools/client/webconsole/components/Output/message-types/PaywallMessage.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/PaywallMessage.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// React & Redux
+const { createElement, createFactory, useEffect } = require("react");
+const PropTypes = require("prop-types");
+const Message = createFactory(require("devtools/client/webconsole/components/Output/Message"));
+
+PaywallMessage.displayName = "PaywallMessage";
+
+PaywallMessage.propTypes = {
+  message: PropTypes.object.isRequired,
+  timestampsVisible: PropTypes.bool.isRequired,
+  maybeScrollToBottom: PropTypes.func,
+};
+
+/**
+ * Displays input from the console.
+ */
+function PaywallMessage(props) {
+  const { message, timestampsVisible, maybeScrollToBottom, isPaused, dispatch } = props;
+  const { indent, source, level, timeStamp, executionPointTime } = message;
+
+  return Message({
+    source,
+    type: "paywall",
+    level,
+    topLevelClasses: [],
+    messageBody: createElement("span", {
+      className: "text-gray-500 font-bold",
+      children: "Evaluations are only available for Developers in the Team plan.",
+    }),
+    indent,
+    timeStamp,
+    timestampsVisible,
+    executionPointTime,
+    maybeScrollToBottom,
+    message,
+    isPaused,
+    dispatch,
+  });
+}
+
+module.exports = PaywallMessage;

--- a/src/devtools/client/webconsole/types.js
+++ b/src/devtools/client/webconsole/types.js
@@ -57,3 +57,34 @@ exports.ConsoleMessage = function (props) {
     props
   );
 };
+
+exports.PaywallMessage = function (props) {
+  return Object.assign(
+    {
+      id: null,
+      innerWindowID: null,
+      allowRepeating: true,
+      source: null,
+      timeStamp: null,
+      type: MESSAGE_TYPE.RESULT,
+      level: MESSAGE_LEVEL.LOG,
+      category: null,
+      messageText: null,
+      parameters: null,
+      repeatId: null,
+      stacktrace: null,
+      frame: null,
+      groupId: null,
+      errorMessageName: null,
+      exceptionDocURL: null,
+      executionPoint: undefined,
+      userProvidedStyles: null,
+      notes: null,
+      indent: 0,
+      prefix: "",
+      private: false,
+      logpointId: undefined,
+    },
+    props
+  );
+};

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -22,6 +22,7 @@ export const GET_RECORDING = gql`
       private
       isInitialized
       ownerNeedsInvite
+      userRole
       owner {
         id
         name

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -27,6 +27,7 @@ const GET_WORKSPACE_RECORDINGS = gql`
               createdAt
               private
               isInitialized
+              userRole
               comments {
                 user {
                   id
@@ -63,6 +64,7 @@ const GET_MY_RECORDINGS = gql`
             createdAt
             private
             isInitialized
+            userRole
             owner {
               id
               name
@@ -127,7 +129,7 @@ export async function getRecording(recordingId: RecordingId) {
 }
 
 export function useGetRecording(
-  recordingId: RecordingId | null
+  recordingId: RecordingId | null | undefined
 ): { recording: Recording | undefined; isAuthorized: boolean; loading: boolean } {
   const { data, error, loading } = useQuery(GET_RECORDING, {
     variables: { recordingId },
@@ -169,6 +171,7 @@ function convertRecording(rec: any): Recording | undefined {
     comments: rec.comments,
     collaborators,
     ownerNeedsInvite: rec.ownerNeedsInvite,
+    userRole: rec.userRole,
   };
 }
 

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -68,6 +68,21 @@ export interface Subscription {
   paymentMethods: PaymentMethod[];
 }
 
+export enum RecordingRole {
+  // A user accessing a public recording may have no role (even if authenticated)
+  None = "none",
+  // The creator of the recording that exists in their library
+  Owner = "owner",
+  // A user invited to collaborate on recording
+  Collaborator = "collaborator",
+  // A user with access to the recording via their team with the "user" role on that team
+  TeamUser = "team-user",
+  // A user with access to the recording via their team with the "developer" role on that team
+  TeamDeveloper = "team-developer",
+  // A user with access to the recording via their team with the "admin" role on that team
+  TeamAdmin = "team-admin",
+}
+
 export interface Recording {
   id: string;
   url: string;
@@ -82,6 +97,7 @@ export interface Recording {
   workspace?: Workspace;
   collaborators?: string[];
   comments?: any;
+  userRole?: RecordingRole;
 }
 
 export interface PendingWorkspaceInvitation extends Workspace {


### PR DESCRIPTION
## Summary

* Adds `roles` to the `Recording` type to represent the possible roles a user might have for the given recording
* Adds a wrapper around the console input to show the locked message for "team-user" roles
* Prevents editing breakpoints for "team-user" roles
* Updates the styling of the breakpoint editor to match https://github.com/RecordReplay/devtools/issues/3408#issuecomment-909914767

![image](https://user-images.githubusercontent.com/788456/132566927-06b34af9-cb42-42cd-a404-a1bbce413796.png)

