### PR TITLE
fix upexpected prop warning

### DIFF
--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -1,6 +1,6 @@
 import classnames from "classnames";
 import React from "react";
-import { connect, ConnectedProps } from "react-redux";
+import { connect, ConnectedProps, useSelector } from "react-redux";
 import * as selectors from "ui/reducers/app";
 import { UIState } from "ui/state";
 import "./MaterialIcon.css";
@@ -14,24 +14,23 @@ const SIZE_STYLES = {
   "2xl": "text-2xl",
 };
 
-type MaterialIconProps = PropsFromRedux &
-  React.HTMLProps<HTMLDivElement> & {
-    children: string;
-    outlined?: boolean;
-    // tailwind text color style, e.g. text-white, text-blue-200
-    color?: string;
-    iconSize?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl";
-  };
+type MaterialIconProps = React.HTMLProps<HTMLDivElement> & {
+  children: string;
+  outlined?: boolean;
+  // tailwind text color style, e.g. text-white, text-blue-200
+  color?: string;
+  iconSize?: keyof typeof SIZE_STYLES;
+};
 
-function MaterialIcon({
+export default function MaterialIcon({
   children,
-  fontLoading,
   className,
   outlined,
   color,
   iconSize = "base",
   ...rest
 }: MaterialIconProps) {
+  const fontLoading = useSelector((state: UIState) => selectors.getFontLoading(state));
   return (
     <div
       {...rest}
@@ -49,8 +48,3 @@ function MaterialIcon({
     </div>
   );
 }
-
-const connector = connect((state: UIState) => ({ fontLoading: selectors.getFontLoading(state) }));
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export default connector(MaterialIcon);


### PR DESCRIPTION
This might be related to #4231 or maybe it was happening before 🤷 

Some redux props were getting passed to a `<div>` and generating some warnings.

![Screen Shot 2021-10-29 at 1 37 50 PM](https://user-images.githubusercontent.com/478109/139478773-adf22d61-0f24-4eb0-aa62-b582d73cf073.png)

See the warning in this replay: https://app.replay.io/recording/8f10b8d8-77d1-46c0-b640-957f803108fb

Since it was a simple one, I switched `MaterialIcon` to the `useSelector` hook, so we don't have to worry about those other props sneaking through.