### PR TITLE
Show the replay info in the events panel

### DIFF
--- a/src/ui/components/Events/Events.css
+++ b/src/ui/components/Events/Events.css
@@ -1,3 +1,0 @@
-.accordion .events {
-  flex: 1;
-}

--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -10,7 +10,6 @@ const { getExecutionPoint } = require("devtools/client/debugger/src/reducers/pau
 import Event from "./Event";
 import EventsLoader from "./EventsLoader";
 import { trackEvent } from "ui/utils/telemetry";
-import "./Events.css";
 
 function CurrentTimeLine() {
   return <div className="bg-secondaryAccent w-full m-0" style={{ height: "3px" }} />;

--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -1,11 +1,11 @@
 import React, { ReactNode } from "react";
 import hooks from "ui/hooks";
-import { OperationsData } from "ui/types";
 import { formatRelativeTime } from "ui/utils/comments";
 import { getRecordingId } from "ui/utils/environment";
 import { AvatarImage } from "../Avatar";
 import MaterialIcon from "../shared/MaterialIcon";
 import { getPrivacySummaryAndIcon } from "../shared/SharingModal/PrivacyDropdown";
+import { getUniqueDomains } from "../UploadScreen/Privacy";
 
 const Row = ({ children }: { children: ReactNode }) => {
   return (
@@ -15,33 +15,6 @@ const Row = ({ children }: { children: ReactNode }) => {
   );
 };
 
-const getRecordingOperationsSummary = (operations: OperationsData) => {
-  const cookies = operations.cookies || [];
-  const localStorage = operations.storage || [];
-
-  if (!cookies.length && !localStorage.length) {
-    return;
-  }
-
-  let summary = [];
-
-  if (cookies.length) {
-    summary.push(`cookies from ${cookies.length} domain${cookies.length === 1 ? "" : "s"}`);
-  }
-
-  if (localStorage.length) {
-    summary.push(
-      `local storage from ${localStorage.length} domain${cookies.length === 1 ? "" : "s"}`
-    );
-  }
-
-  if (summary.length > 1) {
-    summary.splice(-1, 0, "and");
-  }
-
-  return `Accesses ${summary.join(" ")}`;
-};
-
 export const ReplayInfo = () => {
   const { recording } = hooks.useGetRecording(getRecordingId()!);
 
@@ -49,23 +22,26 @@ export const ReplayInfo = () => {
 
   const time = formatRelativeTime(new Date(recording.date));
   const { summary, icon } = getPrivacySummaryAndIcon(recording);
+  const uniqueDomains = getUniqueDomains(recording.operations);
 
   return (
     <div className="flex-grow overflow-auto overflow-x-hidden flex flex-column items-center bg-white border-b border-splitter">
       <div className="flex flex-col p-1.5 self-stretch space-y-1.5 w-full text-xs group">
+        {recording.user ? (
+          <Row>
+            <AvatarImage className="h-5 w-5 rounded-full avatar" src={recording.user.picture} />
+            <div>{recording.user.name}</div>
+            <div className="opacity-50">{time}</div>
+          </Row>
+        ) : null}
         <Row>
-          <AvatarImage className="h-5 w-5 rounded-full avatar" src={recording.user?.picture} />
-          <div className="">{recording?.user?.name}</div>
-          <div className="">{time}</div>
-        </Row>
-        <Row>
-          <MaterialIcon className="">{icon}</MaterialIcon>
-          <div className="">{summary}</div>
+          <MaterialIcon>{icon}</MaterialIcon>
+          <div>{summary}</div>
         </Row>
         {recording.operations ? (
           <Row>
-            <MaterialIcon className="">info</MaterialIcon>
-            <div className="">{getRecordingOperationsSummary(recording.operations)}</div>
+            <MaterialIcon>info</MaterialIcon>
+            <div>{`Contains potentially sensitive data from ${uniqueDomains.length} domains`}</div>
           </Row>
         ) : null}
       </div>

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -31,18 +31,14 @@ function SidePanel({ selectedPrimaryPanel }: SidePanelProps) {
             className: "replay-info",
             component: <ReplayInfo />,
             opened: !replayInfoCollapsed,
-            onToggle: () => {
-              setReplayInfoCollapsed(!replayInfoCollapsed);
-            },
+            onToggle: () => setReplayInfoCollapsed(!replayInfoCollapsed),
           },
           {
             header: "Events",
-            className: "events",
+            className: "events flex-1",
             component: <Events />,
             opened: !eventsCollapsed,
-            onToggle: () => {
-              setEventsCollapsed(!eventsCollapsed);
-            },
+            onToggle: () => setEventsCollapsed(!eventsCollapsed),
           },
         ]}
       />

--- a/src/ui/components/UploadScreen/Privacy.tsx
+++ b/src/ui/components/UploadScreen/Privacy.tsx
@@ -3,7 +3,7 @@ import React, { Dispatch, SetStateAction } from "react";
 import { OperationsData } from "ui/types";
 import MaterialIcon from "../shared/MaterialIcon";
 
-function getUniqueDomains(operations: OperationsData) {
+export function getUniqueDomains(operations: OperationsData) {
   const cookies = operations.cookies || [];
   const storage = operations.storage || [];
   let domains = [...operations.scriptDomains, ...cookies, ...storage];

--- a/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
+++ b/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
@@ -2,35 +2,33 @@ import React, { useState } from "react";
 import PortalDropdown from "../PortalDropdown";
 import { Dropdown, DropdownItem, DropdownItemContent } from "ui/components/Library/LibraryDropdown";
 import { WorkspaceId } from "ui/state/app";
-import { Recording } from "ui/types";
+import { Recording, Workspace } from "ui/types";
 import hooks from "ui/hooks";
 import MaterialIcon from "../MaterialIcon";
 import { trackEvent } from "ui/utils/telemetry";
 
-export function getPrivacySummaryAndIcon(recording: Recording) {
-  const workspaceId = recording.workspace?.id || null;
-  let summary, icon;
+const WorkspacePrivacySummary = ({ workspace: { name } }: { workspace: Workspace }) => (
+  <span>
+    {`Members of `}
+    <span className="underline">{name}</span>
+    {` can view`}
+  </span>
+);
 
+export function getPrivacySummaryAndIcon(recording: Recording) {
   if (!recording.private) {
-    icon = "link";
-    summary = "Anyone with the link can view";
-  } else {
-    if (workspaceId) {
-      icon = "domain";
-      summary = (
-        <span>
-          {`Members of `}
-          <span className="underline">{recording.workspace?.name}</span>
-          {` can view`}
-        </span>
-      );
-    } else {
-      icon = "group";
-      summary = "Only people with access can view";
-    }
+    return { icon: "link", summary: "Anyone with the link can view" };
   }
 
-  return { summary, icon };
+  if (recording.workspace) {
+    return {
+      icon: "domain",
+      summary: <WorkspacePrivacySummary workspace={recording.workspace} />,
+    };
+  }
+
+  // If the recording is private and in an individual's library.
+  return { icon: "group", summary: "Only people with access can view" };
 }
 
 export default function PrivacyDropdown({ recording }: { recording: Recording }) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,9 +25,6 @@ module.exports = {
       cursor: {
         "ew-resize": "ew-resize",
       },
-      padding: {
-        5.5: "1.125rem",
-      },
     },
   },
   variants: {


### PR DESCRIPTION
Fix #4040.

![image](https://user-images.githubusercontent.com/15959269/138470331-3df3c2e2-c036-4a35-9979-b5ae54c7bbb0.png)

This is a draft, I just have the information plumbed in. Followed the comments's visuals since I know we have an outstanding ticket for copying that over to the events, and I didn't want to have three different looks between those two panels.

How do we get this to ship shape @jonbell-lot23?