### PR TITLE
Up and down arrow in the console moves through command history

### DIFF
--- a/src/devtools/client/webconsole/selectors/messages.js
+++ b/src/devtools/client/webconsole/selectors/messages.js
@@ -48,6 +48,10 @@ export const getMessages = createSelector(
   (messagesById, visibleMessages) => visibleMessages.map(id => messagesById.get(id))
 );
 
+export const getCommandMessages = createSelector(getMessages, messages =>
+  messages.filter(message => message.type === "command")
+);
+
 export const getMessagesForTimeline = createSelector(getMessages, messages =>
   messages.filter(message => message.source == "console-api" || isError(message))
 );


### PR DESCRIPTION
### Motivation

As mentioned in #3842, a common expectation of consoles is that you can access previous commands by hitting the up arrow. This will add support within a session for traversing history with the arrows.

### Related Changes

While in the messages reducer I tried to hack away at some of the dead code around things like message groups and traces.

### Future Work

I've had this part working for a while, but have spent a couple of hours working on getting history to persist across refresh and page navigations. That is considerably more complicated, and I'm still working on it, but I wanted to get this shipped as fast as possible, since it's useful even in its current form.

### Screenshot

https://user-images.githubusercontent.com/5903784/136268630-b894366a-31e5-403c-be6f-e5310cd16bad.mp4



