### PR TITLE
remove comment auto focus

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -125,14 +125,6 @@ function CommentCard({
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
 
-  useEffect(() => {
-    // If _this_ comment is the pending comment, but it isn't focused, focus it!
-    // That will maintain the comment editor's focus when you reposition the marker.
-    if (!isFocused && pendingComment?.comment.id === comment.id) {
-      setIsFocused(true);
-    }
-  }, [comment, isFocused, pendingComment]);
-
   const replyKeys = commentKeys(comment.replies);
 
   if (comment.id === PENDING_COMMENT_ID) {


### PR DESCRIPTION
@jcmorrow pointed out that its now impossible to _un_ -focus a comment box once its open 🤦 

https://cdn.discordapp.com/attachments/900416856366669847/903422927163248730/CleanShot_2021-10-28_at_16.19.48.mp4

Reverting for now, will find a different solution in the AM.