### PR TITLE
Remove - replay title suffix

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -112,7 +112,7 @@ export function createSession(recordingId: string): UIThunkAction {
       assert(recording);
 
       if (recording.title) {
-        document.title = `${recording.title} - Replay`;
+        document.title = recording.title;
       }
       if (recording.workspace) {
         dispatch(actions.setRecordingWorkspace(recording.workspace));


### PR DESCRIPTION
The title has been a pet peeve of mine for a long time since the favicon already gets the point across and the replay's title should stand on its own.