### PR TITLE
Log a warning to the console when the recording contains too many con…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@auth0/auth0-react": "^1.2.0",
         "@headlessui/react": "^1.4.1",
         "@heroicons/react": "^1.0.1",
-        "@recordreplay/protocol": "^0.10.0",
+        "@recordreplay/protocol": "^0.13.0",
         "@sentry/react": "^6.8.0",
         "@sentry/tracing": "^6.8.0",
         "@stripe/react-stripe-js": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@auth0/auth0-react": "^1.2.0",
     "@headlessui/react": "^1.4.1",
     "@heroicons/react": "^1.0.1",
-    "@recordreplay/protocol": "^0.10.0",
+    "@recordreplay/protocol": "^0.13.0",
     "@sentry/react": "^6.8.0",
     "@sentry/tracing": "^6.8.0",
     "@stripe/react-stripe-js": "^1.4.1",

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -777,7 +777,11 @@ class _ThreadFront {
   async findConsoleMessages(onConsoleMessage: (pause: Pause, message: Message) => void) {
     const sessionId = await this.waitForSession();
 
-    client.Console.findMessages({}, sessionId);
+    client.Console.findMessages({}, sessionId).then(({ overflow }) => {
+      if (overflow) {
+        console.warn("Too many console messages, not all will be shown");
+      }
+    });
     client.Console.addNewMessageListener(async ({ message }) => {
       await this.ensureAllSources();
       const pause = new Pause(sessionId);


### PR DESCRIPTION
…sole messages

This is associated with https://github.com/RecordReplay/backend/pull/3367, which will set this flag in Console.findMessages command results when the recording had too many console messages to return all of them.