### PR TITLE
Align our error screens with the Zypsy jellyfish bubble theme

### DIFF
--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -7,12 +7,12 @@ import { Recording, UserSettings } from "ui/types";
 import { LoadingScreen } from "../shared/BlankScreen";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import { trackEvent } from "ui/utils/telemetry";
-import BubbleBackground from "../shared/Onboarding/BubbleBackground";
 import Sharing, { MY_LIBRARY } from "./Sharing";
 import { Privacy, ToggleShowPrivacyButton } from "./Privacy";
 import MaterialIcon from "../shared/MaterialIcon";
 import PortalTooltip from "../shared/PortalTooltip";
 import { UploadRecordingTrialEnd } from "./UploadRecordingTrialEnd";
+import BubbleModal from "../shared/Onboarding/BubbleModal";
 const { isDemoReplay } = require("ui/utils/demo");
 
 type UploadScreenProps = { recording: Recording; userSettings: UserSettings };
@@ -181,11 +181,7 @@ export default function UploadScreen({ recording, userSettings }: UploadScreenPr
   }
 
   return (
-    <div
-      className="w-full h-full grid fixed z-50 items-center justify-center"
-      style={{ background: "#f3f3f4" }}
-    >
-      <BubbleBackground />
+    <BubbleModal>
       <div className="flex flex-col items-center relative">
         <UploadRecordingTrialEnd {...{ selectedWorkspaceId, workspaces }} />
         <form className="relative flex flex-col items-center overflow-auto" onSubmit={onSubmit}>
@@ -227,6 +223,6 @@ export default function UploadScreen({ recording, userSettings }: UploadScreenPr
           <Actions onDiscard={onDiscard} status={status} />
         </form>
       </div>
-    </div>
+    </BubbleModal>
   );
 }

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -11,10 +11,11 @@ import { getRecordingId, isDevelopment } from "ui/utils/environment";
 import hooks from "ui/hooks";
 import { useHistory } from "react-router";
 import { setModal } from "ui/actions/app";
+import { Dialog, DialogActions, DialogDescription, DialogLogo, DialogTitle } from "./Dialog";
+import { PrimaryButton } from "./Button";
+import BubbleModal from "ui/components/shared/Onboarding/BubbleModal";
 
 export function PopupBlockedError() {
-  const error = { message: "OAuth consent popup blocked" };
-
   return (
     <ExpectedErrorScreen
       error={{
@@ -35,16 +36,9 @@ function RefreshButton() {
   };
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={clicked}
-      className={classNames(
-        "w-full inline-flex items-center justify-center px-16 py-2.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
-      )}
-    >
+    <PrimaryButton className="flex-1 mx-2 justify-center" color="blue" onClick={onClick}>
       {clicked ? `Refreshing...` : `Refresh`}
-    </button>
+    </PrimaryButton>
   );
 }
 
@@ -58,15 +52,9 @@ function SignInButton() {
   };
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={classNames(
-        "w-full inline-flex items-center justify-center px-16 py-2.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
-      )}
-    >
+    <PrimaryButton color="blue" onClick={onClick}>
       Sign in to Replay
-    </button>
+    </PrimaryButton>
   );
 }
 
@@ -76,13 +64,9 @@ function LibraryButton() {
   };
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="w-full inline-flex items-center justify-center px-16 py-2.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
-    >
+    <PrimaryButton color="blue" onClick={onClick}>
       Back to Library
-    </button>
+    </PrimaryButton>
   );
 }
 
@@ -94,13 +78,9 @@ function TeamBillingButtonBase({ currentWorkspaceId, setModal }: BillingPropsFro
   };
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="w-full inline-flex items-center justify-center px-16 py-2.5 border border-transparent font-medium rounded-md text-white bg-primaryAccent hover:bg-primaryAccentHover"
-    >
+    <PrimaryButton color="blue" onClick={onClick}>
       Update Subscription
-    </button>
+    </PrimaryButton>
   );
 }
 
@@ -126,7 +106,7 @@ function ActionButton({ action }: { action: string }) {
     button = <TeamBillingButton />;
   }
 
