### PR TITLE
Change the help icon

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -140,8 +140,11 @@ function Toolbar({
         ) : null}
       </div>
       <div className="flex flex-col space-y-1 items-center">
-        <LaunchIntercomMessengerButton />
-        <IndexingLoader {...{ progressPercentage, viewMode }} />
+        {progressPercentage === 100 || viewMode === "non-dev" ? (
+          <LaunchIntercomMessengerButton />
+        ) : (
+          <IndexingLoader {...{ progressPercentage, viewMode }} />
+        )}
       </div>
     </div>
   );
@@ -157,14 +160,20 @@ function LaunchIntercomMessengerButton() {
 
   return (
     <div className="toolbar-panel-button">
-      <IconWithTooltip
-        icon={<MaterialIcon className="toolbar-panel-icon">contact_support</MaterialIcon>}
-        content={"Chat with us"}
-        handleClick={show}
-      />
+      <IconWithTooltip icon={<Help />} content={"Chat with us"} handleClick={show} />
     </div>
   );
 }
+
+const Help = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M10.2222 14.9922H12.9452V14.7301C12.9452 13.5987 13.4118 13.0554 14.377 12.4801C15.6043 11.7578 16.4161 10.831 16.4161 9.30327C16.4161 6.98295 14.5049 5.73011 11.8714 5.73011C9.46795 5.73011 7.48642 6.92543 7.44806 9.61009H10.3884C10.4076 8.72159 11.0851 8.18466 11.8458 8.18466C12.6001 8.18466 13.2009 8.68963 13.2009 9.45028C13.2009 10.2301 12.5937 10.7287 11.7947 11.2401C10.7783 11.892 10.2286 12.5632 10.2222 14.7301V14.9922ZM11.6349 19.1854C12.5106 19.1854 13.284 18.4439 13.2968 17.5234C13.284 16.6158 12.5106 15.8807 11.6349 15.8807C10.7144 15.8807 9.96014 16.6158 9.97292 17.5234C9.96014 18.4439 10.7144 19.1854 11.6349 19.1854Z"
+      fill="currentColor"
+    />
+    <circle cx="12" cy="12" r="11.225" stroke="currentColor" strokeWidth="1.55" />
+  </svg>
+);
 
 const connector = connect(
   (state: UIState) => ({

--- a/src/ui/components/shared/IconWithTooltip.css
+++ b/src/ui/components/shared/IconWithTooltip.css
@@ -32,7 +32,6 @@
   line-height: 16px;
   position: absolute;
   display: inline-block;
-  top: var(--icon-margin);
   margin-left: 8px;
   animation: tooltip-pop-up 200ms ease;
   z-index: var(--z-index-1--icon-tooltip);


### PR DESCRIPTION
Modified the intercom messenger patch following our discussion:
- In the viewer, the icon is always visible
- In the devtools, the icon is only visible if we've finished scanning the recording