### PR TITLE
Expand input and focus on mouseDown

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -133,7 +133,7 @@ function CommentCard({
         className={`mx-auto w-full group border-b border-gray-300 cursor-pointer transition bg-gray-50`}
         onMouseEnter={() => setHoveredComment(PENDING_COMMENT_ID)}
         onMouseLeave={() => setHoveredComment(null)}
-        onClick={() => {
+        onMouseDown={() => {
           trackEvent("comments.focus");
           setIsFocused(true);
         }}
@@ -163,18 +163,21 @@ function CommentCard({
         `mx-auto relative w-full border-b border-gray-300 cursor-pointer transition`,
         hoveredComment === comment.id ? "bg-toolbarBackground" : "bg-white"
       )}
-      onClick={() => {
-        seekToComment(comment);
-        setIsEditorOpen(true);
-        setIsFocused(true);
+      onMouseDown={e => {
+        if (e.button === 0) {
+          seekToComment(comment);
+          setIsEditorOpen(true);
+          setIsFocused(true);
+        }
       }}
       onMouseEnter={() => setHoveredComment(comment.id)}
       onMouseLeave={() => setHoveredComment(null)}
     >
       <BorderBridge {...{ comments, comment, isPaused }} />
       <div
-        className={classNames("py-2.5 w-full border-l-2 border-transparent px-2.5 pl-2 space-y-2", {
+        className={classNames("p-2.5 pl-2 space-y-2 border-l-2", {
           "border-secondaryAccent": isPaused,
+          "border-transparent": !isPaused,
         })}
       >
         {comment.sourceLocation ? <CommentSource comment={comment} /> : null}


### PR DESCRIPTION
Using onClick gets a little funky when content is moving, because it's
possible for content to move out of the way either as other content
blurs (in this case) or (more commonly) when the thing you are clicking
becomes `:active`. Moving to an `onMouseDown` where we also check that
it's a left click solves the issue. I think a longer-term solution will
probably come soon with resolution to
https://github.com/RecordReplay/devtools/discussions/4227, but this
fixes https://github.com/RecordReplay/devtools/issues/4229 for now.

Also, clean up some styles :)

### Before

https://user-images.githubusercontent.com/5903784/139475519-29f52182-cdc4-49f3-bb2e-d26a85c67039.mp4


### After

https://user-images.githubusercontent.com/5903784/139475312-8fb55276-a611-4af8-8005-96be2ee4445b.mp4



