### PR TITLE
Display line breaks in the comment contents

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -129,7 +129,7 @@ function CommentItem({
     showOptions = false;
   } else {
     content = (
-      <div className="space-y-4 text-xs break-words" style={{ lineHeight: "1.125rem" }}>
+      <div className="space-y-4 text-xs break-words whitespace-pre-wrap leading-comment-text">
         <Markdown>{comment.content}</Markdown>
       </div>
     );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,9 @@ module.exports = {
         textFieldBorder: "var(--text-field-border)",
         toolbarBackground: "var(--theme-toolbar-background)",
       },
+      lineHeight: {
+        "comment-text": "1.125rem",
+      },
     },
   },
   variants: {},


### PR DESCRIPTION
Fix #3870.

![image](https://user-images.githubusercontent.com/15959269/137020805-b6c377fd-80e5-4661-968a-cc3a13831adc.png)
