### PR TITLE
Keep mono fonts in the comments panel 11px

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentSource.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentSource.tsx
@@ -42,9 +42,12 @@ function CommentSource({
       onClick={onSelectSource}
       className="group space-y-5 p-3 rounded-xl rounded-b-none border-b border-gray-200  hover:bg-toolbarBackground cursor-pointer"
     >
-      <div className="font-medium flex flex-col">
+      <div className="font-medium flex flex-col mono">
         <div className="w-full flex flex-row justify-between space-x-1">
-          <div className="font-semibold whitespace-pre overflow-hidden overflow-ellipsis">
+          <div
+            className="font-mono font-semibold whitespace-pre overflow-hidden overflow-ellipsis"
+            style={{ fontSize: "11px" }}
+          >
             {labels.primary}
           </div>
           <div
@@ -56,6 +59,7 @@ function CommentSource({
         </div>
         <div
           className="cm-s-mozilla font-mono overflow-hidden whitespace-pre text-xs"
+          style={{ fontSize: "11px" }}
           dangerouslySetInnerHTML={{ __html: labels.secondary || "" }}
         />
       </div>


### PR DESCRIPTION
Fix #3775.

![image](https://user-images.githubusercontent.com/15959269/135169858-78fc0478-b32a-4abf-9259-7d2484aa6f60.png)
