### PR TITLE
Add billing route (#3470)

### DIFF
--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -1,4 +1,5 @@
-import React, { ChangeEvent, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
+import { matchPath, useHistory, useLocation } from "react-router-dom";
 import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
 import hooks from "ui/hooks";
@@ -189,10 +190,23 @@ const settings: Settings<
 ];
 
 function WorkspaceSettingsModal({ workspaceId, ...rest }: PropsFromRedux) {
+  const history = useHistory();
+  const { pathname } = useLocation();
+  const match = matchPath<{ workspaceId: string }>(pathname, {
+    path: "/team/:workspaceId/settings/billing",
+  });
+  const [defaultTab, setDefaultTab] = useState<string>("Team Members");
   const { members } = hooks.useGetWorkspaceMembers(workspaceId!);
   const { userId: localUserId } = hooks.useGetUserId();
 
-  if (!workspaceId) return null;
+  useEffect(() => {
+    if (match) {
+      setDefaultTab("Billing");
+      history.replace("/");
+    }
+  }, []);
+
+  if (match || !workspaceId) return null;
 
   const roles = members?.find(m => m.userId === localUserId)?.roles;
   const isAdmin = roles?.includes("admin") || false;
@@ -211,7 +225,7 @@ function WorkspaceSettingsModal({ workspaceId, ...rest }: PropsFromRedux) {
   return (
     <SettingsModal
       hiddenTabs={hiddenTabs}
-      defaultSelectedTab="Team Members"
+      defaultSelectedTab={defaultTab}
       panelProps={{ isAdmin, workspaceId, ...rest }}
       settings={settings}
       size="lg"

--- a/src/views/app.tsx
+++ b/src/views/app.tsx
@@ -25,8 +25,8 @@ const AppRouting = () => (
               <React.Suspense fallback={<LoadingScreen />}>
                 <Switch>
                   <Route path="/recording/:recordingId" component={Recording} />
-                  <Route exact path="/" component={Account} />
                   <Route exact path="/view" component={ViewRedirect} />
+                  <Route component={Account} />
                 </Switch>
               </React.Suspense>
             </ErrorBoundary>


### PR DESCRIPTION
Adds a `/team/:workspaceId/settings/billing` route. `workspaceId` needs to be the GraphQL ID of a workspace.