### PR TITLE
Highlight tokens while the preview loads

### DIFF
--- a/src/devtools/client/debugger/src/actions/preview.js
+++ b/src/devtools/client/debugger/src/actions/preview.js
@@ -40,7 +40,13 @@ export function updatePreview(cx, target, tokenPos, codeMirror) {
 export function setPreview(cx, expression, location, tokenPos, cursorPos, target) {
   return async ({ dispatch, getState, client, sourceMaps }) => {
     // if we pass the target here we can use it from redux
-    dispatch({ type: "START_PREVIEW" });
+    dispatch({
+      type: "START_PREVIEW",
+      value: {
+        expression,
+        target,
+      },
+    });
     const previewCount = getPreviewCount(getState());
     if (getPreview(getState())) {
       dispatch(clearPreview(cx));

--- a/src/devtools/client/debugger/src/actions/preview.js
+++ b/src/devtools/client/debugger/src/actions/preview.js
@@ -39,7 +39,6 @@ export function updatePreview(cx, target, tokenPos, codeMirror) {
 
 export function setPreview(cx, expression, location, tokenPos, cursorPos, target) {
   return async ({ dispatch, getState, client, sourceMaps }) => {
-    // if we pass the target here we can use it from redux
     dispatch({
       type: "START_PREVIEW",
       value: {

--- a/src/devtools/client/debugger/src/actions/preview.js
+++ b/src/devtools/client/debugger/src/actions/preview.js
@@ -12,7 +12,7 @@ import {
   getSelectedSource,
   getSelectedFrame,
 } from "../selectors";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 
 export function updatePreview(cx, target, tokenPos, codeMirror) {
   return ({ dispatch, getState }) => {

--- a/src/devtools/client/debugger/src/actions/preview.js
+++ b/src/devtools/client/debugger/src/actions/preview.js
@@ -39,6 +39,7 @@ export function updatePreview(cx, target, tokenPos, codeMirror) {
 
 export function setPreview(cx, expression, location, tokenPos, cursorPos, target) {
   return async ({ dispatch, getState, client, sourceMaps }) => {
+    // if we pass the target here we can use it from redux
     dispatch({ type: "START_PREVIEW" });
     const previewCount = getPreviewCount(getState());
     if (getPreview(getState())) {

--- a/src/devtools/client/debugger/src/actions/preview.js
+++ b/src/devtools/client/debugger/src/actions/preview.js
@@ -12,7 +12,6 @@ import {
   getSelectedSource,
   getSelectedFrame,
 } from "../selectors";
-import uniqueId from "lodash/uniqueId";
 
 export function updatePreview(cx, target, tokenPos, codeMirror) {
   return ({ dispatch, getState }) => {
@@ -50,8 +49,7 @@ export function setPreview(cx, expression, location, tokenPos, cursorPos, target
       },
     });
 
-    const partialPreview = getPreview(getState());
-    const previewId = partialPreview.previewId;
+    const { previewId } = getPreview(getState());
 
     const source = getSelectedSource(getState());
     if (!source) {

--- a/src/devtools/client/debugger/src/components/Editor/Preview/Popup.js
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/Popup.js
@@ -168,8 +168,8 @@ export class Popup extends Component {
   }
 
   onMouseOut = () => {
-    const { clearPreview, cx } = this.props;
-    clearPreview(cx);
+    const { clearPreview, cx, preview } = this.props;
+    clearPreview(cx, preview.previewId);
   };
 
   render() {

--- a/src/devtools/client/debugger/src/components/Editor/Preview/Popup.js
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/Popup.js
@@ -46,6 +46,7 @@ export class Popup extends Component {
   }
 
   addHighlightToToken() {
+    // could we pull the "highlight" logic out of here so we can show the highlight sooner?
     const target = this.props.preview.target;
     if (target) {
       target.classList.add("preview-token");

--- a/src/devtools/client/debugger/src/components/Editor/Preview/Popup.js
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/Popup.js
@@ -37,31 +37,6 @@ export class Popup extends Component {
     super(props);
   }
 
-  componentDidMount() {
-    this.addHighlightToToken();
-  }
-
-  componentWillUnmount() {
-    this.removeHighlightFromToken();
-  }
-
-  addHighlightToToken() {
-    // could we pull the "highlight" logic out of here so we can show the highlight sooner?
-    const target = this.props.preview.target;
-    if (target) {
-      target.classList.add("preview-token");
-      addHighlightToTargetSiblings(target, this.props);
-    }
-  }
-
-  removeHighlightFromToken() {
-    const target = this.props.preview.target;
-    if (target) {
-      target.classList.remove("preview-token");
-      removeHighlightForTargetSiblings(target);
-    }
-  }
-
   calculateMaxHeight = () => {
     const { editorRef } = this.props;
     if (!editorRef) {
@@ -219,65 +194,6 @@ export class Popup extends Component {
         {this.renderPreview()}
       </Popover>
     );
-  }
-}
-
-export function addHighlightToTargetSiblings(target, props) {
-  // This function searches for related tokens that should also be highlighted when previewed.
-  // Here is the process:
-  // It conducts a search on the target's next siblings and then another search for the previous siblings.
-  // If a sibling is not an element node (nodeType === 1), the highlight is not added and the search is short-circuited.
-  // If the element sibling is the same token type as the target, and is also found in the preview expression, the highlight class is added.
-
-  const tokenType = target.classList.item(0);
-  const previewExpression = props.preview.expression;
-
-  if (tokenType && previewExpression && target.innerHTML !== previewExpression) {
-    let nextSibling = target.nextSibling;
-    let nextElementSibling = target.nextElementSibling;
-    // Note: Declaring previous/next ELEMENT siblings as well because
-    // properties like innerHTML can't be checked on nextSibling
-    // without creating a flow error even if the node is an element type.
-    while (
-      nextElementSibling?.className.includes(tokenType) &&
-      previewExpression.includes(nextElementSibling.innerHTML)
-    ) {
-      // All checks passed, add highlight and continue the search.
-      nextElementSibling.classList.add("preview-token");
-
-      nextSibling = nextSibling.nextSibling;
-      nextElementSibling = nextElementSibling.nextElementSibling;
-    }
-
-    let previousSibling = target.previousSibling;
-    let previousElementSibling = target.previousElementSibling;
-
-    while (
-      previousElementSibling?.className.includes(tokenType) &&
-      previewExpression?.includes(previousElementSibling.innerHTML)
-    ) {
-      // All checks passed, add highlight and continue the search.
-      previousElementSibling.classList.add("preview-token");
-
-      previousSibling = previousSibling.previousSibling;
-      previousElementSibling = previousElementSibling.previousElementSibling;
-    }
-  }
-}
-
-export function removeHighlightForTargetSiblings(target) {
-  // Look at target's previous and next token siblings.
-  // If they also have the highlight class 'preview-token',
-  // remove that class.
-  let nextSibling = target.nextElementSibling;
-  while (nextSibling?.className.includes("preview-token")) {
-    nextSibling.classList.remove("preview-token");
-    nextSibling = nextSibling.nextElementSibling;
-  }
-  let previousSibling = target.previousElementSibling;
-  while (previousSibling?.className.includes("preview-token")) {
-    previousSibling.classList.remove("preview-token");
-    previousSibling = previousSibling.previousElementSibling;
   }
 }
 

--- a/src/devtools/client/debugger/src/components/Editor/Preview/PreviewHighlight.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/PreviewHighlight.tsx
@@ -1,0 +1,83 @@
+import { useEffect } from "react";
+
+function addHighlightToToken(target: HTMLElement) {
+  target.classList.add("preview-token");
+}
+
+function removeHighlightFromToken(target: HTMLElement) {
+  target.classList.remove("preview-token");
+}
+
+function addHighlightToTargetSiblings(target: HTMLElement, expression: string) {
+  // This function searches for related tokens that should also be highlighted when previewed.
+  // Here is the process:
+  // It conducts a search on the target's next siblings and then another search for the previous siblings.
+  // If a sibling is not an element node (nodeType === 1), the highlight is not added and the search is short-circuited.
+  // If the element sibling is the same token type as the target, and is also found in the preview expression, the highlight class is added.
+
+  const tokenType = target.classList.item(0);
+  const previewExpression = expression;
+
+  if (tokenType && previewExpression && target.innerHTML !== previewExpression) {
+    let nextElementSibling = target.nextElementSibling;
+    // Note: Declaring previous/next ELEMENT siblings as well because
+    // properties like innerHTML can't be checked on nextSibling
+    // without creating a flow error even if the node is an element type.
+    while (
+      nextElementSibling?.className.includes(tokenType) &&
+      previewExpression.includes(nextElementSibling.innerHTML)
+    ) {
+      // All checks passed, add highlight and continue the search.
+      nextElementSibling.classList.add("preview-token");
+
+      nextElementSibling = nextElementSibling.nextElementSibling;
+    }
+
+    let previousElementSibling = target.previousElementSibling;
+
+    while (
+      previousElementSibling?.className.includes(tokenType) &&
+      previewExpression?.includes(previousElementSibling.innerHTML)
+    ) {
+      // All checks passed, add highlight and continue the search.
+      previousElementSibling.classList.add("preview-token");
+      previousElementSibling = previousElementSibling.previousElementSibling;
+    }
+  }
+}
+
+function removeHighlightForTargetSiblings(target: HTMLElement) {
+  // Look at target's previous and next token siblings.
+  // If they also have the highlight class 'preview-token',
+  // remove that class.
+  let nextSibling = target.nextElementSibling;
+  while (nextSibling?.className.includes("preview-token")) {
+    nextSibling.classList.remove("preview-token");
+    nextSibling = nextSibling.nextElementSibling;
+  }
+  let previousSibling = target.previousElementSibling;
+  while (previousSibling?.className.includes("preview-token")) {
+    previousSibling.classList.remove("preview-token");
+    previousSibling = previousSibling.previousElementSibling;
+  }
+}
+
+type PropTypes = {
+  expression: string;
+  target: HTMLElement;
+};
+
+// this could probably be a hook, but it's used in a Class Component at the moment
+export const PreviewHighlight = ({ expression, target }: PropTypes) => {
+  useEffect(() => {
+    addHighlightToToken(target);
+    return () => removeHighlightFromToken(target);
+  }, [target]);
+
+  useEffect(() => {
+    addHighlightToTargetSiblings(target, expression);
+    return () => removeHighlightForTargetSiblings(target);
+  }, [expression, target]);
+
+  return null;
+};

--- a/src/devtools/client/debugger/src/components/Editor/Preview/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/index.js
@@ -11,6 +11,7 @@ import Popup from "./Popup";
 
 import { getPreview, getThreadContext } from "../../../selectors";
 import actions from "../../../actions";
+import { PreviewHighlight } from "./PreviewHighlight";
 
 class Preview extends PureComponent {
   target = null;
@@ -72,11 +73,18 @@ class Preview extends PureComponent {
 
   render() {
     const { preview } = this.props;
-    if (!preview || this.state.selecting) {
-      return null;
-    }
+    const { selecting } = this.state;
 
-    return <Popup preview={preview} editor={this.props.editor} editorRef={this.props.editorRef} />;
+    return (
+      <>
+        {!selecting && preview && (
+          <PreviewHighlight expression={preview.expression} target={preview.target} />
+        )}
+        {!selecting && preview?.resultGrip && (
+          <Popup preview={preview} editor={this.props.editor} editorRef={this.props.editorRef} />
+        )}
+      </>
+    );
   }
 }
 
@@ -84,6 +92,7 @@ const mapStateToProps = state => {
   return {
     cx: getThreadContext(state),
     preview: getPreview(state),
+    target: state.preview.target,
   };
 };
 

--- a/src/devtools/client/debugger/src/components/Editor/Preview/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/index.js
@@ -67,7 +67,7 @@ class Preview extends PureComponent {
 
   onScroll = () => {
     const { clearPreview, cx, preview } = this.props;
-    if (cx.isPaused) {
+    if (cx.isPaused && preview) {
       clearPreview(cx, preview.previewId);
     }
   };
@@ -93,7 +93,6 @@ const mapStateToProps = state => {
   return {
     cx: getThreadContext(state),
     preview: getPreview(state),
-    target: state.preview.target,
   };
 };
 

--- a/src/devtools/client/debugger/src/components/Editor/Preview/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/index.js
@@ -66,8 +66,9 @@ class Preview extends PureComponent {
   };
 
   onScroll = () => {
-    if (this.props.cx.isPaused) {
-      this.props.clearPreview(this.props.cx);
+    const { clearPreview, cx, preview } = this.props;
+    if (cx.isPaused) {
+      clearPreview(cx, preview.previewId);
     }
   };
 

--- a/src/devtools/client/debugger/src/reducers/preview.js
+++ b/src/devtools/client/debugger/src/reducers/preview.js
@@ -18,11 +18,11 @@ function update(state = initialPreviewState(), action) {
     }
 
     case "START_PREVIEW": {
-      return { ...state, previewCount: state.previewCount + 1 };
+      return { ...state, previewCount: state.previewCount + 1, preview: action.value };
     }
 
     case "SET_PREVIEW": {
-      return { ...state, preview: action.value };
+      return { ...state, target: action.value.target, preview: action.value };
     }
   }
 

--- a/src/devtools/client/debugger/src/reducers/preview.js
+++ b/src/devtools/client/debugger/src/reducers/preview.js
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { uniqueId } from "lodash";
-
-//
+import uniqueId from "lodash/uniqueId";
 
 export function initialPreviewState() {
   return {

--- a/src/devtools/client/debugger/src/reducers/preview.js
+++ b/src/devtools/client/debugger/src/reducers/preview.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+import { uniqueId } from "lodash";
+
 //
 
 export function initialPreviewState() {
@@ -13,15 +15,34 @@ export function initialPreviewState() {
 function update(state = initialPreviewState(), action) {
   switch (action.type) {
     case "CLEAR_PREVIEW": {
-      return { ...state, preview: null };
+      if (action.previewId !== state.preview?.previewId) {
+        return state;
+      }
+
+      return { preview: null };
     }
 
     case "START_PREVIEW": {
-      return { ...state, preview: action.value };
+      return {
+        preview: {
+          ...action.value,
+          previewId: uniqueId(),
+        },
+      };
     }
 
-    case "SET_PREVIEW": {
-      return { ...state, target: action.value.target, preview: action.value };
+    case "COMPLETE_PREVIEW": {
+      const { previewId, value } = action;
+      if (previewId !== state.preview?.previewId) {
+        return state;
+      }
+
+      return {
+        preview: {
+          ...state.preview,
+          ...value,
+        },
+      };
     }
   }
 

--- a/src/devtools/client/debugger/src/reducers/preview.js
+++ b/src/devtools/client/debugger/src/reducers/preview.js
@@ -7,7 +7,6 @@
 export function initialPreviewState() {
   return {
     preview: null,
-    previewCount: 0,
   };
 }
 
@@ -18,7 +17,7 @@ function update(state = initialPreviewState(), action) {
     }
 
     case "START_PREVIEW": {
-      return { ...state, previewCount: state.previewCount + 1, preview: action.value };
+      return { ...state, preview: action.value };
     }
 
     case "SET_PREVIEW": {
@@ -34,10 +33,6 @@ function update(state = initialPreviewState(), action) {
 
 export function getPreview(state) {
   return state.preview.preview;
-}
-
-export function getPreviewCount(state) {
-  return state.preview.previewCount;
 }
 
 export default update;

--- a/src/ui/utils/sanitize.ts
+++ b/src/ui/utils/sanitize.ts
@@ -18,7 +18,7 @@ const forbiddenClasses: Record<string, any> = {
   NodeBoundsFront,
 };
 
-const excludedActions = ["SET_SYMBOLS", "SET_PREVIEW"];
+const excludedActions = ["SET_SYMBOLS", "START_PREVIEW", "COMPLETE_PREVIEW"];
 
 const loggedCategories = new Set<string>();
 


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/devtools/issues/3696

Highlight tokens in the source explore immediately, which the preview loads in the background. Before the token wouldn't be highlighted until the preview loaded.

![Kapture 2021-10-27 at 15 30 55](https://user-images.githubusercontent.com/478109/139144164-4830a65e-0eee-4ff1-8b37-824182fcf74a.gif)

The easy part was splitting up the highlight rendering and the popover rendering. Unfortunately that created some unfortunate race-conditions with the existing redux flow, e.g. where things would stay highlighted in some cases after you moved the mouse away or the highlight would get cleared out from under the popover.