### PR TITLE
Don't hide comment markers when hovering over the timeline (#3380)

### DIFF
--- a/src/ui/components/Comments/VideoComments/VideoComment.tsx
+++ b/src/ui/components/Comments/VideoComments/VideoComment.tsx
@@ -9,25 +9,13 @@ import { ChatAltIcon } from "@heroicons/react/solid";
 const MARKER_DIAMETER = 28;
 const MARKER_RADIUS = 14;
 
-function VideoComment({
-  comment,
-  canvas,
-  setHoveredComment,
-  hoveredComment,
-  currentTime,
-  hoverTime,
-}: PropsFromRedux) {
+function VideoComment({ comment, canvas, setHoveredComment, hoveredComment }: PropsFromRedux) {
   if (!canvas || !comment) {
     return null;
   }
 
   const { scale } = canvas;
   const position = comment.position;
-
-  // Hide pins while the user is hovering in the timeline
-  if (!hoveredComment && hoverTime && hoverTime != currentTime) {
-    return null;
-  }
 
   const isHighlighted = hoveredComment === comment.id;
 
@@ -61,8 +49,6 @@ function VideoComment({
 
 const connector = connect(
   (state: UIState) => ({
-    currentTime: selectors.getCurrentTime(state),
-    hoverTime: selectors.getHoverTime(state),
     pendingComment: selectors.getPendingComment(state),
     canvas: selectors.getCanvas(state),
     hoveredComment: selectors.getHoveredComment(state),


### PR DESCRIPTION
We added this behavior when hovering over the timeline changed the displayed screenshot - in that case it didn't make sense to show comment markers that were set on a different screenshot. But since we're not changing the screenshot on timeline hover anymore, hiding the comment markers also doesn't make sense anymore.