### PR TITLE
Hide editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Replay</title>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -827,9 +827,9 @@
       "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
     },
     "@headlessui/react": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.0.0.tgz",
-      "integrity": "sha512-mjqRJrgkbcHQBfAHnqH0yRxO/y/22jYrdltpE7WkurafREKZ+pj5bPBwYHMt935Sdz/n16yRcVmsSCqDFHee9A=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.4.1.tgz",
+      "integrity": "sha512-gL6Ns5xQM57cZBzX6IVv6L7nsam8rDEpRhs5fg28SN64ikfmuuMgunc+Rw5C1cMScnvFM+cz32ueVrlSFEVlSg=="
     },
     "@heroicons/react": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@draft-js-plugins/editor": "^4.1.0",
     "@draft-js-plugins/emoji": "^4.2.0",
     "@draft-js-plugins/mention": "^4.3.1",
-    "@headlessui/react": "^1.0.0",
+    "@headlessui/react": "^1.4.1",
     "@heroicons/react": "^1.0.1",
     "@recordreplay/playwright": "^1.10.3",
     "@recordreplay/protocol": "^0.10.0",

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -95,6 +95,9 @@ export type SetLoadedRegions = Action<"set_loaded_regions"> & {
 export type SetShowVideoPanelAction = Action<"set_show_video_panel"> & {
   showVideoPanel: boolean;
 };
+export type SetShowEditorAction = Action<"set_show_editor"> & {
+  showEditor: boolean;
+};
 
 export type AppActions =
   | SetRecordingDurationAction
@@ -126,6 +129,7 @@ export type AppActions =
   | SetRecordingWorkspaceAction
   | SetLoadedRegions
   | SetShowVideoPanelAction
+  | SetShowEditorAction
   | SetAwaitingSourcemapsAction;
 
 export function setupApp(store: UIStore) {
@@ -366,4 +370,8 @@ export function setRecordingWorkspace(workspace: Workspace): SetRecordingWorkspa
 
 export function setShowVideoPanel(showVideoPanel: boolean): SetShowVideoPanelAction {
   return { type: "set_show_video_panel", showVideoPanel };
+}
+
+export function setShowEditor(showEditor: boolean): SetShowEditorAction {
+  return { type: "set_show_editor", showEditor };
 }

--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -16,7 +16,10 @@
   border-bottom: 1px solid var(--theme-splitter-color);
 }
 
-.secondary-toolbox-header:not(.node) {
+/* This makes sure that in cases where the toolbox is the only one
+displayed in a column, we don't add an additional border. Otherwise,
+the border added is duplicated. */
+.secondary-toolbox-header:not(.video-hidden *) {
   border-top: 1px solid var(--theme-splitter-color);
 }
 

--- a/src/ui/components/SecondaryToolbox/ToolboxOptions.css
+++ b/src/ui/components/SecondaryToolbox/ToolboxOptions.css
@@ -1,0 +1,3 @@
+.secondary-toolbox-options {
+  z-index: var(--z-index-8--dropdown);
+}

--- a/src/ui/components/SecondaryToolbox/ToolboxOptions.tsx
+++ b/src/ui/components/SecondaryToolbox/ToolboxOptions.tsx
@@ -1,0 +1,85 @@
+/* This example requires Tailwind CSS v2.0+ */
+import React, { Fragment } from "react";
+import { Menu, Transition } from "@headlessui/react";
+import { DotsHorizontalIcon } from "@heroicons/react/solid";
+import "./ToolboxOptions.css";
+import { connect, ConnectedProps } from "react-redux";
+import { selectors } from "ui/reducers";
+import { actions } from "ui/actions";
+import { UIState } from "ui/state";
+import classNames from "classnames";
+import MaterialIcon from "../shared/MaterialIcon";
+
+function ToolboxOptions({
+  showVideoPanel,
+  setShowVideoPanel,
+  showEditor,
+  setShowEditor,
+}: PropsFromRedux) {
+  return (
+    <Menu as="div" className="relative inline-block text-left secondary-toolbox-options">
+      <div>
+        <Menu.Button className="flex items-center text-gray-400 hover:text-gray-600">
+          <span className="sr-only">Open options</span>
+          <MaterialIcon className="h-4 w-4" style={{ fontSize: "16px" }}>
+            view_compact
+          </MaterialIcon>
+        </Menu.Button>
+      </div>
+
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-100"
+        enterFrom="transform opacity-0 scale-95"
+        enterTo="transform opacity-100 scale-100"
+        leave="transition ease-in duration-75"
+        leaveFrom="transform opacity-100 scale-100"
+        leaveTo="transform opacity-0 scale-95"
+      >
+        <Menu.Items className="origin-top-right text-sm absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+          <div className="py-1">
+            <Menu.Item>
+              {({ active }) => (
+                <a
+                  href="#"
+                  className={classNames(
+                    active ? "bg-gray-100 text-gray-900" : "text-gray-700",
+                    "block px-4 py-2"
+                  )}
+                  onClick={() => setShowVideoPanel(!showVideoPanel)}
+                >
+                  {`${showVideoPanel ? "Hide" : "Show"} Video`}
+                </a>
+              )}
+            </Menu.Item>
+            <Menu.Item>
+              {({ active }) => (
+                <a
+                  href="#"
+                  className={classNames(
+                    active ? "bg-gray-100 text-gray-900" : "text-gray-700",
+                    "block px-4 py-2"
+                  )}
+                  onClick={() => setShowEditor(!showEditor)}
+                >
+                  {`${showEditor ? "Hide" : "Show"} Editor`}
+                </a>
+              )}
+            </Menu.Item>
+          </div>
+        </Menu.Items>
+      </Transition>
+    </Menu>
+  );
+}
+
+const connector = connect(
+  (state: UIState) => ({
+    showVideoPanel: selectors.getShowVideoPanel(state),
+    showEditor: selectors.getShowEditor(state),
+  }),
+  { setShowVideoPanel: actions.setShowVideoPanel, setShowEditor: actions.setShowEditor }
+);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default connector(ToolboxOptions);

--- a/src/ui/components/SecondaryToolbox/ToolboxOptions.tsx
+++ b/src/ui/components/SecondaryToolbox/ToolboxOptions.tsx
@@ -20,8 +20,11 @@ function ToolboxOptions({
     <Menu as="div" className="relative inline-block text-left secondary-toolbox-options">
       <div>
         <Menu.Button className="flex items-center text-gray-400 hover:text-gray-600">
-          <span className="sr-only">Open options</span>
-          <MaterialIcon className="h-4 w-4" style={{ fontSize: "16px" }}>
+          <MaterialIcon
+            outlined
+            className="h-4 w-4 hover:text-primaryAccentHover"
+            style={{ fontSize: "16px" }}
+          >
             view_compact
           </MaterialIcon>
         </Menu.Button>

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -14,6 +14,7 @@ import { UIState } from "ui/state";
 import { PanelName } from "ui/state/app";
 import { isDemo } from "ui/utils/environment";
 import { Redacted } from "../Redacted";
+import ToolboxOptions from "./ToolboxOptions";
 
 const InspectorApp = React.lazy(() => import("devtools/client/inspector/components/App"));
 
@@ -109,7 +110,6 @@ function SecondaryToolbox({
   const { userSettings } = hooks.useGetUserSettings();
   const showReact = userSettings.showReact;
   const isNode = recordingTarget === "node";
-  const toggleShowVideoPanel = () => setShowVideoPanel(!showVideoPanel);
 
   return (
     <Redacted allowOptIn className={classnames(`secondary-toolbox`, { node: isNode })}>
@@ -121,11 +121,7 @@ function SecondaryToolbox({
             isNode={isNode}
             hasReactComponents={hasReactComponents}
           />
-          <button className="" onClick={toggleShowVideoPanel}>
-            <MaterialIcon className="hover:text-primaryAccent">
-              {showVideoPanel ? "videocam_off" : "videocam"}
-            </MaterialIcon>
-          </button>
+          <ToolboxOptions />
         </header>
       )}
       <div className="secondary-toolbox-content text-xs">

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -10,7 +10,11 @@ const SecondaryPanes = require("devtools/client/debugger/src/components/Secondar
 
 const SIDEPANEL_WIDTH = 240;
 
-function SidePanel({ selectedPrimaryPanel }: PropsFromRedux) {
+type SidePanelProps = {
+  resizable?: boolean;
+} & PropsFromRedux;
+
+function SidePanel({ selectedPrimaryPanel, resizable }: SidePanelProps) {
   let sidepanel;
 
   if (selectedPrimaryPanel === "explorer") {
@@ -27,7 +31,7 @@ function SidePanel({ selectedPrimaryPanel }: PropsFromRedux) {
     <Redacted
       allowOptIn
       style={{
-        width: `${SIDEPANEL_WIDTH}px`,
+        width: resizable ? "100%" : `${SIDEPANEL_WIDTH}px`,
         height: "100%",
         borderRight: "1px solid var(--theme-splitter-color)",
       }}

--- a/src/ui/components/Views/NonDevView.css
+++ b/src/ui/components/Views/NonDevView.css
@@ -17,12 +17,9 @@
   background-color: var(--theme-accordion-header-background);
 }
 
-.comments {
-  margin-bottom: 1px;
-}
-
 .right-sidebar-toolbar-item {
   font-size: 15px;
+  line-height: 19px;
   font-weight: 400;
   color: var(--theme-body-color);
   overflow: hidden;

--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -9,6 +9,7 @@ type MaterialIconProps = PropsFromRedux &
   React.HTMLProps<HTMLDivElement> & {
     children: string;
     highlighted?: boolean;
+    outlined?: boolean;
   };
 
 function MaterialIcon({
@@ -16,6 +17,7 @@ function MaterialIcon({
   fontLoading,
   highlighted,
   className,
+  outlined,
   dispatch, // unused
   ...rest
 }: MaterialIconProps) {
@@ -23,7 +25,7 @@ function MaterialIcon({
     <div
       {...rest}
       className={classnames(
-        "material-icons",
+        outlined ? "material-icons-outlined" : "material-icons",
         className,
         highlighted ? "text-primaryAccent" : "text-gray-800",
         { invisible: fontLoading }

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
@@ -21,7 +21,6 @@ import { trackEvent } from "ui/utils/telemetry";
 import { removeUrlParameters } from "ui/utils/environment";
 import { DownloadPage } from "../Onboarding/DownloadPage";
 import { DownloadingPage } from "../Onboarding/DownloadingPage";
-import { features } from "ui/utils/prefs";
 
 const DOWNLOAD_PAGE_INDEX = 4;
 

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -42,6 +42,7 @@ function initialAppState(): AppState {
     recordingWorkspace: null,
     loadedRegions: null,
     showVideoPanel: true,
+    showEditor: true,
   };
 }
 
@@ -219,6 +220,10 @@ export default function update(
       return { ...state, showVideoPanel: action.showVideoPanel };
     }
 
+    case "set_show_editor": {
+      return { ...state, showEditor: action.showEditor };
+    }
+
     default: {
       return state;
     }
@@ -311,6 +316,7 @@ export const getRecordingTarget = (state: UIState) => state.app.recordingTarget;
 export const getFontLoading = (state: UIState) => state.app.fontLoading;
 export const getRecordingWorkspace = (state: UIState) => state.app.recordingWorkspace;
 export const getShowVideoPanel = (state: UIState) => state.app.showVideoPanel;
+export const getShowEditor = (state: UIState) => state.app.showEditor;
 export const isRegionLoaded = (state: UIState, time: number | null | undefined) =>
   typeof time !== "number" ||
   !!getLoadedRegions(state)?.loaded.some(

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -64,8 +64,9 @@ export function bootstrapApp() {
   });
 
   if (!isTest()) {
-    var font = new FontFaceObserver("Material Icons");
-    font.load().then(() => store.dispatch(setFontLoading(false)));
+    var font1 = new FontFaceObserver("Material Icons");
+    var font2 = new FontFaceObserver("Material Icons Outlined");
+    Promise.all([font1.load(), font2.load()]).then(() => store.dispatch(setFontLoading(false)));
   } else {
     // FontFaceObserver doesn't work in e2e tests.
     store.dispatch(setFontLoading(false));

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -92,6 +92,7 @@ export interface AppState {
   recordingWorkspace: Workspace | null;
   loadedRegions: loadedRegions | null;
   showVideoPanel: boolean;
+  showEditor: boolean;
 }
 
 export interface AnalysisPoints {


### PR DESCRIPTION
Fix #3299.

This adds a button that allows the user to toggle the video and the editor in DevTools.
### Case 1: editor: !shown, video: shown
Toolbar + Sidepanel + Splitter(SecondaryToolbox + Video)

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/15959269/132715533-0b21aabb-0e2f-4c45-9b2d-a9193859e3e0.png"/></details>

### Case 2: editor: !shown, video: !shown
Toolbar + Sidepanel + SecondaryToolbox

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/15959269/132715627-228fd240-1699-49f9-b172-672f203661dd.png"/></details>

### Case 3: editor: shown, video: shown
Toolbar + Splitter(Toolbox (Sidepanel + Editor) + Viewer (Video + SecondaryToolbox))

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/15959269/132715425-4fa5579c-7bc8-481f-bf02-9e766c220f1b.png"/></details>

### Case 4: editor: shown, video: !shown
Toolbar + Splitter(Toolbox (Sidepanel + Editor) + SecondaryToolbox)

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/15959269/132715469-8550e668-0b64-4dba-adf1-4a927d73f3c2.png"/></details>