### PR TITLE
Show the current time in the timeline

### DIFF
--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { KeyboardEvent, NavigationEvent } from "@recordreplay/protocol";
+import classNames from "classnames";
+import { ReplayEvent } from "ui/state/app";
+import { getFormattedTime } from "ui/utils/timeline";
+import MaterialIcon from "../shared/MaterialIcon";
+
+function Event({
+  onSeek,
+  currentTime,
+  executionPoint,
+  event,
+}: {
+  event: ReplayEvent;
+  currentTime: any;
+  executionPoint: any;
+  onSeek: (point: string, time: number) => void;
+}) {
+  const isPaused = event.time === currentTime && executionPoint === event.point;
+
+  let text: string;
+  let title: string;
+  let icon: string;
+
+  if (event.kind?.includes("mouse")) {
+    text = "Mouse Click";
+    title = "Mouse Click Event";
+    icon = "ads_click";
+  } else if (event.kind?.includes("navigation")) {
+    const ev = event as NavigationEvent;
+    text = `${ev.url}`;
+    title = "Navigation Event";
+    icon = "place";
+  } else {
+    icon = "keyboard";
+    let ev = event as KeyboardEvent;
+    let eventText;
+
+    if (ev.kind === "keydown") {
+      eventText = `Key Down`;
+    } else if (ev.kind === "keyup") {
+      eventText = `Key Up`;
+    } else {
+      eventText = `Key Press`;
+    }
+
+    text = `${eventText} ${ev.key}`;
+    title = `${eventText} event`;
+  }
+
+  return (
+    <button
+      onClick={() => onSeek(event.point, event.time)}
+      onKeyDown={event => {
+        if (event.key === " ") {
+          event.preventDefault();
+        }
+      }}
+      title={title}
+      className={classNames(
+        "group",
+        "flex flex-row w-full items-center justify-between p-3 rounded-lg hover:bg-gray-100 focus:outline-none space-x-2",
+        {
+          "text-lightGrey": currentTime < event.time,
+          "text-primaryAccent": isPaused,
+        }
+      )}
+    >
+      <div className="flex flex-row space-x-2 items-center overflow-hidden">
+        <MaterialIcon className="group-hover:text-primaryAccent">{icon}</MaterialIcon>
+        <div
+          className={classNames("overflow-ellipsis overflow-hidden whitespace-pre", {
+            "font-semibold": isPaused,
+          })}
+        >
+          {text}
+        </div>
+      </div>
+      <div className={classNames({ "text-primaryAccent": isPaused })}>
+        {getFormattedTime(event.time)}
+      </div>
+    </button>
+  );
+}
+
+export default Event;

--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -1,139 +1,35 @@
-import { KeyboardEvent, NavigationEvent } from "@recordreplay/protocol";
-import classNames from "classnames";
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
+
 import { actions } from "ui/actions";
 import { selectors } from "ui/reducers";
 import { UIState } from "ui/state";
-import { ReplayEvent } from "ui/state/app";
-import { getFormattedTime } from "ui/utils/timeline";
-import MaterialIcon from "../shared/MaterialIcon";
-import Spinner from "../shared/Spinner";
+import sortedLastIndex from "lodash/sortedLastIndex";
 const { getExecutionPoint } = require("devtools/client/debugger/src/reducers/pause");
 
