### PR TITLE
Fix async prefs

### DIFF
--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -54,11 +54,13 @@ export async function getInitialAppState(): Promise<AppState> {
     return syncInitialAppState;
   }
 
+  const { viewMode, showVideoPanel, showEditor } = syncInitialAppState;
+
   return {
     ...syncInitialAppState,
-    viewMode: session.viewMode,
-    showVideoPanel: session.showVideoPanel,
-    showEditor: session.showEditor,
+    viewMode: session.viewMode || viewMode,
+    showVideoPanel: "showVideoPanel" in session ? session.showVideoPanel : showVideoPanel,
+    showEditor: "showEditor" in session ? session.showEditor : showEditor,
   };
 }
 


### PR DESCRIPTION
Right now, `getInitialAppState` incorrectly overwrites the initial app state with falsy values. This happens when the user's current data stored for that replay's session doesn't contain a value for that pref.

This checks if the pref exists, and defaults to the default pref correctly.