### PR TITLE
Make sure that redacted panels fill their parent

### DIFF
--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -8,8 +8,6 @@ import { Redacted } from "./Redacted";
 const PrimaryPanes = require("devtools/client/debugger/src/components/PrimaryPanes").default;
 const SecondaryPanes = require("devtools/client/debugger/src/components/SecondaryPanes").default;
 
-const SIDEPANEL_WIDTH = 240;
-
 type SidePanelProps = PropsFromRedux;
 
 function SidePanel({ selectedPrimaryPanel }: SidePanelProps) {
@@ -17,13 +15,13 @@ function SidePanel({ selectedPrimaryPanel }: SidePanelProps) {
 
   if (selectedPrimaryPanel === "explorer") {
     sidepanel = (
-      <Redacted>
+      <Redacted className="h-full">
         <PrimaryPanes />
       </Redacted>
     );
   } else if (selectedPrimaryPanel === "debug") {
     sidepanel = (
-      <Redacted>
+      <Redacted className="h-full">
         <SecondaryPanes />
       </Redacted>
     );


### PR DESCRIPTION
The accordion is sometimes wrapped in a containing `private` div, and when that happens its contents no longer expand to take up the available space. This will probably be improved further when we get to https://github.com/RecordReplay/devtools/issues/3200 but for right now this should fix https://github.com/RecordReplay/devtools/issues/3917.