### PR TITLE
Fix moving recordings from the library

### DIFF
--- a/src/ui/components/Library/MoveRecordingMenu.tsx
+++ b/src/ui/components/Library/MoveRecordingMenu.tsx
@@ -19,7 +19,8 @@ function MoveRecordingMenu({
   workspaces,
 }: RecordingOptionsDropdownProps) {
   const { workspace, loading } = hooks.useGetWorkspace(currentWorkspaceId || "");
-  if (loading || !workspace?.subscription || subscriptionExpired(workspace)) return null;
+  if (loading || (workspace && (!workspace?.subscription || subscriptionExpired(workspace))))
+    return null;
 
   return (
     <>


### PR DESCRIPTION
## Issue

#4049 suppressed the move dropdown for expired teams but inadvertently also for the Library

## Resolution

Only block if there is a current workspace and that workspace has expired