### PR TITLE
Allow material icon components to inherit text color from their parents

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -87,7 +87,7 @@ function LineNumberTooltip({
   return (
     <StaticTooltip targetNode={lineNumberNode} className={isHot ? "hot" : ""}>
       <>
-        {isHot && <MaterialIcon>warning_amber</MaterialIcon>}
+        <MaterialIcon className="mr-1">warning_amber</MaterialIcon>
         <span>{`${points} hit${points == 1 ? "" : "s"}`}</span>
       </>
     </StaticTooltip>

--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -59,12 +59,13 @@ function Event({
       onClick={() => onSeek(event.point, event.time)}
       title={title}
       className={classNames(
-        "flex flex-row items-center justify-between p-3 rounded-lg hover:bg-gray-100 focus:outline-none",
+        "group",
+        "flex flex-row items-center justify-between p-3 rounded-lg hover:bg-gray-100 focus:outline-none space-x-2",
         isPaused ? "text-primaryAccent" : ""
       )}
     >
-      <div className="flex flex-row space-x-1.5 items-center overflow-hidden">
-        <MaterialIcon highlighted={isPaused}>{icon}</MaterialIcon>
+      <div className="flex flex-row space-x-2 items-center overflow-hidden">
+        <MaterialIcon className="group-hover:text-primaryAccent">{icon}</MaterialIcon>
         <div
           className={classNames(
             isPaused ? "font-semibold" : "",

--- a/src/ui/components/SecondaryToolbox/ToolboxOptions.tsx
+++ b/src/ui/components/SecondaryToolbox/ToolboxOptions.tsx
@@ -21,7 +21,7 @@ function ToolboxOptions({
         <Menu.Button className="flex items-center text-gray-400 hover:text-gray-600">
           <MaterialIcon
             outlined
-            className="h-4 w-4 hover:text-primaryAccentHover"
+            className="h-4 w-4 hover:text-primaryAccentHover text-gray-800"
             style={{ fontSize: "16px" }}
           >
             view_compact

--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -8,7 +8,6 @@ import "./MaterialIcon.css";
 type MaterialIconProps = PropsFromRedux &
   React.HTMLProps<HTMLDivElement> & {
     children: string;
-    highlighted?: boolean;
     outlined?: boolean;
     // tailwind text color style, e.g. text-white, text-blue-200
     color?: string;
@@ -17,7 +16,6 @@ type MaterialIconProps = PropsFromRedux &
 function MaterialIcon({
   children,
   fontLoading,
-  highlighted,
   className,
   outlined,
   color,
@@ -27,12 +25,9 @@ function MaterialIcon({
   return (
     <div
       {...rest}
-      className={classnames(
-        outlined ? "material-icons-outlined" : "material-icons",
-        className,
-        highlighted ? "text-primaryAccent" : color ? color : "text-gray-800",
-        { invisible: fontLoading }
-      )}
+      className={classnames(outlined ? "material-icons-outlined" : "material-icons", className, {
+        invisible: fontLoading,
+      })}
     >
       {children}
     </div>


### PR DESCRIPTION
Fixes #3538.

Checked the following components that would have been affected to make sure they still look correct, and they are.

component | screenshot
-- | --
linenumbertooltip | ![image](https://user-images.githubusercontent.com/15959269/132922483-c2f97d9d-9662-450c-8ac2-08555ab91f28.png)
panelsummary | ![image](https://user-images.githubusercontent.com/15959269/132923107-b0a4107b-92eb-42b2-ac58-efce0938b3a8.png)
events sidebar | ![image](https://user-images.githubusercontent.com/15959269/132923224-52d91d02-7b3b-4dc8-91db-5e4ab3bc4b14.png)
useroptions | ![image](https://user-images.githubusercontent.com/15959269/132923256-0de300e7-e1f3-4094-80b8-73c4b7c37750.png)
batchactiondropdown | ![image](https://user-images.githubusercontent.com/15959269/132923277-dce76603-43a6-4e15-8619-40f9ae725fda.png)
recordingdropdown | ![image](https://user-images.githubusercontent.com/15959269/132923311-e3054e8a-737f-4a8a-a494-869bd13304d4.png)
recordingrow | ![image](https://user-images.githubusercontent.com/15959269/132923356-13fc4f8b-172e-414b-9699-52ba937de0ab.png)
toolboxoptions | ![image](https://user-images.githubusercontent.com/15959269/132923479-af53afc0-604d-4efd-bcb9-f5426179957d.png)
settingsnavigation | ![image](https://user-images.githubusercontent.com/15959269/132923578-f6b4cb58-000c-4a75-85d8-d6068805c4fc.png)
workspacemember | ![image](https://user-images.githubusercontent.com/15959269/132923671-48901c64-cd2b-4aae-90e5-2f0ab744b3fb.png)
transcript | ![image](https://user-images.githubusercontent.com/15959269/132923791-27bade47-ff61-48b8-b43e-448dafd56901.png)


