### PR TITLE
Preload modules to avoid issues with old clients

### DIFF
--- a/src/views/recording.tsx
+++ b/src/views/recording.tsx
@@ -8,6 +8,10 @@ import { LoadingScreen } from "ui/components/shared/BlankScreen";
 import Upload from "views/upload";
 import DevTools from "ui/components/DevTools";
 
+import("ui/components/Views/DevView");
+import("devtools/client/debugger/src/utils/editor/source-editor");
+import("ui/components/Comments/TranscriptComments/CommentEditor/draftjs");
+
 function Recording({ getAccessibleRecording }: PropsFromRedux) {
   const recordingId = useGetRecordingId();
   const [recording, setRecording] = useState<RecordingInfo | null>();


### PR DESCRIPTION
I think this will help with two issues we're seeing

1. the issue with old clients trying to fetch chunks that have been cleared
2. the issue with syntax errors `<` where we're trying to load a chunk during a deploy and get corrupted assets