### PR TITLE
protocol: make dispatch URL a build time variable

### DIFF
--- a/src/protocol/socket.ts
+++ b/src/protocol/socket.ts
@@ -48,7 +48,7 @@ window.addEventListener("beforeunload", () => {
   willClose = true;
 });
 
-export function initSocket(store: UIStore, address?: string) {
+export function initSocket(store: UIStore, address: string) {
   if (isMock()) {
     waitForMockEnvironment().then(env => {
       env!.setOnSocketMessage(onSocketMessage as any);
@@ -57,7 +57,7 @@ export function initSocket(store: UIStore, address?: string) {
     return;
   }
 
-  socket = new WebSocket(address || "wss://dispatch.replay.io");
+  socket = new WebSocket(address);
 
   socket.onopen = makeInfallible(onSocketOpen);
   socket.onclose = makeInfallible(() => store.dispatch(onSocketClose()));

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -38,6 +38,7 @@ import { DevToolsToolbox } from "ui/utils/devtools-toolbox";
 import { asyncStore } from "ui/utils/prefs";
 import { getUserSettings } from "ui/hooks/settings";
 import { initialMessageState } from "devtools/client/webconsole/reducers/messages";
+import { assert } from "protocol/utils";
 const { LocalizationHelper } = require("devtools/shared/l10n");
 const { setupDemo } = require("ui/utils/demo");
 
@@ -59,7 +60,8 @@ declare global {
 }
 
 const url = new URL(window.location.href);
-const dispatch = url.searchParams.get("dispatch") || undefined;
+const dispatchUrl = url.searchParams.get("dispatch") || process.env.DISPATCH_URL;
+assert(dispatchUrl);
 
 (async () => {
   window.gToolbox = new DevToolsToolbox();
@@ -105,7 +107,7 @@ const dispatch = url.searchParams.get("dispatch") || undefined;
   dbgClient.bootstrap(store);
 
   // Initialize the socket so we can communicate with the server
-  initSocket(store, dispatch);
+  initSocket(store, dispatchUrl);
 
   addEventListener("Recording.uploadedData", (data: uploadedData) =>
     store.dispatch(actions.onUploadedData(data))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = {
     new webpack.EnvironmentPlugin({
       REPLAY_RELEASE: null,
       API_URL: "https://api.replay.io/v1/graphql",
+      DISPATCH_URL: "wss://dispatch.replay.io",
     }),
     new CopyPlugin({
       patterns: [


### PR DESCRIPTION
It can still be overridden with a URL param, but this paves the way for
the world that Ryan and I talked about going to earlier today where
everything is a build time variable. Here's what that would look like:

* For local dev build on-demand frontends that are configured to talk
the appropriate backend services
* For tests I'm not sure what to do, probably will involve generating
frontends that are configured to talk to the appropriate backend ahead
of time.
* For frontend folks nothing changes, they already don't typically
need to adjust these variables

Once we figure out the test case we can remove the URL override.