### PR TITLE
Handle failed repaintGraphics

### DIFF
--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -239,19 +239,26 @@ export function setupGraphics(store: UIStore) {
     assert(pause);
 
     const rv = await pause.repaintGraphics();
-    if (pause === ThreadFront.currentPause && rv) {
-      const { mouse } = await getGraphicsAtTime(ThreadFront.currentTime);
-      let { description, screenShot } = rv;
-      if (screenShot) {
-        repaintedScreenshots.set(description.hash, screenShot);
-      } else {
-        screenShot = repaintedScreenshots.get(description.hash);
-        if (!screenShot) {
-          console.error("Missing repainted screenshot", description);
-          return;
+    if (pause === ThreadFront.currentPause) {
+      // First try to use the new graphics,
+      // then fallback to the most recent graphics.
+      if (rv) {
+        const { mouse } = await getGraphicsAtTime(ThreadFront.currentTime);
+        let { description, screenShot } = rv;
+        if (screenShot) {
+          repaintedScreenshots.set(description.hash, screenShot);
+        } else {
+          screenShot = repaintedScreenshots.get(description.hash);
+          if (!screenShot) {
+            console.error("Missing repainted screenshot", description);
+            return;
+          }
         }
+        paintGraphics(screenShot, mouse);
+      } else {
+        const { screen, mouse } = await getGraphicsAtTime(ThreadFront.currentTime);
+        paintGraphics(screen, mouse);
       }
-      paintGraphics(screenShot, mouse);
     }
   });
 }


### PR DESCRIPTION
This adds support for catching failed repaintGraphics commands painting the closest graphics. fixes #3900 

before: [replay](https://app.replay.io/recording/d3d01584-4b52-4a3b-8eb6-9c34e40319aa?point=8762000950135628567926910023107222&time=3924.6592465753424&hasFrames=true#)
after: [replay](https://app.replay.io/recording/25166723-69c5-43ca-8287-b277ae505b02?point=13954297809385237553354531699427275&time=8415.865964625295&hasFrames=true)