### PR TITLE
Fix user api key UI unmounting after creating a key

### DIFF
--- a/src/ui/components/shared/APIKeys.tsx
+++ b/src/ui/components/shared/APIKeys.tsx
@@ -33,7 +33,7 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
               <div className="mx-3 text-primaryAccent">Copied!</div>
             ) : (
               <MaterialIcon
-                className="material-icons mx-2.5 w-5 h-5 text-primaryAccent"
+                className="material-icons mx-2.5 w-5 text-primaryAccent"
                 onClick={() => navigator.clipboard.writeText(keyValue!).then(() => setCopied(true))}
               >
                 assignment_outline

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -128,6 +128,12 @@ function UserAPIKeys({ apiKeys }: { apiKeys: ApiKey[] }) {
   );
 }
 
+function ApiKeysWrapper({ settings }: { settings?: UserSettings }) {
+  if (!settings) return null;
+
+  return <UserAPIKeys apiKeys={settings.apiKeys} />;
+}
+
 const getSettings = (internal: boolean): Settings<SettingsTabTitle, UserSettings, {}> => [
   {
     title: "Personal",
@@ -142,11 +148,7 @@ const getSettings = (internal: boolean): Settings<SettingsTabTitle, UserSettings
   {
     title: "API Keys",
     icon: "vpn_key",
-    component: function ApiKeysWrapper({ settings }) {
-      if (!settings) return null;
-
-      return <UserAPIKeys apiKeys={settings.apiKeys} />;
-    },
+    component: ApiKeysWrapper,
   },
   {
     title: "Experimental",


### PR DESCRIPTION
## Summary

Regression from #3377. The ApiKeysWrapper component was unmounted and remounted when adding a new key making it impossible to copy the key because the display of the key was immediately unmounted upon render.

Details: https://app.replay.io/recording/0dcdbe68-c28b-4434-9bb4-76ff2c0137ce