### PR TITLE
More resliliant react node picker

### DIFF
--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -116,7 +116,12 @@ class ReplayWall implements Wall {
       case "startInspectingNative": {
         ThreadFront.ensureCurrentPause();
         await ThreadFront.currentPause!.createWaiter;
-        await ThreadFront.currentPause!.loadMouseTargets();
+        const rv = await ThreadFront.currentPause!.loadMouseTargets();
+
+        if (!rv) {
+          this._listener?.({ event: "stopInspectingNative", payload: true });
+          break;
+        }
 
         const nodeToElementId = await this.mapNodesToElements();
 
@@ -130,6 +135,7 @@ class ReplayWall implements Wall {
           },
           enabledNodeIds: [...nodeToElementId.keys()],
         });
+
         break;
       }
 


### PR DESCRIPTION
The ReactDevTools Node Picker currently fails when we cannot fetch the boundingClientRects. For the user, this looks like the node picker is selected and should work, but there aren't any components on the page. 

This PR changes two things
1. it wraps `getBoundingClientRects` similar to how we wrap `repaintGraphics` 
2. it adds some error handling for ReactDevtools