### PR TITLE
Stop comments from flashing upon creation

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -4,6 +4,9 @@ inputs:
   stripe:
     description: "Stripe to run, in the form INDEX/TOTAL"
     required: true
+  github_ci:
+    description: "A flag to tell whether we are in CI"
+    required: false
 
 runs:
   using: "node12"

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -17,6 +17,9 @@ import "reactjs-popup/dist/index.css";
 import "ui/components/reactjs-popup.css";
 import Log from "./Log";
 import Condition from "./Condition";
+import useAuth0 from "ui/utils/useAuth0";
+import { useGetRecordingId } from "ui/hooks/recordings";
+import { useGetUserId } from "ui/hooks/users";
 
 export type Input = "condition" | "logValue";
 
@@ -37,6 +40,9 @@ function PanelSummary({
   analysisPoints,
 }: PanelSummaryProps) {
   const { isTeamDeveloper } = hooks.useIsTeamDeveloper();
+  const { user } = useAuth0();
+  const { userId } = useGetUserId();
+  const recordingId = useGetRecordingId();
   const conditionValue = breakpoint.options.condition;
   const logValue = breakpoint.options.logValue;
 
@@ -66,11 +72,22 @@ function PanelSummary({
     trackEvent("breakpoint.add_comment");
 
     if (pausedOnHit) {
-      console.log("createFrameComment", currentTime, executionPoint, breakpoint);
-      createFrameComment(currentTime, executionPoint, null, breakpoint);
+      createFrameComment(
+        currentTime,
+        executionPoint,
+        null,
+        { ...user, userId },
+        recordingId,
+        breakpoint
+      );
     } else {
-      console.log("createFloatingCodeComment", currentTime, executionPoint, breakpoint);
-      createFloatingCodeComment(currentTime, executionPoint, breakpoint);
+      createFloatingCodeComment(
+        currentTime,
+        executionPoint,
+        { ...user, id: userId },
+        recordingId,
+        breakpoint
+      );
     }
   };
 

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -4,6 +4,9 @@
 
 "use strict";
 
+const { getUserId } = require("ui/hooks/users");
+const { withAuth0 } = require("@auth0/auth0-react");
+const { withRouter } = require("react-router");
 const { Component, createFactory, createElement } = require("react");
 const dom = require("react-dom-factories");
 const { l10n } = require("devtools/client/webconsole/utils/messages");
@@ -179,9 +182,20 @@ class Message extends Component {
 
       this.onViewSourceInDebugger({ ...frame, url: frame.source });
     };
-    let handleAddComment = () => {
+    let handleAddComment = async () => {
       trackEvent("console.add_comment");
-      dispatch(actions.createComment(executionPointTime, executionPoint, undefined, true, frame));
+      let userId = await getUserId();
+      dispatch(
+        actions.createComment(
+          executionPointTime,
+          executionPoint,
+          undefined,
+          true,
+          frame,
+          { ...this.props.auth0.user, id: userId },
+          this.props.match.params.recordingId
+        )
+      );
     };
 
     if (BigInt(executionPoint) > BigInt(pausedExecutionPoint)) {
@@ -464,4 +478,4 @@ class Message extends Component {
   }
 }
 
-module.exports = Message;
+module.exports = withAuth0(withRouter(Message));

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -250,7 +250,7 @@ class _ThreadFront {
     const sessionId = await this.waitForSession();
 
     client.Session.addLoadedRegionsListener((parameters: loadedRegions) => {
-      console.log("LoadedRegions", parameters);
+      // console.log("LoadedRegions", parameters);
       listenerCallback(parameters);
     });
 

--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -8,6 +8,8 @@ import { setSelectedPrimaryPanel } from "./app";
 import escapeHtml from "escape-html";
 import { waitForTime } from "protocol/utils";
 import { PENDING_COMMENT_ID } from "ui/reducers/comments";
+import { RecordingId } from "@recordreplay/protocol";
+import { User } from "ui/types";
 const { getFilenameFromURL } = require("devtools/client/debugger/src/utils/sources-tree/getURL");
 const { getTextAtLocation } = require("devtools/client/debugger/src/reducers/sources");
 const { findClosestFunction } = require("devtools/client/debugger/src/utils/ast");
@@ -45,7 +47,9 @@ export function createComment(
   point: string,
   position: { x: number; y: number } | null,
   hasFrames: boolean,
-  sourceLocation: SourceLocation | null
+  sourceLocation: SourceLocation | null,
+  user: User,
+  recordingId: RecordingId
 ): UIThunkAction {
   return async ({ dispatch }) => {
     const labels = sourceLocation ? await dispatch(createLabels(sourceLocation)) : undefined;
@@ -62,11 +66,13 @@ export function createComment(
         point,
         position,
         primaryLabel,
+        recordingId,
         replies: [],
         secondaryLabel,
         sourceLocation,
         time,
         updatedAt: new Date().toISOString(),
+        user,
       },
     };
 
@@ -79,12 +85,14 @@ export function createFrameComment(
   time: number,
   point: string,
   position: { x: number; y: number } | null,
+  user: User,
+  recordingId: RecordingId,
   breakpoint?: any
 ): UIThunkAction {
   return async ({ dispatch }) => {
     const sourceLocation =
       breakpoint?.location || (await getCurrentPauseSourceLocationWithTimeout());
-    dispatch(createComment(time, point, position, true, sourceLocation || null));
+    dispatch(createComment(time, point, position, true, sourceLocation || null, user, recordingId));
   };
 }
 
@@ -95,11 +103,13 @@ function getCurrentPauseSourceLocationWithTimeout() {
 export function createFloatingCodeComment(
   time: number,
   point: string,
+  user: User,
+  recordingId: RecordingId,
   breakpoint: any
 ): UIThunkAction {
   return async ({ dispatch }) => {
     const { location: sourceLocation } = breakpoint;
-    dispatch(createComment(time, point, null, false, sourceLocation || null));
+    dispatch(createComment(time, point, null, false, sourceLocation || null, user, recordingId));
   };
 }
 
@@ -171,26 +181,5 @@ export function seekToComment(item: Comment | Reply | PendingComment["comment"])
       cx = selectors.getThreadContext(getState());
       dispatch(actions.selectLocation(cx, item.sourceLocation));
     }
-  };
-}
-
-export function replyToComment(parentId: string, point: string, time: number): UIThunkAction {
-  return ({ dispatch }) => {
-    const pendingComment: PendingComment = {
-      type: "new_reply",
-      comment: {
-        content: "",
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        id: PENDING_COMMENT_ID,
-        hasFrames: false,
-        sourceLocation: null,
-        parentId,
-        point,
-        time,
-      },
-    };
-
-    dispatch(setPendingComment(pendingComment));
   };
 }

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -4,7 +4,7 @@ import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
 import { UIState } from "ui/state";
 import hooks from "ui/hooks";
-import { Comment, PendingNewComment, PendingNewReply, Reply } from "ui/state/comments";
+import { Comment, Reply } from "ui/state/comments";
 
 import "./CommentEditor.css";
 import { User } from "ui/types";
@@ -13,7 +13,7 @@ import { FocusContext } from "../CommentCard";
 import classNames from "classnames";
 
 type CommentEditorProps = PropsFromRedux & {
-  comment: Comment | Reply | PendingNewComment | PendingNewReply;
+  comment: Comment | Reply;
   editable: boolean;
   handleSubmit: (inputValue: string) => void;
 };

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
@@ -3,10 +3,10 @@ import { connect, ConnectedProps } from "react-redux";
 import hooks from "ui/hooks";
 import { actions } from "ui/actions";
 import CommentEditor from "./CommentEditor";
-import { Comment, PendingNewComment, PendingNewReply, Reply } from "ui/state/comments";
+import { Comment, Reply } from "ui/state/comments";
 
 type ExistingCommentEditorProps = PropsFromRedux & {
-  comment: Comment | Reply | PendingNewComment | PendingNewReply;
+  comment: Comment | Reply;
   editable: boolean;
   type: "comment" | "reply";
 };

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
@@ -2,18 +2,17 @@ import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import hooks from "ui/hooks";
 import { actions } from "ui/actions";
-import { PendingNewComment, PendingNewReply } from "ui/state/comments";
+import { Comment, Reply } from "ui/state/comments";
 import CommentEditor from "./CommentEditor";
 import { useAuth0 } from "@auth0/auth0-react";
 
 interface NewCommentEditorProps extends PropsFromRedux {
-  comment: PendingNewComment | PendingNewReply;
+  comment: Comment | Reply;
   type: "new_reply" | "new_comment";
 }
 
 function NewCommentEditor({ clearPendingComment, comment, setModal, type }: NewCommentEditorProps) {
   const { isAuthenticated } = useAuth0();
-  const recordingId = hooks.useGetRecordingId();
   const addComment = hooks.useAddComment();
   const addCommentReply = hooks.useAddCommentReply();
 
@@ -24,30 +23,30 @@ function NewCommentEditor({ clearPendingComment, comment, setModal, type }: NewC
     }
 
     if (type == "new_reply") {
-      handleReplySave(comment as PendingNewReply, inputValue);
+      handleReplySave(comment as Reply, inputValue);
     } else {
-      handleNewSave(comment as PendingNewComment, inputValue);
+      handleNewSave(comment as Comment, inputValue);
     }
 
     clearPendingComment();
   };
 
-  const handleReplySave = async (comment: PendingNewReply, inputValue: string) => {
+  const handleReplySave = async (comment: Reply, inputValue: string) => {
     const reply = {
       ...comment,
       content: inputValue,
     };
 
-    addCommentReply(reply, recordingId!);
+    addCommentReply(reply);
   };
 
-  const handleNewSave = async (comment: PendingNewComment, inputValue: string) => {
+  const handleNewSave = async (comment: Comment, inputValue: string) => {
     const newComment = {
       ...comment,
       content: inputValue,
     };
 
-    addComment(newComment, recordingId!);
+    addComment(newComment);
   };
 
   return <CommentEditor editable={true} {...{ comment, handleSubmit }} />;

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -59,10 +59,14 @@ const TipTapEditor = ({
           return {
             "Cmd-Enter": ({ editor }) => {
               handleSubmit(JSON.stringify(editor.getJSON()));
+              blur();
+              close();
               return true;
             },
             Enter: ({ editor }) => {
               handleSubmit(JSON.stringify(editor.getJSON()));
+              blur();
+              close();
               return true;
             },
             Escape: ({ editor }) => {

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -5,10 +5,11 @@ import sortBy from "lodash/sortBy";
 import hooks from "ui/hooks";
 import "./Transcript.css";
 import { UIState } from "ui/state";
-import { Comment, PendingNewComment } from "ui/state/comments";
+import { Comment } from "ui/state/comments";
 import CommentCard from "ui/components/Comments/TranscriptComments/CommentCard";
 import useAuth0 from "ui/utils/useAuth0";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
+import { commentKeys } from "ui/utils/comments";
 
 function Transcript({ pendingComment }: PropsFromRedux) {
   const recordingId = hooks.useGetRecordingId();
@@ -20,12 +21,13 @@ function Transcript({ pendingComment }: PropsFromRedux) {
     return null;
   }
 
-  const displayedComments: (Comment | PendingNewComment)[] = [...comments];
+  const displayedComments: Comment[] = [...comments];
   if (pendingComment?.type == "new_comment") {
     displayedComments.push(pendingComment.comment);
   }
 
   const sortedComments = sortBy(displayedComments, ["time", "createdAt"]);
+  const keys = commentKeys(sortedComments);
 
   return (
     <div className="right-sidebar">
@@ -35,14 +37,8 @@ function Transcript({ pendingComment }: PropsFromRedux) {
       <div className="transcript-list flex-grow overflow-auto overflow-x-hidden flex flex-col items-center bg-white h-full text-xs">
         {displayedComments.length > 0 ? (
           <div className="overflow-auto w-full flex-grow">
-            {sortedComments.map(comment => {
-              return (
-                <CommentCard
-                  comments={sortedComments}
-                  comment={comment}
-                  key={"id" in comment ? comment.id : 0}
-                />
-              );
+            {sortedComments.map((comment, i) => {
+              return <CommentCard comments={sortedComments} comment={comment} key={keys[i]} />;
             })}
           </div>
         ) : (

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -29,7 +29,6 @@ function Video({
   setVideoNode,
   videoUrl,
 }: PropsFromRedux) {
-  const { isAuthenticated } = useAuth0();
   const recordingId = hooks.useGetRecordingId();
   const isPaused = !playback;
   const isNodeTarget = recordingTarget == "node";
@@ -86,8 +85,6 @@ const connector = connect(
   }),
   {
     setVideoNode: actions.setVideoNode,
-    togglePlayback: actions.togglePlayback,
-    clearPendingComment: actions.clearPendingComment,
   }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -9,6 +9,9 @@ import { Comment, Reply } from "ui/state/comments";
 import classNames from "classnames";
 import { Canvas } from "ui/state/app";
 import { ThreadFront } from "protocol/thread";
+import { useGetRecordingId } from "ui/hooks/recordings";
+import useAuth0 from "ui/utils/useAuth0";
+import { useGetUserId } from "ui/hooks/users";
 
 const mouseEventCanvasPosition = (e: MouseEvent) => {
   const canvas = document.getElementById("graphics");
@@ -75,6 +78,9 @@ function CommentTool({
 }: CommentToolProps) {
   const [showHelper, setShowHelper] = useState(false);
   const [mousePosition, setMousePosition] = useState<Coordinates | null>(null);
+  const recordingId = useGetRecordingId();
+  const { user } = useAuth0();
+  const { userId } = useGetUserId();
   const captionNode = useRef<HTMLDivElement | null>(null);
 
   const addListeners = () => {
@@ -107,7 +113,13 @@ function CommentTool({
     // If there's no pending comment at that point and time, create one
     // with the mouse click as its position.
     if (!pendingComment) {
-      createFrameComment(currentTime, executionPoint, mouseEventCanvasPosition(e));
+      createFrameComment(
+        currentTime,
+        executionPoint,
+        mouseEventCanvasPosition(e),
+        { ...user, id: userId },
+        recordingId
+      );
       return;
     }
 

--- a/src/ui/state/comments.ts
+++ b/src/ui/state/comments.ts
@@ -44,11 +44,11 @@ export interface Reply extends Remark {
 
 export type PendingComment =
   | {
-      comment: PendingNewComment;
+      comment: Comment;
       type: "new_comment";
     }
   | {
-      comment: PendingNewReply;
+      comment: Reply;
       type: "new_reply";
     }
   | {
@@ -61,6 +61,3 @@ export type PendingComment =
     };
 
 export type PendingCommentAction = "edit_reply" | "edit_comment" | "new_reply" | "new_comment";
-
-export type PendingNewComment = Omit<Comment, "recordingId" | "user">;
-export type PendingNewReply = Omit<Reply, "recordingId" | "user">;

--- a/src/ui/utils/comments.ts
+++ b/src/ui/utils/comments.ts
@@ -1,0 +1,42 @@
+import differenceInMinutes from "date-fns/differenceInMinutes";
+import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
+import differenceInWeeks from "date-fns/differenceInWeeks";
+import differenceInMonths from "date-fns/differenceInMonths";
+import differenceInYears from "date-fns/differenceInYears";
+import { Comment, Reply } from "ui/state/comments";
+import sortBy from "lodash/sortBy";
+import indexOf from "lodash/indexOf";
+import { range } from "lodash";
+
+export function formatRelativeTime(date: Date) {
+  const minutes = differenceInMinutes(Date.now(), date);
+  const days = differenceInCalendarDays(Date.now(), date);
+  const weeks = differenceInWeeks(Date.now(), date);
+  const months = differenceInMonths(Date.now(), date);
+  const years = differenceInYears(Date.now(), date);
+
+  if (years > 0) {
+    return `${years}y`;
+  }
+  if (months > 0) {
+    return `${months}m`;
+  }
+  if (weeks > 0) {
+    return `${weeks}w`;
+  }
+  if (days > 0) {
+    return `${days}d`;
+  }
+  if (minutes >= 60) {
+    return `${Math.floor(minutes / 60)}h`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m`;
+  }
+  return "Now";
+}
+
+export function commentKeys(comments: (Comment | Reply)[]): number[] {
+  const indices = range(comments.length);
+  return sortBy(indices, [i => comments[i].user.id, i => Number(comments[i].createdAt)]);
+}

--- a/test/ui/components/Comments/TranscriptComments/CommentEditor/githubLink.test.js
+++ b/test/ui/components/Comments/TranscriptComments/CommentEditor/githubLink.test.js
@@ -1,0 +1,15 @@
+const {
+  inputRegex,
+} = require("ui/components/Comments/TranscriptComments/CommentEditor/githubLink");
+
+describe("GitHubLink", () => {
+  test("when there are no github links it does not match", () => {
+    expect("text with no link".match(inputRegex)).toEqual(null);
+  });
+
+  test("when there are github links it does match", () => {
+    expect("https://github.com/RecordReplay/devtools/issues/3926".match(inputRegex)).toEqual([
+      "https://github.com/RecordReplay/devtools/issues/3926",
+    ]);
+  });
+});

--- a/test/ui/utils/comments.test.js
+++ b/test/ui/utils/comments.test.js
@@ -1,15 +1,20 @@
-const {
-  inputRegex,
-} = require("ui/components/Comments/TranscriptComments/CommentEditor/githubLink");
+const { commentKeys } = require("ui/utils/comments");
 
-describe("GitHubLink", () => {
-  test("when there are no github links it does not match", () => {
-    expect("text with no link".match(inputRegex)).toEqual(null);
-  });
+describe("commentKeys", () => {
+  test("keeps the same order even when the createdAt times changes a bit", () => {
+    const frozenNow = Date.now();
+    const secondsAgo = seconds => new Date(frozenNow - seconds * 1000);
 
-  test("when there are github links it does match", () => {
-    expect("https://github.com/RecordReplay/devtools/issues/3926".match(inputRegex)).toEqual([
-      "https://github.com/RecordReplay/devtools/issues/3926",
-    ]);
+    const optimisticResponse = [
+      { user: { id: "1" }, createdAt: secondsAgo(30) },
+      { user: { id: "1" }, createdAt: secondsAgo(15) },
+    ];
+    const serverResponse = [
+      { user: { id: "1" }, createdAt: secondsAgo(28) },
+      { user: { id: "1" }, createdAt: secondsAgo(14) },
+    ];
+
+    expect(commentKeys(optimisticResponse)).toEqual([0, 1]);
+    expect(commentKeys(serverResponse)).toEqual([0, 1]);
   });
 });


### PR DESCRIPTION
Here's the shape of the problem this is solving:

- A user clicks a button to add a comment: 
  - We create a `pendingComment` which has a constant, known ID of `PENDING`. It's okay that this is constant, because we only allow one pending reply per comment, and one pending comment overall (This might change in the near future, but we wouldn't need to change this too much, just use the generated ID like we do for the others).
  - That comment gets submitted, and we optimistically update the apollo cache with that comment, but we don't know any permanent attributes about it other than its content, which is not guaranteed to be unique. That means that anything we use as a key will get changed slightly between our optimistic version and the server-supplied version. For example, we might have `Jan 1, 01:01:01` as the timestamp on the client, but the server changes that to `Jan 1, 01:01:05` because of a few seconds lost to round-tripping to the server, writing to the DB, etc. In order for the optimistic rendering not to flash, we need the key to remain stable across optimistic and confirmed updates.

This took a bit of creative thinking. I tried:

- Using `userId:createdAt` - this does not work, because we initially populate `createdAt` on the client, but the server overwrites that with its own `createdAt`, causing a flash.
- Using `index` - this *almost* works, except that we allow multiplayer comments, so that technically I could be working on reply 4, while some other user submits a new reply to that same comment, and now my client think I'm actually trying to compose reply 5 and all my work is smashed.
- Using `user:index` *mostly* gets around this, but there are still weird corner cases if the same user has multiple pending comments/replies in one or several clients.

What I realized is this: we don't have perfectly stable values, but we have *almost* stable values, so as long as we worry about the order, and not the exact time, it's all good. So now we `key` things by their `userId:createdAt`, but we turn that into an index first. This works because arrays of millisecond timestamps always produce the same order, even if one changes a little during the optimistic update confirmation. And if you're asking "yes, but why do you need userId"? The answer is `because theoretically two users could create comments at the same time and we would get indeterminate ordering`. And yes, that is unlikely, and I'm a little paranoid, but it was barely any additional complexity. And, sure, it's still *technically* possible to have a collision, but the same user would have to get exactly the same timestamp, which seems so unlikely as to be not worth considering.

Other things this fixes:
- Remove `PendingComment` and `PendingReply` types - the only thing these types omitted were `recordingId` and `user`, but those are actually two things that we *definitely* know when the comment is created, so there is no reason to omit them.
- Try to standardize how we create comments and replies, so that all fields are present at all times, from all creation paths. This is important because tiny differences in fields (like `null` vs. `undefined`) can cause the Apollo cache to hiccup silently and cause ugly flashes of the entire comment section.
- Comment out the `console.log` for `loadedRegions`. I assume this was left in because it was useful to somebody. It's really noisy sometimes in my console so I've commented it. If we want to put it behind a flag or something that's fine too.
- Move `githubLink` tests. I put these in the wrong spot, oops!

Closes https://github.com/RecordReplay/devtools/issues/4133