### PR TITLE
Skip browser internal errors

### DIFF
--- a/src/devtools/client/webconsole/actions/messages.js
+++ b/src/devtools/client/webconsole/actions/messages.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-import { getAllFilters } from "../selectors/filters";
+import { getAllFilters, isBrowserInternalMessage } from "../selectors/filters";
 
 const { prepareMessage } = require("devtools/client/webconsole/utils/messages");
 const { IdGenerator } = require("devtools/client/webconsole/utils/id-generator");
@@ -62,6 +62,11 @@ function onConsoleMessage(msg) {
     const sourceId = stacktrace?.[0]?.sourceId;
 
     let { url, sourceId: msgSourceId, line, column } = msg;
+
+    // Skip messages that are coming from a firefox internal JS file
+    if (isBrowserInternalMessage(msg.text)) {
+      return;
+    }
 
     if (msg.point.frame) {
       // If the execution point has a location, use any mappings in that location.

--- a/src/devtools/client/webconsole/utils/messages.js
+++ b/src/devtools/client/webconsole/utils/messages.js
@@ -451,12 +451,18 @@ function isError(message) {
   return message.source === "javascript" && message.level === "error";
 }
 
+// messages with a resource:///modules path are considered internal
+function isBrowserInternalMessage(msg) {
+  return msg.match(/resource:\/\/\/modules\/\S+\.jsm/);
+}
+
 module.exports = {
   getArrayTypeNames,
   getDescriptorValue,
   isContentBlockingMessage,
   isGroupType,
   isError,
+  isBrowserInternalMessage,
   l10n,
   prepareMessage,
 };


### PR DESCRIPTION
fixes https://github.com/RecordReplay/backend/issues/3113

This takes the approach that it's the devtools job to decide what to show to the user. Could be persuaded that this is more of a backend role since these are browser errors and not user errors...