### PR TITLE
Make the team trial badge consistent with its row

### DIFF
--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -24,7 +24,7 @@ function Avatars({ recordingId }: { recordingId: RecordingId | null }) {
     recordingId || "00000000-0000-0000-0000-000000000000"
   );
 
-  if (loading || error) {
+  if (loading || error || !users?.length) {
     return null;
   }
 

--- a/src/ui/components/Library/TeamTrialEnd.tsx
+++ b/src/ui/components/Library/TeamTrialEnd.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
+import { useHistory } from "react-router";
+import { actions } from "ui/actions";
 import hooks from "ui/hooks";
 import { selectors } from "ui/reducers";
 import { UIState } from "ui/state";
 import { TrialEnd } from "../shared/TrialEnd";
 
-function TeamTrialEnd({ currentWorkspaceId }: PropsFromRedux) {
+function TeamTrialEnd({ currentWorkspaceId, setModal }: PropsFromRedux) {
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
+  const history = useHistory();
 
   // There's no workspace ID if they are in their personal library.
   if (loading || !currentWorkspaceId) {
@@ -19,11 +22,26 @@ function TeamTrialEnd({ currentWorkspaceId }: PropsFromRedux) {
     return null;
   }
 
-  return <TrialEnd trialEnds={workspace.subscription.trialEnds} color="yellow" />;
+  const onClick = () => {
+    history.push(`/team/${currentWorkspaceId}/settings/billing`);
+    setModal("workspace-settings");
+  };
+
+  return (
+    <TrialEnd
+      trialEnds={workspace.subscription.trialEnds}
+      color="yellow"
+      className="py-2 cursor-pointer"
+      onClick={onClick}
+    />
+  );
 }
 
-const connector = connect((state: UIState) => ({
-  currentWorkspaceId: selectors.getWorkspaceId(state),
-}));
+const connector = connect(
+  (state: UIState) => ({
+    currentWorkspaceId: selectors.getWorkspaceId(state),
+  }),
+  { setModal: actions.setModal }
+);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(TeamTrialEnd);

--- a/src/ui/components/shared/TrialEnd.tsx
+++ b/src/ui/components/shared/TrialEnd.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import React from "react";
 import MaterialIcon from "./MaterialIcon";
 
@@ -11,9 +12,13 @@ function getDaysLeft(trialEndDate: string) {
 export function TrialEnd({
   trialEnds,
   color = "gray",
+  className,
+  onClick,
 }: {
   trialEnds: string;
   color?: "yellow" | "gray";
+  className?: string;
+  onClick?: () => void;
 }) {
   let style;
 
@@ -25,11 +30,15 @@ export function TrialEnd({
 
   const daysLeft = getDaysLeft(trialEnds);
   if (daysLeft >= 21) {
-    return null
+    return null;
   }
 
   return (
-    <div className="py-1 p-4 rounded-lg flex flex-row space-x-2 items-center" style={style}>
+    <div
+      className={classNames("py-1 p-4 rounded-lg flex flex-row space-x-2 items-center", className)}
+      style={style}
+      onClick={onClick}
+    >
       <MaterialIcon style={{ fontSize: "1.25rem" }}>timer</MaterialIcon>
       <span className="overflow-hidden whitespace-pre overflow-ellipsis">
         Trial expires in {daysLeft} days


### PR DESCRIPTION
Fix #3897

This also makes the badge clickable when in the library. That pops open the team settings, defaulting to the billing page.

![image](https://user-images.githubusercontent.com/15959269/136433444-f06e82a3-2207-4f61-b632-e4401ec1d64a.png)
![image](https://user-images.githubusercontent.com/15959269/136433567-194bf0cf-50c2-4c21-9889-c8ca4843dbf8.png)

