### PR TITLE
Simplify editor open and close states

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -140,6 +140,7 @@ export const FocusContext = React.createContext({
   autofocus: false,
   isFocused: false,
   blur: () => {},
+  close: () => {},
 });
 
 function CommentCard({
@@ -154,6 +155,7 @@ function CommentCard({
 }: CommentCardProps) {
   const isPaused = currentTime === comment.time && executionPoint === comment.point;
 
+  const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
 
   if (comment.id === PENDING_COMMENT_ID) {
@@ -171,7 +173,12 @@ function CommentCard({
           <div className={classNames("px-2.5 pl-2 space-y-2")}>
             {comment.sourceLocation ? <CommentSource comment={comment} /> : null}
             <FocusContext.Provider
-              value={{ autofocus: true, isFocused, blur: () => setIsFocused(false) }}
+              value={{
+                autofocus: true,
+                isFocused,
+                blur: () => setIsFocused(false),
+                close: () => setIsEditorOpen(false),
+              }}
             >
               <NewCommentEditor comment={comment} type={"new_comment"} />
             </FocusContext.Provider>
@@ -189,6 +196,7 @@ function CommentCard({
       )}
       onClick={() => {
         seekToComment(comment);
+        setIsEditorOpen(true);
         setIsFocused(true);
       }}
       onMouseEnter={() => setHoveredComment(comment.id)}
@@ -207,9 +215,14 @@ function CommentCard({
             <CommentItem type="reply" comment={reply} pendingComment={pendingComment} />
           </div>
         ))}
-        {isPaused && !pendingComment ? (
+        {isEditorOpen && (
           <FocusContext.Provider
-            value={{ autofocus: isFocused, isFocused, blur: () => setIsFocused(false) }}
+            value={{
+              autofocus: isFocused,
+              isFocused,
+              blur: () => setIsFocused(false),
+              close: () => setIsEditorOpen(false),
+            }}
           >
             <NewCommentEditor
               key={`${comment.id}-${(comment.replies || []).length}`}
@@ -217,7 +230,7 @@ function CommentCard({
               type={"new_reply"}
             />
           </FocusContext.Provider>
-        ) : null}
+        )}
       </div>
     </div>
   );

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -39,14 +39,17 @@ function CommentEditor({
     <div className="comment-input-container">
       <div className={classNames("comment-input")}>
         <FocusContext.Consumer>
-          {({ autofocus, blur, isFocused }) => (
+          {({ autofocus, blur, close, isFocused }) => (
             <TipTapEditor
               autofocus={autofocus}
               blur={blur}
+              close={close}
               content={comment.content || ""}
               editable={editable}
               handleCancel={() => {
                 clearPendingComment();
+                blur();
+                close();
               }}
               handleSubmit={handleSubmit}
               possibleMentions={users || []}

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -10,6 +10,7 @@ import { ReplayLink } from "./replayLink";
 interface TipTapEditorProps {
   autofocus: boolean;
   blur: () => void;
+  close: () => void;
   content: string;
   editable: boolean;
   handleSubmit: (text: string) => void;
@@ -37,6 +38,7 @@ const tryToParse = (content: string): any => {
 const TipTapEditor = ({
   autofocus,
   blur,
+  close,
   content,
   editable,
   handleSubmit,
@@ -112,7 +114,12 @@ const TipTapEditor = ({
           border: editable,
         })}
         editor={editor}
-        onBlur={blur}
+        onBlur={() => {
+          blur();
+          if ((editor?.getCharacterCount() || 0) === 0) {
+            close();
+          }
+        }}
       />
     </div>
   );


### PR DESCRIPTION
There are two primary changes in this PR, with more changes coming up, which will be detailed at the end.

### Simplify when to open and close comment editors (closes #4120)

- There's a pretty long thread on discord about this, but basically the "always-open-when-paused", "auto-closing-on-blur" comment editors are _a lot_. They make the UI jumpy, and they make it _very_ easy to accidentally wipe out your comment by clicking on another comment either accidentally or on purpose (for example, to copy some text from it). The new strategy is:

- start with _all_ comment editors hidden
- When you click on a comment, open its corresponding reply box
- If you blur that comment box, and you haven't typed anything in it, allow it to close (this situation often occurs because someone is jumping around in the timeline by clicking on comments)
- If you blur that comment box, but you have written something in the reply box, then leave it open. This way, it's much harder to erase user input without warning.
- It's still possible to lose user input, by doing things like refreshing the page (I often accidentally close the tab when I actually mean to close a CodeMirror tab, for example), or even by switching from DevTools to Viewer mode or vice versa. It would be better to write partially composed comments to local storage, much how the GitHub editor does it (I think, idk, maybe they are posting drafts to the backend, but either way, they do a great job of never losing my long commit messages even if I accidentally navigate away from the tab where I am composing them).
- We also still smash pending new comments upon reply submission, but that's a bigger scope than this change, so it will be a follow-on task.

### Also Closes #4053 

  - In the Replay browser, when you edit a comment, and your cursor is at the end of the line, typing a space and then any letter will result in the space you just typed getting deleted. I've spent a _long_ time tracking this bug down. I haven't _exactly_ found it, but I'm pretty sure that I have fixed it. A replay, with my commentary, is [here](https://app.replay.io/recording/cb56f8c8-6202-41d6-b537-3551abff45e1). I'm fairly certain that the interaction has to do with setting `focus` to the end of the line upon making an editor newly editable. This sets the selection manually from inside of TipTap, and it causes ProseMirror to think that we are adding a mark instead of typing text, which results in spaces getting replaced. This is not a perfect explanation, but there is a lot of code to sift through, and reproducing took a long time. Ironically, I took a break to fix some other UX things, and then realized that in the process I had fixed the bug. If, by some chance, I have lost my marbles and in fact this fix _does not_ fix the bug, we should just remove the `focus("end")` code, because slightly annoying UX is way better than this horrible typing bug that won't allow you to type spaces (it is _really_ annoying).

### Future Work

- Stop comments from ever "flashing" upon submission! This is a much bigger task because it involves all of the various pathways that we use to add comments. I think I'm close to fixing all of them, but it's turned out to be large enough that we're going to get this in first separately (thanks @jasonLaster for keeping my eye on the ball on this one!)
- Store comment drafts in local storage (see above)
- Don't close pending new comments when replies are submitted

# Screenshots

### Before

https://user-images.githubusercontent.com/5903784/138923908-af04b48a-8410-4c3e-94db-6998ec384870.mp4


### After

https://user-images.githubusercontent.com/5903784/138923943-ffffcffa-c36a-415c-b3e8-031609522b10.mp4
