### PR TITLE
Reload the app when navigating back to the library (#3879)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,7 @@ require("ui/utils/whatwg-url-fix");
 const React = require("react");
 const ReactDOM = require("react-dom");
 const { BrowserRouter: Router, Route, Switch } = require("react-router-dom");
+const { InstallRouteListener } = require("ui/utils/routeListener");
 import "devtools/client/debugger/src/components/variables.css";
 import "devtools/client/themes/variables.css";
 
@@ -46,6 +47,7 @@ ReactDOM.render(
     fallback={<BlankProgressScreen statusMessage="Fetching data" background="white" />}
   >
     <Router>
+      <InstallRouteListener />
       <Switch>
         <Route path={maintenanceMode ? "/" : "/maintenance"} component={MaintenanceModeScreen} />
         <Route exact path="/browser/error" component={BrowserError} />

--- a/src/ui/utils/routeListener.tsx
+++ b/src/ui/utils/routeListener.tsx
@@ -1,0 +1,17 @@
+import { useHistory } from "react-router";
+
+let listenerInstalled = false;
+let currentRoute = window.location.pathname;
+
+export function InstallRouteListener() {
+  const history = useHistory();
+  if (!listenerInstalled) {
+    history.listen((location, action) => {
+      const newRoute = location.pathname;
+      if (currentRoute.startsWith("/recording/") && newRoute === "/") {
+        window.location.reload();
+      }
+      currentRoute = newRoute;
+    });
+  }
+}


### PR DESCRIPTION
This is just a temporary workaround for #3879 (because the proper fix takes a bit longer than I anticipated): we install a listener for the router and when the route changes from `/recording/...` to `/`, it reloads the app.
Replay: https://app.replay.io/recording/4645c176-3844-4e6d-932c-d5588149e9c6
Note that I could sometimes see a little flicker (the LoadingScreen or the Library would show up for a split second before reloading), but I think that's OK for a temporary workaround.
