### PR TITLE
Use onmousedown over onclick for moving content

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.css
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.css
@@ -84,3 +84,8 @@
   pointer-events: none;
   height: 0;
 }
+
+.ProseMirror {
+  word-wrap: break-word;
+  white-space: break-spaces;
+}

--- a/src/ui/components/shared/PortalDropdown.tsx
+++ b/src/ui/components/shared/PortalDropdown.tsx
@@ -26,9 +26,11 @@ export default function PortalDropdown(props: PortalDropdownProps) {
   );
 
   const expand = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-    props.setExpanded(true);
+    if (e.button === 0) {
+      e.stopPropagation();
+      e.preventDefault();
+      props.setExpanded(true);
+    }
   };
   const collapse = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -52,7 +54,7 @@ export default function PortalDropdown(props: PortalDropdownProps) {
       <button
         type="button"
         className={`expand-dropdown w-full ${buttonStyle}`}
-        onClick={expand}
+        onMouseDown={expand}
         ref={buttonRef}
       >
         {buttonContent}


### PR DESCRIPTION
This is a follow-up to f7b55d03d2a568fd7ed6efedb59ba5bccaf11483. As @colbyr spotted, there are other click targets that can move in response to a reply box disappearing.

### Before (you can get all *kinds* of behavior with this thing)

https://user-images.githubusercontent.com/5903784/139486587-d8e0e41d-c888-4afb-a438-b718581da715.mp4

### After (better!)

https://user-images.githubusercontent.com/5903784/139486697-4d717520-86f7-4559-852e-d4c891351f74.mp4

### What's up with the CSS change?

You wanna see some crazy stuff? (watch Shawn Presser's comment):

https://user-images.githubusercontent.com/5903784/139487007-4d6e4225-7702-4937-a351-06d8c6e023ac.mp4

Spooky 👻 

Apparently Prosemirror will add or remove a little bit of CSS depending on whether or not there is an active editor on screen . I've added that CSS permanently to our editor.css to keep it consistent.