### PR TITLE
use the keyboard to interact with the confirmation dialogs

### DIFF
--- a/src/ui/components/shared/Button.tsx
+++ b/src/ui/components/shared/Button.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React from "react";
+import React, { forwardRef } from "react";
 
 type ButtonSizes = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl";
 type ButtonStyles = "primary" | "secondary" | "disabled";
@@ -74,19 +74,14 @@ export function getButtonClasses(color: Colors, style: ButtonStyles, size: Butto
   return classNames(standardClasses, colorClasses, focusClasses);
 }
 
-export function Button({
-  size,
-  children,
-  style,
-  color,
-  className,
-  onClick = () => {},
-  type,
-}: ButtonProps & {
-  color: Colors;
-  size: ButtonSizes;
-  style: ButtonStyles;
-}) {
+export const Button = forwardRef<
+  HTMLButtonElement,
+  ButtonProps & {
+    color: Colors;
+    size: ButtonSizes;
+    style: ButtonStyles;
+  }
+>(({ size, children, style, color, className, onClick = () => {}, type }, ref) => {
   const buttonClasses = getButtonClasses(color, style, size);
 
   return (
@@ -94,12 +89,14 @@ export function Button({
       onClick={onClick}
       disabled={style === "disabled"}
       className={classNames(buttonClasses, className)}
+      ref={ref}
       type={type}
     >
       {children}
     </button>
   );
-}
+});
+Button.displayName = "Button";
 
 interface ButtonProps {
   children?: React.ReactNode;

--- a/src/ui/components/shared/Confirm/ConfirmDialog.tsx
+++ b/src/ui/components/shared/Confirm/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { PrimaryButton, SecondaryButton } from "../Button";
+import { Button, PrimaryButton, SecondaryButton } from "../Button";
 import {
   Dialog,
   DialogActions,
@@ -7,7 +7,7 @@ import {
   DialogPropTypes,
   DialogTitle,
 } from "../Dialog";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import classNames from "classnames";
 
 export type ConfirmOptions = {
@@ -33,10 +33,28 @@ export const ConfirmDialog = ({
   onDecline,
   ...props
 }: PropTypes) => {
+  const primaryButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const prevActiveElement = document.activeElement;
+    primaryButtonRef.current?.focus();
+    return () => {
+      if (prevActiveElement instanceof HTMLElement) {
+        prevActiveElement.focus();
+      }
+    };
+  }, []);
+
   return (
     <Dialog
       {...props}
       className={classNames("flex flex-col items-center", className)}
+      onKeyUp={evt => {
+        if (evt.key === "Escape") {
+          evt.stopPropagation();
+          onDecline();
+        }
+      }}
       style={{ animation: "dropdownFadeIn ease 200ms", width: 400 }}
     >
       <DialogLogo />
@@ -46,13 +64,16 @@ export const ConfirmDialog = ({
         <SecondaryButton color="blue" className="flex-1 mx-3 justify-center" onClick={onDecline}>
           {declineLabel}
         </SecondaryButton>
-        <PrimaryButton
+        <Button
           className="flex-1 mx-2 justify-center"
           color={isDestructive ? "pink" : "blue"}
           onClick={onAccept}
+          ref={primaryButtonRef}
+          size="md"
+          style="primary"
         >
           {acceptLabel}
-        </PrimaryButton>
+        </Button>
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
In working through https://github.com/RecordReplay/devtools/issues/4042 I got kind of annoyed that the dialog did have focus for keyboarding.

This adds the basics for dialogs.
1. focuses the primary action when the dialog opens
2. restores focus to the previously focused element when the dialog closes
3. closes when you press escape

![Kapture 2021-10-28 at 17 21 26](https://user-images.githubusercontent.com/478109/139337543-a46d3103-ea22-4d98-b14e-407f4ccddcfb.gif)


Replay: https://app.replay.io/recording/41a5ea12-b8cf-4e81-b3ac-3a4a1d864059