### PR TITLE
Avoid reload after uploading recording

### DIFF
--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -15,7 +15,7 @@ import PortalTooltip from "../shared/PortalTooltip";
 import { UploadRecordingTrialEnd } from "./UploadRecordingTrialEnd";
 const { isDemoReplay } = require("ui/utils/demo");
 
-type UploadScreenProps = { recording: Recording; userSettings: UserSettings };
+type UploadScreenProps = { recording: Recording; userSettings: UserSettings; onUpload: () => void };
 type Status = "saving" | "deleting" | "deleted" | null;
 
 function DeletedScreen({ url }: { url: string }) {
@@ -121,7 +121,7 @@ function ReplayScreenshot({
   );
 }
 
-export default function UploadScreen({ recording, userSettings }: UploadScreenProps) {
+export default function UploadScreen({ recording, userSettings, onUpload }: UploadScreenProps) {
   const recordingId = useGetRecordingId();
   // This is pre-loaded in the parent component.
   const { screenData, loading: loading1 } = hooks.useGetRecordingPhoto(recordingId!);
@@ -165,6 +165,7 @@ export default function UploadScreen({ recording, userSettings }: UploadScreenPr
       variables: { recordingId, title: inputValue, workspaceId },
     });
     updateIsPrivate({ variables: { recordingId, isPrivate: !isPublic } });
+    onUpload();
   };
   const onDiscard = () => {
     setStatus("deleting");

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -143,9 +143,8 @@ export function useGetRecording(
   recording: Recording | undefined;
   isAuthorized: boolean;
   loading: boolean;
-  refetch: () => void;
 } {
-  const { data, error, loading, refetch } = useQuery(GET_RECORDING, {
+  const { data, error, loading } = useQuery(GET_RECORDING, {
     variables: { recordingId },
     skip: !recordingId,
   });
@@ -158,7 +157,7 @@ export function useGetRecording(
   // Tests don't have an associated user so we just let it bypass the check here.
   const isAuthorized = isTest() || recording;
 
-  return { recording, isAuthorized: !!isAuthorized, loading, refetch };
+  return { recording, isAuthorized: !!isAuthorized, loading };
 }
 
 export function useIsTeamDeveloper() {

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -139,8 +139,13 @@ export async function getRecording(recordingId: RecordingId) {
 
 export function useGetRecording(
   recordingId: RecordingId | null | undefined
-): { recording: Recording | undefined; isAuthorized: boolean; loading: boolean } {
-  const { data, error, loading } = useQuery(GET_RECORDING, {
+): {
+  recording: Recording | undefined;
+  isAuthorized: boolean;
+  loading: boolean;
+  refetch: () => void;
+} {
+  const { data, error, loading, refetch } = useQuery(GET_RECORDING, {
     variables: { recordingId },
     skip: !recordingId,
   });
@@ -153,7 +158,7 @@ export function useGetRecording(
   // Tests don't have an associated user so we just let it bypass the check here.
   const isAuthorized = isTest() || recording;
 
-  return { recording, isAuthorized: !!isAuthorized, loading };
+  return { recording, isAuthorized: !!isAuthorized, loading, refetch };
 }
 
 export function useIsTeamDeveloper() {

--- a/src/views/recording.tsx
+++ b/src/views/recording.tsx
@@ -11,6 +11,7 @@ import DevTools from "ui/components/DevTools";
 function Recording({ getAccessibleRecording }: PropsFromRedux) {
   const recordingId = useGetRecordingId();
   const [recording, setRecording] = useState<RecordingInfo | null>();
+  const [uploadComplete, setUploadComplete] = useState(false);
   useEffect(() => {
     async function getRecording() {
       setRecording(await getAccessibleRecording(recordingId));
@@ -25,8 +26,8 @@ function Recording({ getAccessibleRecording }: PropsFromRedux) {
   // Add a check to make sure the recording has an associated user ID.
   // We skip the upload step if there's no associated user ID, which
   // is the case for CI test recordings.
-  if (recording.isInitialized === false && !isTest() && recording.userId) {
-    return <Upload />;
+  if (!uploadComplete && recording.isInitialized === false && !isTest() && recording.userId) {
+    return <Upload onUpload={() => setUploadComplete(true)} />;
   } else {
     return <DevTools />;
   }

--- a/src/views/upload.tsx
+++ b/src/views/upload.tsx
@@ -4,16 +4,16 @@ import { useGetUserSettings } from "ui/hooks/settings";
 import BlankScreen, { LoadingScreen } from "ui/components/shared/BlankScreen";
 import UploadScreen from "ui/components/UploadScreen";
 
-function UploadScreenWrapper() {
+function UploadScreenWrapper({ onUpload }: { onUpload: () => void }) {
   const recordingId = useGetRecordingId();
-  const { recording } = useGetRecording(recordingId);
+  const { recording, refetch } = useGetRecording(recordingId);
   // Make sure to get the user's settings before showing the upload screen.
   const { userSettings, loading } = useGetUserSettings();
 
   useEffect(() => {
     if (recording?.isInitialized) {
       window.onbeforeunload = null;
-      document.location.reload();
+      refetch();
     }
   });
 
@@ -21,7 +21,11 @@ function UploadScreenWrapper() {
     return <LoadingScreen />;
   }
 
-  return recording ? <UploadScreen {...{ userSettings, recording }} /> : <BlankScreen />;
+  return recording ? (
+    <UploadScreen userSettings={userSettings} recording={recording} onUpload={onUpload} />
+  ) : (
+    <BlankScreen />
+  );
 }
 
 export default UploadScreenWrapper;

--- a/src/views/upload.tsx
+++ b/src/views/upload.tsx
@@ -6,14 +6,13 @@ import UploadScreen from "ui/components/UploadScreen";
 
 function UploadScreenWrapper({ onUpload }: { onUpload: () => void }) {
   const recordingId = useGetRecordingId();
-  const { recording, refetch } = useGetRecording(recordingId);
+  const { recording } = useGetRecording(recordingId);
   // Make sure to get the user's settings before showing the upload screen.
   const { userSettings, loading } = useGetUserSettings();
 
   useEffect(() => {
     if (recording?.isInitialized) {
       window.onbeforeunload = null;
-      refetch();
     }
   });
 


### PR DESCRIPTION
## Issue

The forced reload after upload was hampering tracking the user-facing time to upload and was extra work that generally made the app less responsive.

## Resolution

Use some callback plumbing to let the recording view know that upload has completed and the user can be redirected to devtools. Also refetches the recording query so we have the most recent data in memory.