### PR TITLE
Simplify login screen

### DIFF
--- a/src/ui/components/Account/index.tsx
+++ b/src/ui/components/Account/index.tsx
@@ -65,21 +65,18 @@ function WelcomePage() {
             <p>In order to join your team, we first need you to sign in.</p>
           ) : (
             <>
-              <p>
-                Replay captures everything you need for the perfect bug report, all in one link.
-                Spend less time reproducing issues and more time getting real work done.
-              </p>
-              <p>
-                Learn more at{" "}
+              <p className="text-center">
+                Replay captures everything you need for the perfect bug report, all in one link.{" "}
                 <a href="https://replay.io" className="underline pointer-hand">
-                  Replay.io
+                  Learn more
                 </a>
               </p>
+              <p></p>
             </>
           )}
         </div>
         <PrimaryLgButton color="blue" onClick={onLogin} className="w-full justify-center">
-          {isTeamMemberInvite() ? "Sign in with Google" : "Log into Replay"}
+          {isTeamMemberInvite() ? "Sign in with Google" : "Login"}
         </PrimaryLgButton>
       </OnboardingContentWrapper>
     </OnboardingModalContainer>


### PR DESCRIPTION
This PR simplifies the login screen with the principle that we should not be giving people too much to read / think about when there is an important CTA. Curious what others think

### before
<img width="1264" alt="Screen Shot 2021-09-25 at 7 22 36 AM" src="https://user-images.githubusercontent.com/254562/134775129-e35ea6da-a876-4ad1-af25-bd9fae1ee156.png">


### after
<img width="1216" alt="Screen Shot 2021-09-25 at 7 33 10 AM" src="https://user-images.githubusercontent.com/254562/134775125-074b8713-6e44-4721-8824-282d9185ca17.png">
