### PR TITLE
Hide breakpoint nag when the breakpoint is not editable

### DIFF
--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -1,5 +1,4 @@
 import {
-  RecordingId,
   SessionId,
   PointDescription,
   Location,


### PR DESCRIPTION
Fixes #4105

This is a bigger change than you might expect because it involved lifting some state up into a higher component, so that the `analysisPoints` were available to more components without having to load them multiple times.

https://user-images.githubusercontent.com/5903784/138999528-4a59f67e-0731-4b89-b570-fbe8bbbeda27.mp4
