### PR TITLE
Track comment changes in Redux

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -4,7 +4,7 @@ import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
 import { UIState } from "ui/state";
 import hooks from "ui/hooks";
-import { Comment, isReply, PendingComment, Remark, Reply } from "ui/state/comments";
+import { Comment, PendingComment, Reply } from "ui/state/comments";
 
 import "./CommentEditor.css";
 import { User } from "ui/types";

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -4,13 +4,24 @@ import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
 import { UIState } from "ui/state";
 import hooks from "ui/hooks";
-import { Comment, Reply } from "ui/state/comments";
+import { Comment, isReply, PendingComment, Remark, Reply } from "ui/state/comments";
 
 import "./CommentEditor.css";
 import { User } from "ui/types";
 import TipTapEditor from "./TipTapEditor";
 import { FocusContext } from "../CommentCard";
 import classNames from "classnames";
+
+/**
+ * Updates the `content` field of a Reply or Comment in such a way that
+ * TypeScript doesn't complain at you.
+ */
+function updateCommentContent<P extends PendingComment>(pending: P, content: string): P {
+  return {
+    ...pending,
+    comment: { ...pending.comment, content },
+  };
+}
 
 type CommentEditorProps = PropsFromRedux & {
   comment: Comment | Reply;
@@ -37,22 +48,12 @@ function CommentEditor({
     [loading]
   );
 
-  const handleBlur = (text: string) => {
-    if (
-      !pendingComment ||
-      pendingComment.type !== "new_comment" ||
-      text === pendingComment.comment.content
-    ) {
-      return;
+  const handleBlur = (nextContent: string) => {
+    const prevContent = pendingComment?.comment.content || "";
+    if (pendingComment && nextContent !== prevContent) {
+      setPendingComment(updateCommentContent(pendingComment, nextContent));
     }
 
-    setPendingComment({
-      ...pendingComment,
-      comment: {
-        ...pendingComment.comment,
-        content: text,
-      },
-    });
     blur();
   };
 

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -23,6 +23,8 @@ function CommentEditor({
   comment,
   editable,
   handleSubmit,
+  pendingComment,
+  setPendingComment,
 }: CommentEditorProps) {
   const recordingId = hooks.useGetRecordingId();
   const { collaborators, recording, loading } = hooks.useGetOwnersAndCollaborators(recordingId!);
@@ -35,6 +37,25 @@ function CommentEditor({
     [loading]
   );
 
+  const handleBlur = (text: string) => {
+    if (
+      !pendingComment ||
+      pendingComment.type !== "new_comment" ||
+      text === pendingComment.comment.content
+    ) {
+      return;
+    }
+
+    setPendingComment({
+      ...pendingComment,
+      comment: {
+        ...pendingComment.comment,
+        content: text,
+      },
+    });
+    blur();
+  };
+
   return (
     <div className="comment-input-container">
       <div className={classNames("comment-input")}>
@@ -42,7 +63,7 @@ function CommentEditor({
           {({ autofocus, blur, close, isFocused }) => (
             <TipTapEditor
               autofocus={autofocus}
-              blur={blur}
+              blur={handleBlur}
               close={close}
               content={comment.content || ""}
               editable={editable}
@@ -73,7 +94,7 @@ const connector = connect(
   (state: UIState) => ({
     pendingComment: selectors.getPendingComment(state),
   }),
-  { clearPendingComment: actions.clearPendingComment }
+  { clearPendingComment: actions.clearPendingComment, setPendingComment: actions.setPendingComment }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(CommentEditor);

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
-import { Editor as EditorType } from "@tiptap/core";
-import { useEditor, EditorContent, Extension, Editor } from "@tiptap/react";
+import { Editor } from "@tiptap/core";
+import { useEditor, EditorContent, Extension } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { User } from "ui/types";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -22,7 +22,7 @@ interface TipTapEditorProps {
   takeFocus: boolean;
 }
 
-const getContent = (editor: EditorType) => {
+const getContent = (editor: Editor) => {
   const charCount = editor.getCharacterCount();
   if (charCount === 0) {
     return "";

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
-import { useEditor, EditorContent, Extension } from "@tiptap/react";
+import { Editor as EditorType } from "@tiptap/core";
+import { useEditor, EditorContent, Extension, Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { User } from "ui/types";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -9,7 +10,7 @@ import { ReplayLink } from "./replayLink";
 
 interface TipTapEditorProps {
   autofocus: boolean;
-  blur: () => void;
+  blur: (text: string) => void;
   close: () => void;
   content: string;
   editable: boolean;
@@ -20,6 +21,14 @@ interface TipTapEditorProps {
   possibleMentions: User[];
   takeFocus: boolean;
 }
+
+const getContent = (editor: EditorType) => {
+  const charCount = editor.getCharacterCount();
+  if (charCount === 0) {
+    return "";
+  }
+  return JSON.stringify(editor.getJSON());
+};
 
 const tryToParse = (content: string): any => {
   try {
@@ -58,14 +67,16 @@ const TipTapEditor = ({
         addKeyboardShortcuts() {
           return {
             "Cmd-Enter": ({ editor }) => {
-              handleSubmit(JSON.stringify(editor.getJSON()));
-              blur();
+              const content = getContent(editor);
+              handleSubmit(content);
+              blur(content);
               close();
               return true;
             },
             Enter: ({ editor }) => {
-              handleSubmit(JSON.stringify(editor.getJSON()));
-              blur();
+              const content = getContent(editor);
+              handleSubmit(content);
+              blur(content);
               close();
               return true;
             },
@@ -119,8 +130,9 @@ const TipTapEditor = ({
         })}
         editor={editor}
         onBlur={() => {
-          blur();
-          if ((editor?.getCharacterCount() || 0) === 0) {
+          const content = editor ? getContent(editor) : "";
+          blur(content);
+          if (!content) {
             close();
           }
         }}

--- a/src/ui/state/comments.ts
+++ b/src/ui/state/comments.ts
@@ -42,14 +42,6 @@ export interface Reply extends Remark {
   parentId: string;
 }
 
-export function isComment(maybeComment: Comment | Reply): maybeComment is Comment {
-  return "replies" in maybeComment;
-}
-
-export function isReply(maybeReply: Comment | Reply): maybeReply is Reply {
-  return "parentId" in maybeReply;
-}
-
 export type PendingComment =
   | {
       comment: Comment;

--- a/src/ui/state/comments.ts
+++ b/src/ui/state/comments.ts
@@ -42,6 +42,14 @@ export interface Reply extends Remark {
   parentId: string;
 }
 
+export function isComment(maybeComment: Comment | Reply): maybeComment is Comment {
+  return "replies" in maybeComment;
+}
+
+export function isReply(maybeReply: Comment | Reply): maybeReply is Reply {
+  return "parentId" in maybeReply;
+}
+
 export type PendingComment =
   | {
       comment: Comment;


### PR DESCRIPTION
In https://github.com/RecordReplay/devtools/issues/4042, we want to show a confirmation dialog if the user takes an action that would delete a comment they started writing. However, we don't want to show a prompt if they haven't typed anything yet.

The problem right now is that only the CommentEditor has the in progress comment's state, but the comment can be clear from many different places (e.g. [in the Timeline](https://github.com/RecordReplay/devtools/blob/386715395a9caf8d07ac62ae622d67d09bb17fdd/src/ui/components/Timeline/index.tsx#L166-L171)).

This change updates `pendingComment.comment.content` in the redux store when the comment editor loses focus. That way my next PR will be able to check if a comment has any content before prompting the user about deleting it.

In my thinking and testing, it seems to work ok, but obviously my knowledge is still pretty limited thoughts are very much welcome.