### PR TITLE
Fix bubbles on Firefox/Replay

### DIFF
--- a/src/image/images/bubble.svg
+++ b/src/image/images/bubble.svg
@@ -9,7 +9,6 @@
 <defs>
 <filter id="filter0_b" x="-293" y="-293" width="1785.95" height="1785.95" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feGaussianBlur in="BackgroundImage" stdDeviation="30"/>
 <feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur"/>
 <feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur" result="shape"/>
 </filter>


### PR DESCRIPTION
Removes `<feGaussianBlur>` from the filter to allow them to render in FF

Fixes #3586

![image](https://user-images.githubusercontent.com/788456/133357927-09db2bdc-1a83-43b0-a466-d95c025f6f0c.png)
