### PR TITLE
Keep the trial badge content from overflowing

### DIFF
--- a/src/ui/components/shared/TrialEnd.tsx
+++ b/src/ui/components/shared/TrialEnd.tsx
@@ -26,7 +26,9 @@ export function TrialEnd({
   return (
     <div className="py-1 p-4 rounded-lg flex flex-row space-x-2 items-center" style={style}>
       <MaterialIcon style={{ fontSize: "1.25rem" }}>timer</MaterialIcon>
-      <span>Trial expires in {getDaysLeft(trialEnds)} days</span>
+      <span className="overflow-hidden whitespace-pre overflow-ellipsis">
+        Trial expires in {getDaysLeft(trialEnds)} days
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
Fix #3867.

![image](https://user-images.githubusercontent.com/15959269/136046132-f0cadb22-298b-4195-82bd-458d1fb17c47.png)
