### PR TITLE
Add a guard for checking that there's an actual session when fetching preferences

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -383,7 +383,7 @@ export function loadReplayPrefs(recordingId: RecordingId): UIThunkAction {
     const replaySessions = await asyncStore.replaySessions;
     const session = replaySessions[recordingId];
 
-    if (recordingId) {
+    if (recordingId && session) {
       const { viewMode, showVideoPanel, showEditor, selectedPrimaryPanel } = session;
 
       dispatch(setViewMode(viewMode));


### PR DESCRIPTION
Fix #4067.