### PR TITLE
Don't send telemetry events if Replay was disconnected or updated (ops#190, ops#192)

### DIFF
--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -277,7 +277,7 @@ function DebuggerLoader(props) {
         await waitForEditor();
         setLoadingEditor(false);
       } catch {
-        props.setUnexpectedError(ReplayUpdatedError);
+        props.setUnexpectedError(ReplayUpdatedError, true);
       }
     })();
   }, []);

--- a/src/protocol/socket.ts
+++ b/src/protocol/socket.ts
@@ -164,7 +164,7 @@ function onSocketClose() {
     gSocketOpen = false;
 
     if (!willClose) {
-      dispatch(setUnexpectedError(disconnectedError));
+      dispatch(setUnexpectedError(disconnectedError, true));
     }
   };
 }
@@ -186,7 +186,7 @@ function onSocketError(evt: Event) {
         })
       );
     } else {
-      dispatch(setUnexpectedError(disconnectedError));
+      dispatch(setUnexpectedError(disconnectedError, true));
     }
   };
 }

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -205,16 +205,18 @@ export function setExpectedError(error: ExpectedError): UIThunkAction {
   };
 }
 
-export function setUnexpectedError(error: UnexpectedError): UIThunkAction {
+export function setUnexpectedError(error: UnexpectedError, skipTelemetry = false): UIThunkAction {
   return ({ getState, dispatch }) => {
     const state = getState();
 
-    sendTelemetryEvent("DevtoolsUnexpectedError", {
-      ...error,
-      recordingId: getRecordingId(),
-      sessionId: selectors.getSessionId(state),
-      environment: isDevelopment() ? "dev" : "prod",
-    });
+    if (!skipTelemetry) {
+      sendTelemetryEvent("DevtoolsUnexpectedError", {
+        ...error,
+        recordingId: getRecordingId(),
+        sessionId: selectors.getSessionId(state),
+        environment: isDevelopment() ? "dev" : "prod",
+      });
+    }
 
     dispatch({ type: "set_unexpected_error", error });
   };

--- a/src/ui/components/ErrorBoundary.tsx
+++ b/src/ui/components/ErrorBoundary.tsx
@@ -16,7 +16,7 @@ class ErrorBoundary extends Component<PropsFromRedux & { children: ReactNode }> 
   componentDidCatch(error: any, errorInfo: any) {
     const { setUnexpectedError } = this.props;
     if (error.name === "ChunkLoadError") {
-      setUnexpectedError(ReplayUpdatedError);
+      setUnexpectedError(ReplayUpdatedError, true);
     } else {
       setUnexpectedError({
         message: "Unexpected error",


### PR DESCRIPTION
- the error when Replay was disconnected due to user inactivity doesn't need to show up in telemetry
- the error when Replay was updated shows up in Sentry
- I'm not sure if other unexpected errors show up in Sentry, so I keep sending telemetry events for those
