### PR TITLE
Add feature flag for new user invitations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4041,8 +4041,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "7.9.0",
@@ -6662,6 +6661,32 @@
       "dev": true,
       "requires": {
         "language-subtag-registry": "~0.3.2"
+      }
+    },
+    "launchdarkly-js-client-sdk": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-2.19.2.tgz",
+      "integrity": "sha512-qkCtIf6RPJV2Aftxy/XjXFy5A3+XTafd+DiC9EpdzA+MPse2e542cm9+lt4tr69hT7HoPGJQk9bqZXhrSTfotg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "launchdarkly-js-sdk-common": "3.3.2"
+      }
+    },
+    "launchdarkly-js-sdk-common": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-3.3.2.tgz",
+      "integrity": "sha512-0445DdhkGrByaI+8f+2OcLAEazoFAkBBqItyGg5uL50kAlvLsjIF3v5d/2U8fp7OF9CGwvPdfPDWYMr3zrCrfA==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "fast-deep-equal": "^2.0.1",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
       }
     },
     "levn": {
@@ -11000,8 +11025,7 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "fontfaceobserver": "^2.1.0",
     "graphql": "^15.3.0",
     "jwt-decode": "^3.1.2",
+    "launchdarkly-js-client-sdk": "^2.19.2",
     "lodash": "^4.17.20",
     "logrocket": "^1.0.13",
     "logrocket-react": "^3.0.1",

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -20,6 +20,7 @@ import { getRecording } from "ui/hooks/recordings";
 import { getUserId, getUserInfo } from "ui/hooks/users";
 import { jumpToInitialPausePoint } from "./timeline";
 import { Recording } from "ui/types";
+import { getFeatureFlag } from "ui/utils/launchdarkly";
 
 export type SetUnexpectedErrorAction = Action<"set_unexpected_error"> & {
   error: UnexpectedError;
@@ -71,7 +72,7 @@ function getRecordingNotAccessibleError(
   const isAuthorized = !!(isTest() || recording);
   const isAuthenticated = !!(isTest() || isMock() || tokenManager.auth0Client?.isAuthenticated);
 
-  if (recording?.ownerNeedsInvite) {
+  if (recording?.ownerNeedsInvite && getFeatureFlag("new-user-invitations", true)) {
     const isAuthor = userId && userId == recording.userId;
 
     if (isAuthor) {

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -18,6 +18,7 @@ import { SettingsBodyHeader } from "../SettingsModal/SettingsBody";
 
 import ReplayInvitations from "./ReplayInvitations";
 import { UserInfo } from "ui/hooks/users";
+import { getFeatureFlag } from "ui/utils/launchdarkly";
 
 function Support() {
   return (
@@ -222,9 +223,12 @@ export function UserSettingsModal(props: PropsFromRedux) {
     }
   };
 
+  const hiddenTabs = getFeatureFlag("new-user-invitations", true) ? undefined : ["Invitations"];
+
   const settings = getSettings(internal);
   return (
     <SettingsModal
+      hiddenTabs={hiddenTabs}
       defaultSelectedTab={props.defaultSettingsTab}
       loading={loading || userInfoLoading}
       onChange={onChange}

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -12,6 +12,7 @@ import { setAccessTokenInBrowserPrefs, setUserInBrowserPrefs } from "ui/utils/br
 import { getUserInfo } from "ui/hooks/users";
 import { getUserSettings } from "ui/hooks/settings";
 import { isTest } from "ui/utils/environment";
+import { initLaunchDarkly } from "ui/utils/launchdarkly";
 const FontFaceObserver = require("fontfaceobserver");
 
 declare global {
@@ -61,6 +62,8 @@ export function bootstrapApp() {
 
     const userSettings = await getUserSettings();
     store.dispatch(setWorkspaceId(userSettings.defaultWorkspaceId));
+
+    initLaunchDarkly();
   });
 
   if (!isTest()) {

--- a/src/ui/utils/launchdarkly.ts
+++ b/src/ui/utils/launchdarkly.ts
@@ -1,0 +1,26 @@
+import * as LDClient from "launchdarkly-js-client-sdk";
+import { UserInfo } from "ui/hooks/users";
+import { isDevelopment } from "./environment";
+
+let client: LDClient.LDClient;
+let ready = false;
+const LD_KEY = isDevelopment() ? "60ca05fb43d6f10d234bb3ce" : "60ca05fb43d6f10d234bb3cf";
+
+function initLaunchDarkly(user?: UserInfo) {
+  ready = false;
+  client = LDClient.initialize(LD_KEY, {
+    key: user ? user.id : "anon",
+  });
+
+  client.on("ready", () => {
+    ready = true;
+  });
+}
+
+function getFeatureFlag(name: string, defaultValue: any) {
+  if (!ready) return defaultValue;
+
+  return client.variation(name, defaultValue);
+}
+
+export { initLaunchDarkly, getFeatureFlag };


### PR DESCRIPTION
## Summary

* Adds LaunchDarkly sdk
* Adds `new-user-invitations` feature flag to:
  * Guarding viewing a recording from an uninvited author which, when the flag is active, will treat the author as always invited
  * Displaying the Invitations tab (hidden when the flag is active)