### PR TITLE
Fix focus and click targets for comments

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.css
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.css
@@ -47,10 +47,6 @@
   background: var(--primary-accent);
 }
 
-.transcript-list .comment-input:hover {
-  cursor: text;
-}
-
 .transcript-list .draft-editor-container {
   /* Create a positioning context for the emoji picker */
   position: relative;

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
@@ -9,6 +9,8 @@ import { Comment, PendingNewComment, PendingNewReply, Reply } from "ui/state/com
 import "./CommentEditor.css";
 import { User } from "ui/types";
 import TipTapEditor from "./TipTapEditor";
+import { FocusContext } from "../CommentCard";
+import classNames from "classnames";
 
 type CommentEditorProps = PropsFromRedux & {
   comment: Comment | Reply | PendingNewComment | PendingNewReply;
@@ -34,22 +36,31 @@ function CommentEditor({
   );
 
   return (
-    <div className="comment-input-container" onClick={e => e.stopPropagation()}>
-      <div className="comment-input">
-        <TipTapEditor
-          content={comment.content || ""}
-          editable={editable}
-          handleCancel={clearPendingComment}
-          handleSubmit={handleSubmit}
-          possibleMentions={users || []}
-          placeholder={
-            comment.content == ""
-              ? "parentId" in comment
-                ? "Write a reply..."
-                : "Type a comment"
-              : ""
-          }
-        />
+    <div className="comment-input-container">
+      <div className={classNames("comment-input")}>
+        <FocusContext.Consumer>
+          {({ autofocus, blur, isFocused }) => (
+            <TipTapEditor
+              autofocus={autofocus}
+              blur={blur}
+              content={comment.content || ""}
+              editable={editable}
+              handleCancel={() => {
+                clearPendingComment();
+              }}
+              handleSubmit={handleSubmit}
+              possibleMentions={users || []}
+              placeholder={
+                comment.content == ""
+                  ? "parentId" in comment
+                    ? "Write a reply..."
+                    : "Type a comment"
+                  : ""
+              }
+              takeFocus={isFocused}
+            />
+          )}
+        </FocusContext.Consumer>
       </div>
     </div>
   );

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
@@ -11,7 +11,7 @@ interface NewCommentEditorProps extends PropsFromRedux {
   type: "new_reply" | "new_comment";
 }
 
-function NewCommentEditor({ comment, type, clearPendingComment, setModal }: NewCommentEditorProps) {
+function NewCommentEditor({ clearPendingComment, comment, setModal, type }: NewCommentEditorProps) {
   const { isAuthenticated } = useAuth0();
   const recordingId = hooks.useGetRecordingId();
   const addComment = hooks.useAddComment();

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -4,8 +4,11 @@ import StarterKit from "@tiptap/starter-kit";
 import { User } from "ui/types";
 import Placeholder from "@tiptap/extension-placeholder";
 import classNames from "classnames";
+import { Plugin, PluginKey } from "prosemirror-state";
 
 interface TipTapEditorProps {
+  autofocus: boolean;
+  blur: () => void;
   content: string;
   editable: boolean;
   handleSubmit: (text: string) => void;
@@ -13,6 +16,7 @@ interface TipTapEditorProps {
   placeholder: string;
   // Not actually implementing this now, but leaving it in the API for later
   possibleMentions: User[];
+  takeFocus: boolean;
 }
 
 const tryToParse = (content: string): any => {
@@ -30,11 +34,14 @@ const tryToParse = (content: string): any => {
 };
 
 const TipTapEditor = ({
+  autofocus,
+  blur,
   content,
   editable,
   handleSubmit,
   handleCancel,
   placeholder,
+  takeFocus,
 }: TipTapEditorProps) => {
   const editor = useEditor({
     extensions: [
@@ -53,7 +60,8 @@ const TipTapEditor = ({
               handleSubmit(JSON.stringify(editor.getJSON()));
               return true;
             },
-            Escape: () => {
+            Escape: ({ editor }) => {
+              editor.commands.blur();
               handleCancel();
               return true;
             },
@@ -68,7 +76,7 @@ const TipTapEditor = ({
     },
     content: tryToParse(content),
     editable,
-    autofocus: true,
+    autofocus,
   });
 
   useEffect(() => {
@@ -78,14 +86,23 @@ const TipTapEditor = ({
     }
   }, [editable]);
 
+  useEffect(() => {
+    if (takeFocus) {
+      console.log("taking focus");
+      editor?.commands.focus("end");
+    }
+  }, [takeFocus]);
+
   return (
     <EditorContent
       className={classNames("outline-none w-full rounded-md py-1 px-2 transition", {
-        "border-gray-400": editable,
         "bg-white": editable,
+        "border-gray-400": editable,
+        "cursor-text": editable,
         border: editable,
       })}
       editor={editor}
+      onBlur={blur}
     />
   );
 };


### PR DESCRIPTION
This is more complicated than I expected! It's complicated for these reasons:
- There are multiple editors per CommentCard (at least one, that is disabled by default, for the top-level comment, and at least one for the enabled reply box [assuming we're paused there, otherwise none of this really matters])
- Every part of the comment serves as a click target to focus the related reply box
- Reply boxes can appear and disappear (sometimes several at once!), so you have to think about both competing for focus as well as competing for autofocus.

I went with a context here. This is one of the scenarios where I've seen them work pretty well, and it makes it much easier that we don't have to thread focus information through like 4 layers of components.

Screencaps
---
Easy situation - clicking on a comment card focuses its related input, clicking away blurs it, clicking on it multiple times doesn't do anything special, it just stays focused


https://user-images.githubusercontent.com/5903784/137574505-659e74cf-6417-4b86-b206-89675af18839.mp4

---

Slightly harder - focus switches between cards smoothly

https://user-images.githubusercontent.com/5903784/137574574-7e587a9b-c4df-4000-a429-06dc00ff4703.mp4

---

Harder still - focus and autofocus is managed while editors are appearing and disappearing


https://user-images.githubusercontent.com/5903784/137574590-97845350-523b-4577-80be-ea51ba6a74f4.mp4