### PR TITLE
New upload screen

### DIFF
--- a/src/ui/components/Library/LibraryDropdown.tsx
+++ b/src/ui/components/Library/LibraryDropdown.tsx
@@ -31,9 +31,9 @@ export function Dropdown({
   menuItemsClassName,
   widthClass = "w-56",
 }: {
-  children: (React.ReactElement | null)[];
+  children: React.ReactElement | (React.ReactElement | null)[];
   menuItemsClassName?: string;
-  widthClass?: "w-56" | "w-80";
+  widthClass?: "w-56" | "w-64" | "w-80";
 }) {
   return (
     <Menu as="div" className="inline-block text-left recording-options">

--- a/src/ui/components/Library/LibraryDropdown.tsx
+++ b/src/ui/components/Library/LibraryDropdown.tsx
@@ -31,7 +31,7 @@ export function Dropdown({
   menuItemsClassName,
   widthClass = "w-56",
 }: {
-  children: React.ReactElement | (React.ReactElement | null)[];
+  children: React.ReactNode;
   menuItemsClassName?: string;
   widthClass?: "w-56" | "w-64" | "w-80";
 }) {

--- a/src/ui/components/UploadScreen/ReplayTitle.tsx
+++ b/src/ui/components/UploadScreen/ReplayTitle.tsx
@@ -1,5 +1,4 @@
-import React, { ChangeEvent, Dispatch, SetStateAction, useEffect } from "react";
-import { TextInput } from "ui/components/shared/Forms";
+import React, { ChangeEvent, Dispatch, SetStateAction } from "react";
 
 export default function ReplayTitle({
   inputValue,
@@ -13,18 +12,14 @@ export default function ReplayTitle({
   };
 
   return (
-    <div>
-      <label htmlFor="replay-title" className="block text-xs uppercase font-semibold ">
-        Title
-      </label>
-      <div className="mt-1">
-        <TextInput
-          placeholder="Your replay's title"
-          value={inputValue}
-          onChange={onChange}
-          id="replay-title"
-        />
-      </div>
+    <div className="flex flex-col space-y-3">
+      <div>Replay Title</div>
+      <input
+        type="textbox"
+        className="bg-white rounded-lg shadow-xl py-3.5 px-6 font-medium focus:outline-none focus:ring-2 focus:ring-primaryAccent"
+        onChange={onChange}
+        value={inputValue}
+      />
     </div>
   );
 }

--- a/src/ui/components/UploadScreen/SettingsPreview.tsx
+++ b/src/ui/components/UploadScreen/SettingsPreview.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Workspace } from "ui/types";
+
+const getIconAndText = (
+  isPublic: boolean,
+  selectedWorkspaceId: string | null,
+  workspaceName: string
+) => {
+  let text, icon;
+
+  if (!isPublic) {
+    if (selectedWorkspaceId) {
+      text = `Shared privately with ${workspaceName}`;
+      icon = "groups";
+    } else {
+      text = `Only you can view this`;
+      icon = "person";
+    }
+  } else {
+    text = "This replay can be viewed by anyone with the link";
+    icon = "public";
+  }
+
+  return { text, icon };
+};
+
+export default function SettingsPreview({
+  onClick,
+  isPublic,
+  workspaces,
+  selectedWorkspaceId,
+}: {
+  onClick: () => void;
+  isPublic: boolean;
+  workspaces: Workspace[];
+  selectedWorkspaceId: string | null;
+}) {
+  const personalWorkspace = { id: null, name: "My Library" };
+  const workspaceName = [...workspaces, personalWorkspace].find(w => w.id === selectedWorkspaceId)!
+    .name;
+
+  const { icon, text } = getIconAndText(isPublic, selectedWorkspaceId, workspaceName);
+
+  return (
+    <button
+      className="w-full flex flex-row justify-between items-center focus:outline-none"
+      onClick={onClick}
+      style={{ minHeight: "38px" }}
+    >
+      <div className="space-x-2.5 flex flex-row items-center">
+        <span className="material-icons" style={{ fontSize: "24px" }}>
+          {icon}
+        </span>
+        <div className="font-medium">{text}</div>
+      </div>
+      <div className="space-x-2 flex flex-row items-center text-primaryAccent">
+        <div className="font-medium">Edit</div>
+        <span className="material-icons" style={{ fontSize: "24px" }}>
+          edit
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/src/ui/components/UploadScreen/SettingsPreview.tsx
+++ b/src/ui/components/UploadScreen/SettingsPreview.tsx
@@ -1,20 +1,24 @@
 import React from "react";
 import { Workspace } from "ui/types";
+import { MY_LIBRARY, personalWorkspace } from "./Sharing";
 
 const getIconAndText = (
   isPublic: boolean,
-  selectedWorkspaceId: string | null,
+  selectedWorkspaceId: string,
   workspaceName: string
-) => {
+): {
+  text: string;
+  icon: string;
+} => {
   let text, icon;
 
   if (!isPublic) {
-    if (selectedWorkspaceId) {
-      text = `Shared privately with ${workspaceName}`;
-      icon = "groups";
-    } else {
+    if ((selectedWorkspaceId = MY_LIBRARY)) {
       text = `Only you can view this`;
       icon = "person";
+    } else {
+      text = `Shared privately with ${workspaceName}`;
+      icon = "groups";
     }
   } else {
     text = "This replay can be viewed by anyone with the link";
@@ -24,18 +28,19 @@ const getIconAndText = (
   return { text, icon };
 };
 
+type SettingsPreviewProps = {
+  onClick: () => void;
+  isPublic: boolean;
+  workspaces: Workspace[];
+  selectedWorkspaceId: string;
+};
+
 export default function SettingsPreview({
   onClick,
   isPublic,
   workspaces,
   selectedWorkspaceId,
-}: {
-  onClick: () => void;
-  isPublic: boolean;
-  workspaces: Workspace[];
-  selectedWorkspaceId: string | null;
-}) {
-  const personalWorkspace = { id: null, name: "My Library" };
+}: SettingsPreviewProps) {
   const workspaceName = [...workspaces, personalWorkspace].find(w => w.id === selectedWorkspaceId)!
     .name;
 

--- a/src/ui/components/UploadScreen/Sharing.tsx
+++ b/src/ui/components/UploadScreen/Sharing.tsx
@@ -1,0 +1,60 @@
+import React, { Dispatch, SetStateAction, useState } from "react";
+import hooks from "ui/hooks";
+import TeamSelect from "./TeamSelect";
+import { Workspace } from "ui/types";
+import { Toggle } from "../shared/Forms";
+import SettingsPreview from "./SettingsPreview";
+
+type SharingProps = {
+  workspaces: Workspace[];
+  selectedWorkspaceId: string | null;
+  setSelectedWorkspaceId: Dispatch<SetStateAction<string | null>>;
+  isPublic: boolean;
+  setIsPublic: Dispatch<SetStateAction<boolean>>;
+};
+
+function EditableSettings({
+  workspaces,
+  selectedWorkspaceId,
+  setSelectedWorkspaceId,
+  isPublic,
+  setIsPublic,
+}: Omit<SharingProps, "showSharingSettings">) {
+  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
+  const handleWorkspaceSelect = (id: string | null) => {
+    updateDefaultWorkspace({
+      variables: { workspaceId: id },
+    });
+    setSelectedWorkspaceId(id);
+  };
+
+  return (
+    <div className="w-full grid grid-cols-2 gap-5 text-base">
+      {workspaces.length ? (
+        <TeamSelect {...{ workspaces, handleWorkspaceSelect, selectedWorkspaceId }} />
+      ) : null}
+      <div
+        className="space-x-2 flex flex-row items-center justify-between w-full border border-textFieldBorder rounded-md shadow-sm px-2.5 py-1.5 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-primaryAccent focus:border-primaryAccentHover bg-white"
+        onClick={() => setIsPublic(!isPublic)}
+      >
+        <div>Public Access</div>
+        <Toggle enabled={isPublic} setEnabled={setIsPublic} />
+      </div>
+    </div>
+  );
+}
+
+export default function Sharing(props: SharingProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const toggleIsEditing = () => setIsEditing(!isEditing);
+
+  let content;
+
+  if (isEditing) {
+    content = <EditableSettings {...props} />;
+  } else {
+    content = <SettingsPreview {...props} onClick={toggleIsEditing} />;
+  }
+
+  return <div className="relative border-t border-gray-300 py-10 px-8">{content}</div>;
+}

--- a/src/ui/components/UploadScreen/Sharing.tsx
+++ b/src/ui/components/UploadScreen/Sharing.tsx
@@ -5,10 +5,13 @@ import { Workspace } from "ui/types";
 import { Toggle } from "../shared/Forms";
 import SettingsPreview from "./SettingsPreview";
 
+export const MY_LIBRARY = "My Library";
+export const personalWorkspace = { id: MY_LIBRARY, name: MY_LIBRARY };
+
 type SharingProps = {
   workspaces: Workspace[];
-  selectedWorkspaceId: string | null;
-  setSelectedWorkspaceId: Dispatch<SetStateAction<string | null>>;
+  selectedWorkspaceId: string;
+  setSelectedWorkspaceId: Dispatch<SetStateAction<string>>;
   isPublic: boolean;
   setIsPublic: Dispatch<SetStateAction<boolean>>;
 };
@@ -21,7 +24,7 @@ function EditableSettings({
   setIsPublic,
 }: Omit<SharingProps, "showSharingSettings">) {
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
-  const handleWorkspaceSelect = (id: string | null) => {
+  const handleWorkspaceSelect = (id: string) => {
     updateDefaultWorkspace({
       variables: { workspaceId: id },
     });
@@ -46,15 +49,14 @@ function EditableSettings({
 
 export default function Sharing(props: SharingProps) {
   const [isEditing, setIsEditing] = useState(false);
-  const toggleIsEditing = () => setIsEditing(!isEditing);
 
-  let content;
-
-  if (isEditing) {
-    content = <EditableSettings {...props} />;
-  } else {
-    content = <SettingsPreview {...props} onClick={toggleIsEditing} />;
-  }
-
-  return <div className="relative border-t border-gray-300 py-10 px-8">{content}</div>;
+  return (
+    <div className="relative border-t border-gray-300 py-10 px-8">
+      {isEditing ? (
+        <EditableSettings {...props} />
+      ) : (
+        <SettingsPreview {...props} onClick={() => setIsEditing(!isEditing)} />
+      )}
+    </div>
+  );
 }

--- a/src/ui/components/UploadScreen/TeamSelect.tsx
+++ b/src/ui/components/UploadScreen/TeamSelect.tsx
@@ -1,6 +1,19 @@
-import React, { Dispatch, SetStateAction } from "react";
+import React, { useState } from "react";
 import { Workspace } from "ui/types";
-import { SelectMenu } from "ui/components/shared/Forms";
+import { Dropdown, DropdownItem } from "../Library/LibraryDropdown";
+import PortalDropdown from "../shared/PortalDropdown";
+import { SelectorIcon } from "@heroicons/react/solid";
+
+const TeamSelectButton = ({ selectedWorkspaceName }: { selectedWorkspaceName: string }) => {
+  return (
+    <div className="bg-white relative w-full border border-textFieldBorder rounded-md shadow-sm pl-2.5 pr-8 py-1.5 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-primaryAccent focus:border-primaryAccentHover">
+      <span className="block truncate">{selectedWorkspaceName}</span>
+      <span className="absolute inset-y-0 right-0 flex items-center pr-1.5 pointer-events-none">
+        <SelectorIcon className="h-4 w-4 text-textFieldBorder" aria-hidden="true" />
+      </span>
+    </div>
+  );
+};
 
 export default function TeamSelect({
   workspaces,
@@ -11,13 +24,36 @@ export default function TeamSelect({
   selectedWorkspaceId: string | null;
   handleWorkspaceSelect: (id: string | null) => void;
 }) {
-  const displayedWorkspaces = [{ id: null, name: "My Library" }, ...workspaces].sort();
+  const [expanded, setExpanded] = useState(false);
+  const personalWorkspace = { id: null, name: "My Library" };
+  const displayedWorkspaces = [personalWorkspace, ...workspaces].sort();
+
+  const handleSelect = (workspace: Workspace | typeof personalWorkspace) => {
+    handleWorkspaceSelect(workspace.id);
+    setExpanded(false);
+  };
+
+  const selectedWorkspaceName = displayedWorkspaces.find(w => w.id === selectedWorkspaceId)!.name;
+  const button = <TeamSelectButton selectedWorkspaceName={selectedWorkspaceName} />;
 
   return (
-    <SelectMenu
-      selected={selectedWorkspaceId}
-      setSelected={handleWorkspaceSelect}
-      options={displayedWorkspaces}
-    />
+    <PortalDropdown
+      buttonContent={button}
+      setExpanded={setExpanded}
+      expanded={expanded}
+      buttonStyle=""
+      distance={0}
+      position="bottom-right"
+    >
+      <Dropdown widthClass="w-64">
+        <div className="max-h-48 overflow-auto">
+          {displayedWorkspaces.map(w => (
+            <DropdownItem onClick={() => handleSelect(w)} key={w.id}>
+              {w.name}
+            </DropdownItem>
+          ))}
+        </div>
+      </Dropdown>
+    </PortalDropdown>
   );
 }

--- a/src/ui/components/UploadScreen/TeamSelect.tsx
+++ b/src/ui/components/UploadScreen/TeamSelect.tsx
@@ -3,6 +3,7 @@ import { Workspace } from "ui/types";
 import { Dropdown, DropdownItem } from "../Library/LibraryDropdown";
 import PortalDropdown from "../shared/PortalDropdown";
 import { SelectorIcon } from "@heroicons/react/solid";
+import { personalWorkspace } from "./Sharing";
 
 const TeamSelectButton = ({ selectedWorkspaceName }: { selectedWorkspaceName: string }) => {
   return (
@@ -21,11 +22,10 @@ export default function TeamSelect({
   handleWorkspaceSelect,
 }: {
   workspaces: Workspace[];
-  selectedWorkspaceId: string | null;
-  handleWorkspaceSelect: (id: string | null) => void;
+  selectedWorkspaceId: string;
+  handleWorkspaceSelect: (id: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const personalWorkspace = { id: null, name: "My Library" };
   const displayedWorkspaces = [personalWorkspace, ...workspaces].sort();
 
   const handleSelect = (workspace: Workspace | typeof personalWorkspace) => {
@@ -47,9 +47,9 @@ export default function TeamSelect({
     >
       <Dropdown widthClass="w-64">
         <div className="max-h-48 overflow-auto">
-          {displayedWorkspaces.map(w => (
-            <DropdownItem onClick={() => handleSelect(w)} key={w.id}>
-              {w.name}
+          {displayedWorkspaces.map(workspace => (
+            <DropdownItem onClick={() => handleSelect(workspace)} key={workspace.id}>
+              {workspace.name}
             </DropdownItem>
           ))}
         </div>

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -8,7 +8,7 @@ import { LoadingScreen } from "../shared/BlankScreen";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import { trackEvent } from "ui/utils/telemetry";
 import BubbleBackground from "../shared/Onboarding/BubbleBackground";
-import Sharing from "./Sharing";
+import Sharing, { MY_LIBRARY } from "./Sharing";
 const { isDemoReplay } = require("ui/utils/demo");
 
 type UploadScreenProps = { recording: Recording; userSettings: UserSettings };
@@ -98,8 +98,8 @@ export default function UploadScreen({ recording, userSettings }: UploadScreenPr
   // Before being initialized, public/private behaves similarly since non-authors
   // can't view the replay.
   const [isPublic, setIsPublic] = useState(false);
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
-    userSettings?.defaultWorkspaceId || null
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>(
+    userSettings?.defaultWorkspaceId || MY_LIBRARY
   );
 
   const initializeRecording = hooks.useInitializeRecording();

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -1,16 +1,14 @@
-import React, { useState, useEffect, Dispatch, SetStateAction } from "react";
+import React, { useState, useEffect } from "react";
 import hooks from "ui/hooks";
-import TeamSelect from "./TeamSelect";
-import { getFormattedTime } from "ui/utils/timeline";
 import ReplayTitle from "./ReplayTitle";
 import classNames from "classnames";
 import Modal from "ui/components/shared/NewModal";
-import { Recording, UserSettings, Workspace } from "ui/types";
+import { Recording, UserSettings } from "ui/types";
 import { LoadingScreen } from "../shared/BlankScreen";
-import MaterialIcon from "../shared/MaterialIcon";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import { trackEvent } from "ui/utils/telemetry";
-import { UploadRecordingTrialEnd } from "./UploadRecordingTrialEnd";
+import BubbleBackground from "../shared/Onboarding/BubbleBackground";
+import Sharing from "./Sharing";
 const { isDemoReplay } = require("ui/utils/demo");
 
 type UploadScreenProps = { recording: Recording; userSettings: UserSettings };
@@ -55,199 +53,41 @@ function DeletedScreen({ url }: { url: string }) {
   );
 }
 
-function SoftLimitWarning() {
-  return (
-    <div className="flex flex-row space-x-2 border rounded-lg p-4 border-yellow-400 bg-yellow-50">
-      <div className="flex flex-col space-y-2">
-        <div className="flex flex-row text-yellow-800 font-medium text-xl items-center space-x-1">
-          <MaterialIcon className="text-yellow-800">warning_amber</MaterialIcon>
-          <div>This replay is over 2 minutes</div>
-        </div>
-        <div>We recommend keeping replays below 2 minutes for the best debugging experience.</div>
-      </div>
-    </div>
-  );
-}
-
 function Actions({ onDiscard, status }: { onDiscard: () => void; status: Status }) {
   const isSaving = status === "saving";
   const isDeleting = status === "deleting";
+  const shouldDisableActions = isSaving || isDeleting;
 
   return (
-    <div className="grid grid-cols-2 gap-4 text-sm">
+    <div className="space-x-5">
       <button
         type="button"
         onClick={onDiscard}
-        disabled={isSaving || isDeleting}
-        className={classNames(
-          "inline-flex items-center px-4 py-2 border border-textFieldBorder font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent justify-center",
-          "text-gray-500 hover:bg-gray-100 hover:"
-        )}
+        disabled={shouldDisableActions}
+        className="text-secondaryAccent underline py-3.5 px-8"
       >
         {isDeleting ? `Discarding…` : `Discard`}
       </button>
       <input
         type="submit"
-        disabled={isSaving || isDeleting}
-        value={isSaving ? `Uploading…` : `Save & Upload`}
-        className={classNames(
-          "inline-flex items-center px-4 py-2 border border-transparent font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccentHover justify-center cursor-pointer",
-          "text-white bg-primaryAccent hover:bg-primaryAccentHover"
-        )}
-      ></input>
+        disabled={shouldDisableActions}
+        value={isSaving ? `Uploading…` : `Save`}
+        className="text-white py-3.5 px-16 rounded-xl font-bold cursor-pointer bg-primaryAccent"
+      />
     </div>
   );
 }
 
-function ReplayPreview({ recording, screenData }: { recording: Recording; screenData: string }) {
+function ReplayScreenshot({ screenData }: { screenData: string }) {
   return (
-    <div className="space-y-1">
-      <div className="block text-xs uppercase font-semibold ">Preview</div>
-      <div
-        className="relative bg-gray-100 border border-gray-200 rounded-lg text-xs"
-        style={{ height: "200px" }}
-      >
-        <img src={screenData} className="h-full m-auto" />
-        <div
-          style={{ maxWidth: "50%" }}
-          className="bg-gray-700 text-white bottom-4 left-4 rounded-lg px-3 py-0.5 absolute select-none"
-        >
-          <div className="whitespace-pre overflow-hidden overflow-ellipsis">{recording.url}</div>
-        </div>
-        <div className="bg-gray-700 text-white bottom-4 right-4 rounded-lg px-3 py-0.5 absolute select-none">
-          {getFormattedTime(recording!.duration)}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export function SharingSettings({
-  workspaces,
-  selectedWorkspaceId,
-  setSelectedWorkspaceId,
-  isPublic,
-  setIsPublic,
-}: {
-  workspaces: Workspace[];
-  selectedWorkspaceId: string | null;
-  setSelectedWorkspaceId: Dispatch<SetStateAction<string | null>>;
-  isPublic: boolean;
-  setIsPublic: Dispatch<SetStateAction<boolean>>;
-}) {
-  const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
-  const selectedWorkspace = workspaces.find(w => w.id === selectedWorkspaceId);
-  const privateText =
-    selectedWorkspaceId === null ? (
-      `Only you can view this Replay`
-    ) : (
-      <span>
-        This replay can be viewed by anyone from{" "}
-        <span className="font-semibold">{selectedWorkspace!.name}</span>
-      </span>
-    );
-  const handleWorkspaceSelect = (id: string | null) => {
-    updateDefaultWorkspace({
-      variables: { workspaceId: id },
-    });
-    setSelectedWorkspaceId(id);
-  };
-
-  return (
-    <>
-      {workspaces.length ? (
-        <div className="">
-          <label className="block text-xs uppercase font-semibold">Team</label>
-          <TeamSelect {...{ workspaces, handleWorkspaceSelect, selectedWorkspaceId }} />
-        </div>
-      ) : null}
-      <div className="space-y-2 text-sm">
-        <label className="block text-xs uppercase font-semibold">Privacy</label>
-        <div className="space-y-1">
-          <div className="space-x-2 items-center">
-            <input
-              type="radio"
-              name="privacy"
-              value="public"
-              id="public"
-              checked={isPublic}
-              onChange={() => setIsPublic(true)}
-            />
-            <label htmlFor="public">
-              <span className="font-semibold">Public: </span>This replay can be viewed by anyone
-              with the link
-            </label>
-          </div>
-          <div className="space-x-2 items-center">
-            <input
-              type="radio"
-              name="privacy"
-              value="private"
-              id="private"
-              checked={!isPublic}
-              onChange={() => setIsPublic(false)}
-            />
-            <label htmlFor="private">
-              <span className="font-semibold">Private: </span>
-              {privateText}
-            </label>
-          </div>
-        </div>
-      </div>
-    </>
-  );
-}
-
-function SharingPreview({
-  toggleShowSharingSettings,
-  isPublic,
-  workspaces,
-  selectedWorkspaceId,
-}: {
-  toggleShowSharingSettings: () => void;
-  isPublic: boolean;
-  workspaces: Workspace[];
-  selectedWorkspaceId: string | null;
-}) {
-  const personalWorkspace = { id: null, name: "My Library" };
-  const workspaceName = [...workspaces, personalWorkspace].find(w => w.id === selectedWorkspaceId)!
-    .name;
-  let icon;
-  let text;
-
-  if (!isPublic) {
-    if (selectedWorkspaceId) {
-      text = `Shared privately with ${workspaceName}`;
-      icon = "groups";
-    } else {
-      text = `Only you can view this`;
-      icon = "person";
-    }
-  } else {
-    text = "This replay can be viewed by anyone with the link";
-    icon = "public";
-  }
-
-  return (
-    <div className="flex flex-row items-center space-x-4 text-sm">
-      <span className="material-icons">{icon}</span>
-      <div className="flex flex-col flex-grow overflow-hidden">
-        <div className="overflow-hidden overflow-ellipsis whitespace-pre">{text}</div>
-      </div>
-      <button
-        type="button"
-        className="text-blue-700 underline p-2"
-        onClick={toggleShowSharingSettings}
-      >
-        Edit
-      </button>
+    <div className="bg-white rounded-lg px-6 pt-6 shadow-xl h-64" style={{ height: "320px" }}>
+      <img src={screenData} className="h-full m-auto" />
     </div>
   );
 }
 
 export default function UploadScreen({ recording, userSettings }: UploadScreenProps) {
   const recordingId = useGetRecordingId();
-  const [showSharingSettings, setShowSharingSettings] = useState(false);
   // This is pre-loaded in the parent component.
   const { screenData, loading: loading1 } = hooks.useGetRecordingPhoto(recordingId!);
   const { workspaces, loading: loading2 } = hooks.useGetNonPendingWorkspaces();
@@ -277,8 +117,6 @@ export default function UploadScreen({ recording, userSettings }: UploadScreenPr
     };
   }, []);
 
-  const toggleShowSharingSettings = () => setShowSharingSettings(!showSharingSettings);
-
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -306,39 +144,35 @@ export default function UploadScreen({ recording, userSettings }: UploadScreenPr
     return <DeletedScreen url="/" />;
   }
 
-  // Soft limit is set at 2 minutes.
-  const showLimitWarning = recording.duration > 120 * 1000;
-
   return (
-    <div className="w-full h-full" style={{ background: "" }}>
-      <Modal>
+    <div
+      className="w-full h-full grid fixed z-50 items-center justify-center"
+      style={{ background: "#f3f3f4" }}
+    >
+      <BubbleBackground />
+      <form
+        className="relative flex flex-col items-center space-y-11 overflow-auto"
+        onSubmit={onSubmit}
+      >
         <div
-          className="p-12 bg-white rounded-lg shadow-xl text-lg space-y-12 relative flex flex-col justify-between overflow-y-auto"
-          style={{ width: "520px", maxHeight: "90vh" }}
+          className="flex flex-col overflow-hidden relative rounded-xl shadow-xl text-lg font-medium"
+          style={{ width: "620px" }}
         >
-          <h2 className="font-bold text-2xl ">Save and Upload</h2>
-          <form className="space-y-6" onSubmit={e => onSubmit(e)}>
+          <div className="absolute w-full h-full bg-white opacity-40" />
+          <div className="py-9 px-8 space-y-6 relative">
             <ReplayTitle inputValue={inputValue} setInputValue={setInputValue} />
-            <ReplayPreview recording={recording} screenData={screenData!} />
-            {showSharingSettings ? (
-              <SharingSettings
-                workspaces={workspaces}
-                selectedWorkspaceId={selectedWorkspaceId}
-                setSelectedWorkspaceId={setSelectedWorkspaceId}
-                isPublic={isPublic}
-                setIsPublic={setIsPublic}
-              />
-            ) : (
-              <SharingPreview
-                {...{ toggleShowSharingSettings, isPublic, workspaces, selectedWorkspaceId }}
-              />
-            )}
-            {showLimitWarning ? <SoftLimitWarning /> : null}
-            <Actions onDiscard={onDiscard} status={status} />
-          </form>
-          <UploadRecordingTrialEnd {...{ selectedWorkspaceId, workspaces }} />
+            <ReplayScreenshot screenData={screenData!} />
+          </div>
+          <Sharing
+            workspaces={workspaces}
+            selectedWorkspaceId={selectedWorkspaceId}
+            setSelectedWorkspaceId={setSelectedWorkspaceId}
+            isPublic={isPublic}
+            setIsPublic={setIsPublic}
+          />
         </div>
-      </Modal>
+        <Actions onDiscard={onDiscard} status={status} />
+      </form>
     </div>
   );
 }

--- a/src/ui/components/shared/Forms/SelectMenu.tsx
+++ b/src/ui/components/shared/Forms/SelectMenu.tsx
@@ -59,7 +59,7 @@ export default function SelectMenu({
   const selectedName = options.find(option => option.id === selected)!.name;
 
   return (
-    <div className="text-sm">
+    <div>
       <Listbox value={selected} onChange={setSelected}>
         {({ open }) => (
           <>

--- a/src/ui/components/shared/Forms/Toggle.tsx
+++ b/src/ui/components/shared/Forms/Toggle.tsx
@@ -1,28 +1,28 @@
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import { Switch } from "@headlessui/react";
-import classnames from "classnames";
+import classNames from "classnames";
 
 export default function Toggle({
   enabled,
   setEnabled,
 }: {
   enabled: boolean;
-  setEnabled: (enabled: boolean) => void;
+  setEnabled: Dispatch<SetStateAction<boolean>>;
 }) {
   return (
     <Switch
       checked={enabled}
       onChange={setEnabled}
-      className={classnames(
-        enabled ? "bg-green-600" : "bg-gray-200",
-        "relative inline-flex flex-shrink-0 h-4 w-8 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
+      className={classNames(
+        enabled ? "bg-primaryAccent" : "bg-gray-200",
+        "relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent"
       )}
     >
       <span
         aria-hidden="true"
-        className={classnames(
+        className={classNames(
           enabled ? "translate-x-5" : "translate-x-0",
-          "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200"
+          "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200"
         )}
       />
     </Switch>

--- a/src/ui/components/shared/Onboarding/BubbleBackground.tsx
+++ b/src/ui/components/shared/Onboarding/BubbleBackground.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function BubbleBackground() {
   return (
-    <div className="w-full h-full">
+    <div className="w-full h-full absolute">
       <div className="absolute">
         <img
           src="/images/bubble.svg"

--- a/src/ui/components/shared/Onboarding/index.tsx
+++ b/src/ui/components/shared/Onboarding/index.tsx
@@ -156,12 +156,10 @@ export function OnboardingModalContainer({
           theme === "dark" ? "bg-black text-white" : "bg-white text-black"
         )}
       >
-        <>
-          <BubbleBackground />
-          <Modal options={{ maskTransparency: "transparent" }} blurMask={false}>
-            {children}
-          </Modal>
-        </>
+        <BubbleBackground />
+        <Modal options={{ maskTransparency: "transparent" }} blurMask={false}>
+          {children}
+        </Modal>
       </div>
     </OnboardingContext.Provider>
   );

--- a/src/ui/components/shared/PortalDropdown.tsx
+++ b/src/ui/components/shared/PortalDropdown.tsx
@@ -49,7 +49,7 @@ export default function PortalDropdown(props: PortalDropdownProps) {
 
   return (
     <div className="portal-dropdown-wrapper">
-      <button className={`expand-dropdown ${buttonStyle}`} onClick={expand} ref={buttonRef}>
+      <button className={`expand-dropdown w-full ${buttonStyle}`} onClick={expand} ref={buttonRef}>
         {buttonContent}
       </button>
       {expanded

--- a/src/ui/components/shared/SettingsModal/SettingsBodyItem.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBodyItem.tsx
@@ -36,7 +36,7 @@ function Dropdown<K>({ value }: InputProps<K>) {
 
   return (
     <div className="w-48">
-      <SelectMenu selected={value} setSelected={onChange} options={[]} />
+      <SelectMenu selected={value} setSelected={onChange} options={[]} className="text-sm" />
     </div>
   );
 }


### PR DESCRIPTION
Replay demo: https://app.replay.io/recording/a3aeae6c-dc65-489f-802a-0ebe2f189374?point=66201784950761379877771993315018196&time=33727&hasFrames=false#

Demo:
https://user-images.githubusercontent.com/15959269/138306336-6cf27d74-0b13-4e46-ac0f-74da8575c110.mov

This fixes #4041.

This is the first part of implementing the new "jellyfish" design that we worked on with Zypsy. Functionally, the upload screen still largely works the same. 

Summary of noticeable changes are:
- Removed the replay target URL, and the replay's duration from the upload screen.
- Removed the badge that indicates that the trial is expiring.
- Removed the warning when a user records something that is over 2 minutes.