### PR TITLE
Only show tooltip warning when the breakpoint has been hit too many times

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -87,7 +87,7 @@ function LineNumberTooltip({
   return (
     <StaticTooltip targetNode={lineNumberNode} className={isHot ? "hot" : ""}>
       <>
-        <MaterialIcon className="mr-1">warning_amber</MaterialIcon>
+        {isHot ? <MaterialIcon className="mr-1">warning_amber</MaterialIcon> : null}
         <span>{`${points} hit${points == 1 ? "" : "s"}`}</span>
       </>
     </StaticTooltip>


### PR DESCRIPTION
Fix #3588.