### PR TITLE
Don't yellow highlight the codemirror lines in the widget

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Editor.css
+++ b/src/devtools/client/debugger/src/components/Editor/Editor.css
@@ -183,7 +183,8 @@ html[dir="rtl"] .editor-mount {
 .new-debug-line-error .CodeMirror-activeline-background {
   display: none;
 }
-.highlight-line .CodeMirror-line {
+
+.highlight-line > .CodeMirror-line {
   animation-name: fade-highlight-out;
   animation-duration: var(--highlight-line-duration);
   animation-timing-function: ease-out;


### PR DESCRIPTION
Fix #3587.