### PR TITLE
Make sure that we close a dropdown after clicking on an dropdown item

### DIFF
--- a/src/ui/components/Library/BatchActionDropdown.tsx
+++ b/src/ui/components/Library/BatchActionDropdown.tsx
@@ -40,12 +40,15 @@ function BatchActionDropdown({
       selectedIds.forEach(recordingId => deleteRecording(recordingId, currentWorkspaceId));
       setSelectedIds([]);
     }
+
+    setExpanded(false);
   };
   const updateRecordings = (targetWorkspaceId: WorkspaceId | null) => {
     selectedIds.forEach(recordingId =>
       updateRecordingWorkspace(recordingId, currentWorkspaceId, targetWorkspaceId)
     );
     setSelectedIds([]);
+    setExpanded(false);
   };
 
   let button, buttonClasses;
@@ -80,7 +83,6 @@ function BatchActionDropdown({
       expanded={expanded}
       distance={0}
     >
-      {/* <div className="relative"> */}
       <Dropdown menuItemsClassName="z-50">
         <DropdownItem onClick={deleteSelectedIds}>{`Delete ${selectedIds.length} item${
           selectedIds.length > 1 ? "s" : ""

--- a/src/ui/components/Library/RecordingOptionsDropdown.tsx
+++ b/src/ui/components/Library/RecordingOptionsDropdown.tsx
@@ -32,8 +32,8 @@ function RecordingOptionsDropdown({
   const toggleIsPrivate = () => {
     setIsPrivate(!isPrivate);
     updateIsPrivate({ variables: { recordingId: recording.id, isPrivate: !isPrivate } });
+    setExpanded(false);
   };
-
   const onDeleteRecording = (recordingId: RecordingId) => {
     const message =
       "This action will permanently delete this replay. \n\nAre you sure you want to proceed?";
@@ -41,9 +41,15 @@ function RecordingOptionsDropdown({
     if (window.confirm(message)) {
       deleteRecording(recordingId, currentWorkspaceId);
     }
+    setExpanded(false);
   };
   const updateRecording = (targetWorkspaceId: WorkspaceId | null) => {
     updateRecordingWorkspace(recordingId, currentWorkspaceId, targetWorkspaceId);
+    setExpanded(false);
+  };
+  const handleShareClick = () => {
+    setModal("sharing", { recordingId });
+    setExpanded(false);
   };
 
   const button = (
@@ -71,7 +77,7 @@ function RecordingOptionsDropdown({
         <DropdownItem onClick={toggleIsPrivate}>{`Make ${
           isPrivate ? "public" : "private"
         }`}</DropdownItem>
-        <DropdownItem onClick={() => setModal("sharing", { recordingId })}>Share</DropdownItem>
+        <DropdownItem onClick={handleShareClick}>Share</DropdownItem>
         <div className="px-4 py-2 text-xs uppercase font-bold">Move to:</div>
         <DropdownDivider />
         <div className="overflow-y-auto max-h-48">


### PR DESCRIPTION
This is a quick fix. Fix #3880.

The way we do dropdown components right now is almost _too_ composable. This makes it difficult to just register an onClick handler for each dropdown (menu) item, and not worry about having to manage the dropdown's state.

This manages the dropdown's expanded state manually in every click handler. Ideally, things would be such that we don't have to manually do that in each callback.