### PR TITLE
Parse dates when sorting

### DIFF
--- a/src/ui/utils/comments.ts
+++ b/src/ui/utils/comments.ts
@@ -38,5 +38,9 @@ export function formatRelativeTime(date: Date) {
 
 export function commentKeys(comments: (Comment | Reply)[]): number[] {
   const indices = range(comments.length);
-  return sortBy(indices, [i => comments[i].user.id, i => Number(comments[i].createdAt)]);
+  const permutation = sortBy(indices, [
+    i => Number(Date.parse(comments[i].createdAt)),
+    i => comments[i].user.id,
+  ]);
+  return indices.map(i => permutation.indexOf(i));
 }

--- a/test/ui/utils/comments.test.js
+++ b/test/ui/utils/comments.test.js
@@ -3,18 +3,20 @@ const { commentKeys } = require("ui/utils/comments");
 describe("commentKeys", () => {
   test("keeps the same order even when the createdAt times changes a bit", () => {
     const frozenNow = Date.now();
-    const secondsAgo = seconds => new Date(frozenNow - seconds * 1000);
+    const secondsAgo = seconds => new Date(frozenNow - seconds * 1000).toISOString();
 
     const optimisticResponse = [
+      { user: { id: "1" }, createdAt: secondsAgo(5) },
       { user: { id: "1" }, createdAt: secondsAgo(30) },
       { user: { id: "1" }, createdAt: secondsAgo(15) },
     ];
     const serverResponse = [
+      { user: { id: "1" }, createdAt: secondsAgo(6) },
       { user: { id: "1" }, createdAt: secondsAgo(28) },
       { user: { id: "1" }, createdAt: secondsAgo(14) },
     ];
 
-    expect(commentKeys(optimisticResponse)).toEqual([0, 1]);
-    expect(commentKeys(serverResponse)).toEqual([0, 1]);
+    expect(commentKeys(optimisticResponse)).toEqual([2, 0, 1]);
+    expect(commentKeys(serverResponse)).toEqual([2, 0, 1]);
   });
 });


### PR DESCRIPTION
I thought that we were doing date parsing when we loaded information from the API, but it turns out that we are just passing around strings, so even the more intelligent `sortBy` from `lodash` will result in string comparison rather than real datetime comparison. I've changed the tests to reflect this requirement as well. I've made two other small tweaks: what we were passing back from `commentKeys` was not *quite* the right permutation map. I'm not a combinatorics programmer so I don't know the word for this thing (maybe it's the transposition map?), but it's like the inverse permutation map. Running `indexOf` gets back the map that we actually want.

Also, it's totally fine to sort by user and then comment created at, but it's probably more accurate to think of user as the tie breaker, so I've made that the second sort condition. This won't change any behavior, but I think it makes it easier to verify the logic in simple cases.