### PR TITLE
Mega library touch up

### DIFF
--- a/src/ui/components/Library/RecordingOptionsDropdown.tsx
+++ b/src/ui/components/Library/RecordingOptionsDropdown.tsx
@@ -1,0 +1,150 @@
+import React, { Fragment, useState } from "react";
+import { Menu, Transition } from "@headlessui/react";
+import { connect, ConnectedProps } from "react-redux";
+import { selectors } from "ui/reducers";
+import { actions } from "ui/actions";
+import { UIState } from "ui/state";
+import { Recording } from "ui/types";
+import classNames from "classnames";
+import MaterialIcon from "../shared/MaterialIcon";
+import hooks from "ui/hooks";
+import { RecordingId } from "@recordreplay/protocol";
+import { WorkspaceId } from "ui/state/app";
+
+type RecordingOptionsDropdownProps = PropsFromRedux & {
+  recording: Recording;
+};
+
+function Dropdown({
+  button,
+  children,
+}: {
+  button: React.ReactElement;
+  children: React.ReactElement[];
+}) {
+  return (
+    <Menu as="div" className="inline-block text-left recording-options">
+      <div className="opacity-0 group-hover:opacity-100">
+        <Menu.Button className="flex items-center text-gray-400 hover:text-gray-600">
+          {button}
+        </Menu.Button>
+      </div>
+
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-100"
+        enterFrom="transform opacity-0 scale-95"
+        enterTo="transform opacity-100 scale-100"
+        leave="transition ease-in duration-75"
+        leaveFrom="transform opacity-100 scale-100"
+        leaveTo="transform opacity-0 scale-95"
+      >
+        <Menu.Items
+          className={classNames(
+            "mr-8",
+            "origin-top-right text-sm absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none"
+          )}
+        >
+          <div className="py-1">{children}</div>
+        </Menu.Items>
+      </Transition>
+    </Menu>
+  );
+}
+
+function DropdownItem({
+  children,
+  onClick,
+}: {
+  children: string;
+  onClick: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <Menu.Item>
+      {({ active }) => (
+        <a
+          href="#"
+          className={classNames(
+            active ? "bg-gray-100 text-gray-900" : "text-gray-700",
+            "block px-4 py-2"
+          )}
+          onClick={onClick}
+        >
+          {children}
+        </a>
+      )}
+    </Menu.Item>
+  );
+}
+
+function RecordingOptionsDropdown({
+  currentWorkspaceId,
+  recording,
+  setModal,
+}: RecordingOptionsDropdownProps) {
+  const [isPrivate, setIsPrivate] = useState(recording.private);
+  const deleteRecording = hooks.useDeleteRecordingFromLibrary();
+  const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
+  const updateRecordingWorkspace = hooks.useUpdateRecordingWorkspace();
+  const updateIsPrivate = hooks.useUpdateIsPrivate();
+  const recordingId = recording.id;
+
+  const toggleIsPrivate = () => {
+    setIsPrivate(!isPrivate);
+    updateIsPrivate({ variables: { recordingId: recording.id, isPrivate: !isPrivate } });
+  };
+
+  const onDeleteRecording = (recordingId: RecordingId) => {
+    const message =
+      "This action will permanently delete this replay. \n\nAre you sure you want to proceed?";
+
+    if (window.confirm(message)) {
+      deleteRecording(recordingId, currentWorkspaceId);
+    }
+  };
+  const updateRecording = (targetWorkspaceId: WorkspaceId | null) => {
+    updateRecordingWorkspace(recordingId, currentWorkspaceId, targetWorkspaceId);
+  };
+
+  const button = (
+    <MaterialIcon outlined className="h-4 w-4 hover:text-primaryAccentHover">
+      more_vert
+    </MaterialIcon>
+  );
+
+  return (
+    <Dropdown button={button}>
+      <DropdownItem onClick={() => onDeleteRecording(recordingId)}>Delete</DropdownItem>
+      <DropdownItem onClick={toggleIsPrivate}>{`Make ${
+        isPrivate ? "public" : "private"
+      }`}</DropdownItem>
+      <DropdownItem onClick={() => setModal("sharing", { recordingId })}>Share</DropdownItem>
+      <div className="border-b border-gray-200 w-full" />
+      <div className="overflow-y-auto max-h-28">
+        {currentWorkspaceId !== null ? (
+          <DropdownItem onClick={() => updateRecording(null)}>
+            Move to your personal library
+          </DropdownItem>
+        ) : null}
+        {!loading
+          ? workspaces
+              .filter(w => w.id !== currentWorkspaceId)
+              .map(({ id, name }) => (
+                <DropdownItem onClick={() => updateRecording(id)} key={id}>
+                  {`Move to ${name}`}
+                </DropdownItem>
+              ))
+          : null}
+      </div>
+    </Dropdown>
+  );
+}
+
+const connector = connect(
+  (state: UIState) => ({ currentWorkspaceId: selectors.getWorkspaceId(state) }),
+  {
+    setModal: actions.setModal,
+  }
+);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(RecordingOptionsDropdown);

