### PR TITLE
Setup inspector store earlier fixes #3947

### DIFF
--- a/src/devtools/client/inspector/inspector.ts
+++ b/src/devtools/client/inspector/inspector.ts
@@ -10,6 +10,8 @@ const EventEmitter = require("devtools/shared/event-emitter");
 // const { log } = require("protocol/socket");
 import { NodeFront } from "protocol/thread/node";
 import { UIStore } from "ui/actions";
+import { extendStore } from "ui/setup/store";
+import * as inspectorReducers from "devtools/client/inspector/reducers";
 
 require("devtools/client/themes/breadcrumbs.css");
 require("devtools/client/themes/inspector.css");
@@ -39,6 +41,7 @@ import CSSProperties from "./css-properties";
 import RulesView from "./rules/rules";
 
 const Highlighter = require("highlighter/highlighter");
+extendStore({}, inspectorReducers, {});
 
 /**
  * Represents an open instance of the Inspector for a tab.

--- a/src/ui/setup/dynamic/inspector.ts
+++ b/src/ui/setup/dynamic/inspector.ts
@@ -1,5 +1,3 @@
-import { extendStore } from "../store";
-import * as inspectorReducers from "devtools/client/inspector/reducers";
 import { prefs, features } from "devtools/client/inspector/prefs";
 
 declare global {
@@ -10,7 +8,5 @@ declare global {
     };
   }
 }
-
-extendStore({}, inspectorReducers, {});
 
 window.app.inspector = { prefs, features };


### PR DESCRIPTION
It's possible for `setup/dynamic/inspector.ts` to load to late and not extend the store

This moves the extension up to when we're importing the inspector.
https://app.replay.io/recording/188676cf-61bb-48c9-882d-acdb3407d2b3?point=18497557567046066831611991368401916&time=8371.653561517114&hasFrames=true