### PR TITLE
Fix transcript flash upon comment submission

### DIFF
--- a/src/ui/hooks/comments/useAddComment.tsx
+++ b/src/ui/hooks/comments/useAddComment.tsx
@@ -68,6 +68,8 @@ export default function useAddComment() {
         const newComment = {
           ...comment,
           id: commentId,
+          primaryLabel: comment.primaryLabel || null,
+          secondaryLabel: comment.secondaryLabel || null,
           user: {
             id: userId,
             name: user.name,


### PR DESCRIPTION
# Summary

I hit this once in development, it took a *very* long time to solve, but eventually I tracked it down to a missing field while writing to the Apollo cache. I thought the bug was gone, but then on production it started happening again. I carefully (I thought) compared the objects that I was pulling from and writing to the cache, and didn't spot any immediate differences, but then I found this issue: https://github.com/apollographql/apollo-client/issues/6375. This is the exact issue we are experiencing here, and the fact that someone mentioned `null` vs. `undefined` made me wonder if I had missed a small difference. It turns out, that we were writing `primaryLabel: undefined, secondaryLabel: undefined` into the cache when making comments that did not have labels. The cache was expecting `null` values when those are missing. It was silently failing, as described in the issue, and then (I think) refetching from the server because it was effectively a cache-miss (I didn't investigate this part too thoroughly since it wasn't super relevant).