### PR TITLE
Allow comments on unbreakable lines

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoint.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoint.js
@@ -4,7 +4,7 @@
 
 //
 
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
 import classnames from "classnames";
 import { actions } from "ui/actions";
 import { connect } from "devtools/client/debugger/src/utils/connect";

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -143,7 +143,7 @@ function PanelSummary({
 }
 
 const connector = connect(
-  (state: UIState, { breakpoint }: { breakpoint: any }) => ({
+  (state: UIState) => ({
     currentTime: selectors.getCurrentTime(state),
   }),
   {

--- a/src/devtools/client/debugger/src/components/Editor/menus/editor.js
+++ b/src/devtools/client/debugger/src/components/Editor/menus/editor.js
@@ -51,13 +51,7 @@ const blackBoxMenuItem = (cx, selectedSource, editorActions) => ({
   click: () => editorActions.toggleBlackBox(cx, selectedSource),
 });
 
-export function editorMenuItems({
-  cx,
-  editorActions,
-  selectedSource,
-  selectionText,
-  isTextSelected,
-}) {
+export function editorMenuItems({ cx, editorActions, selectedSource }) {
   const items = [];
 
   items.push(

--- a/src/devtools/client/debugger/src/reducers/pause.d.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.d.ts
@@ -1,0 +1,3 @@
+import { UIState } from "ui/state";
+
+declare function getExecutionPoint(state: UIState): string | null;

--- a/src/ui/actions/contextMenus.ts
+++ b/src/ui/actions/contextMenus.ts
@@ -1,0 +1,28 @@
+import { Action } from "redux";
+
+export interface GutterContextMenu {
+  column: number;
+  line: number;
+  location: number;
+  sourceId: string;
+  sourceUrl: string;
+}
+
+export interface ContextMenu {
+  x: number;
+  y: number;
+  contextMenuItem: GutterContextMenu;
+}
+
+type OpenContextMenu = Action<"open_context_menu"> & { contextMenu: ContextMenu };
+type CloseContextMenu = Action<"close_context_menu">;
+
+export function openContextMenu(contextMenu: ContextMenu): OpenContextMenu {
+  return { type: "open_context_menu", contextMenu };
+}
+
+export function closeContextMenu(): CloseContextMenu {
+  return { type: "close_context_menu" };
+}
+
+export type ContextMenusAction = OpenContextMenu | CloseContextMenu;

--- a/src/ui/components/ContextMenu/GutterContextMenu.tsx
+++ b/src/ui/components/ContextMenu/GutterContextMenu.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import useAuth0 from "ui/utils/useAuth0";
+import { ContextMenu as ContextMenuType } from "ui/actions/contextMenus";
+import { ContextMenu } from "./index";
+import { Dropdown, DropdownItem } from "../Library/LibraryDropdown";
+import { UIState } from "ui/state";
+import { actions } from "ui/actions";
+import { assert } from "protocol/utils";
+import { connect, ConnectedProps } from "react-redux";
+import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
+import { selectors } from "ui/reducers";
+import { trackEvent } from "ui/utils/telemetry";
+import { useGetRecordingId } from "ui/hooks/recordings";
+import { useGetUserId } from "ui/hooks/users";
+
+export interface GutterContextMenuProps extends PropsFromRedux {
+  close: () => void;
+  contextMenu: ContextMenuType;
+}
+
+function GutterContextMenu({
+  close,
+  contextMenu,
+  createFloatingCodeComment,
+  currentTime,
+  executionPoint,
+}: GutterContextMenuProps) {
+  const { user } = useAuth0();
+  const { userId } = useGetUserId();
+  const recordingId = useGetRecordingId();
+
+  const addComment = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    trackEvent("gutter.add_comment");
+    assert(executionPoint);
+    createFloatingCodeComment(currentTime, executionPoint, { ...user, id: userId }, recordingId, {
+      location: contextMenu.contextMenuItem.location,
+    });
+    close();
+  };
+
+  return (
+    <ContextMenu close={close} x={contextMenu.x} y={contextMenu.y}>
+      <Dropdown>
+        <DropdownItem onClick={addComment}>Add comment</DropdownItem>
+      </Dropdown>
+    </ContextMenu>
+  );
+}
+
+const connector = connect(
+  (state: UIState) => ({
+    currentTime: selectors.getCurrentTime(state),
+    executionPoint: getExecutionPoint(state),
+  }),
+  {
+    createFloatingCodeComment: actions.createFloatingCodeComment,
+  }
+);
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default connector(GutterContextMenu);

--- a/src/ui/components/ContextMenu/index.tsx
+++ b/src/ui/components/ContextMenu/index.tsx
@@ -1,0 +1,21 @@
+import React, { ReactNode } from "react";
+import ReactDOM from "react-dom";
+
+export interface ContextMenuProps {
+  children: ReactNode;
+  close: () => void;
+  x: number;
+  y: number;
+}
+
+export function ContextMenu({ close, children, x, y }: ContextMenuProps) {
+  return ReactDOM.createPortal(
+    <div className="portal-dropdown-container">
+      <div className="mask" onClick={close} />
+      <div className="absolute" style={{ left: x, top: y, zIndex: 1001 }}>
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { selectors } from "ui/reducers";
 import sortBy from "lodash/sortBy";

--- a/src/ui/reducers/comments.ts
+++ b/src/ui/reducers/comments.ts
@@ -1,4 +1,4 @@
-import { CommentsState, PendingComment } from "ui/state/comments";
+import { CommentsState } from "ui/state/comments";
 import { CommentsAction } from "ui/actions/comments";
 import { UIState } from "ui/state";
 import cloneDeep from "lodash/cloneDeep";

--- a/src/ui/reducers/contextMenus.ts
+++ b/src/ui/reducers/contextMenus.ts
@@ -1,0 +1,35 @@
+import { ContextMenu, ContextMenusAction } from "ui/actions/contextMenus";
+import { UIState } from "ui/state";
+
+export interface ContextMenusState {
+  contextMenu: ContextMenu | null;
+}
+
+function initialState(): ContextMenusState {
+  return { contextMenu: null };
+}
+
+export default function update(
+  state = initialState(),
+  action: ContextMenusAction
+): ContextMenusState {
+  switch (action.type) {
+    case "open_context_menu": {
+      return {
+        ...state,
+        contextMenu: action.contextMenu,
+      };
+    }
+    case "close_context_menu": {
+      return {
+        ...state,
+        contextMenu: null,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export const getContextMenu = (state: UIState) => state.contextMenus.contextMenu;

--- a/src/ui/reducers/index.ts
+++ b/src/ui/reducers/index.ts
@@ -1,6 +1,7 @@
 import app, * as appSelectors from "./app";
 import timeline, * as timelineSelectors from "./timeline";
 import comments, * as commentsSelectors from "./comments";
+import contextMenus from "./contextMenus";
 import reactDevTools, * as reactDevToolsSelectors from "./reactDevTools";
 import * as eventListenerBreakpointsSelectors from "devtools/client/debugger/src/reducers/event-listeners";
 import debuggerReducers from "devtools/client/debugger/src/reducers";
@@ -13,6 +14,7 @@ export const reducers = {
   app,
   timeline,
   comments,
+  contextMenus,
   reactDevTools,
   ...debuggerReducers,
   ...consoleReducers.reducers,

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -11,6 +11,7 @@ import { extendStore } from "../store";
 import app from "ui/reducers/app";
 import timeline from "ui/reducers/timeline";
 import comments from "ui/reducers/comments";
+import contextMenus from "ui/reducers/contextMenus";
 import reactDevTools from "ui/reducers/reactDevTools";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
@@ -87,6 +88,7 @@ const dispatch = url.searchParams.get("dispatch") || undefined;
     app,
     timeline,
     comments,
+    contextMenus,
     reactDevTools,
     ...debuggerReducers,
     ...consoleReducers.reducers,

--- a/src/ui/state/index.ts
+++ b/src/ui/state/index.ts
@@ -1,6 +1,7 @@
 import { TimelineState } from "./timeline";
 import { AppState } from "./app";
 import { CommentsState } from "./comments";
+import { ContextMenusState } from "../reducers/contextMenus";
 import { ReactDevToolsState } from "./reactDevTools";
 import { InspectorState } from "devtools/client/inspector/state";
 import { MarkupState } from "devtools/client/inspector/markup/state/markup";
@@ -15,6 +16,7 @@ export interface UIState {
   timeline: TimelineState;
   app: AppState;
   comments: CommentsState;
+  contextMenus: ContextMenusState;
   reactDevTools: ReactDevToolsState;
   inspector: InspectorState;
   markup: MarkupState;

--- a/src/ui/utils/comments.ts
+++ b/src/ui/utils/comments.ts
@@ -4,9 +4,9 @@ import differenceInWeeks from "date-fns/differenceInWeeks";
 import differenceInMonths from "date-fns/differenceInMonths";
 import differenceInYears from "date-fns/differenceInYears";
 import { Comment, Reply } from "ui/state/comments";
+import compact from "lodash/compact";
+import range from "lodash/range";
 import sortBy from "lodash/sortBy";
-import indexOf from "lodash/indexOf";
-import { range } from "lodash";
 
 export function formatRelativeTime(date: Date) {
   const minutes = differenceInMinutes(Date.now(), date);
@@ -36,11 +36,25 @@ export function formatRelativeTime(date: Date) {
   return "Now";
 }
 
-export function commentKeys(comments: (Comment | Reply)[]): number[] {
+export function commentKeys(comments: (Comment | Reply)[]): string[] {
+  const createdAt = orderedByApproximatelyCreatedAt(comments);
+  return comments.map((c, i) => commentKey(c, createdAt[i]));
+}
+
+function commentKey(comment: Comment | Reply, createdAtOrder: number): string {
+  return compact([createdAtOrder + 1, commentIdentifiers(comment)]).join("-");
+}
+
+function orderedByApproximatelyCreatedAt(comments: (Comment | Reply)[]): number[] {
   const indices = range(comments.length);
-  const permutation = sortBy(indices, [
-    i => Number(Date.parse(comments[i].createdAt)),
-    i => comments[i].user.id,
-  ]);
+  const permutation = sortBy(indices, [i => Number(Date.parse(comments[i].createdAt))]);
   return indices.map(i => permutation.indexOf(i));
+}
+
+function commentIdentifiers(comment: Comment | Reply): string {
+  return compact([
+    comment.point,
+    comment.sourceLocation?.sourceId,
+    comment.sourceLocation?.line,
+  ]).join("-");
 }

--- a/test/ui/utils/comments.test.js
+++ b/test/ui/utils/comments.test.js
@@ -1,9 +1,10 @@
 const { commentKeys } = require("ui/utils/comments");
 
+const freezeTime = now => seconds => new Date(now - seconds * 1000).toISOString();
+
 describe("commentKeys", () => {
   test("keeps the same order even when the createdAt times changes a bit", () => {
-    const frozenNow = Date.now();
-    const secondsAgo = seconds => new Date(frozenNow - seconds * 1000).toISOString();
+    const secondsAgo = freezeTime(Date.now());
 
     const optimisticResponse = [
       { user: { id: "1" }, createdAt: secondsAgo(5) },
@@ -16,7 +17,24 @@ describe("commentKeys", () => {
       { user: { id: "1" }, createdAt: secondsAgo(14) },
     ];
 
-    expect(commentKeys(optimisticResponse)).toEqual([2, 0, 1]);
-    expect(commentKeys(serverResponse)).toEqual([2, 0, 1]);
+    // Notice the one-indexing, because 0 is falsey and sometimes that leads to subtle bugs
+    expect(commentKeys(optimisticResponse)).toEqual(["3", "1", "2"]);
+    expect(commentKeys(serverResponse)).toEqual(["3", "1", "2"]);
+  });
+
+  test("includes source location and point if present", () => {
+    const secondsAgo = freezeTime(Date.now());
+
+    const comments = [
+      { user: { id: "1" }, createdAt: secondsAgo(1), point: "1" },
+      {
+        user: { id: "1" },
+        createdAt: secondsAgo(2),
+        point: "2",
+        sourceLocation: { sourceId: "abc", line: 10 },
+      },
+    ];
+
+    expect(commentKeys(comments)).toEqual(["2-1", "1-2-abc-10"]);
   });
 });


### PR DESCRIPTION
This has been a long time coming, I kept starting this card and then getting distracted, but it's finally here! Here are the major changes:

- Add a `ContextMenus` reducers and state slice
  - This is going to be helpful as we standardize some context menus across the application. The current editor context menu is something like a roll-your-own portal, it's probably up next to be redone. I decided to go with a reducer because there should only ever be *one* context menu open, and also we need to know (across components) *where* that context menu should appear (absolutely) and *what* it should contain (usually one of several types of context menus, right now there is only `GutterContextMenu`). Of course this comes with some selectors and actions, but all of that stuff is not particularly interesting.
- Add a `ContextMenu` component - this is *very* similar to our `PortalDropdownMenu`, but that component relies on having a button to anchor to. `ContextMenu` is a bit weird because it can throw stuff anywhere on the screen.
- Change the way we generate comment keys (again). I know, I know, it's like the third time I'm making a change around here. But while developing this feature I found a subtle problem. If you are currently commenting on a line, and then you decide to comment on a *different* line, then we update that comment in redux, but the key doesn't change, because their approximate times are the same. The way to deal with this is:
  - For now, decide what makes a comment unique (in other words, if this changes, start over). Right now that is `sourceLocation` details and `point`. I've left `position` out because you can actually move comments around the screen and that is not a restart.
  - Allow users to have more than one pending comment. We don't allow this right now, but theoretically it would be totally fine, and it would give us the option *not* to smash the user's content when changing their comment (actually, we could probably do that now too, but I can't tell if it's what a user would usually want).

Future Work

- Add `Rewind to Here` and `Advance to Here` to the menu?

Closes https://github.com/RecordReplay/devtools/issues/3644

https://user-images.githubusercontent.com/5903784/139160531-b9f96055-ea8c-43dd-ad41-fe22cfee60bc.mp4



