### PR TITLE
Add team and settings routes (#3470)

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -344,10 +344,6 @@ export function setCanvas(canvas: Canvas): SetCanvas {
   return { type: "set_canvas", canvas };
 }
 
-export function setWorkspaceId(workspaceId: WorkspaceId | null): SetWorkspaceId {
-  return { type: "set_workspace_id", workspaceId };
-}
-
 export function setDefaultSettingsTab(tabTitle: SettingsTabTitle): SetDefaultSettingsTab {
   return { type: "set_default_settings_tab", tabTitle };
 }

--- a/src/ui/components/Account/index.tsx
+++ b/src/ui/components/Account/index.tsx
@@ -3,7 +3,7 @@ import { useHistory } from "react-router-dom";
 import useAuth0 from "ui/utils/useAuth0";
 import { setUserInBrowserPrefs } from "../../utils/browser";
 import { isTeamLeaderInvite, isTeamMemberInvite } from "ui/utils/environment";
-import { createReplayURL } from "views/app";
+import { createRouteFromLegacyParams } from "ui/utils/routes";
 import Library from "../Library/index";
 
 import "./Account.css";
@@ -54,8 +54,7 @@ function WelcomePage() {
   }
 
   return (
-    <main
-      className="w-full h-full grid">
+    <main className="w-full h-full grid">
       <section className="max-w-sm w-72 m-auto bg-white rounded-md overflow-hidden">
         <div className="p-12 space-y-9">
           <div className="space-y-3 place-content-center">
@@ -89,7 +88,7 @@ export default function Account() {
 
   useEffect(() => {
     if (searchParams.get("id")) {
-      history.replace(createReplayURL(searchParams));
+      history.replace(createRouteFromLegacyParams(searchParams));
     }
   }, []);
 

--- a/src/ui/components/Library/BatchActionDropdown.tsx
+++ b/src/ui/components/Library/BatchActionDropdown.tsx
@@ -2,23 +2,22 @@ import React from "react";
 import Dropdown from "devtools/client/debugger/src/components/shared/Dropdown";
 import classnames from "classnames";
 import hooks from "ui/hooks";
-import { connect, ConnectedProps } from "react-redux";
-import * as selectors from "ui/reducers/app";
-import { UIState } from "ui/state";
 import { RecordingId } from "@recordreplay/protocol";
 import { WorkspaceId } from "ui/state/app";
+import { useGetWorkspaceId } from "ui/utils/routes";
+
 import "./BatchActionDropdown.css";
 
-type BatchActionDropdownProps = PropsFromRedux & {
+interface BatchActionDropdownProps {
   selectedIds: RecordingId[];
   setSelectedIds: any;
-};
+}
 
-function BatchActionDropdown({
+export default function BatchActionDropdown({
   selectedIds,
   setSelectedIds,
-  currentWorkspaceId,
 }: BatchActionDropdownProps) {
+  const currentWorkspaceId = useGetWorkspaceId();
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
   const updateRecordingWorkspace = hooks.useUpdateRecordingWorkspace();
   const deleteRecording = hooks.useDeleteRecordingFromLibrary();
@@ -83,9 +82,3 @@ function BatchActionDropdown({
     </div>
   );
 }
-
-const connector = connect((state: UIState) => ({
-  currentWorkspaceId: selectors.getWorkspaceId(state),
-}));
-type PropsFromRedux = ConnectedProps<typeof connector>;
-export default connector(BatchActionDropdown);

--- a/src/ui/components/Library/ItemDropdown.tsx
+++ b/src/ui/components/Library/ItemDropdown.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from "react";
 import * as actions from "ui/actions/app";
-import * as selectors from "ui/reducers/app";
 import { connect, ConnectedProps } from "react-redux";
 import hooks from "ui/hooks";
 import { RecordingId } from "@recordreplay/protocol";
 import { Recording } from "ui/types";
 import { WorkspaceId } from "ui/state/app";
-import { UIState } from "ui/state";
+import { useGetWorkspaceId } from "ui/utils/routes";
 
 function Privacy({
   isPrivate,
@@ -33,7 +32,8 @@ type DropdownPanelProps = PropsFromRedux & {
   recording: Recording;
 };
 
-const ItemDropdown = ({ currentWorkspaceId, recording, setModal }: DropdownPanelProps) => {
+const ItemDropdown = ({ recording, setModal }: DropdownPanelProps) => {
+  const currentWorkspaceId = useGetWorkspaceId();
   const [isPrivate, setIsPrivate] = useState(recording.private);
   const deleteRecording = hooks.useDeleteRecordingFromLibrary();
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
@@ -86,11 +86,8 @@ const ItemDropdown = ({ currentWorkspaceId, recording, setModal }: DropdownPanel
   );
 };
 
-const connector = connect(
-  (state: UIState) => ({ currentWorkspaceId: selectors.getWorkspaceId(state) }),
-  {
-    setModal: actions.setModal,
-  }
-);
+const connector = connect(null, {
+  setModal: actions.setModal,
+});
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(ItemDropdown);

--- a/src/ui/components/Library/PendingTeamPrompt.tsx
+++ b/src/ui/components/Library/PendingTeamPrompt.tsx
@@ -1,18 +1,18 @@
 import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
 import hooks from "ui/hooks";
 import { PendingWorkspaceInvitation } from "ui/types";
+import { getWorkspaceRoute } from "ui/utils/routes";
 import { PrimaryButton, SecondaryButton } from "../shared/Button";
 
-import { connect, ConnectedProps } from "react-redux";
-import * as selectors from "ui/reducers/app";
-import * as actions from "ui/actions/app";
-import { UIState } from "ui/state";
+interface PendingTeamPromptProps {
+  workspace: PendingWorkspaceInvitation;
+}
 
-type PendingTeamPromptProps = PropsFromRedux & { workspace: PendingWorkspaceInvitation };
-
-function PendingTeamPrompt({ workspace, setWorkspaceId }: PendingTeamPromptProps) {
+export default function PendingTeamPrompt({ workspace }: PendingTeamPromptProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const { id, name, inviterEmail } = workspace;
+  const history = useHistory();
 
   const acceptPendingInvitation = hooks.useAcceptPendingInvitation(onAcceptCompleted);
   const declinePendingInvitation = hooks.useRejectPendingInvitation(onDeclineCompleted);
@@ -30,7 +30,7 @@ function PendingTeamPrompt({ workspace, setWorkspaceId }: PendingTeamPromptProps
     }
   };
   function onDeclineCompleted() {
-    setWorkspaceId(null);
+    history.push(getWorkspaceRoute(null));
   }
   function onAcceptCompleted() {
     updateDefaultWorkspace({
@@ -67,12 +67,3 @@ function PendingTeamPrompt({ workspace, setWorkspaceId }: PendingTeamPromptProps
     </div>
   );
 }
-
-const connector = connect(
-  (state: UIState) => ({
-    currentWorkspaceId: selectors.getWorkspaceId(state),
-  }),
-  { setWorkspaceId: actions.setWorkspaceId }
-);
-type PropsFromRedux = ConnectedProps<typeof connector>;
-export default connector(PendingTeamPrompt);

--- a/src/ui/components/Library/TeamButton.tsx
+++ b/src/ui/components/Library/TeamButton.tsx
@@ -1,45 +1,38 @@
 import React from "react";
-import { connect, ConnectedProps } from "react-redux";
-import * as selectors from "ui/reducers/app";
-import * as actions from "ui/actions/app";
-import { UIState } from "ui/state";
-import hooks from "ui/hooks";
-import SidebarButton from "./SidebarButton";
+import { useHistory } from "react-router-dom";
 import classNames from "classnames";
+import { getWorkspaceRoute, getWorkspaceSettingsRoute, useGetWorkspaceId } from "ui/utils/routes";
+import SidebarButton from "./SidebarButton";
 import { Redacted } from "../Redacted";
 
-type TeamButtonProps = PropsFromRedux & {
+interface TeamButtonProps {
   text: string;
   isNew?: boolean;
   id: string | null;
-};
+}
 
-function TeamButton({
-  text,
-  isNew,
-  id,
-  currentWorkspaceId,
-  setWorkspaceId,
-  setModal,
-}: TeamButtonProps) {
-  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
+export default function TeamButton({ text, isNew, id }: TeamButtonProps) {
+  const history = useHistory();
+  const currentWorkspaceId = useGetWorkspaceId()!;
+  // const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
   const isSelected = currentWorkspaceId == id;
   const showSettingsButton = id && isSelected && !isNew;
 
   const handleTeamClick = (e: React.MouseEvent) => {
     e.preventDefault();
-    setWorkspaceId(id);
+    history.push(getWorkspaceRoute(id));
 
     // We only set the new team as the default team if this is a non-pending team.
     // Otherwise, it would be possible to set pending teams as a default team.
     if (!isNew) {
-      updateDefaultWorkspace({
-        variables: { workspaceId: id },
-      });
+      // updateDefaultWorkspace({
+      //   variables: { workspaceId: id },
+      // });
     }
   };
-  const handleSettingsClick = () => {
-    setModal("workspace-settings");
+  const handleSettingsClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    history.push(getWorkspaceSettingsRoute(currentWorkspaceId));
   };
 
   const badge = isNew && (
@@ -65,7 +58,7 @@ function TeamButton({
   );
 }
 
-function SettingsButton({ onClick }: { onClick: () => void }) {
+function SettingsButton({ onClick }: { onClick: (e: React.MouseEvent) => void }) {
   return (
     <button
       onClick={onClick}
@@ -75,12 +68,3 @@ function SettingsButton({ onClick }: { onClick: () => void }) {
     </button>
   );
 }
-
-const connector = connect(
-  (state: UIState) => ({
-    currentWorkspaceId: selectors.getWorkspaceId(state),
-  }),
-  { setWorkspaceId: actions.setWorkspaceId, setModal: actions.setModal }
-);
-type PropsFromRedux = ConnectedProps<typeof connector>;
-export default connector(TeamButton);

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -1,10 +1,7 @@
 import React from "react";
-import Loader from "../shared/Loader";
+import { Route, Switch } from "react-router-dom";
+import { useGetWorkspaceId } from "ui/utils/routes";
 import Viewer from "./Viewer";
-
-import { connect, ConnectedProps } from "react-redux";
-import * as selectors from "ui/reducers/app";
-import { UIState } from "ui/state";
 import hooks from "ui/hooks";
 import Spinner from "../shared/Spinner";
 import { PendingTeamScreen } from "./PendingTeamScreen";
@@ -29,8 +26,8 @@ function MyLibrary({ searchString }: ViewerRouterProps) {
 }
 
 function TeamLibrary(props: ViewerRouterProps) {
+  const currentWorkspaceId = useGetWorkspaceId();
   const { pendingWorkspaces, loading } = hooks.useGetPendingWorkspaces();
-  const { currentWorkspaceId } = props;
 
   if (loading) {
     return <ViewerLoader />;
@@ -46,7 +43,8 @@ function TeamLibrary(props: ViewerRouterProps) {
   }
 }
 
-function NonPendingTeamLibrary({ currentWorkspaceId, searchString }: ViewerRouterProps) {
+function NonPendingTeamLibrary({ searchString }: ViewerRouterProps) {
+  const currentWorkspaceId = useGetWorkspaceId();
   const { recordings, loading } = hooks.useGetWorkspaceRecordings(currentWorkspaceId!);
   const { workspaces, loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
 
@@ -65,22 +63,19 @@ function NonPendingTeamLibrary({ currentWorkspaceId, searchString }: ViewerRoute
   );
 }
 
-type ViewerRouterProps = PropsFromRedux & {
+interface ViewerRouterProps {
   searchString: string;
-};
-
-function ViewerRouter(props: ViewerRouterProps) {
-  const { currentWorkspaceId } = props;
-
-  if (currentWorkspaceId === null) {
-    return <MyLibrary {...props} />;
-  } else {
-    return <TeamLibrary {...props} />;
-  }
 }
 
-const connector = connect((state: UIState) => ({
-  currentWorkspaceId: selectors.getWorkspaceId(state),
-}));
-type PropsFromRedux = ConnectedProps<typeof connector>;
-export default connector(ViewerRouter);
+export default function ViewerRouter(props: ViewerRouterProps) {
+  return (
+    <Switch>
+      <Route path="/team/:workspaceId">
+        <TeamLibrary {...props} />
+      </Route>
+      <Route>
+        <MyLibrary {...props} />
+      </Route>
+    </Switch>
+  );
+}

--- a/src/ui/components/shared/Modal.tsx
+++ b/src/ui/components/shared/Modal.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { connect } from "react-redux";
+import { useHistory } from "react-router-dom";
 import * as actions from "ui/actions/app";
+import { getWorkspaceRoute, useGetSettingsTab, useGetWorkspaceId } from "ui/utils/routes";
 import "./Modal.css";
 
 interface ModalProps {
@@ -10,12 +12,21 @@ interface ModalProps {
 }
 
 function Modal({ hideModal, children, showClose = true }: ModalProps) {
+  const history = useHistory();
+  const workspaceId = useGetWorkspaceId();
+  const workspaceSettingsTab = useGetSettingsTab();
+  function hideModalAndUpdateRoute() {
+    hideModal();
+    if (workspaceSettingsTab) {
+      history.push(getWorkspaceRoute(workspaceId));
+    }
+  }
   return (
     <div className="modal-container">
-      <div className="modal-mask" onClick={hideModal} />
+      <div className="modal-mask" onClick={hideModalAndUpdateRoute} />
       <div className="modal-content text-sm">
         {showClose && (
-          <button className="modal-close" onClick={hideModal}>
+          <button className="modal-close" onClick={hideModalAndUpdateRoute}>
             <div className="img close" />
           </button>
         )}

--- a/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -8,11 +8,12 @@ import React, {
   useState,
 } from "react";
 import { connect, ConnectedProps } from "react-redux";
+import { useHistory } from "react-router-dom";
 import * as actions from "ui/actions/app";
+import { getWorkspaceRoute } from "ui/utils/routes";
 import hooks from "ui/hooks";
 import { Workspace, WorkspaceUser } from "ui/types";
 import { removeUrlParameters } from "ui/utils/environment";
-import { features } from "ui/utils/prefs";
 import { isValidTeamName, validateEmail } from "ui/utils/helpers";
 import { TextInput } from "../Forms";
 import Modal from "../NewModal";
@@ -271,13 +272,14 @@ type SlideBody3Props = PropsFromRedux & {
   current: number;
 };
 
-function SlideBody3({ setWorkspaceId, hideModal, newWorkspace }: SlideBody3Props) {
+function SlideBody3({ hideModal, newWorkspace }: SlideBody3Props) {
+  const history = useHistory();
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
 
   const onClick = () => {
     removeUrlParameters();
 
-    setWorkspaceId(newWorkspace.id);
+    history.push(getWorkspaceRoute(newWorkspace.id));
     updateDefaultWorkspace({ variables: { workspaceId: newWorkspace.id } });
     hideModal();
   };
@@ -342,7 +344,6 @@ function OnboardingModal(props: PropsFromRedux) {
 
 const connector = connect(() => ({}), {
   hideModal: actions.hideModal,
-  setWorkspaceId: actions.setWorkspaceId,
 });
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(OnboardingModal);

--- a/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react";
 import { useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
+import { useHistory } from "react-router-dom";
 import * as actions from "ui/actions/app";
 import hooks from "ui/hooks";
 import { PendingWorkspaceInvitation } from "ui/types";
 import { removeUrlParameters } from "ui/utils/environment";
+import { getWorkspaceRoute } from "ui/utils/routes";
 import { trackEvent } from "ui/utils/telemetry";
 import { PrimaryLgButton, SecondaryLgButton } from "../Button";
 import { DownloadingPage } from "../Onboarding/DownloadingPage";
@@ -50,13 +52,14 @@ function SingleInviteModalLoader(props: PropsFromRedux) {
 
 // Once we have the workspace, this component should handle auto-accepting that invitation.
 function AutoAccept(props: SingleInviteModalProps) {
-  const { setWorkspaceId, workspace } = props;
+  const { workspace } = props;
+  const history = useHistory();
   const [accepted, setAccepted] = useState(false);
 
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
   const acceptPendingInvitation = hooks.useAcceptPendingInvitation(() => {
     updateDefaultWorkspace({ variables: { workspaceId: workspace.id } });
-    setWorkspaceId(workspace.id);
+    history.push(getWorkspaceRoute(workspace.id));
     setAccepted(true);
   });
 
@@ -160,7 +163,6 @@ function SingleInviteModal({ hideModal, workspace }: SingleInviteModalProps) {
 
 const connector = connect(() => ({}), {
   hideModal: actions.hideModal,
-  setWorkspaceId: actions.setWorkspaceId,
 });
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(SingleInviteModalLoader);

--- a/src/ui/components/shared/SettingsModal/SettingsModal.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsModal.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from "react";
+import React from "react";
+import classnames from "classnames";
+import { useGetSettingsTab } from "ui/utils/routes";
 import Modal from "ui/components/shared/Modal";
 import SettingsNavigation from "./SettingsNavigation";
 import SettingsBody from "./SettingsBody";
-
 import { Settings } from "./types";
 
 import "./SettingsModal.css";
-import classnames from "classnames";
 
 export default function SettingsModal<
   T extends string,
@@ -33,7 +33,7 @@ export default function SettingsModal<
   size?: "sm" | "lg";
   title?: string;
 }) {
-  const [selectedTab, setSelectedTab] = useState<T | undefined>(defaultSelectedTab);
+  const selectedTab = useGetSettingsTab();
   const selectedSetting = settings.find(setting => setting.title === selectedTab)!;
 
   if (loading) {
@@ -47,7 +47,7 @@ export default function SettingsModal<
   return (
     <div className={classnames("settings-modal", { "settings-modal-large": size === "lg" })}>
       <Modal>
-        <SettingsNavigation {...{ hiddenTabs, settings, selectedTab, setSelectedTab, title }} />
+        <SettingsNavigation {...{ hiddenTabs, settings, selectedTab, title }} />
         <SettingsBody
           values={values}
           selectedSetting={selectedSetting}

--- a/src/ui/components/shared/SettingsModal/SettingsNavigation.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsNavigation.tsx
@@ -1,9 +1,12 @@
 import React from "react";
+import { useHistory } from "react-router-dom";
 import classnames from "classnames";
+import { getWorkspaceSettingsRoute, useGetSettingsTab, useGetWorkspaceId } from "ui/utils/routes";
 import { Setting, Settings } from "./types";
-import "./SettingsNavigation.css";
 import MaterialIcon from "../MaterialIcon";
 import { SettingsHeader } from "./SettingsBody";
+
+import "./SettingsNavigation.css";
 
 interface SettingNavigationItemProps<
   T extends string,
@@ -11,8 +14,6 @@ interface SettingNavigationItemProps<
   P extends Record<string, unknown>
 > {
   setting: Setting<T, V, P>;
-  selectedTab?: T;
-  setSelectedTab: (title: T) => void;
 }
 
 interface SettingNavigationProps<
@@ -21,8 +22,6 @@ interface SettingNavigationProps<
   P extends Record<string, unknown>
 > {
   settings: Settings<T, V, P>;
-  selectedTab?: T;
-  setSelectedTab: (title: T) => void;
   title?: string;
   hiddenTabs?: T[];
 }
@@ -31,10 +30,13 @@ function SettingNavigationItem<
   T extends string,
   V extends Record<string, unknown>,
   P extends Record<string, unknown>
->({ setting, selectedTab, setSelectedTab }: SettingNavigationItemProps<T, V, P>) {
+>({ setting }: SettingNavigationItemProps<T, V, P>) {
   const { title, icon } = setting;
+  const history = useHistory();
+  const workspaceId = useGetWorkspaceId()!;
+  const selectedTab = useGetSettingsTab()!;
   const onClick = () => {
-    setSelectedTab(title);
+    history.push(getWorkspaceSettingsRoute(workspaceId, title));
   };
 
   return (
@@ -49,13 +51,7 @@ export default function SettingNavigation<
   T extends string,
   V extends Record<string, unknown>,
   P extends Record<string, unknown>
->({
-  hiddenTabs,
-  settings,
-  selectedTab,
-  setSelectedTab,
-  title = "Settings",
-}: SettingNavigationProps<T, V, P>) {
+>({ hiddenTabs, settings, title = "Settings" }: SettingNavigationProps<T, V, P>) {
   return (
     <nav>
       <SettingsHeader>{title}</SettingsHeader>
@@ -63,7 +59,7 @@ export default function SettingNavigation<
         {settings
           .filter(setting => !hiddenTabs || !hiddenTabs.includes(setting.title))
           .map((setting, index) => (
-            <SettingNavigationItem {...{ setting, selectedTab, setSelectedTab }} key={index} />
+            <SettingNavigationItem {...{ setting }} key={index} />
           ))}
       </ul>
     </nav>

--- a/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
+++ b/src/ui/components/shared/TeamLeaderOnboardingModal/TeamLeaderOnboardingModal.tsx
@@ -1,5 +1,7 @@
 import React, { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
+import { useHistory } from "react-router-dom";
+import { getWorkspaceRoute } from "ui/utils/routes";
 import * as actions from "ui/actions/app";
 import hooks from "ui/hooks";
 import { Workspace, WorkspaceUser } from "ui/types";
@@ -21,7 +23,6 @@ import { trackEvent } from "ui/utils/telemetry";
 import { removeUrlParameters } from "ui/utils/environment";
 import { DownloadPage } from "../Onboarding/DownloadPage";
 import { DownloadingPage } from "../Onboarding/DownloadingPage";
-import { features } from "ui/utils/prefs";
 
 const DOWNLOAD_PAGE_INDEX = 4;
 
@@ -127,11 +128,8 @@ function TeamNamePage({
   );
 }
 
-function TeamMemberInvitationPage({
-  newWorkspace,
-  setWorkspaceId,
-  onSkipToDownload,
-}: SlideBodyProps) {
+function TeamMemberInvitationPage({ newWorkspace, onSkipToDownload }: SlideBodyProps) {
+  const history = useHistory();
   const [inputValue, setInputValue] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -142,7 +140,7 @@ function TeamMemberInvitationPage({
   });
 
   useEffect(() => {
-    setWorkspaceId(newWorkspace!.id);
+    history.push(getWorkspaceRoute(newWorkspace!.id));
   });
 
   // This is hacky. A member entry will only have an e-mail if it was pending. If
@@ -283,7 +281,6 @@ function OnboardingModal(props: PropsFromRedux) {
 
 const connector = connect(() => ({}), {
   hideModal: actions.hideModal,
-  setWorkspaceId: actions.setWorkspaceId,
 });
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(OnboardingModal);

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
@@ -1,5 +1,7 @@
 import classnames from "classnames";
 import React, { useState, useEffect } from "react";
+import { useHistory } from "react-router-dom";
+import { getWorkspaceRoute } from "ui/utils/routes";
 import hooks from "ui/hooks";
 import { WorkspaceUser, WorkspaceUserRole } from "ui/types";
 import PortalDropdown from "ui/components/shared/PortalDropdown";
@@ -173,16 +175,15 @@ export function NonRegisteredWorkspaceMember({
 function Role({
   canLeave,
   member,
-  setWorkspaceId,
   hideModal,
   isAdmin,
 }: {
   member: WorkspaceUser;
-  setWorkspaceId: any;
   hideModal: any;
   isAdmin: boolean;
   canLeave: boolean;
 }) {
+  const history = useHistory();
   const [expanded, setExpanded] = useState(false);
   const deleteUserFromWorkspace = hooks.useDeleteUserFromWorkspace();
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
@@ -204,7 +205,7 @@ function Role({
       // to the personal workspace.
       if (isPersonal) {
         hideModal();
-        setWorkspaceId(null);
+        history.push(getWorkspaceRoute(null));
         updateDefaultWorkspace({ variables: { workspaceId: null } });
       }
     }
@@ -237,13 +238,7 @@ function Role({
   );
 }
 
-function WorkspaceMember({
-  member,
-  setWorkspaceId,
-  hideModal,
-  isAdmin,
-  canLeave = false,
-}: WorkspaceMemberProps) {
+function WorkspaceMember({ member, hideModal, isAdmin, canLeave = false }: WorkspaceMemberProps) {
   return (
     <li className="flex flex-row items-center space-x-1.5">
       <AvatarImage
@@ -254,19 +249,12 @@ function WorkspaceMember({
       <div className="flex-grow" data-private>
         {member.user!.name}
       </div>
-      <Role
-        member={member}
-        setWorkspaceId={setWorkspaceId}
-        hideModal={hideModal}
-        isAdmin={isAdmin}
-        canLeave={canLeave}
-      />
+      <Role member={member} hideModal={hideModal} isAdmin={isAdmin} canLeave={canLeave} />
     </li>
   );
 }
 
 const connector = connect(() => ({}), {
-  setWorkspaceId: actions.setWorkspaceId,
   hideModal: actions.hideModal,
 });
 export type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -35,7 +35,6 @@ function initialAppState(): AppState {
     canvas: null,
     videoUrl: null,
     videoNode: null,
-    workspaceId: null,
     defaultSettingsTab: "Personal",
     recordingTarget: null,
     fontLoading: true,
@@ -195,10 +194,6 @@ export default function update(
       };
     }
 
-    case "set_workspace_id": {
-      return { ...state, workspaceId: action.workspaceId };
-    }
-
     case "set_default_settings_tab": {
       return { ...state, defaultSettingsTab: action.tabTitle };
     }
@@ -305,7 +300,6 @@ export const getIsNodePickerActive = (state: UIState) => state.app.isNodePickerA
 export const getCanvas = (state: UIState) => state.app.canvas;
 export const getVideoUrl = (state: UIState) => state.app.videoUrl;
 export const getVideoNode = (state: UIState) => state.app.videoNode;
-export const getWorkspaceId = (state: UIState) => state.app.workspaceId;
 export const getDefaultSettingsTab = (state: UIState) => state.app.defaultSettingsTab;
 export const getRecordingTarget = (state: UIState) => state.app.recordingTarget;
 export const getFontLoading = (state: UIState) => state.app.fontLoading;

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -5,7 +5,7 @@ import { setupDOMHelpers } from "./dom";
 import { setTelemetryContext, setupTelemetry } from "ui/utils/telemetry";
 import { UIStore } from "ui/actions";
 import { getTheme } from "ui/reducers/app";
-import { setFontLoading, setModal, setWorkspaceId } from "ui/actions/app";
+import { setFontLoading, setModal } from "ui/actions/app";
 import tokenManager from "ui/utils/tokenManager";
 import { bootIntercom } from "ui/utils/intercom";
 import { setAccessTokenInBrowserPrefs, setUserInBrowserPrefs } from "ui/utils/browser";
@@ -60,7 +60,7 @@ export function bootstrapApp() {
     }
 
     const userSettings = await getUserSettings();
-    store.dispatch(setWorkspaceId(userSettings.defaultWorkspaceId));
+    // store.dispatch(setWorkspaceId(userSettings.defaultWorkspaceId));
   });
 
   if (!isTest()) {

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -85,7 +85,6 @@ export interface AppState {
   canvas: Canvas | null;
   videoUrl: string | null;
   videoNode: HTMLVideoElement | null;
-  workspaceId: WorkspaceId | null;
   defaultSettingsTab: SettingsTabTitle;
   recordingTarget: RecordingTarget | null;
   fontLoading: boolean;

--- a/src/ui/utils/routes.ts
+++ b/src/ui/utils/routes.ts
@@ -1,0 +1,37 @@
+import { matchPath, useLocation } from "react-router-dom";
+
+/**
+ * Create a library route with the given parameters. Used for replacing
+ * legacy routes with their current equivalents.
+ */
+export function createRouteFromLegacyParams(currentParams: URLSearchParams) {
+  const recordingId = currentParams.get("id");
+  const path = recordingId ? `/recording/${recordingId}` : "/";
+  const newParams = new URLSearchParams();
+  currentParams.forEach((value, key) => {
+    if (key !== "id") {
+      newParams.set(key, value);
+    }
+  });
+  return `${path}?${newParams.toString()}`;
+}
+
+export function useGetWorkspaceId(): string | null {
+  const { pathname } = useLocation();
+  const params: any = matchPath(pathname, { path: "/team/:workspaceId" })?.params;
+  return params?.workspaceId || null;
+}
+
+export function useGetSettingsTab(): string | null {
+  const { pathname } = useLocation();
+  const params: any = matchPath(pathname, { path: "/team/:workspaceId/settings/:tab" })?.params;
+  return params?.tab || null;
+}
+
+export function getWorkspaceRoute(workspaceId: string | null) {
+  return workspaceId ? `/team/${workspaceId}` : "/";
+}
+
+export function getWorkspaceSettingsRoute(workspaceId: string, tab?: string) {
+  return `/team/${workspaceId}/settings/${tab || "Team Members"}`;
+}

--- a/src/views/app.tsx
+++ b/src/views/app.tsx
@@ -8,6 +8,7 @@ import { LoadingScreen } from "ui/components/shared/BlankScreen";
 import ErrorBoundary from "ui/components/ErrorBoundary";
 import App from "ui/components/App";
 import { bootstrapApp } from "ui/setup";
+import { createRouteFromLegacyParams } from "ui/utils/routes";
 import "image/image.css";
 
 const Recording = React.lazy(() => import("./recording"));
@@ -25,6 +26,7 @@ const AppRouting = () => (
               <React.Suspense fallback={<LoadingScreen />}>
                 <Switch>
                   <Route path="/recording/:recordingId" component={Recording} />
+                  <Route path="/team/:workspaceId" component={Account} />
                   <Route exact path="/" component={Account} />
                   <Route exact path="/view" component={ViewRedirect} />
                 </Switch>
@@ -42,25 +44,9 @@ function ViewRedirect() {
   const history = useHistory();
   const currentParams = new URLSearchParams(window.location.search);
   useEffect(() => {
-    history.replace(createReplayURL(currentParams));
+    history.replace(createRouteFromLegacyParams(currentParams));
   });
   return null;
-}
-
-/**
- * Create a (host relative) URL with the given parameters. Used for replacing
- * legacy routes with their current equivalents.
- */
-export function createReplayURL(currentParams: URLSearchParams) {
-  const recordingId = currentParams.get("id");
-  const path = recordingId ? `/recording/${recordingId}` : "/";
-  const newParams = new URLSearchParams();
-  currentParams.forEach((value, key) => {
-    if (key !== "id") {
-      newParams.set(key, value);
-    }
-  });
-  return `${path}?${newParams.toString()}`;
 }
 
 export default AppRouting;


### PR DESCRIPTION
Adds routes `/team/:teamID` and `/team/:teamID/settings/:tab`.
TODO: 
- the `tab` in the settings route now uses the tab's title, but that should be an ID instead because the title may contain characters that are not safe to put in a URL
- the displayed modal is still stored in redux (and the settings route triggers a corresponding update to the redux store) - it would be nice to take this out of redux and have all modals triggered by routes
