### PR TITLE
Fix editing comments

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -106,11 +106,13 @@ function CommentItemHeader({
 }
 
 function CommentItem({
-  pendingComment,
   comment,
+  pendingComment,
+  type,
 }: {
-  pendingComment: PendingComment | null;
   comment: Comment | Reply;
+  pendingComment: PendingComment | null;
+  type: "comment" | "reply";
 }) {
   const isEditing = Boolean(pendingComment?.comment?.id == comment.id);
   const showOptions = !isEditing;
@@ -118,7 +120,11 @@ function CommentItem({
   return (
     <div className="space-y-1.5 group">
       <CommentItemHeader {...{ comment, showOptions }} />
-      <ExistingCommentEditor comment={comment} pendingComment={pendingComment} />
+      <ExistingCommentEditor
+        comment={comment}
+        type={type}
+        editable={pendingComment?.comment.id === comment.id}
+      />
     </div>
   );
 }
@@ -191,10 +197,10 @@ function CommentCard({
         })}
       >
         {comment.sourceLocation ? <CommentSource comment={comment} /> : null}
-        <CommentItem comment={comment as Comment} pendingComment={pendingComment} />
+        <CommentItem type="comment" comment={comment as Comment} pendingComment={pendingComment} />
         {comment.replies?.map((reply: Reply) => (
           <div key={reply.id}>
-            <CommentItem comment={reply} pendingComment={pendingComment} />
+            <CommentItem type="reply" comment={reply} pendingComment={pendingComment} />
           </div>
         ))}
         {isPaused && !pendingComment ? (

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
@@ -3,43 +3,33 @@ import { connect, ConnectedProps } from "react-redux";
 import hooks from "ui/hooks";
 import { actions } from "ui/actions";
 import CommentEditor from "./CommentEditor";
-import {
-  Comment,
-  PendingComment,
-  PendingNewComment,
-  PendingNewReply,
-  Reply,
-} from "ui/state/comments";
+import { Comment, PendingNewComment, PendingNewReply, Reply } from "ui/state/comments";
 
 type ExistingCommentEditorProps = PropsFromRedux & {
   comment: Comment | Reply | PendingNewComment | PendingNewReply;
-  pendingComment: PendingComment | null;
+  editable: boolean;
+  type: "comment" | "reply";
 };
 
 function ExistingCommentEditor({
   comment,
-  pendingComment,
   clearPendingComment,
+  editable,
+  type,
 }: ExistingCommentEditorProps) {
   const updateComment = hooks.useUpdateComment();
   const updateCommentReply = hooks.useUpdateCommentReply();
 
   const handleSubmit = (inputValue: string) => {
-    if (pendingComment?.type === "edit_comment") {
-      updateComment(pendingComment.comment.id, inputValue, pendingComment.comment.position);
-    } else if (pendingComment?.type === "edit_reply") {
-      updateCommentReply(pendingComment.comment.id, inputValue);
+    if (type === "comment") {
+      updateComment(comment.id, inputValue, (comment as Comment).position);
+    } else if (type === "reply") {
+      updateCommentReply(comment.id, inputValue);
     }
     clearPendingComment();
   };
 
-  return (
-    <CommentEditor
-      editable={pendingComment?.comment?.id === comment.id}
-      comment={comment}
-      handleSubmit={handleSubmit}
-    />
-  );
+  return <CommentEditor editable={editable} comment={comment} handleSubmit={handleSubmit} />;
 }
 
 const connector = connect(null, { clearPendingComment: actions.clearPendingComment });

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -88,22 +88,30 @@ const TipTapEditor = ({
 
   useEffect(() => {
     if (takeFocus) {
-      console.log("taking focus");
       editor?.commands.focus("end");
     }
   }, [takeFocus]);
 
   return (
-    <EditorContent
-      className={classNames("outline-none w-full rounded-md py-1 px-2 transition", {
-        "bg-white": editable,
-        "border-gray-400": editable,
-        "cursor-text": editable,
-        border: editable,
-      })}
-      editor={editor}
-      onBlur={blur}
-    />
+    <div
+      className="w-full"
+      onClick={e => {
+        if (editable) {
+          e.stopPropagation();
+        }
+      }}
+    >
+      <EditorContent
+        className={classNames("outline-none w-full rounded-md py-1 px-2 transition", {
+          "bg-white": editable,
+          "border-gray-400": editable,
+          "cursor-text": editable,
+          border: editable,
+        })}
+        editor={editor}
+        onBlur={blur}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
I have only been able to reproduce https://github.com/RecordReplay/devtools/issues/4053 once, and I still haven't figured out *exactly* what is causing it. However, during my investigation, I *have* discovered that we are not actually updating comments upon edit right now. This is happening because when we render the `ExistingCommentEditor` the first time (on load) `pendingComment` is always `null`. I suspect that using `pendingComment` to manage editor states was a bit of a mis-step. When we have to have global state for things like that, it would be good to make it so that all of the changes come from one single place in the UI, and everywhere else basically has read-only access. So yeah, I don't think this will handle #4053, but it's worth merging anyways, and I'll keep an eye out for what might be causing that one.