### PR TITLE
Properly display breakpoints when they are not editable

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
@@ -9,7 +9,7 @@ const { prefs } = require("ui/utils/prefs");
 
 export interface SummaryExpressionProps {
   value: string;
-  isUnderMaxHitsEditable: boolean;
+  isEditable: boolean;
 }
 
 function getSyntaxHighlightedMarkup(string: string) {
@@ -45,14 +45,13 @@ function Expression({ value, isEditable }: { value: string; isEditable: boolean 
 }
 
 export function SummaryExpression({
-  isUnderMaxHitsEditable,
+  isEditable,
   handleClick,
   value,
 }: SummaryExpressionProps & {
   handleClick: (event: React.MouseEvent) => void;
 }) {
   const { isTeamDeveloper } = hooks.useIsTeamDeveloper();
-  const isEditable = isUnderMaxHitsEditable && isTeamDeveloper;
 
   return (
     <button

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -40,10 +40,7 @@ function PanelSummary({
   const logValue = breakpoint.options.logValue;
 
   const isHot = analysisPoints && analysisPoints.length > prefs.maxHitsDisplayed;
-  const isUnderMaxHitsEditable = !!(
-    analysisPoints && analysisPoints.length < prefs.maxHitsEditable
-  );
-  const isEditable = isUnderMaxHitsEditable && isTeamDeveloper;
+  const isEditable = Boolean(analysisPoints && !isHot && isTeamDeveloper);
 
   const handleClick = (event: React.MouseEvent, input: Input) => {
     if (!isEditable) {
@@ -75,7 +72,7 @@ function PanelSummary({
     return (
       <div className="summary">
         <div className="options items-center flex-col flex-grow">
-          <Log value={logValue} hasCondition={!!conditionValue} {...{ isUnderMaxHitsEditable }} />
+          <Log value={logValue} hasCondition={!!conditionValue} />
         </div>
         <CommentButton addComment={addComment} pausedOnHit={pausedOnHit} />
       </div>
@@ -105,15 +102,11 @@ function PanelSummary({
     <div className="summary space-x-2" onClick={e => handleClick(e, "logValue")}>
       <div className="options items-center flex-col flex-grow">
         {conditionValue ? (
-          <Condition
-            handleClick={handleClick}
-            isUnderMaxHitsEditable={isUnderMaxHitsEditable}
-            value={conditionValue}
-          />
+          <Condition handleClick={handleClick} isEditable={isEditable} value={conditionValue} />
         ) : null}
         <Log
           handleClick={handleClick}
-          isUnderMaxHitsEditable={isUnderMaxHitsEditable}
+          isEditable={isEditable}
           hasCondition={!!conditionValue}
           value={logValue}
         />


### PR DESCRIPTION
Somewhere in this quagmire of conditionals (I'm still not sure exactly where) we had a bug where the breakpoint panel would say "This breakpoint is not editable because it was hit 700+ times" while also saying "This breakpoint was hit 350 times".

# Before

https://user-images.githubusercontent.com/5903784/138303272-c88d8a68-5df2-4298-ba54-9c751bf500cb.mp4

# After

https://user-images.githubusercontent.com/5903784/138303532-8540bacd-3d52-4a25-bba3-897b2485acff.mp4


