### PR TITLE
Make the login button consistent with the header buttons

### DIFF
--- a/src/ui/components/LoginButton.tsx
+++ b/src/ui/components/LoginButton.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import useAuth0 from "ui/utils/useAuth0";
 import Avatar from "ui/components/Avatar";
 import { handleIntercomLogout } from "ui/utils/intercom";
-import { PrimaryButton } from "./shared/Button";
 
 const LoginButton = () => {
   const { loginWithRedirect, isAuthenticated, logout, user } = useAuth0();
@@ -17,7 +16,8 @@ const LoginButton = () => {
   }
 
   return (
-    <PrimaryButton
+    <button
+      className="inline-flex items-center px-3 py-1.5 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
       onClick={() =>
         loginWithRedirect({
           appState: { returnTo: window.location.pathname + window.location.search },
@@ -26,7 +26,7 @@ const LoginButton = () => {
       color="blue"
     >
       Sign In
-    </PrimaryButton>
+    </button>
   );
 };
 


### PR DESCRIPTION
Fix #3724.

This makes the sign in button 30px, which is the same height as the view toggle container.

![image](https://user-images.githubusercontent.com/15959269/136231758-981fe665-4e05-4e24-b5e1-b94bb40afff8.png)