-function Event({
-  onSeek,
-  currentTime,
-  executionPoint,
-  event,
-}: {
-  event: ReplayEvent;
-  currentTime: any;
-  executionPoint: any;
-  onSeek: (point: string, time: number) => void;
-}) {
-  const isPaused = event.time === currentTime && executionPoint === event.point;
+import Event from "./Event";
+import EventsLoader from "./EventsLoader";
 
-  let text: string;
-  let title: string;
-  let icon: string;
-
-  if (event.kind?.includes("mouse")) {
-    text = "Mouse Click";
-    title = "Mouse Click Event";
-    icon = "ads_click";
-  } else if (event.kind?.includes("navigation")) {
-    const ev = event as NavigationEvent;
-    text = `${ev.url}`;
-    title = "Navigation Event";
-    icon = "place";
-  } else {
-    icon = "keyboard";
-    let ev = event as KeyboardEvent;
-    let eventText;
-
-    if (ev.kind === "keydown") {
-      eventText = `Key Down`;
-    } else if (ev.kind === "keyup") {
-      eventText = `Key Up`;
-    } else {
-      eventText = `Key Press`;
-    }
-
-    text = `${eventText} ${ev.key}`;
-    title = `${eventText} event`;
-  }
-
-  return (
-    <button
-      onClick={() => onSeek(event.point, event.time)}
-      title={title}
-      className={classNames(
-        "group",
-        "flex flex-row items-center justify-between p-3 rounded-lg hover:bg-gray-100 focus:outline-none space-x-2",
-        isPaused ? "text-primaryAccent" : ""
-      )}
-    >
-      <div className="flex flex-row space-x-2 items-center overflow-hidden">
-        <MaterialIcon className="group-hover:text-primaryAccent">{icon}</MaterialIcon>
-        <div
-          className={classNames(
-            isPaused ? "font-semibold" : "",
-            "overflow-ellipsis overflow-hidden whitespace-pre"
-          )}
-        >
-          {text}
-        </div>
-      </div>
-      <div className={classNames("", isPaused ? "text-primaryAccent" : "")}>
-        {getFormattedTime(event.time)}
-      </div>
-    </button>
-  );
-}
-
-function EventsLoaderItem({ category, isLoading }: { category: string; isLoading: boolean }) {
-  return (
-    <div className="flex flex-row space-x-2 items-center overflow-hidden">
-      {isLoading ? (
-        <div
-          className="flex flex-col items-center justify-center"
-          style={{ minHeight: "22px", minWidth: "22px" }}
-        >
-          <Spinner className="animate-spin h-5 w-5" />
-        </div>
-      ) : (
-        <MaterialIcon>done</MaterialIcon>
-      )}
-      <span>{category} events</span>
-    </div>
-  );
-}
-
-function EventsLoader({
-  eventCategoriesLoading,
-}: {
-  eventCategoriesLoading: { [key: string]: boolean };
-}) {
-  return (
-    <div className="space-y-3 flex flex-col w-full p-3 bg-gray-100 rounded-md">
-      <strong>Loading events:</strong>
-      <div className="flex flex-col w-full space-y-1">
-        {Object.keys(eventCategoriesLoading).map(category => {
-          return (
-            <EventsLoaderItem
-              category={category}
-              isLoading={eventCategoriesLoading[category]}
-              key={category}
-            />
-          );
-        })}
-      </div>
-    </div>
-  );
+function CurrentTimeLine() {
+  return <div className="bg-secondaryAccent w-full m-0" style={{ height: "3px" }} />;
 }
 
 function Events({
-  events,
-  eventCategoriesLoading,
-  seek,
   currentTime,
+  eventCategoriesLoading,
+  events,
   executionPoint,
   progressPercentage,
+  seek,
 }: PropsFromRedux) {
   const onSeek = (point: string, time: number) => {
     seek(point, time, false);
   };
+
+  const currentEventIndex = sortedLastIndex(
+    events.map(e => e.time),
+    currentTime
+  );
 
   return (
     <div className="right-sidebar">
@@ -141,11 +37,19 @@ function Events({
         <div className="right-sidebar-toolbar-item">Events</div>
       </div>
       <div className="flex-grow overflow-auto overflow-x-hidden flex flex-column items-center bg-white h-full">
-        <div className="flex flex-col p-1.5 self-stretch space-y-1.5 w-full text-xs">
+        <div className="flex flex-col py-1.5 self-stretch space-y-1.5 w-full text-xs">
           {progressPercentage < 100 ? <EventsLoader {...{ eventCategoriesLoading }} /> : null}
-          {events.map((e, i) => (
-            <Event key={i} onSeek={onSeek} event={e} {...{ currentTime, executionPoint }} />
-          ))}
+          {events.map((e, i) => {
+            return (
+              <div key={e.point}>
+                {i === currentEventIndex ? <CurrentTimeLine /> : null}
+                <div className="px-1.5">
+                  <Event onSeek={onSeek} event={e} {...{ currentTime, executionPoint }} />
+                </div>
+              </div>
+            );
+          })}
+          {currentEventIndex === events.length ? <CurrentTimeLine /> : null}
         </div>
       </div>
     </div>
@@ -154,15 +58,13 @@ function Events({
 
 const connector = connect(
   (state: UIState) => ({
-    events: selectors.getFlatEvents(state),
     currentTime: selectors.getCurrentTime(state),
+    eventCategoriesLoading: selectors.getEventCategoriesLoading(state),
+    events: selectors.getFlatEvents(state),
     executionPoint: getExecutionPoint(state),
     progressPercentage: selectors.getIndexing(state),
-    eventCategoriesLoading: selectors.getEventCategoriesLoading(state),
   }),
-  {
-    seek: actions.seek,
-  }
+  { seek: actions.seek }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(Events);

--- a/src/ui/components/Events/EventsLoader.tsx
+++ b/src/ui/components/Events/EventsLoader.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import MaterialIcon from "../shared/MaterialIcon";
+import Spinner from "../shared/Spinner";
+
+function EventsLoaderItem({ category, isLoading }: { category: string; isLoading: boolean }) {
+  return (
+    <div className="flex flex-row space-x-2 items-center overflow-hidden">
+      {isLoading ? (
+        <div
+          className="flex flex-col items-center justify-center"
+          style={{ minHeight: "22px", minWidth: "22px" }}
+        >
+          <Spinner className="animate-spin h-5 w-5" />
+        </div>
+      ) : (
+        <MaterialIcon>done</MaterialIcon>
+      )}
+      <span>{category} events</span>
+    </div>
+  );
+}
+
+interface EventsLoaderProps {
+  eventCategoriesLoading: { [key: string]: boolean };
+}
+
+function EventsLoader({ eventCategoriesLoading }: EventsLoaderProps) {
+  return (
+    <div className="space-y-3 flex flex-col w-full p-3 bg-gray-100 rounded-md">
+      <strong>Loading events:</strong>
+      <div className="flex flex-col w-full space-y-1">
+        {Object.keys(eventCategoriesLoading).map(category => {
+          return (
+            <EventsLoaderItem
+              category={category}
+              isLoading={eventCategoriesLoading[category]}
+              key={category}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default EventsLoader;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,10 +6,11 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        lightGrey: "var(--light-grey)",
         primaryAccent: "var(--primary-accent)",
         primaryAccentHover: "var(--primary-accent-hover)",
-        primaryAccentLegacy: "var(--primary-accent-legacy)",
         primaryAccentHoverLegacy: "var(--primary-accent-hover-legacy)",
+        primaryAccentLegacy: "var(--primary-accent-legacy)",
         secondaryAccent: "var(--secondary-accent)",
         textFieldBorder: "var(--text-field-border)",
         toolbarBackground: "var(--theme-toolbar-background)",


### PR DESCRIPTION
Closes #3822 , #3320 is coming up next.

Changes
---

- Split out some of the components in the Events folder, to try and give them some room to grow, since I'm about to add a bunch of logic.
- Add `lightGrey` to the colors that our tailwind knows about
- Add a secondary accent (the *now* color) line that shows where in the event timeline the current time is, and fade events that have not yet happened. This is quite pleasing to watch as the video plays.
- Fix what I *think* is a bug. Events on the timeline are represented in html as `button` elements, so that they behave like they are clickable (which makes sense, because they are). When you click on one of them, it gets focus. If you then press space bar two things happen at once:

1. The viewer attempts to start playing
2. The viewer immediately jumps to that point in time and pauses

It manifests as like a small UI hiccup every time you press the space bar while having focus on a timeline event. I could actually see a good argument for allowing timeline events to work this way, if people wanted to use the keyboard to navigate the timeline, but I think most of the time this behavior is just confusing, and if they *really* want to tab through and select they can always hit "Enter", which has the same effect as space, but doesn't try to start the player first.

https://user-images.githubusercontent.com/5903784/137043297-bf7d02b6-a69d-49af-907d-cabe9ccacee3.mp4


