### PR TITLE
Fix CSS overflow regression in NonDevView

### DIFF
--- a/src/ui/components/Views/NonDevView.tsx
+++ b/src/ui/components/Views/NonDevView.tsx
@@ -50,7 +50,7 @@ function NonDevView({ updateTimelineDimensions }: PropsFromRedux) {
   };
 
   return (
-    <div className="flex flex-row h-full">
+    <div className="flex flex-row h-full overflow-hidden">
       <Toolbar />
       <SplitBox
         startPanel={<SidePanel />}


### PR DESCRIPTION
This addresses https://github.com/RecordReplay/devtools/issues/3921.

It was unclear what the `horizontal-panels` div was doing in NonDevView but it turns out it was setting:

```overflow: hidden;```

Which is kind of important for making sure that long comment columns can't push the timeline out of view.

# Before

![CleanShot 2021-10-07 at 12 21 28](https://user-images.githubusercontent.com/5903784/136449005-b14756ff-5055-4bc9-8377-d34155cd6f38.png)

# After

![CleanShot 2021-10-07 at 12 21 39](https://user-images.githubusercontent.com/5903784/136449014-22f760bb-ff38-46de-875a-bb5088129b6c.png)

