### PR TITLE
Do not request workspace members without workspace

### DIFF
--- a/src/ui/components/Library/TeamTrialEnd.tsx
+++ b/src/ui/components/Library/TeamTrialEnd.tsx
@@ -1,4 +1,3 @@
-import { subscriptionManager } from "framer-motion/types/utils/subscription-manager";
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { useHistory } from "react-router";

--- a/src/ui/hooks/workspaces_user.ts
+++ b/src/ui/hooks/workspaces_user.ts
@@ -2,6 +2,9 @@ import { gql, useQuery, useMutation } from "@apollo/client";
 import { WorkspaceUser } from "ui/types";
 
 export function useGetWorkspaceMembers(workspaceId: string) {
+  if (!workspaceId) {
+    return { members: [], loading: false };
+  }
   const { data, loading, error } = useQuery(
     gql`
       query GetWorkspaceMembers($workspaceId: ID!) {


### PR DESCRIPTION
I'm not 100% clear on what's going on here, but we for sure don't need to request a `null` workspace from the backend.