### PR TITLE
Fix the layout of the elements panel sidebar (#3745)

### DIFF
--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -196,8 +196,8 @@ class InspectorApp extends Component<PropsFromRedux> {
           <SplitBox
             ref={this.splitBoxRef}
             className="inspector-sidebar-splitter"
-            initialSize={`${is3PaneModeEnabled ? prefs.sidebarSize : prefs.splitSidebarSize}`}
-            minSize="10%"
+            initialSize={`${is3PaneModeEnabled ? prefs.sidebarSize : prefs.splitSidebarSize}px`}
+            minSize="20%"
             maxSize="80%"
             onMove={this.onSplitboxResize}
             splitterSize={1}
@@ -206,7 +206,7 @@ class InspectorApp extends Component<PropsFromRedux> {
             endPanel={
               <SplitBox
                 ref={this.sidebarSplitboxRef}
-                initialSize={`${is3PaneModeEnabled ? prefs.splitSidebarSize : 0}`}
+                initialSize={`${is3PaneModeEnabled ? prefs.splitSidebarSize : 0}px`}
                 minSize={is3PaneModeEnabled ? "20%" : "0"}
                 maxSize="80%"
                 onMove={this.onSidebarSplitboxResize}

--- a/src/devtools/client/themes/inspector.css
+++ b/src/devtools/client/themes/inspector.css
@@ -169,6 +169,14 @@ window {
   right: 0;
 }
 
+#inspector-sidebar .tab-panel-box {
+  height: 100%;
+}
+
+#ruleview-container .accordion {
+  height: auto;
+}
+
 /* Override `-moz-user-focus:ignore;` from toolkit/content/minimal-xul.css */
 .inspector-tabpanel > * {
   -moz-user-focus: normal;


### PR DESCRIPTION
Fixes 4 issues:
- the minimum sidebar width was too small
- the sidebar width set by the user was not restored
- the panels in the sidebar showed no scrollbar when they overflowed
- the "Pseudo-elements" accordion was pushing other rules out of view 