### PR TITLE
Allow untitled recordings to be displayed in the Library

### DIFF
--- a/src/ui/components/Header/Header.css
+++ b/src/ui/components/Header/Header.css
@@ -90,6 +90,10 @@
   font-weight: 600;
 }
 
+#header .input {
+  min-width: 200px;
+}
+
 #header input.title:focus {
   border: none;
   outline: none;

--- a/src/ui/components/Library/RecordingRow.tsx
+++ b/src/ui/components/Library/RecordingRow.tsx
@@ -114,7 +114,7 @@ export default function RecordingRow({
 
             <div className="flex flex-col overflow-hidden space-y-0.5">
               <div className="text-gray-900 overflow-hidden overflow-ellipsis whitespace-pre">
-                {recording.title}
+                {recording.title || <span className="italic">Untitled</span>}
               </div>
               <div className="flex flex-row space-x-4 text-gray-500">
                 <div

--- a/src/ui/components/Library/Viewer.tsx
+++ b/src/ui/components/Library/Viewer.tsx
@@ -73,9 +73,11 @@ export default function Viewer({
   workspaceName: string;
   searchString: string;
 }) {
-  const filteredRecordings = recordings.filter(
-    r => subStringInString(searchString, r.url) || subStringInString(searchString, r.title)
-  );
+  const filteredRecordings = searchString
+    ? recordings.filter(
+        r => subStringInString(searchString, r.url) || subStringInString(searchString, r.title)
+      )
+    : recordings;
 
   return (
     <div className="flex flex-col flex-grow px-8 py-6 bg-gray-100 space-y-5 overflow-hidden">

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -116,7 +116,8 @@ const dispatch = url.searchParams.get("dispatch") || undefined;
       actions.setUnexpectedError({
         ...error,
         message: "Our apologies!",
-        content: "Something went wrong, so we've contacted our engineers and they'll look into it as soon as possible.",
+        content:
+          "Something went wrong, so we've contacted our engineers and they'll look into it as soon as possible.",
         action: "refresh",
       })
     )


### PR DESCRIPTION
## Summary

* Updates library filtering logic to display recordings without a title
* Updates Header title editor to handle untitled recordings better

Full walkthrough in the replay:
https://app.replay.io/recording/ddfcfc61-5ebc-4443-aa54-e061d61f6d4e