### PR TITLE
Persist console history across refreshes

### DIFF
--- a/src/devtools/client/webconsole/actions/input.js
+++ b/src/devtools/client/webconsole/actions/input.js
@@ -4,12 +4,7 @@
 
 "use strict";
 
-const {
-  EVALUATE_EXPRESSION,
-  SET_TERMINAL_INPUT,
-  SET_TERMINAL_EAGER_RESULT,
-} = require("devtools/client/webconsole/constants");
-const { getAllPrefs } = require("devtools/client/webconsole/selectors/prefs");
+const { EVALUATE_EXPRESSION } = require("devtools/client/webconsole/constants");
 const { ThreadFront, createPrimitiveValueFront } = require("protocol/thread");
 const { assert } = require("protocol/utils");
 

--- a/src/devtools/client/webconsole/components/Input/JSTerm.js
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.js
@@ -11,9 +11,8 @@ import actions from "devtools/client/webconsole/actions/index";
 
 import { getRecordingId } from "ui/utils/environment";
 import { getRecording } from "ui/hooks/recordings";
-import { getCommandMessages } from "../../selectors/messages";
+import { getCommandHistory } from "../../selectors/messages";
 
-import uniq from "lodash/uniq";
 import clamp from "lodash/clamp";
 
 async function createEditor({ execute, historyCursorUp, historyCursorDown }) {
@@ -88,14 +87,13 @@ class JSTerm extends React.Component {
   historyCursorDown = () => this.moveHistoryCursor(-1);
 
   moveHistoryCursor(difference) {
-    const messages = uniq(this.props.commandHistory.map(m => m.messageText).reverse());
+    const { commandHistory } = this.props;
+    if (commandHistory.length > 0) {
+      const newIndex = clamp(this.state.historyIndex + difference, 0, commandHistory.length);
 
-    if (messages.length === 0) {
-      return;
+      this.setValue(["", ...commandHistory][newIndex]);
+      this.setState({ historyIndex: newIndex });
     }
-    const newIndex = clamp(this.state.historyIndex + difference, 0, messages.length);
-    this.setValue(["", ...messages][newIndex]);
-    this.setState({ historyIndex: newIndex });
   }
 
   /**
@@ -174,7 +172,7 @@ class JSTerm extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    commandHistory: getCommandMessages(state),
+    commandHistory: getCommandHistory(state),
   };
 }
 

--- a/src/devtools/client/webconsole/reducers/messages.d.ts
+++ b/src/devtools/client/webconsole/reducers/messages.d.ts
@@ -1,0 +1,5 @@
+export interface MessageState {
+  commandHistory: Command[];
+}
+
+export declare function initialMessageState(overrides: MessageState): MessageState;

--- a/src/devtools/client/webconsole/selectors/messages.js
+++ b/src/devtools/client/webconsole/selectors/messages.js
@@ -11,13 +11,11 @@ const { getExecutionPoint } = require("devtools/client/debugger/src/reducers/pau
 
 import { createSelector } from "reselect";
 
-export const getAllMessagesUiById = state => state.messages.messagesUiById;
 export const getAllMessagesPayloadById = state => state.messages.messagesPayloadById;
-export const getAllGroupsById = state => state.messages.groupsById;
-export const getCurrentGroup = state => state.messages.currentGroup;
-export const getFilteredMessagesCount = state => state.messages.filteredMessagesCount;
+export const getAllMessagesUiById = state => state.messages.messagesUiById;
 export const getAllRepeatById = state => state.messages.repeatById;
-export const getGroupsById = state => state.messages.groupsById;
+export const getCommandHistory = state => state.messages.commandHistory;
+export const getFilteredMessagesCount = state => state.messages.filteredMessagesCount;
 
 function messageTime(msg) {
   const { executionPointTime, lastExecutionPoint } = msg;
@@ -46,10 +44,6 @@ export const getMessages = createSelector(
   getAllMessagesById,
   getVisibleMessages,
   (messagesById, visibleMessages) => visibleMessages.map(id => messagesById.get(id))
-);
-
-export const getCommandMessages = createSelector(getMessages, messages =>
-  messages.filter(message => message.type === "command")
 );
 
 export const getMessagesForTimeline = createSelector(getMessages, messages =>

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -36,6 +36,7 @@ const {
 import { DevToolsToolbox } from "ui/utils/devtools-toolbox";
 import { asyncStore } from "ui/utils/prefs";
 import { getUserSettings } from "ui/hooks/settings";
+import { initialMessageState } from "devtools/client/webconsole/reducers/messages";
 const { LocalizationHelper } = require("devtools/shared/l10n");
 const { setupDemo } = require("ui/utils/demo");
 
@@ -73,7 +74,11 @@ const dispatch = url.searchParams.get("dispatch") || undefined;
   const initialDebuggerState = await dbgClient.loadInitialState();
   const initialConsoleState = getConsoleInitialState();
 
+  const commandHistory = await asyncStore.commandHistory;
+  const messages = initialMessageState({ commandHistory });
+
   const initialState = {
+    messages,
     ...initialDebuggerState,
     ...initialConsoleState,
   };

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -49,6 +49,7 @@ export function updatePrefs(state: UIState, oldState: UIState) {
   updatePref("splitConsole", isSplitConsoleOpen);
   updatePref("selectedPanel", getSelectedPanel);
   updateAsyncPref("eventListenerBreakpoints", (state: UIState) => state.eventListenerBreakpoints);
+  updateAsyncPref("commandHistory", (state: UIState) => state.messages?.commandHistory);
 
   updateReplaySessions(state);
 }

--- a/src/ui/state/index.ts
+++ b/src/ui/state/index.ts
@@ -9,6 +9,7 @@ import { ClassListState } from "devtools/client/inspector/rules/state/class-list
 import { PseudoClassesState } from "devtools/client/inspector/rules/state/pseudo-classes";
 import { RulesState } from "devtools/client/inspector/rules/state/rules";
 import { ComputedState } from "devtools/client/inspector/computed/state";
+import { MessageState } from "devtools/client/webconsole/reducers/messages";
 
 export interface UIState {
   timeline: TimelineState;
@@ -17,6 +18,7 @@ export interface UIState {
   reactDevTools: ReactDevToolsState;
   inspector: InspectorState;
   markup: MarkupState;
+  messages: MessageState;
   eventTooltip: EventTooltipState;
   classList: ClassListState;
   pseudoClasses: PseudoClassesState;

--- a/src/ui/utils/commandHistory.ts
+++ b/src/ui/utils/commandHistory.ts
@@ -1,0 +1,9 @@
+import uniq from "lodash/uniq";
+
+export type Command = string;
+
+const MAX_HISTORY_LENGTH = 1000;
+
+export const appendToHistory = (command: Command, history: Command[]): Command[] => {
+  return uniq([command, ...history].slice(0, MAX_HISTORY_LENGTH));
+};

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -1,11 +1,7 @@
 import { PrefsHelper } from "devtools/client/shared/prefs";
 const { asyncStoreHelper } = require("devtools/shared/async-store-helper");
 
-import Services from "devtools-services";
-
-// Schema version to bump when the async store format has changed incompatibly
-// and old stores should be cleared.
-const { pref } = Services;
+import { pref } from "devtools-services";
 
 // Get prefs from the URL with the format
 // &prefs=<key>:<value>,<key>:<value> e.g. &prefs=video:true
@@ -95,4 +91,5 @@ export const features = new PrefsHelper("devtools.features", {
 export const asyncStore = asyncStoreHelper("devtools", {
   eventListenerBreakpoints: ["event-listener-breakpoints", undefined],
   replaySessions: ["replay-sessions", {}],
+  commandHistory: ["command-history", []],
 });


### PR DESCRIPTION
### Motivation

This is just an extension of #3896, making it a little easier to pick up where you left off in case you have to refresh the page.

### Storing and Retrieving from Async Storage

I'm just writing this down because it took me a while to figure out how to thread all of this together:

`UIState` is the store, but because it's a mish-mash of old reducers and new ones it's type definition is only *some* of what it has. If you're adding some functionality in the new typescript files and referencing old reducers you might see tsc complain. In that case, you can back-fill type definitions using `.d.ts` files to help. So in this case I was referencing the `messages` reducer, which is defined in 

```
src/devtools/client/webconsole/reducers/messages.js
```

So I had to add a set of type annotations in

```
src/devtools/client/webconsole/reducers/messages.d.ts
```

I only added the bare minimum that I needed to implement this feature, since a lot of that reducer will probably get re-worked soon anyways.

### Populating Redux Store from Async Storage on Page Load

Because asyncStorage is... well... async, it's not as simple as writing 

```
initialState = {
   localStorage.getKey("store")
}
```

Instead, you should populate the store from inside of `src/ui/setup/dynamic/devtools.ts`, which is responsible for injecting new `initialState` pieces that come from async functions.

### Updating Async Storage from Redux Store on Event

`src/ui/setup/prefs.ts` has an `updatePrefs` function, which is subscribed to the redux store. `updateAsyncPref` takes a key and a selector, and updates that key in `asyncStorage` whenever the value of that selector changes.

