### PR TITLE
Re-enable browser context menu support

### DIFF
--- a/src/ui/setup/dom.ts
+++ b/src/ui/setup/dom.ts
@@ -7,8 +7,6 @@ declare global {
 }
 
 export function setupDOMHelpers() {
-  document.body.addEventListener("contextmenu", e => e.preventDefault());
-
   // Set the current mouse position on the window. This is used in places where
   // testing element.matches(":hover") does not work right for some reason.
   document.body.addEventListener("mousemove", e => {


### PR DESCRIPTION
This was added by https://github.com/recordReplay/devtools/commit/452ea7fd but I don't think it's necessary so I'm proposing we remove it so native right-click behavior works.