### PR TITLE
Team Plan Expiration Polish

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -26,7 +26,7 @@ import { ApolloError } from "@apollo/client";
 export type SetUnexpectedErrorAction = Action<"set_unexpected_error"> & {
   error: UnexpectedError;
 };
-export type SetTrialExpiredAction = Action<"set_trial_expired">;
+export type SetTrialExpiredAction = Action<"set_trial_expired"> & { expired: boolean };
 export type SetExpectedErrorAction = Action<"set_expected_error"> & { error: ExpectedError };
 export type SessionActions =
   | SetExpectedErrorAction
@@ -222,8 +222,11 @@ export function setExpectedError(error: ExpectedError): UIThunkAction {
   };
 }
 
-export function setTrialExpired(): SetTrialExpiredAction {
-  return { type: "set_trial_expired" };
+export function setTrialExpired(expired = true): SetTrialExpiredAction {
+  return { type: "set_trial_expired", expired };
+}
+export function clearTrialExpired(): UIThunkAction {
+  return ({ dispatch }) => dispatch(setTrialExpired(false));
 }
 export function setUnexpectedError(error: UnexpectedError, skipTelemetry = false): UIThunkAction {
   return ({ getState, dispatch }) => {

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { selectors } from "../reducers";
 import { UIState } from "ui/state";
-import { createSession } from "ui/actions/session";
+import { clearTrialExpired, createSession } from "ui/actions/session";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import Header from "./Header/index";
 import { LoadingScreen } from "./shared/BlankScreen";
@@ -13,11 +13,18 @@ import "ui/setup/dynamic/devtools";
 
 const DevView = React.lazy(() => import("./Views/DevView"));
 
-function _DevTools({ loadingFinished, viewMode, createSession }: PropsFromRedux) {
+function _DevTools({
+  clearTrialExpired,
+  loadingFinished,
+  viewMode,
+  createSession,
+}: PropsFromRedux) {
   const recordingId = useGetRecordingId();
   useEffect(() => {
     createSession(recordingId);
-  }, [recordingId]);
+
+    return () => clearTrialExpired();
+  }, [clearTrialExpired, recordingId]);
 
   if (!loadingFinished) {
     return <LoadingScreen />;
@@ -38,6 +45,7 @@ const connector = connect(
   }),
   {
     createSession,
+    clearTrialExpired,
   }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/Library/BatchActionDropdown.tsx
+++ b/src/ui/components/Library/BatchActionDropdown.tsx
@@ -10,6 +10,7 @@ import { getButtonClasses } from "../shared/Button";
 import MaterialIcon from "../shared/MaterialIcon";
 import classNames from "classnames";
 import PortalDropdown from "../shared/PortalDropdown";
+import MoveRecordingMenu from "./MoveRecordingMenu";
 
 type BatchActionDropdownProps = PropsFromRedux & {
   selectedIds: RecordingId[];
@@ -87,20 +88,9 @@ function BatchActionDropdown({
         <DropdownItem onClick={deleteSelectedIds}>{`Delete ${selectedIds.length} item${
           selectedIds.length > 1 ? "s" : ""
         }`}</DropdownItem>
-        <div className="px-4 py-2 text-xs uppercase font-bold">Move to:</div>
-        <DropdownDivider />
-        <div className="overflow-y-auto max-h-48">
-          {currentWorkspaceId ? (
-            <DropdownItem onClick={() => updateRecordings(null)}>Your library</DropdownItem>
-          ) : null}
-          {workspaces
-            .filter(w => w.id !== currentWorkspaceId)
-            .map(({ id, name }) => (
-              <DropdownItem onClick={() => updateRecordings(id)} key={id}>
-                {name}
-              </DropdownItem>
-            ))}
-        </div>
+        {!loading ? (
+          <MoveRecordingMenu workspaces={workspaces} onMoveRecording={updateRecordings} />
+        ) : null}
       </Dropdown>
     </PortalDropdown>
   );

--- a/src/ui/components/Library/MoveRecordingMenu.tsx
+++ b/src/ui/components/Library/MoveRecordingMenu.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { selectors } from "ui/reducers";
+import { UIState } from "ui/state";
+import { Workspace } from "ui/types";
+import { WorkspaceId } from "ui/state/app";
+import { DropdownDivider, DropdownItem } from "./LibraryDropdown";
+import hooks from "ui/hooks";
+import { subscriptionExpired } from "ui/utils/workspace";
+
+type RecordingOptionsDropdownProps = PropsFromRedux & {
+  onMoveRecording: (targetWorkspaceId: WorkspaceId | null) => void;
+  workspaces: Workspace[];
+};
+
+function MoveRecordingMenu({
+  currentWorkspaceId,
+  onMoveRecording,
+  workspaces,
+}: RecordingOptionsDropdownProps) {
+  const { workspace, loading } = hooks.useGetWorkspace(currentWorkspaceId || "");
+  if (loading || !workspace?.subscription || subscriptionExpired(workspace)) return null;
+
+  return (
+    <>
+      <div className="px-4 py-2 text-xs uppercase font-bold">Move to:</div>
+      <DropdownDivider />
+      <div className="overflow-y-auto max-h-48">
+        {currentWorkspaceId !== null ? (
+          <DropdownItem onClick={() => onMoveRecording(null)}>Your library</DropdownItem>
+        ) : null}
+        {workspaces
+          .filter(w => w.id !== currentWorkspaceId)
+          .map(({ id, name }) => (
+            <DropdownItem onClick={() => onMoveRecording(id)} key={id}>
+              {name}
+            </DropdownItem>
+          ))}
+      </div>
+    </>
+  );
+}
+
+const connector = connect((state: UIState) => ({
+  currentWorkspaceId: selectors.getWorkspaceId(state),
+}));
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(MoveRecordingMenu);

--- a/src/ui/components/Library/RecordingOptionsDropdown.tsx
+++ b/src/ui/components/Library/RecordingOptionsDropdown.tsx
@@ -11,6 +11,7 @@ import { WorkspaceId } from "ui/state/app";
 import { Dropdown, DropdownDivider, DropdownItem } from "./LibraryDropdown";
 import PortalDropdown from "../shared/PortalDropdown";
 import classNames from "classnames";
+import MoveRecordingMenu from "./MoveRecordingMenu";
 
 type RecordingOptionsDropdownProps = PropsFromRedux & {
   recording: Recording;
@@ -78,22 +79,9 @@ function RecordingOptionsDropdown({
           isPrivate ? "public" : "private"
         }`}</DropdownItem>
         <DropdownItem onClick={handleShareClick}>Share</DropdownItem>
-        <div className="px-4 py-2 text-xs uppercase font-bold">Move to:</div>
-        <DropdownDivider />
-        <div className="overflow-y-auto max-h-48">
-          {currentWorkspaceId !== null ? (
-            <DropdownItem onClick={() => updateRecording(null)}>Your library</DropdownItem>
-          ) : null}
-          {!loading
-            ? workspaces
-                .filter(w => w.id !== currentWorkspaceId)
-                .map(({ id, name }) => (
-                  <DropdownItem onClick={() => updateRecording(id)} key={id}>
-                    {name}
-                  </DropdownItem>
-                ))
-            : null}
-        </div>
+        {!loading ? (
+          <MoveRecordingMenu workspaces={workspaces} onMoveRecording={updateRecording} />
+        ) : null}
       </Dropdown>
     </PortalDropdown>
   );

--- a/src/ui/components/Library/TeamTrialEnd.tsx
+++ b/src/ui/components/Library/TeamTrialEnd.tsx
@@ -11,7 +11,9 @@ import { TrialEnd } from "../shared/TrialEnd";
 
 function TeamTrialEnd({ currentWorkspaceId, setModal }: PropsFromRedux) {
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
+  const { members } = hooks.useGetWorkspaceMembers(currentWorkspaceId!);
   const history = useHistory();
+  const { userId: localUserId } = hooks.useGetUserId();
 
   // There's no workspace ID if they are in their personal library.
   if (loading || !currentWorkspaceId) {
@@ -24,10 +26,16 @@ function TeamTrialEnd({ currentWorkspaceId, setModal }: PropsFromRedux) {
     return null;
   }
 
-  const onClick = () => {
-    history.push(`/team/${currentWorkspaceId}/settings/billing`);
-    setModal("workspace-settings");
-  };
+  const roles = members?.find(m => m.userId === localUserId)?.roles;
+  const isAdmin = roles?.includes("admin") || false;
+  const onClick = isAdmin
+    ? () => {
+        if (isAdmin) {
+          history.push(`/team/${currentWorkspaceId}/settings/billing`);
+          setModal("workspace-settings");
+        }
+      }
+    : undefined;
 
   const expiresIn = subscriptionEndsIn(workspace);
 

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -7,7 +7,10 @@ import { UIState } from "ui/state";
 import BlankScreen from "./BlankScreen";
 import classNames from "classnames";
 import { ExpectedError, UnexpectedError } from "ui/state/app";
-import { isDevelopment } from "ui/utils/environment";
+import { getRecordingId, isDevelopment } from "ui/utils/environment";
+import hooks from "ui/hooks";
+import { useHistory } from "react-router";
+import { setModal } from "ui/actions/app";
 
 export function PopupBlockedError() {
   const error = { message: "OAuth consent popup blocked" };
@@ -85,6 +88,35 @@ function LibraryButton() {
   );
 }
 
+function TeamBillingButtonBase({ currentWorkspaceId, setModal }: BillingPropsFromRedux) {
+  const history = useHistory();
+  const onClick = () => {
+    history.push(`/team/${currentWorkspaceId}/settings/billing`);
+    setModal("workspace-settings");
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={classNames(
+        "w-full inline-flex items-center justify-center px-16 py-2.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
+      )}
+    >
+      Update Subscription
+    </button>
+  );
+}
+
+const billingConnector = connect(
+  (state: UIState) => ({
+    currentWorkspaceId: selectors.getWorkspaceId(state),
+  }),
+  { setModal }
+);
+type BillingPropsFromRedux = ConnectedProps<typeof billingConnector>;
+const TeamBillingButton = billingConnector(TeamBillingButtonBase);
+
 function ActionButton({ action }: { action: string }) {
   let button;
 
@@ -94,6 +126,8 @@ function ActionButton({ action }: { action: string }) {
     button = <SignInButton />;
   } else if (action == "library") {
     button = <LibraryButton />;
+  } else if (action == "team-billing") {
+    button = <TeamBillingButton />;
   }
 
   return <div>{button}</div>;
@@ -166,6 +200,9 @@ function UnexpectedErrorScreen({ error }: { error: UnexpectedError }) {
 }
 
 function TrialExpired() {
+  const recordingId = getRecordingId();
+  const { recording, loading } = hooks.useGetRecording(recordingId!);
+
   return (
     <Modal options={{ maskTransparency: "translucent" }}>
       <section className="max-w-lg w-full m-auto bg-white shadow-lg rounded-lg overflow-hidden text-base">
@@ -180,7 +217,9 @@ function TrialExpired() {
               expired.
             </div>
           </div>
-          <ActionButton action={"library"} />
+          <ActionButton
+            action={loading || recording?.userRole !== "team-admin" ? "library" : "team-billing"}
+          />
         </div>
       </section>
     </Modal>

--- a/src/ui/components/shared/TrialEnd.tsx
+++ b/src/ui/components/shared/TrialEnd.tsx
@@ -13,13 +13,10 @@ export function TrialEnd({
   className?: string;
   onClick?: () => void;
 }) {
-  let style;
-
-  if (color === "yellow") {
-    style = { backgroundColor: "#FFFB96" };
-  } else {
-    style = { backgroundColor: "#E9E9EB" };
-  }
+  const style = {
+    backgroundColor: color === "yellow" ? "#FFFB96" : "#E9E9EB",
+    cursor: onClick ? "pointer" : "default",
+  };
 
   if (expiresIn >= 21) {
     return null;

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -104,7 +104,7 @@ export default function update(
     }
 
     case "set_trial_expired": {
-      return { ...state, trialExpired: true };
+      return { ...state, trialExpired: action.expired };
     }
 
     case "update_theme": {


### PR DESCRIPTION
## Issue

Fixes #4010 

## Resolution

* Prevents a user from moving a recording from an expired team to another team or library
* Hitting the browser back button when the trial modal is dismisses the trial expiration modal
* Adds a button to navigate to the billing page for admins from the modal
* Clicking on the trial banner in the library is now navigates for an admin

## Notes

* Also refactors the "move menu item" into a separate component since it was used in two places and both needed the update.
* Requires a backend change (which is still in progress) to detect if the user is an admin on the workspace when viewing the modal.