### PR TITLE
Making the jellyfish a bit less see-through

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
         textFieldBorder: "var(--text-field-border)",
         toolbarBackground: "var(--theme-toolbar-background)",
         bodyColor: "var(--theme-body-color)",
-        jellyfish: "rgba(255,255,255,0.4)",
+        jellyfish: "rgba(255,255,255,0.8)",
         splitter: "var(--theme-splitter-color)",
       },
       lineHeight: {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9154902/139181961-4dc2b7bd-afef-4996-a264-b683f323b28a.png)

After:
![image](https://user-images.githubusercontent.com/9154902/139181937-2224dc02-7da2-43d4-9278-a74044805880.png)

By dialling this down, we get a similar effect without the usability concerns. 