### PR TITLE
Use reactjs-popup for the tooltips in the breakpoint panel (#3553)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8863,6 +8863,11 @@
       "resolved": "https://registry.npmjs.org/react-use-intercom/-/react-use-intercom-1.2.0.tgz",
       "integrity": "sha512-Cbs9E5p8ISzyq4GnV04mVluHhfgSwM84FlHeY7clk9shW0XvuIylNUjnyopMjZgh5HawKWHIhRrcml20gPWVSQ=="
     },
+    "reactjs-popup": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-2.0.5.tgz",
+      "integrity": "sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA=="
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-tooltip": "^4.2.21",
     "react-transition-group": "^2.0.1",
     "react-use-intercom": "^1.2.0",
+    "reactjs-popup": "^2.0.5",
     "redux": "^4.0.5",
     "remark-emoji": "^2.1.0",
     "reselect": "^4.0.0",

--- a/src/ui/components/reactjs-popup.css
+++ b/src/ui/components/reactjs-popup.css
@@ -1,0 +1,14 @@
+#popup-root .popup-content {
+  background: var(--theme-popup-color);
+  color: var(--theme-popup-background);
+  font-family: "Inter", sans-serif;
+  font-size: 12px;
+  width: auto;
+  padding: 8px 12px;
+  border: none;
+}
+
+#popup-root .popup-arrow {
+  color: var(--theme-popup-color);
+  filter: none;
+}


### PR DESCRIPTION
Using `react-tooltip` in the breakpoint panel created several issues:
- #3553
- the tooltip had rendering issues in Firefox
- recently it stopped working altogether, even in Chrome

I replaced it with `reactjs-popup` and removed the duplicated "Editing logpoints is available for Developers in the Team plan" tooltip because it was also shown if the breakpoint was not editable because it was hit too many times. If the user is not a developer in the team plan, there is still a lock icon with that tooltip message.