### PR TITLE
Add GitHub ref to telemetry events

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -105,7 +105,13 @@ function sendTelemetryEvent(telemetryEvent, tags) {
     request.on("error", e => {
       log(`Error sending telemetry ping: ${e}`);
     });
-    request.write(JSON.stringify({ event: telemetryEvent, ...tags }));
+    request.write(
+      JSON.stringify({
+        event: telemetryEvent,
+        ...tags,
+        github_ref: process.env.GITHUB_REF,
+      })
+    );
     request.end();
   } catch (e) {
     console.error(`Couldn't send telemetry event ${telemetryEvent}`, e);


### PR DESCRIPTION
This is handy, so when you see a failed test event you can also see the branch or pull request information.