### PR TITLE
Hide the entire team dropdown element including labels when the user doesn't have a team yet

### DIFF
--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -154,12 +154,12 @@ export function SharingSettings({
 
   return (
     <>
-      <div className="">
-        <label className="block text-sm uppercase font-semibold">Team</label>
-        {workspaces.length ? (
+      {workspaces.length ? (
+        <div className="">
+          <label className="block text-xs uppercase font-semibold">Team</label>
           <TeamSelect {...{ workspaces, handleWorkspaceSelect, selectedWorkspaceId }} />
-        ) : null}
-      </div>
+        </div>
+      ) : null}
       <div className="space-y-2 text-sm">
         <label className="block text-xs uppercase font-semibold">Privacy</label>
         <div className="space-y-1">


### PR DESCRIPTION
Fixes #3565.

![image](https://user-images.githubusercontent.com/15959269/133116083-16df2628-8c2a-40b6-8579-c7cd3924e6a2.png)
