### PR TITLE
Dont show comment button unless were hovering on the message

### DIFF
--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -983,7 +983,6 @@ a.learn-more-link.webconsole-learn-more-link {
 
 .webconsole-output .overlay-container.debug .button {
   cursor: pointer;
-  margin-left: calc(0px - var(--message-left-padding));
   background: linear-gradient(
     0deg,
     var(--paused-background-color) 0%,


### PR DESCRIPTION
The comment btn in the console should behave similarly to the fast forward and rewind button and only be visible on hover.

Before this change, the comment btn in the console was too prominent and would class with the comment button in the print statement panel and other ff/rw in the console


<img width="1152" alt="Screen Shot 2021-10-09 at 7 41 30 AM" src="https://user-images.githubusercontent.com/254562/136662642-1c1a7564-17bc-4989-b58a-327027fc7020.png">
<img width="1152" alt="Screen Shot 2021-10-09 at 7 41 16 AM" src="https://user-images.githubusercontent.com/254562/136662646-a2ff33cc-df1f-437b-8deb-f393c30f0199.png">

