### PR TITLE
Router missing JS files to ensure they report a 404

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
-	"routes": [
-	  { "handle": "filesystem" },
-	  { "src": "/(.*)", "dest": "/index.html" }
-	]
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*\\.js", "dest": "/notfound.js" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
 }


### PR DESCRIPTION
Redirects requests for JS files that do not exist to a path we know to not exist so it reports as a 404 rather than our root index.html