### PR TITLE
Better default teams screen

### DIFF
--- a/src/ui/components/Library/Viewer.tsx
+++ b/src/ui/components/Library/Viewer.tsx
@@ -39,27 +39,7 @@ function DownloadLinks() {
 
   return (
     <div className="flex flex-col space-y-6 text-sm" style={{ maxWidth: "24rem" }}>
-      <div>{`There's nothing here yet. To create your first replay, you first need to download the Replay Browser`}</div>
-      <div className="grid gap-3 grid-cols-2">
-        <a
-          href="https://static.replay.io/downloads/replay.dmg"
-          className={
-            "w-full text-center px-3 py-1.5 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
-          }
-          onClick={() => setClicked(true)}
-        >
-          Download for Mac
-        </a>
-        <a
-          href="https://static.replay.io/downloads/linux-replay.tar.bz2"
-          className={
-            "w-full text-center px-3 py-1.5 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent text-white bg-primaryAccent hover:bg-primaryAccentHover"
-          }
-          onClick={() => setClicked(true)}
-        >
-          Download for Linux
-        </a>
-      </div>
+      <div className="text-lg">{`👋 This is where your replays will go!`}</div>      
     </div>
   );
 }
@@ -106,7 +86,19 @@ function ViewerContent({
     <ViewerHeaderLeft>
       <>
         <Redacted>{workspaceName}</Redacted>
-        <span>({recordings.length})</span>
+        <span>
+          
+          {recordings.length != 0 ? (
+            <>              
+                ({recordings.length})            
+            </>
+          ) : (
+            <>
+              
+            </>
+          )}
+          
+        </span>
       </>
     </ViewerHeaderLeft>
   );


### PR DESCRIPTION
Old:
<img width="655" alt="image" src="https://user-images.githubusercontent.com/9154902/133886522-f290393f-62a4-4b42-a70d-b9f45d69bc31.png">

New:
<img width="653" alt="image" src="https://user-images.githubusercontent.com/9154902/133886528-8afe4c5b-0da5-4aa7-bcc3-387aeac8bb80.png">

Removed the "(0)" and the download links. The download links made sense months back, but our onboarding flow (and dynamic download button) makes the buttons out of place now.

We can add more personality later, like adding an illustration. 