### PR TITLE
Fix team developer warning

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
@@ -85,12 +85,12 @@ export function SummaryExpression({
             }
           >
             {isTeamDeveloper ? (
-              "Editing logpoints is available for Developers in the Team plan"
-            ) : (
               <>
                 This log cannot be edited because <br />
                 it was hit {prefs.maxHitsDisplayed}+ times
               </>
+            ) : (
+              "Editing logpoints is available for Developers in the Team plan"
             )}
           </Popup>
         </>


### PR DESCRIPTION
We had this logic backwards, so that team developers got a warning that indicated they weren't on a team, while non-team developers got a warning about how many times a breakpoint was hit. This rights that and closes https://github.com/RecordReplay/devtools/issues/4072.