### PR TITLE
Use a portal dropdown for the library

### DIFF
--- a/src/devtools/client/inspector/markup/components/EventTooltip.tsx
+++ b/src/devtools/client/inspector/markup/components/EventTooltip.tsx
@@ -73,7 +73,9 @@ class EventTooltip extends PureComponent<EventTooltipProps & PropsFromRedux> {
         expanded={!!events}
         setExpanded={this.setExpanded}
       >
-        <div className="devtools-tooltip-events-container">{this.renderEvents(events)}</div>
+        <div className="devtools-tooltip-events-container old-portal">
+          {this.renderEvents(events)}
+        </div>
       </PortalDropdown>
     );
   }

--- a/src/ui/components/Comments/TranscriptComments/CommentActions.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentActions.tsx
@@ -58,19 +58,21 @@ function CommentActions({ comment, editItem, isRoot }: CommentActionsProps) {
         buttonStyle=""
         position="bottom-right"
       >
-        <div
-          className="comments-dropdown-item edit-comment text-xs"
-          title="Edit Comment"
-          onClick={editComment}
-        >
-          Edit comment
-        </div>
-        <div
-          className="comments-dropdown-item delete-comment text-xs"
-          title="Delete Comment"
-          onClick={handleDelete}
-        >
-          {isRoot ? "Delete comment and replies" : "Delete comment"}
+        <div className="old-portal">
+          <div
+            className="comments-dropdown-item edit-comment text-xs"
+            title="Edit Comment"
+            onClick={editComment}
+          >
+            Edit comment
+          </div>
+          <div
+            className="comments-dropdown-item delete-comment text-xs"
+            title="Delete Comment"
+            onClick={handleDelete}
+          >
+            {isRoot ? "Delete comment and replies" : "Delete comment"}
+          </div>
         </div>
       </PortalDropdown>
     </div>

--- a/src/ui/components/Library/BatchActionDropdown.tsx
+++ b/src/ui/components/Library/BatchActionDropdown.tsx
@@ -1,14 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import hooks from "ui/hooks";
 import { connect, ConnectedProps } from "react-redux";
 import * as selectors from "ui/reducers/app";
 import { UIState } from "ui/state";
 import { RecordingId } from "@recordreplay/protocol";
 import { WorkspaceId } from "ui/state/app";
-import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from "./LibraryDropdown";
+import { Dropdown, DropdownDivider, DropdownItem } from "./LibraryDropdown";
 import { getButtonClasses } from "../shared/Button";
 import MaterialIcon from "../shared/MaterialIcon";
 import classNames from "classnames";
+import PortalDropdown from "../shared/PortalDropdown";
 
 type BatchActionDropdownProps = PropsFromRedux & {
   selectedIds: RecordingId[];
@@ -21,6 +22,7 @@ function BatchActionDropdown({
   currentWorkspaceId,
 }: BatchActionDropdownProps) {
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
+  const [expanded, setExpanded] = useState(false);
   const updateRecordingWorkspace = hooks.useUpdateRecordingWorkspace();
   const deleteRecording = hooks.useDeleteRecordingFromLibrary();
 
@@ -46,33 +48,40 @@ function BatchActionDropdown({
     setSelectedIds([]);
   };
 
-  const button =
-    selectedIds.length > 0 ? (
-      <DropdownButton className={getButtonClasses("blue", "secondary", "md")}>
-        <span className={classNames("space-x-1 flex flex-row items-center leading-4")}>
-          <MaterialIcon outlined className="text-sm leading-4 font-bold" color="text-primaryAccent">
-            expand_more
-          </MaterialIcon>
-          <span>{`${selectedIds.length} item${selectedIds.length > 1 ? "s" : ""} selected`}</span>
-        </span>
-      </DropdownButton>
-    ) : (
-      <DropdownButton
-        className={classNames("cursor-default", getButtonClasses("blue", "disabled", "md"))}
-        disabled
-      >
-        <span className={classNames("space-x-1 flex flex-row items-center leading-4")}>
-          <MaterialIcon outlined className="text-sm leading-4 font-bold">
-            expand_more
-          </MaterialIcon>
-          <span>{`${selectedIds.length} item${selectedIds.length > 1 ? "s" : ""} selected`}</span>
-        </span>
-      </DropdownButton>
+  let button, buttonClasses;
+
+  if (selectedIds.length > 0) {
+    button = (
+      <span className={classNames("space-x-1 flex flex-row items-center leading-4")}>
+        <MaterialIcon outlined className="text-sm leading-4 font-bold" color="text-primaryAccent">
+          expand_more
+        </MaterialIcon>
+        <span>{`${selectedIds.length} item${selectedIds.length > 1 ? "s" : ""} selected`}</span>
+      </span>
     );
+    buttonClasses = getButtonClasses("blue", "secondary", "md");
+  } else {
+    button = (
+      <span className={classNames("space-x-1 flex flex-row items-center leading-4")}>
+        <MaterialIcon outlined className="text-sm leading-4 font-bold">
+          expand_more
+        </MaterialIcon>
+        <span>{`${selectedIds.length} item${selectedIds.length > 1 ? "s" : ""} selected`}</span>
+      </span>
+    );
+    buttonClasses = classNames("cursor-default", getButtonClasses("blue", "disabled", "md"));
+  }
 
   return (
-    <div className="relative">
-      <Dropdown button={button} menuItemsClassName="z-50">
+    <PortalDropdown
+      buttonContent={button}
+      buttonStyle={buttonClasses}
+      setExpanded={setExpanded}
+      expanded={expanded}
+      distance={0}
+    >
+      {/* <div className="relative"> */}
+      <Dropdown menuItemsClassName="z-50">
         <DropdownItem onClick={deleteSelectedIds}>{`Delete ${selectedIds.length} item${
           selectedIds.length > 1 ? "s" : ""
         }`}</DropdownItem>
@@ -91,7 +100,7 @@ function BatchActionDropdown({
             ))}
         </div>
       </Dropdown>
-    </div>
+    </PortalDropdown>
   );
 }
 

--- a/src/ui/components/Library/LibraryDropdown.tsx
+++ b/src/ui/components/Library/LibraryDropdown.tsx
@@ -1,5 +1,5 @@
-import React, { Fragment } from "react";
-import { Menu, Transition } from "@headlessui/react";
+import React from "react";
+import { Menu } from "@headlessui/react";
 import classNames from "classnames";
 
 // This should be the standard dropdown component for the Library
@@ -26,35 +26,25 @@ export function DropdownButton({
 }
 
 export function Dropdown({
-  button,
   children,
   menuItemsClassName,
 }: {
-  button: React.ReactElement;
   children: (React.ReactElement | null)[];
   menuItemsClassName?: string;
 }) {
   return (
     <Menu as="div" className="inline-block text-left recording-options">
-      {button}
-      <Transition
-        as={Fragment}
-        enter="transition ease-out duration-100"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
-        leave="transition ease-in duration-75"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
-      >
+      {({ open }) => (
         <Menu.Items
+          static
           className={classNames(
             menuItemsClassName,
-            "origin-top-right text-sm absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none"
+            "origin-top-right text-sm right-0 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none"
           )}
         >
           <div className="py-1">{children}</div>
         </Menu.Items>
-      </Transition>
+      )}
     </Menu>
   );
 }

--- a/src/ui/components/Library/RecordingOptionsDropdown.tsx
+++ b/src/ui/components/Library/RecordingOptionsDropdown.tsx
@@ -8,7 +8,9 @@ import MaterialIcon from "../shared/MaterialIcon";
 import hooks from "ui/hooks";
 import { RecordingId } from "@recordreplay/protocol";
 import { WorkspaceId } from "ui/state/app";
-import { Dropdown, DropdownButton, DropdownDivider, DropdownItem } from "./LibraryDropdown";
+import { Dropdown, DropdownDivider, DropdownItem } from "./LibraryDropdown";
+import PortalDropdown from "../shared/PortalDropdown";
+import classNames from "classnames";
 
 type RecordingOptionsDropdownProps = PropsFromRedux & {
   recording: Recording;
@@ -20,6 +22,7 @@ function RecordingOptionsDropdown({
   setModal,
 }: RecordingOptionsDropdownProps) {
   const [isPrivate, setIsPrivate] = useState(recording.private);
+  const [expanded, setExpanded] = useState(false);
   const deleteRecording = hooks.useDeleteRecordingFromLibrary();
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
   const updateRecordingWorkspace = hooks.useUpdateRecordingWorkspace();
@@ -44,40 +47,49 @@ function RecordingOptionsDropdown({
   };
 
   const button = (
-    <DropdownButton className="opacity-0 group-hover:opacity-100">
-      <MaterialIcon
-        outlined
-        className="h-4 w-4 text-gray-400 hover:text-primaryAccentHover text-base leading-4"
-      >
-        more_vert
-      </MaterialIcon>
-    </DropdownButton>
+    <MaterialIcon
+      outlined
+      className={classNames(
+        expanded ? "opacity-100" : "",
+        "h-4 w-4 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-primaryAccentHover text-base leading-4"
+      )}
+    >
+      more_vert
+    </MaterialIcon>
   );
 
   return (
-    <Dropdown button={button} menuItemsClassName={"mr-8"}>
-      <DropdownItem onClick={() => onDeleteRecording(recordingId)}>Delete</DropdownItem>
-      <DropdownItem onClick={toggleIsPrivate}>{`Make ${
-        isPrivate ? "public" : "private"
-      }`}</DropdownItem>
-      <DropdownItem onClick={() => setModal("sharing", { recordingId })}>Share</DropdownItem>
-      <div className="px-4 py-2 text-xs uppercase font-bold">Move to:</div>
-      <DropdownDivider />
-      <div className="overflow-y-auto max-h-48">
-        {currentWorkspaceId !== null ? (
-          <DropdownItem onClick={() => updateRecording(null)}>Your library</DropdownItem>
-        ) : null}
-        {!loading
-          ? workspaces
-              .filter(w => w.id !== currentWorkspaceId)
-              .map(({ id, name }) => (
-                <DropdownItem onClick={() => updateRecording(id)} key={id}>
-                  {name}
-                </DropdownItem>
-              ))
-          : null}
-      </div>
-    </Dropdown>
+    <PortalDropdown
+      buttonContent={button}
+      setExpanded={setExpanded}
+      expanded={expanded}
+      buttonStyle=""
+      distance={0}
+    >
+      <Dropdown>
+        <DropdownItem onClick={() => onDeleteRecording(recordingId)}>Delete</DropdownItem>
+        <DropdownItem onClick={toggleIsPrivate}>{`Make ${
+          isPrivate ? "public" : "private"
+        }`}</DropdownItem>
+        <DropdownItem onClick={() => setModal("sharing", { recordingId })}>Share</DropdownItem>
+        <div className="px-4 py-2 text-xs uppercase font-bold">Move to:</div>
+        <DropdownDivider />
+        <div className="overflow-y-auto max-h-48">
+          {currentWorkspaceId !== null ? (
+            <DropdownItem onClick={() => updateRecording(null)}>Your library</DropdownItem>
+          ) : null}
+          {!loading
+            ? workspaces
+                .filter(w => w.id !== currentWorkspaceId)
+                .map(({ id, name }) => (
+                  <DropdownItem onClick={() => updateRecording(id)} key={id}>
+                    {name}
+                  </DropdownItem>
+                ))
+            : null}
+        </div>
+      </Dropdown>
+    </PortalDropdown>
   );
 }
 

--- a/src/ui/components/Library/RecordingRow.tsx
+++ b/src/ui/components/Library/RecordingRow.tsx
@@ -92,7 +92,7 @@ export default function RecordingRow({
       className="group border-b border-gray-200 hover:bg-gray-50 transition duration-200 cursor-pointer flex flex-row"
       onClick={onClick}
     >
-      <div className="py-3 px-4 overflow-hidden whitespace-pre overflow-ellipsis w-12 flex-shrink-0">
+      <div className="py-3 px-4 overflow-hidden whitespace-pre overflow-ellipsis w-12 flex-shrink-0 flex flex-row items-center">
         {isEditing && isOwner ? (
           <input
             type="checkbox"

--- a/src/ui/components/shared/PortalDropdown.css
+++ b/src/ui/components/shared/PortalDropdown.css
@@ -30,17 +30,21 @@
 }
 
 .portal-dropdown-container .content {
-  background: white;
   width: max-content;
   display: flex;
   flex-direction: column;
   border-radius: 4px;
   position: absolute;
+  color: var(--theme-toolbar-color);
+  z-index: 1001;
+}
+
+/* These are old styles. These should be winded down as we use the tailwind dropdown
+in more places. */
+.portal-dropdown-container .content .old-portal {
   box-shadow: rgba(15, 15, 15, 0.05) 0px 0px 0px 1px, rgba(15, 15, 15, 0.1) 0px 3px 6px,
     rgba(15, 15, 15, 0.2) 0px 9px 24px;
   background: var(--theme-toolbar-background);
-  color: var(--theme-toolbar-color);
-  z-index: 1001;
 }
 
 button.expand-dropdown:focus {

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
@@ -162,10 +162,12 @@ export function NonRegisteredWorkspaceMember({
         buttonStyle=""
         position="bottom-right"
       >
-        <WorkspaceMemberRoles member={member} isAdmin={isAdmin} />
-        <hr />
-        <div className="permissions-dropdown-item" onClick={handleDelete}>
-          Remove
+        <div className="old-portal">
+          <WorkspaceMemberRoles member={member} isAdmin={isAdmin} />
+          <hr />
+          <div className="permissions-dropdown-item" onClick={handleDelete}>
+            Remove
+          </div>
         </div>
       </PortalDropdown>
     </li>


### PR DESCRIPTION
Fix #3671.

This uses a portal so that the dropdown isn't limited inside the scrollable area of the replays in the library. This way, it can open downwards by default, and upwards if there's not enough space.

Follow-up: #3771.

Replay: https://app.replay.io/recording/a2967044-f0be-46aa-a00d-85ff86c8be04