### PR TITLE
Persist the selected sidebar panel between refreshes

### DIFF
--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -54,11 +54,12 @@ export async function getInitialAppState(): Promise<AppState> {
     return syncInitialAppState;
   }
 
-  const { viewMode, showVideoPanel, showEditor } = syncInitialAppState;
+  const { viewMode, showVideoPanel, showEditor, selectedPrimaryPanel } = syncInitialAppState;
 
   return {
     ...syncInitialAppState,
     viewMode: session.viewMode || viewMode,
+    selectedPrimaryPanel: session.selectedPrimaryPanel || selectedPrimaryPanel,
     showVideoPanel: "showVideoPanel" in session ? session.showVideoPanel : showVideoPanel,
     showEditor: "showEditor" in session ? session.showEditor : showEditor,
   };

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -3,6 +3,7 @@ import { UIState } from "ui/state";
 import { prefs, asyncStore } from "ui/utils/prefs";
 import {
   getSelectedPanel,
+  getSelectedPrimaryPanel,
   getShowEditor,
   getShowVideoPanel,
   getViewMode,
@@ -59,6 +60,7 @@ async function updateReplaySessions(state: UIState) {
     viewMode: getViewMode(state),
     showEditor: getShowEditor(state),
     showVideoPanel: getShowVideoPanel(state),
+    selectedPrimaryPanel: getSelectedPrimaryPanel(state),
   };
 
   asyncStore.replaySessions = { ...previousReplaySessions, [recordingId!]: currentReplaySession };


### PR DESCRIPTION
Fix #3855.

Demo: https://app.replay.io/recording/384ab550-49e7-4f72-bb7c-ef7756e66947