### PR TITLE
Allow edits to be canceled

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -41,6 +41,7 @@ function CommentEditor({
         <FocusContext.Consumer>
           {({ autofocus, blur, close, isFocused }) => (
             <TipTapEditor
+              key={comment.updatedAt}
               autofocus={autofocus}
               blur={blur}
               close={close}

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useEditor, EditorContent, Extension } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { User } from "ui/types";
@@ -46,6 +46,12 @@ const TipTapEditor = ({
   placeholder,
   takeFocus,
 }: TipTapEditorProps) => {
+  const onSubmit = (newContent: string) => {
+    handleSubmit(newContent);
+    blur();
+    close();
+  };
+
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -58,19 +64,16 @@ const TipTapEditor = ({
         addKeyboardShortcuts() {
           return {
             "Cmd-Enter": ({ editor }) => {
-              handleSubmit(JSON.stringify(editor.getJSON()));
-              blur();
-              close();
+              onSubmit(JSON.stringify(editor.getJSON()));
               return true;
             },
             Enter: ({ editor }) => {
-              handleSubmit(JSON.stringify(editor.getJSON()));
-              blur();
-              close();
+              onSubmit(JSON.stringify(editor.getJSON()));
               return true;
             },
             Escape: ({ editor }) => {
               editor.commands.blur();
+              editor.commands.setContent(tryToParse(content));
               handleCancel();
               return true;
             },
@@ -78,11 +81,7 @@ const TipTapEditor = ({
         },
       }),
     ],
-    editorProps: {
-      attributes: {
-        class: "focus:outline-none",
-      },
-    },
+    editorProps: { attributes: { class: "focus:outline-none" } },
     content: tryToParse(content),
     editable,
     autofocus,


### PR DESCRIPTION
This fixes #4075. Now, when edits to comment are canceled, we restore the state we were in before the edit, rather than still showing TipTap's stored state. There is one related change, which is adding a `key` to the TipTapEditor component. This is for the following scenario:

- A comment is rendered with the text `My first cmment`
- The user corrects their typo by updating it to `My first comment` and hit `Enter` to save their changes
- They start a second edit, add a period, then decide against it and hit `Esc`.
- The original comment, with the typo still present, gets rendered.

This is because as far as TipTap is concerned, there is the initial state that it got, and the state it has been edited into, but it has no concept of a checkpoint in between those two, which in this case would be like the intermediate edit. One way to achieve that effect would be to keep and update a little `persistedComment` state upon submission, that way you could reset to *that* checkpoint, rather than the original content. This doesn't work as well as it sounds, because the content inside of the key map that you pass to TipTap doesn't update as props change, it's just set once at config time. A different, more clever, but less scrutable way is to pass `updatedAt` as a `key` to the TipTap editor. This means that whenever the server sends down an update, we replace the editor with a fresh copy. This has the nice side-effect of working even in strange scenarios where the same person is editing a comment from multiple clients:

https://user-images.githubusercontent.com/5903784/139506001-75085fff-1199-47d0-8bf0-9ad55c4c90a4.mp4