--- a/src/ui/components/Library/RecordingRow.tsx
+++ b/src/ui/components/Library/RecordingRow.tsx
@@ -9,8 +9,8 @@ import hooks from "ui/hooks";
 import { Redacted } from "../Redacted";
 import { RecordingId } from "@recordreplay/protocol";
 import ItemDropdown from "./ItemDropdown";
-import classNames from "classnames";
 import { Cell } from "./RecordingTable";
+import RecordingOptionsDropdown from "./RecordingOptionsDropdown";
 
 export function getDurationString(durationMs: number) {
   const seconds = Math.round(durationMs / 1000);
@@ -92,6 +92,7 @@ export default function RecordingRow({
             onClick={e => e.stopPropagation()}
             onChange={toggleChecked}
             checked={selected}
+            className="focus:primaryAccentHover h-4 w-4 text-primaryAccent border-gray-300 rounded"
           />
         ) : null}
       </Cell>
@@ -105,7 +106,6 @@ export default function RecordingRow({
             </div>
 
             <div className="flex flex-col overflow-hidden">
-              {/* <div className="flex flex-col overflow-hidden" style={{ maxWidth: "200px" }}> */}
               <div className="text-gray-900 overflow-hidden overflow-ellipsis whitespace-pre">
                 {recording.title}
               </div>
@@ -121,9 +121,9 @@ export default function RecordingRow({
       <Cell>{recording.private ? "Private" : "Public"}</Cell>
       <Cell>{recording.user ? recording.user.name : "Unknown"}</Cell>
       <Cell>{`${recording.comments.length} 💬`}</Cell>
-      <Cell className="text-center opacity-0 group-hover:opacity-100">
-        {isOwner ? <ItemOptions recording={recording} /> : null}
-      </Cell>
+      <td className="text-center py-3 px-4" onClick={e => e.stopPropagation()}>
+        {isOwner && !isEditing ? <RecordingOptionsDropdown {...{ recording }} /> : null}
+      </td>
     </tr>
   );
 }

--- a/src/ui/components/Library/RecordingRow.tsx
+++ b/src/ui/components/Library/RecordingRow.tsx
@@ -9,6 +9,8 @@ import hooks from "ui/hooks";
 import { Redacted } from "../Redacted";
 import { RecordingId } from "@recordreplay/protocol";
 import ItemDropdown from "./ItemDropdown";
+import classNames from "classnames";
+import { Cell } from "./RecordingTable";
 
 export function getDurationString(durationMs: number) {
   const seconds = Math.round(durationMs / 1000);
@@ -83,7 +85,7 @@ export default function RecordingRow({
       className="group border-b border-gray-200 hover:bg-gray-50 transition duration-200 cursor-pointer overflow-hidden"
       onClick={onClick}
     >
-      <td className="text-center">
+      <Cell>
         {isEditing ? (
           <input
             type="checkbox"
@@ -92,17 +94,18 @@ export default function RecordingRow({
             checked={selected}
           />
         ) : null}
-      </td>
-      <td className="py-3 px-6 text-left overflow-hidden">
+      </Cell>
+      <Cell alignment="left">
         <Redacted>
           <div className="flex flex-row items-center space-x-4 overflow-hidden">
-            <div className="bg-gray-100 rounded-sm w-16 h-9">
+            <div className="bg-gray-100 rounded-sm w-16 h-9 flex-shrink-0">
               <LazyLoad height={36} scrollContainer=".recording-list" once>
                 <ItemScreenshot recordingId={recording.id} />
               </LazyLoad>
             </div>
 
-            <div className="flex flex-col overflow-hidden" style={{ maxWidth: "200px" }}>
+            <div className="flex flex-col overflow-hidden">
+              {/* <div className="flex flex-col overflow-hidden" style={{ maxWidth: "200px" }}> */}
               <div className="text-gray-900 overflow-hidden overflow-ellipsis whitespace-pre">
                 {recording.title}
               </div>
@@ -112,17 +115,15 @@ export default function RecordingRow({
             </div>
           </div>
         </Redacted>
-      </td>
-      <td className="text-center">{getDurationString(recording.duration)}</td>
-      <td className="text-center">{getRelativeDate(recording.date)}</td>
-      <td className="text-center">{recording.private ? "Private" : "Public"}</td>
-      <td className="text-center overflow-hidden overflow-ellipsis whitespace-pre">
-        {recording.user ? recording.user.name : "Unknown"}
-      </td>
-      <td className="text-center">{`${recording.comments.length} 💬`}</td>
-      <td className="text-center opacity-0 group-hover:opacity-100">
-        {isOwner && <ItemOptions recording={recording} />}
-      </td>
+      </Cell>
+      <Cell>{getDurationString(recording.duration)}</Cell>
+      <Cell>{getRelativeDate(recording.date)}</Cell>
+      <Cell>{recording.private ? "Private" : "Public"}</Cell>
+      <Cell>{recording.user ? recording.user.name : "Unknown"}</Cell>
+      <Cell>{`${recording.comments.length} 💬`}</Cell>
+      <Cell className="text-center opacity-0 group-hover:opacity-100">
+        {isOwner ? <ItemOptions recording={recording} /> : null}
+      </Cell>
     </tr>
   );
 }

--- a/src/ui/components/Library/RecordingTable.tsx
+++ b/src/ui/components/Library/RecordingTable.tsx
@@ -16,9 +16,9 @@ export default function RecordingTable({
       )}
     >
       <table className={classNames("w-full relative table-fixed", isMock && "filter blur-sm")}>
-        <thead className="bg-gray-50 font-normal text-xs uppercase text-gray-500 sticky top-0 w-full">
+        <thead className="bg-gray-50 font-normal text-xs uppercase text-gray-500 sticky top-0 w-full z-10">
           <tr className="border-b border-gray-200">
-            <Cell isHeader className="w-12"></Cell>
+            <Cell isHeader className="w-12" />
             <Cell isHeader className="w-auto" alignment="left">
               Title
             </Cell>
@@ -37,7 +37,7 @@ export default function RecordingTable({
             <Cell isHeader className="w-32">
               Activity
             </Cell>
-            <Cell isHeader className="w-20"></Cell>
+            <Cell isHeader className="w-20" />
           </tr>
         </thead>
         <tbody className="bg-white text-sm text-gray-500 overflow-hidden">{children}</tbody>

--- a/src/ui/components/Library/RecordingTable.tsx
+++ b/src/ui/components/Library/RecordingTable.tsx
@@ -15,21 +15,58 @@ export default function RecordingTable({
         isMock ? "overflow-hidden pointer-events-none" : "overflow-auto"
       )}
     >
-      <table className={classNames("w-full relative", isMock && "filter blur-sm")}>
+      <table className={classNames("w-full relative table-fixed", isMock && "filter blur-sm")}>
         <thead className="bg-gray-50 font-normal text-xs uppercase text-gray-500 sticky top-0 w-full">
           <tr className="border-b border-gray-200">
-            <th className="py-3 px-4"></th>
-            <th className="py-3 px-6 text-left">Title</th>
-            <th className="py-3 px-6">Length</th>
-            <th className="py-3 px-6">Created</th>
-            <th className="py-3 px-6">Privacy</th>
-            <th className="py-3 px-6">Owner</th>
-            <th className="py-3 px-6">Activity</th>
-            <th className="py-3 px-4"></th>
+            <Cell isHeader className="w-12"></Cell>
+            <Cell isHeader className="w-auto" alignment="left">
+              Title
+            </Cell>
+            <Cell isHeader className="w-32">
+              Length
+            </Cell>
+            <Cell isHeader className="w-32">
+              Created
+            </Cell>
+            <Cell isHeader className="w-32">
+              Privacy
+            </Cell>
+            <Cell isHeader className="w-40">
+              Owner
+            </Cell>
+            <Cell isHeader className="w-32">
+              Activity
+            </Cell>
+            <Cell isHeader className="w-20"></Cell>
           </tr>
         </thead>
         <tbody className="bg-white text-sm text-gray-500 overflow-hidden">{children}</tbody>
       </table>
     </div>
   );
+}
+
+export function Cell({
+  className,
+  children,
+  alignment = "center",
+  isHeader,
+}: {
+  children?: string | React.ReactChild | null;
+  className?: string;
+  alignment?: "left" | "center";
+  isHeader?: boolean;
+}) {
+  const classes = classNames(
+    className,
+    "py-3 px-4",
+    "overflow-hidden whitespace-pre overflow-ellipsis",
+    alignment === "left" ? "text-left" : "text-center"
+  );
+
+  if (isHeader) {
+    return <th className={classes}>{children}</th>;
+  } else {
+    return <td className={classes}>{children}</td>;
+  }
 }

--- a/src/ui/components/Library/Sidebar.tsx
+++ b/src/ui/components/Library/Sidebar.tsx
@@ -13,7 +13,7 @@ export default function Sidebar({ nonPendingWorkspaces }: { nonPendingWorkspaces
   const scrollbarStyle = { scrollbarColor: "#6B7280 #1F2937" };
 
   return (
-    <div className="flex flex-col bg-gray-800 text-gray-300 w-64">
+    <div className="flex flex-col bg-gray-800 text-gray-300 w-64 flex-shrink-0">
       <div className="p-4">
         <img className="w-8 h-8" src="/images/logo.svg" />
       </div>

--- a/src/ui/components/Library/SidebarButton.tsx
+++ b/src/ui/components/Library/SidebarButton.tsx
@@ -15,9 +15,9 @@ export default function SidebarButton({
   return (
     <a
       className={classNames(
-        `group px-4 py-2 hover:bg-gray-900 hover:text-white transition duration-200 text-left flex flex-row justify-between focus:outline-none cursor-pointer`,
+        `group px-4 py-2 hover:bg-gray-900 hover:text-white transition duration-200 text-left flex flex-row justify-between focus:outline-none`,
         { underline },
-        shouldHighlight ? "bg-gray-900 cursor-auto text-white" : ""
+        shouldHighlight ? "bg-gray-900 cursor-auto text-white" : "cursor-pointer"
       )}
       onClick={onClick}
     >

--- a/src/ui/components/SecondaryToolbox/ToolboxOptions.tsx
+++ b/src/ui/components/SecondaryToolbox/ToolboxOptions.tsx
@@ -1,7 +1,6 @@
 /* This example requires Tailwind CSS v2.0+ */
 import React, { Fragment } from "react";
 import { Menu, Transition } from "@headlessui/react";
-import { DotsHorizontalIcon } from "@heroicons/react/solid";
 import "./ToolboxOptions.css";
 import { connect, ConnectedProps } from "react-redux";
 import { selectors } from "ui/reducers";


### PR DESCRIPTION
This fixes #3498, fixes #3503.
- The title column's contents now stretch to fill out the extra space available instead of being truncated
- The column for the checkbox is now less wide (3rem/48px)
- Sidebar width no longer glitches out whenever the user switches teams
- Updated the checkboxes/dropdown to use tailwind components

#### Library Screenshots:
![image](https://user-images.githubusercontent.com/15959269/132758981-57b4223d-6b26-4e1f-9bfe-ea858bd0cbac.png)
![image](https://user-images.githubusercontent.com/15959269/132759022-2d387e4c-1229-44a5-b114-4cf874137608.png)
![image](https://user-images.githubusercontent.com/15959269/132759042-520805af-3de6-442d-8bfe-95257729a9aa.png)
![image](https://user-images.githubusercontent.com/15959269/132759672-f32b586e-3f0c-4076-a01b-e3e7dab91aa7.png)

#### Dropdown demo:
https://user-images.githubusercontent.com/15959269/132759191-e1079128-e0b5-4fce-989e-321d656cefe5.mov