### PR TITLE
Show windows early access badge

### DIFF
--- a/src/image/image.css
+++ b/src/image/image.css
@@ -1,3 +1,8 @@
+.img.windows {
+  mask: url(~image/images/icon-windows.svg);
+  width: 24px;
+  height: 24px;
+}
 .img.webpack {
   background-image: url(~devtools/client/debugger/images/sources/webpack.svg);
 }

--- a/src/ui/components/shared/BlankScreen.tsx
+++ b/src/ui/components/shared/BlankScreen.tsx
@@ -90,6 +90,20 @@ function Logo({ scale = 1 }) {
     </svg>
   );
 }
+function WindowsEarlyAccess() {
+  if (true) {
+    return null;
+  }
+  return (
+    <div
+      className="flex absolute items-center text-primaryAccent"
+      style={{ bottom: "50px", left: "calc(50% - 98px)" }}
+    >
+      <div className="img windows w-6 h-6 mr-2" style={{ background: "var(--primary-accent)" }} />
+      Windows Early Access
+    </div>
+  );
+}
 
 // White progress screen used for showing the scanning progress of a replay
 export function BlankProgressScreen({ progress }: { progress: null | number }) {
@@ -110,6 +124,7 @@ export function BlankProgressScreen({ progress }: { progress: null | number }) {
           </div>
         </div>
       </div>
+      <WindowsEarlyAccess />
     </BlankScreen>
   );
 }
@@ -123,7 +138,6 @@ function _LoadingScreen({ uploading, awaitingSourcemaps, progress, finished }: P
   if (awaitingSourcemaps) {
     return <BlankLoadingScreen statusMessage={"Uploading sourcemaps"} />;
   } else if (uploading) {
-
     const amount = `${Math.round(+uploading.amount)}Mb`;
     const statusMessage = amount ? `Uploading ${amount}` : "Uploading";
 


### PR DESCRIPTION
This adds a windows early access badge while loading the replay. It's missing the platform check though which is surprising to me, since it should be in the buildId `macOS-gecko-20211018105919`, but the buildId only returns `gecko` 

<img width="794" alt="Screen Shot 2021-10-19 at 8 25 31 AM" src="https://user-images.githubusercontent.com/254562/137942429-b274ced0-1269-4085-903d-cdf17dec4a62.png">