-  return <div>{button}</div>;
+  return <div className="m-auto">{button}</div>;
 }
 
 interface ErrorProps {
@@ -162,36 +142,35 @@ function Error({ error }: ErrorProps) {
   }
 
   return (
-    <section className="max-w-lg w-full m-auto bg-white shadow-lg rounded-lg overflow-hidden text-base">
-      <div className="p-12 space-y-12 items-center flex flex-col">
-        <div className="space-y-4 place-content-center">
-          <img className="w-12 h-12 mx-auto" src="/images/logo.svg" />
-        </div>
-        <div className="text-center space-y-3">
-          {message ? <div className="font-bold text-lg">{message}</div> : null}
-          {content ? <div className="text-gray-500">{content}</div> : null}
-        </div>
-        {action ? <ActionButton action={action} /> : null}
-      </div>
-    </section>
+    <Dialog
+      className={classNames("flex flex-col items-center")}
+      style={{ animation: "dropdownFadeIn ease 200ms", width: 400 }}
+    >
+      <DialogLogo />
+      <DialogTitle>{message}</DialogTitle>
+      {content && <DialogDescription>{content}</DialogDescription>}
+      {action ? (
+        <DialogActions>
+          <ActionButton action={action} />
+        </DialogActions>
+      ) : null}
+    </Dialog>
   );
 }
 
 function ExpectedErrorScreen({ error }: { error: ExpectedError }) {
   return (
-    <BlankScreen className="absolute z-10">
-      <Modal>
-        <Error error={error} />
-      </Modal>
-    </BlankScreen>
+    <BubbleModal>
+      <Error error={error} />
+    </BubbleModal>
   );
 }
 
 function UnexpectedErrorScreen({ error }: { error: UnexpectedError }) {
   return (
-    <Modal options={{ maskTransparency: "translucent" }}>
+    <BubbleModal>
       <Error error={error} />
-    </Modal>
+    </BubbleModal>
   );
 }
 

--- a/src/ui/components/shared/Onboarding/BubbleModal.tsx
+++ b/src/ui/components/shared/Onboarding/BubbleModal.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { ReactNode } from "react";
 
-export default function BubbleBackground() {
+export function BubbleBackground() {
   return (
     <div className="w-full h-full absolute">
       <div className="absolute">
@@ -17,6 +17,18 @@ export default function BubbleBackground() {
           style={{ width: "75vw" }}
         />
       </div>
+    </div>
+  );
+}
+
+export default function BubbleModal({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="w-full h-full grid fixed z-50 items-center justify-center"
+      style={{ background: "#f3f3f4" }}
+    >
+      <BubbleBackground />
+      <div className="relative">{children}</div>
     </div>
   );
 }

--- a/src/ui/components/shared/Onboarding/index.tsx
+++ b/src/ui/components/shared/Onboarding/index.tsx
@@ -11,7 +11,7 @@ import { actions } from "ui/actions";
 import { PrimaryLgButton } from "../Button";
 import Modal from "../NewModal";
 import ReplayLogo from "../ReplayLogo";
-import BubbleBackground from "./BubbleBackground";
+import { BubbleBackground } from "./BubbleModal";
 
 const OnboardingContext = React.createContext({ theme: "dark" });
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15959269/139291260-b64c3485-c384-4f9f-a43d-1b39bc81c46a.png)

Should be noted that before we made a distinction between unexpected errors (errors where a refresh _might_ dot eh trick, so we showed a transparent background so it didn't feel too heavy), and expected errors (errors where refreshes won't do the trick, so a solid background was more appropriate). This ends up treating both cases with the same bubbly visuals. Seems okay for now but let's give it a few weeks to see how it feels.

This one's hard to play with because the error UI is different in development vs production. If you pull it down, I recommend commenting out the `if (isDevelopment)` block in `Error.tsx`.

Good thing to run in the console to see what the error looks like:
```
app.store.dispatch({type: "set_expected_error", error: {
  message: "Unexpected error",
  content: "An unexpected error occurred. Please refresh the page.",
  action: "refresh",
}})
```