### PR TITLE
Lazily load node properties

### DIFF
--- a/src/devtools/client/inspector/computed/state/index.ts
+++ b/src/devtools/client/inspector/computed/state/index.ts
@@ -20,3 +20,6 @@ export interface ComputedState {
   search: string;
   showBrowserStyles: boolean;
 }
+export interface InspectorState {
+  computed: ComputedState;
+}

--- a/src/devtools/client/inspector/markup/actions/eventTooltip.ts
+++ b/src/devtools/client/inspector/markup/actions/eventTooltip.ts
@@ -23,7 +23,7 @@ export function showEventTooltip(nodeId: string): UIThunkAction {
   return async ({ dispatch }) => {
     assert(ThreadFront.currentPause);
     const nodeFront = ThreadFront.currentPause.getNodeFront(nodeId);
-    const listenerRaw = nodeFront.getEventListeners() || [];
+    const listenerRaw = (await nodeFront.getEventListeners()) || [];
     const frameworkListeners = await nodeFront.getFrameworkEventListeners();
 
     const listenerInfo = [...listenerRaw, ...frameworkListeners].map(listener => {

--- a/src/devtools/client/inspector/rules/models/element-style.ts
+++ b/src/devtools/client/inspector/rules/models/element-style.ts
@@ -165,10 +165,10 @@ export default class ElementStyle {
    * Returns a promise that will be resolved when the elementStyle is
    * ready.
    */
-  populate() {
+  async populate() {
     this.rules = [];
 
-    const applied = this.element.getAppliedRules();
+    const applied = await this.element.getAppliedRules();
     if (applied === null) {
       this.rules = null;
       return;
@@ -201,7 +201,7 @@ export default class ElementStyle {
         if (parentInline && parentInline.properties.length > 0) {
           this._maybeAddRule(parentInline, elem);
         }
-        const parentApplied = elem.getAppliedRules();
+        const parentApplied = await elem.getAppliedRules();
         if (parentApplied === null) {
           this.rules = null;
           return;

--- a/src/highlighter/highlighter.js
+++ b/src/highlighter/highlighter.js
@@ -11,10 +11,14 @@ let gBoxModelHighlighter;
 const Highlighter = {
   currentNode: null,
 
-  highlight(node) {
+  async highlight(node) {
     if (!node) {
       return;
     }
+    if (node.getBoxModel) {
+      await node.getBoxModel();
+    }
+
     if (gBoxModelHighlighter && !document.getElementById("box-model-root")) {
       gBoxModelHighlighter.destroy();
       gBoxModelHighlighter = undefined;

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -558,13 +558,13 @@ async function getMarkupCanvasCoordinate(text, iframes = []) {
   for (const iframeText of iframes) {
     const node = (await ThreadFront.searchDOM(iframeText))[0];
     await node.ensureLoaded();
-    const { left, top } = node.getBoundingClientRect();
+    const { left, top } = await node.getBoundingClientRect();
     x += left;
     y += top;
   }
   const node = (await ThreadFront.searchDOM(text))[0];
   await node.ensureLoaded();
-  const center = boundsCenter(node.getBoundingClientRect());
+  const center = boundsCenter(await node.getBoundingClientRect());
   x += center.x;
   y += center.y;
   return { x, y };

--- a/src/ui/actions/index.ts
+++ b/src/ui/actions/index.ts
@@ -5,7 +5,7 @@ import * as timelineActions from "./timeline";
 import * as sessionActions from "./session";
 import * as commentsActions from "./comments";
 import * as reactDevToolsActions from "./reactDevTools";
-import { ThunkAction } from "ui/utils/thunk";
+import { ThunkAction, ThunkExtraArgs } from "ui/utils/thunk";
 import { UIState } from "ui/state";
 import type { AppActions } from "./app";
 import type { TimelineActions } from "./timeline";
@@ -30,15 +30,6 @@ export type UIAction =
   | EventTooltipAction
   | SessionActions
   | DebuggerAction;
-
-interface ThunkExtraArgs {
-  client: any;
-  panels: any;
-  prefsService: any;
-  toolbox: any;
-  parser: any;
-  search: any;
-}
 
 export type UIThunkAction<TReturn = void> = ThunkAction<TReturn, UIState, ThunkExtraArgs, UIAction>;
 

--- a/src/ui/utils/thunk.ts
+++ b/src/ui/utils/thunk.ts
@@ -50,6 +50,15 @@ export type ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction extend
   } & TExtraThunkArg
 ) => TReturnType;
 
+export interface ThunkExtraArgs {
+  client: any;
+  panels: any;
+  prefsService: any;
+  toolbox: any;
+  parser: any;
+  search: any;
+}
+
 /**
  * Redux behaviour changed by middleware, so overloads here
  */


### PR DESCRIPTION
We were previously fetching node properties when we loaded the children nodes. Now we load them on demand. improves #3946

This PR has three primary changes:
1. We no longer load all of the element's data upfront
2. The 5 node protocol methods now have their own async request wrappers
3. The redux code now knows that they're async.
