### PR TITLE
Fix first replay modal to only use replay protocol on mac

### DIFF
--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -122,7 +122,12 @@ export function removeUrlParameters() {
 }
 
 export function launchAndRecordUrl(url: string) {
-  const autoRecordUrl = `replay:record?url=${url}`;
+  let autoRecordUrl = url;
+
+  // replay: HTTP scheme is only supported on Mac atm
+  if (navigator.userAgent.includes("Macintosh")) {
+    autoRecordUrl = `replay:record?url=${url}`;
+  }
 
   window.open(autoRecordUrl);
 }


### PR DESCRIPTION
Fixes #3901 by launching the page without the `replay:` protocol on non-Mac systems.

@jaril, @jonbell-lot23 - Do we need to change the messaging to reflect that recording won't happen on non-Mac systems?

Follow ups:
* https://github.com/RecordReplay/gecko-dev/issues/515
* https://github.com/RecordReplay/gecko-dev/issues/565