### PR TITLE
Handle stripe loading failure more gracefully

### DIFF
--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSubscription.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSubscription.tsx
@@ -14,11 +14,16 @@ import { Button } from "../Button";
 // By default, we use the test key for local development and the live key
 // otherwise. Setting RECORD_REPLAY_STRIPE_LIVE to a truthy value will force
 // usage of the live key.
+let stripeLoadFailed = false;
 const stripePromise = loadStripe(
   process.env.RECORD_REPLAY_STRIPE_LIVE || !isDevelopment()
     ? "pk_live_51IxKTQEfKucJn4vkdJyNElRNGAACWDbCZN5DEts1AwxLyO0XyKlkdktz3meLLBQCp63zmuozrnsVlzwIC9yhFPSM00UXegj4R1"
     : "pk_test_51IxKTQEfKucJn4vkBYgiHf8dIZPlzC96neLXfRmOKhEI0tmFwe21aRegxJLUntV8UoETbPj2XNuA3KSayIR4nWXt00Vd4mZq4Z"
-);
+).catch(e => {
+  stripeLoadFailed = true;
+  console.error("Failed to load stripe");
+  return null;
+});
 
 function PlanDetails({
   title,
@@ -187,7 +192,9 @@ const getValue = (form: HTMLFormElement, field: string) => {
 
 function AddPaymentMethod({ onDone, workspaceId }: { onDone: () => void; workspaceId: string }) {
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string>();
+  const [error, setError] = useState<string | undefined>(
+    stripeLoadFailed ? "Unable to add a payment method at this time." : undefined
+  );
   const stripe = useStripe();
   const elements = useElements();
   const { prepareWorkspacePaymentMethod, loading } = hooks.usePrepareWorkspacePaymentMethod();


### PR DESCRIPTION
## Summary

Displays an error message when unable to add a new payment method because the stripe library fails to load

## Notes

I tried to create a replay of this but it seems gecko doesn't respect resource blocking when recording! Creating an issue for that too.