### PR TITLE
Add options to PortalTooltip

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.tsx
@@ -87,7 +87,7 @@ function BreakpointTimeline({
 
   return (
     <div className="breakpoint-navigation-timeline-container relative">
-      <PortalTooltip tooltip={<TimeTooltip time={hoveredTime} />}>
+      <PortalTooltip tooltip={<TimeTooltip time={hoveredTime} />} followX={true}>
         <div
           className={classnames("breakpoint-navigation-timeline relative cursor-pointer")}
           onMouseMove={onMouseMove}

--- a/src/ui/components/shared/PortalTooltip.tsx
+++ b/src/ui/components/shared/PortalTooltip.tsx
@@ -10,9 +10,10 @@ export interface TargetCoordinates {
 interface PortalTooltipProps {
   tooltip: ReactNode;
   children: ReactNode;
+  followX: boolean;
 }
 
-export default function PortalTooltip({ children, tooltip }: PortalTooltipProps) {
+export default function PortalTooltip({ children, tooltip, followX = false }: PortalTooltipProps) {
   const [hoveredCoordinates, setHoveredCoordinates] = useState<TargetCoordinates | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const onMouseMove = (e: React.MouseEvent) => {
@@ -25,7 +26,7 @@ export default function PortalTooltip({ children, tooltip }: PortalTooltipProps)
   return (
     <>
       <div
-        className="w-full h-full"
+        className="w-full h-full leading-3"
         onMouseMove={onMouseMove}
         onMouseLeave={onMouseLeave}
         ref={containerRef}
@@ -34,18 +35,43 @@ export default function PortalTooltip({ children, tooltip }: PortalTooltipProps)
       </div>
       {hoveredCoordinates && containerRef.current
         ? createPortal(
-            <div
-              className="transform -translate-x-1/2 -translate-y-full absolute z-10 animate"
-              style={{
-                left: hoveredCoordinates.x,
-                top: containerRef.current.getBoundingClientRect().y,
-              }}
+            <PortalChild
+              hoveredCoordinates={hoveredCoordinates}
+              containerRect={containerRef.current.getBoundingClientRect()}
+              followX={followX}
             >
               {tooltip}
-            </div>,
+            </PortalChild>,
             document.body
           )
         : null}
     </>
+  );
+}
+
+function PortalChild({
+  hoveredCoordinates,
+  containerRect,
+  followX,
+  children,
+}: {
+  hoveredCoordinates: TargetCoordinates;
+  containerRect: DOMRect;
+  followX: boolean;
+  children: ReactNode;
+}) {
+  const hoveredX = hoveredCoordinates.x;
+  const targetX = containerRect.x;
+
+  return (
+    <div
+      className="transform -translate-x-1/2 -translate-y-full absolute z-50 animate"
+      style={{
+        left: followX ? hoveredX : targetX,
+        top: containerRect.y,
+      }}
+    >
+      {children}
+    </div>
   );
 }


### PR DESCRIPTION
The `PortalTooltip` was initially created for the breakpoint timeline, so that hovering on the timeline would show a tooltip with the time on it.

In that case, it would make sense to position the tooltip based on the user's cursor's x position, but then anchor it to the targeted element's x position, so that the tooltip remains on the same x position while the user hovers left->right.

To extend this tooltip to other things where we don't want the tooltip being positioned according to the user's cursor position, we need to have some way to expose that capability as an option.