### PR TITLE
Don't allow empty comments to be submitted

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
@@ -23,12 +23,6 @@ function NewCommentEditor({ clearPendingComment, comment, setModal, type }: NewC
       return;
     }
 
-    // For now we can simply bail if the input happens to be empty. We should fix
-    // this in the next pass to handle and show an error prompt.
-    if (inputValue == "") {
-      return;
-    }
-
     if (type == "new_reply") {
       handleReplySave(comment as PendingNewReply, inputValue);
     } else {

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -4,7 +4,6 @@ import StarterKit from "@tiptap/starter-kit";
 import { User } from "ui/types";
 import Placeholder from "@tiptap/extension-placeholder";
 import classNames from "classnames";
-import { Plugin, PluginKey } from "prosemirror-state";
 
 interface TipTapEditorProps {
   autofocus: boolean;
@@ -53,11 +52,15 @@ const TipTapEditor = ({
         addKeyboardShortcuts() {
           return {
             "Cmd-Enter": ({ editor }) => {
-              handleSubmit(JSON.stringify(editor.getJSON()));
+              if (editor.getCharacterCount() > 0) {
+                handleSubmit(JSON.stringify(editor.getJSON()));
+              }
               return true;
             },
             Enter: ({ editor }) => {
-              handleSubmit(JSON.stringify(editor.getJSON()));
+              if (editor.getCharacterCount() > 0) {
+                handleSubmit(JSON.stringify(editor.getJSON()));
+              }
               return true;
             },
             Escape: ({ editor }) => {


### PR DESCRIPTION
Previously we were storing comments as markdown, so checking `content.length` would tell us if the comment was empty. Now that we store the comments in json an empty comment is like `{content: blahblahblah}` so we can't just qualify all strings that are longer than 0 as valid comments. Instead, we check at the editor level what our character count is (which only counts characters that actually get rendered), and submit if *that* is greater than 0.