### PR TITLE
Overlay the highlight on top of the pause line when highlighting in the editor

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Editor.css
+++ b/src/devtools/client/debugger/src/components/Editor/Editor.css
@@ -139,9 +139,25 @@ html[dir="rtl"] .editor-mount {
   background-color: var(--debug-expression-error-background);
 }
 
-.new-debug-line > .CodeMirror-line {
-  background-color: var(--debug-line-background) !important ;
+/* Prevent this from creating a stacking context so we can
+separately stack the pause line visuals and the code. */
+.CodeMirror .new-debug-line > .CodeMirror-line {
+  z-index: auto;
+}
+
+.new-debug-line > .CodeMirror-line::before {
+  width: 100%;
+  height: 100%;
+  left: 0px;
+  position: absolute;
+  content: "";
+  background-color: var(--debug-line-background) !important;
   outline: var(--debug-line-border) solid 1px;
+}
+
+.new-debug-line > .CodeMirror-line [role=presentation] {
+  z-index: 1;
+  position: relative;
 }
 
 /* Don't display the highlight color since the debug line


### PR DESCRIPTION
Fix #3407.

https://user-images.githubusercontent.com/15959269/137141815-2240b701-f2da-4a30-b90a-bf939be30f88.mov


