### PR TITLE
Recreate the highlighter if it was broken

### DIFF
--- a/src/devtools/server/actors/highlighters/box-model.js
+++ b/src/devtools/server/actors/highlighters/box-model.js
@@ -289,11 +289,13 @@ class BoxModelHighlighter extends AutoRefreshHighlighter {
    * Destroy the nodes. Remove listeners.
    */
   destroy() {
-    this.highlighterEnv.off("will-navigate", this.onWillNavigate);
+    if (this.highlighterEnv) {
+      this.highlighterEnv?.off("will-navigate", this.onWillNavigate);
 
-    const { pageListenerTarget } = this.highlighterEnv;
-    if (pageListenerTarget) {
-      pageListenerTarget.removeEventListener("pagehide", this.onPageHide);
+      const { pageListenerTarget } = this.highlighterEnv;
+      if (pageListenerTarget) {
+        pageListenerTarget.removeEventListener("pagehide", this.onPageHide);
+      }
     }
 
     this.markup.destroy();

--- a/src/devtools/server/actors/highlighters/utils/markup.js
+++ b/src/devtools/server/actors/highlighters/utils/markup.js
@@ -232,8 +232,10 @@ function CanvasFrameAnonymousContentHelper(highlighterEnv, nodeBuilder) {
 CanvasFrameAnonymousContentHelper.prototype = {
   destroy() {
     this._remove();
-    this.highlighterEnv.off("window-ready", this._onWindowReady);
-    this.highlighterEnv = this.nodeBuilder = this._content = null;
+    if (this.highlighterEnv) {
+      this.highlighterEnv.off("window-ready", this._onWindowReady);
+      this.highlighterEnv = this.nodeBuilder = this._content = null;
+    }
     this.anonymousContentDocument = null;
     this.anonymousContentGlobal = null;
 

--- a/src/highlighter/highlighter.js
+++ b/src/highlighter/highlighter.js
@@ -15,6 +15,10 @@ const Highlighter = {
     if (!node) {
       return;
     }
+    if (gBoxModelHighlighter && !document.getElementById("box-model-root")) {
+      gBoxModelHighlighter.destroy();
+      gBoxModelHighlighter = undefined;
+    }
     if (!gBoxModelHighlighter) {
       gBoxModelHighlighter = new BoxModelHighlighter();
     }


### PR DESCRIPTION
The highlighter markup is not created by React, but it's placed in a container node that is created by React. When the `Video` component that currently renders the container node is rerendered by React (e.g. when changing the layout by toggling the editor visibility), the highlighter markup will be lost, leaving the highlighter broken.
We check if the highlighter markup still exists whenever the highlighter should be shown and recreate it if it doesn't.