### PR TITLE
Always show an error modal when createSession fails (#3647)

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -138,22 +138,17 @@ export function createSession(recordingId: string): UIThunkAction {
 
       dispatch(jumpToInitialPausePoint());
     } catch (e) {
-      if (e.code == 31) {
-        const currentError = selectors.getUnexpectedError(getState());
+      const currentError = selectors.getUnexpectedError(getState());
 
-        // Don't overwrite an existing error.
-        if (!currentError) {
-          dispatch(
-            setUnexpectedError({
-              message: "Unexpected session error",
-              content: "The session has closed due to an error. Please refresh the page.",
-              action: "refresh",
-              ...e,
-            })
-          );
-        }
-      } else {
-        throw e;
+      // Don't overwrite an existing error.
+      if (!currentError) {
+        dispatch(
+          setUnexpectedError({
+            message: "Unexpected session error",
+            content: e.message || "The session has closed due to an error.",
+            action: "library",
+          })
+        );
       }
     }
   };

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -51,7 +51,7 @@ export interface ExpectedError {
 export type UnexpectedError = {
   message: string;
   content: string;
-  action?: "refresh";
+  action?: "refresh" | "library";
 };
 
 export interface UploadInfo {


### PR DESCRIPTION
- we used to show an error modal only for errors with [error code 31](https://github.com/RecordReplay/backend/blob/49f058296183b068c7d162ae5c4cf3661500b515/src/protocol/errors.ts#L39) - for other errors (like #3647) the app got stuck on the loading screen
- we used to ask the user to refresh, but for both errors that we're currently seeing (code 31 and [code 50](https://github.com/RecordReplay/backend/blob/49f058296183b068c7d162ae5c4cf3661500b515/src/protocol/errors.ts#L58)) this doesn't make sense since these are permanent errors
- we used to replace the heading of the error modal with the backend's error message - I think it makes more sense to have a generic heading and put the details in the body