### PR TITLE
Add currentTime to the breakpoint panel props

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -32,6 +32,7 @@ function getPanelWidth({ editor }) {
 function Panel({
   analysisPoints,
   breakpoint,
+  currentTime,
   editor,
   executionPoint,
   insertAt,
@@ -133,6 +134,7 @@ export default connect(
       breakpoint.location,
       breakpoint.options.condition
     ),
+    currentTime: selectors.getCurrentTime(state),
     executionPoint: getExecutionPoint(state),
   }),
   {


### PR DESCRIPTION
Hotfix for a bug introduced in #4181 