### PR TITLE
remove showHelper

### DIFF
--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -75,7 +75,6 @@ function CommentTool({
   setPendingComment,
   createFrameComment,
 }: CommentToolProps) {
-  const [showHelper, setShowHelper] = useState(false);
   const [mousePosition, setMousePosition] = useState<Coordinates | null>(null);
   const recordingId = useGetRecordingId();
   const { user } = useAuth0();
@@ -88,7 +87,6 @@ function CommentTool({
     if (videoNode) {
       videoNode.classList.add("location-marker");
       videoNode.addEventListener("mouseup", onClickInCanvas);
-      videoNode.addEventListener("mouseenter", onMouseEnter);
       videoNode.addEventListener("mousemove", onMouseMove);
       videoNode.addEventListener("mouseleave", onMouseLeave);
     }
@@ -99,7 +97,6 @@ function CommentTool({
     if (videoNode) {
       videoNode.classList.remove("location-marker");
       videoNode.removeEventListener("mouseup", onClickInCanvas);
-      videoNode.removeEventListener("mouseenter", onMouseEnter);
       videoNode.removeEventListener("mousemove", onMouseMove);
       videoNode.removeEventListener("mouseleave", onMouseLeave);
     }
@@ -130,12 +127,8 @@ function CommentTool({
       setPendingComment(newComment);
     }
   };
-  const onMouseEnter = () => {
-    setShowHelper(true);
-  };
   const onMouseMove = (e: MouseEvent) => setMousePosition(mouseEventCanvasPosition(e));
   const onMouseLeave = () => {
-    setShowHelper(false);
     setMousePosition(null);
   };
 
@@ -147,7 +140,6 @@ function CommentTool({
   }, [currentTime, executionPoint, pendingComment, comments]);
 
   if (
-    !showHelper ||
     !mousePosition ||
     pendingComment?.type === "edit_reply" ||
     pendingComment?.type === "new_reply"


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/devtools/issues/4132

Stared at this for long enough and finally realized we don't need `showHelper` or `onMouseEnter` at all.

The presence or absence of `mousePosition` implies the same info should be more resilient to the occasional dropped event since there's no shortage of mousemoves.

Replay: https://app.replay.io/recording/960e7a8e-aac2-4407-8555-4e5c2631c328