### PR TITLE
Display Trial beside team names that are trialing

### DIFF
--- a/src/ui/components/Library/Sidebar.tsx
+++ b/src/ui/components/Library/Sidebar.tsx
@@ -24,7 +24,7 @@ export default function Sidebar({ nonPendingWorkspaces }: { nonPendingWorkspaces
         <TeamButton key={userLibrary.id} id={userLibrary.id} text={userLibrary.name} />
         <Invitations />
         {nonPendingWorkspaces.map(w => (
-          <TeamButton key={w.id} id={w.id} text={w.name} />
+          <TeamButton key={w.id} id={w.id} text={w.name} workspace={w} />
         ))}
         <NewTeamButton />
       </div>

--- a/src/ui/components/Library/SidebarButton.tsx
+++ b/src/ui/components/Library/SidebarButton.tsx
@@ -15,7 +15,7 @@ export default function SidebarButton({
   return (
     <a
       className={classNames(
-        `group px-4 py-2 hover:bg-gray-900 hover:text-white transition duration-200 text-left flex flex-row justify-between focus:outline-none`,
+        `group px-4 py-2 space-x-2 hover:bg-gray-900 hover:text-white transition duration-200 text-left flex flex-row justify-between focus:outline-none`,
         { underline },
         shouldHighlight ? "bg-gray-900 cursor-auto text-white" : "cursor-pointer"
       )}

--- a/src/ui/components/Library/TeamButton.tsx
+++ b/src/ui/components/Library/TeamButton.tsx
@@ -7,11 +7,13 @@ import hooks from "ui/hooks";
 import SidebarButton from "./SidebarButton";
 import classNames from "classnames";
 import { Redacted } from "../Redacted";
+import { Workspace } from "ui/types";
 
 type TeamButtonProps = PropsFromRedux & {
   text: string;
   isNew?: boolean;
   id: string | null;
+  workspace?: Workspace;
 };
 
 function TeamButton({
@@ -19,6 +21,7 @@ function TeamButton({
   isNew,
   id,
   currentWorkspaceId,
+  workspace,
   setWorkspaceId,
   setModal,
 }: TeamButtonProps) {
@@ -42,10 +45,6 @@ function TeamButton({
     setModal("workspace-settings");
   };
 
-  const badge = isNew && (
-    <div className="text-xs bg-blue-500 text-white rounded-lg px-3 py-0.5">New</div>
-  );
-
   return (
     <SidebarButton shouldHighlight={isSelected} onClick={handleTeamClick}>
       <Redacted className="overflow-hidden">
@@ -56,11 +55,15 @@ function TeamButton({
           )}
           title={text}
         >
-          {text}
+          {`${text}${workspace?.subscription?.status === "trialing" ? " (Trial)" : ""}`}
         </div>
       </Redacted>
-      {badge}
-      {showSettingsButton ? <SettingsButton onClick={handleSettingsClick} /> : null}
+      <div className="flex flex-row space-x-1">
+        {isNew ? (
+          <div className={"text-xs rounded-lg px-3 py-0.5 bg-blue-500 text-white"}>New</div>
+        ) : null}
+        {showSettingsButton ? <SettingsButton onClick={handleSettingsClick} /> : null}
+      </div>
     </SidebarButton>
   );
 }
@@ -69,7 +72,7 @@ function SettingsButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       onClick={onClick}
-      className="material-icons ml-2 w-5 text-gray-200 transition duration-200 text-sm"
+      className="material-icons w-5 text-gray-200 transition duration-200 text-sm"
     >
       settings
     </button>

--- a/src/ui/hooks/workspaces.ts
+++ b/src/ui/hooks/workspaces.ts
@@ -97,6 +97,9 @@ export function useGetNonPendingWorkspaces(): { workspaces: Workspace[]; loading
                 invitationCode
                 domain
                 isDomainLimitedCode
+                subscription {
+                  status
+                }
                 members {
                   edges {
                     node {


### PR DESCRIPTION
Fix #3651. This just adds some indication that a team is currently using the trial version of Replay.

Replay: https://app.replay.io/recording/ba8a40b9-675e-4b52-a8d3-74af2001ed41?point=9735556611434107233662403180757476&time=6435.315682551926&hasFrames=true

![image](https://user-images.githubusercontent.com/15959269/134431755-585e798b-9759-4ae9-af77-fc5360a56a0a.png)
