### PR TITLE
Hide keyup and keydown events in timeline

### DIFF
--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -14,6 +14,8 @@ function CurrentTimeLine() {
   return <div className="bg-secondaryAccent w-full m-0" style={{ height: "3px" }} />;
 }
 
+const FILTERED_EVENT_TYPES = ["keydown", "keyup"];
+
 function Events({
   currentTime,
   eventCategoriesLoading,
@@ -25,6 +27,8 @@ function Events({
   const onSeek = (point: string, time: number) => {
     seek(point, time, false);
   };
+
+  events = events.filter(e => !FILTERED_EVENT_TYPES.includes(e.kind || ""));
 
   const currentEventIndex = sortedLastIndex(
     events.map(e => e.time),


### PR DESCRIPTION
Closes https://github.com/RecordReplay/devtools/issues/3317

The timeline gets flooded with keyboard events if any significant typing
happens. Eventually it would be awesome to have grouping and hierarchy
in this event viewer, as described in #3320, but this is a quick
solution for the interim to make it a little easier to scrub through
typing events. All of the nitty details are still visible in the
console's events viewer.

Before
---

<img width="1305" alt="CleanShot 2021-10-12 at 18 26 33@2x" src="https://user-images.githubusercontent.com/5903784/137050981-8248b054-e1d6-4778-a564-20e62665b897.png">

After
---
<img width="977" alt="CleanShot 2021-10-12 at 18 26 59@2x" src="https://user-images.githubusercontent.com/5903784/137051003-13d8145b-8878-4b23-aa78-631a982af208.png">
