### PR TITLE
Don't send mixpanel events for test users

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -127,7 +127,8 @@ export function createSession(recordingId: string): UIThunkAction {
         userInfo,
         auth0User: tokenManager.auth0Client?.user,
       });
-      registerRecording(recordingId);
+
+      registerRecording({ recording, userInfo });
 
       ThreadFront.setTest(getTest() || undefined);
       ThreadFront.recordingId = recordingId;


### PR DESCRIPTION
Here's a replay with the documented changes
https://app.replay.io/recording/cd67c0aa-fa49-4527-9b5a-6a6666094434?point=15252372023245051665127057905418321&time=7979.772493559859&hasFrames=true