### PR TITLE
Add uploading progress

### DIFF
--- a/src/ui/components/shared/BlankScreen.tsx
+++ b/src/ui/components/shared/BlankScreen.tsx
@@ -123,7 +123,10 @@ function _LoadingScreen({ uploading, awaitingSourcemaps, progress, finished }: P
   if (awaitingSourcemaps) {
     return <BlankLoadingScreen statusMessage={"Uploading sourcemaps"} />;
   } else if (uploading) {
-    return <BlankLoadingScreen statusMessage={"Uploading replay"} />;
+    const statusMessage = uploading?.amount
+      ? `Uploading ${uploading?.amount} of ${uploading?.total}`
+      : `Uploading ${uploading?.total || ""}`;
+    return <BlankLoadingScreen statusMessage={statusMessage} />;
   }
 
   return <BlankProgressScreen progress={progress} />;


### PR DESCRIPTION
I kinda like showing a progress bar that shows that we are making progress without being overly literal about the size of the recording or the speed of uploading. 

<img width="1250" alt="Screen Shot 2021-10-02 at 10 15 03 PM" src="https://user-images.githubusercontent.com/254562/135740929-ba7c4bae-8968-4898-8f42-828f1214ef0b.png">


