### PR TITLE
Fix the sign in button size

### DIFF
--- a/src/ui/components/LoginButton.tsx
+++ b/src/ui/components/LoginButton.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import useAuth0 from "ui/utils/useAuth0";
 import Avatar from "ui/components/Avatar";
 import { handleIntercomLogout } from "ui/utils/intercom";
+import { PrimaryButton } from "./shared/Button";
 
 const LoginButton = () => {
   const { loginWithRedirect, isAuthenticated, logout, user } = useAuth0();
@@ -16,17 +17,16 @@ const LoginButton = () => {
   }
 
   return (
-    <button
+    <PrimaryButton
       onClick={() =>
         loginWithRedirect({
           appState: { returnTo: window.location.pathname + window.location.search },
         })
       }
-      type="button"
-      className="inline-flex items-center px-4 py-1.5 text-xl rounded-lg bg-primaryAccent hover:bg-primaryAccentHover text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent mr-0 sharebutton"
+      color="blue"
     >
       Sign In
-    </button>
+    </PrimaryButton>
   );
 };
 


### PR DESCRIPTION
Fix #3529.

This uses the standardized button as the sign in button.

@jonbell-lot23 heads up — even after the change, the header elements (specifically viewtoggle and sign in button) aren't aligned with each others borders. Not sure if you'd prefer making the toggle larger, or button smaller. Let me know.

![image](https://user-images.githubusercontent.com/15959269/132911669-469f4656-8cd9-4bd4-a5a3-b3049ceb8646.png)
