### PR TITLE
Polish paused and playing UI states and transitions

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/index.js
@@ -187,6 +187,10 @@ class Editor extends PureComponent {
     const codeWrapper = codeMirror.getWrapperElement();
     const textArea = codeWrapper.querySelector("textArea");
 
+    if (key === "ArrowRight" || key === "ArrowLeft") {
+      e.preventDefault();
+      return;
+    }
     if (key === "Escape" && target == textArea) {
       e.stopPropagation();
       e.preventDefault();

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -24,7 +24,7 @@ function BreakpointNavigation({
   showCondition,
   setZoomedBreakpoint = () => {},
 }) {
-  const [lastExecutionPoint, setLastExecutionPoint] = useState(null);
+  const [lastExecutionPoint, setLastExecutionPoint] = useState(0);
 
   const navigateToPoint = point => {
     trackEvent("breakpoint.navigate");
@@ -88,14 +88,12 @@ function BreakpointNavigation({
             </button>
           </div>
         ) : null}
-        {executionPoint ? (
-          <BreakpointNavigationStatus
-            indexed={indexed}
-            executionPoint={lastExecutionPoint}
-            analysisPoints={analysisPoints}
-            isHidden={editing}
-          />
-        ) : null}
+        <BreakpointNavigationStatus
+          indexed={indexed}
+          executionPoint={lastExecutionPoint}
+          analysisPoints={analysisPoints}
+          isHidden={editing}
+        />
       </div>
     </div>
   );
@@ -126,6 +124,7 @@ function BreakpointNavigationCommands({ disabled, prev, next, navigateToPoint })
 
 function BreakpointNavigationStatus({ executionPoint, analysisPoints, indexed, isHidden }) {
   let status = "";
+  let maxStatusLength = 0;
   if (!indexed) {
     status = "Indexing";
   } else if (!analysisPoints | !executionPoint) {
@@ -140,13 +139,16 @@ function BreakpointNavigationStatus({ executionPoint, analysisPoints, indexed, i
       : [];
 
     status = `${points.length}/${analysisPoints.length}`;
+    maxStatusLength = `${analysisPoints.length}/${analysisPoints.length}`.length;
   }
 
   return (
-    <div
-      className={classnames("breakpoint-navigation-status-container", isHidden ? "invisible" : "")}
-    >
-      <div className="px-3 py-0.5 rounded-2xl text-gray-500 bg-gray-200">{status}</div>
+    <div className={classnames("breakpoint-navigation-status-container")}>
+      <div className="px-3 py-0.5 rounded-2xl text-gray-500 bg-gray-200">
+        <div className="text-center" style={{ minWidth: `${maxStatusLength}ch` }}>
+          {status}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -72,6 +72,16 @@ function App({ theme, modal, children }: AppProps) {
   const userInfo = useGetUserInfo();
 
   useEffect(() => {
+    // Stop space bar from being used as a universal "scroll down" operator
+    // We have a big play/pause interface, so space makes way more sense for that.
+    window.addEventListener("keydown", function (e) {
+      if (e.code === "Space" && e.target === document.body) {
+        e.preventDefault();
+      }
+    });
+  });
+
+  useEffect(() => {
     document.body.parentElement!.className = theme || "";
   }, [theme]);
 

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -347,6 +347,7 @@ class Timeline extends Component<PropsFromRedux> {
     const percent = getVisiblePosition({ time: currentTime, zoom: zoomRegion }) * 100;
     const hoverPercent = getVisiblePosition({ time: hoverTime, zoom: zoomRegion }) * 100;
     const precachedPercent = getVisiblePosition({ time: precachedTime, zoom: zoomRegion }) * 100;
+    const formattedTime = getFormattedTime(currentTime);
 
     return (
       <div className="timeline">
@@ -380,8 +381,11 @@ class Timeline extends Component<PropsFromRedux> {
           </div>
           <Tooltip timelineWidth={this.overlayWidth} />
         </div>
-        <div className="timeline-time">
-          <span className="time-current">{getFormattedTime(currentTime)}</span>
+        <div
+          className="timeline-time text-right"
+          style={{ minWidth: `${formattedTime.length * 2 + 2}ch` }}
+        >
+          <span className="time-current">{formattedTime}</span>
           <span className="time-divider">/</span>
           <span className="time-total">{getFormattedTime(recordingDuration || 0)}</span>
         </div>

--- a/src/ui/utils/key-shortcuts.ts
+++ b/src/ui/utils/key-shortcuts.ts
@@ -73,13 +73,15 @@ export function cancelBubbling(listener: KeyboardEventListener): KeyboardEventLi
   };
 }
 
+function isEditableTag(target: HTMLElement) {
+  return ["INPUT", "TEXTAREA"].includes(target.tagName) && target.getAttribute("readonly") === null;
+}
+
 export function isEditableElement(target: EventTarget) {
-  if (target instanceof HTMLElement) {
-    if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
-      return true;
-    }
+  if (!(target instanceof HTMLElement)) {
+    return false;
   }
-  return false;
+  return isEditableTag(target) || target.isContentEditable;
 }
 
 export default class KeyShortcuts {


### PR DESCRIPTION
### Summary

- Always show the breakpoint navigation status, even when playing the video. This reduces how much the UI jumps. I don't think it's *too* jarring that the point count doesn't go up as you play. If it is we can always sub in a `-` there or something.
- Always keep the max number of characters worth of space for the navigation status. If this thing changes its width (because we go from point `9 -> 10` or `99 -> 100`), then it ends up changing the width of the timeline as well, which makes the whole UI subtly shift.

https://user-images.githubusercontent.com/5903784/139517858-92452e8a-f41b-4e67-97df-55a63f25a3c7.mp4

- Same thing for the overall timeline time. This one is a lot subtler because the number of digits is constant, but since it's not a fixed-width font the change can result in subtle motion in the corner. This tries to reduce that motion as much as possible:

https://user-images.githubusercontent.com/5903784/139518313-6f927422-7e8a-4093-ac34-5172302b93d0.mp4

- Don't let codemirror interpret left or right arrows as horizontal scrolling. The left and right arrows should default to being timeline nudges. This is a super useful feature, and it's often quite subtle since you are going through one paint at a time, so you can pretty easily hit this key like ten times without realizing it's not doing anything, which is a frustrating experience.
- Don't let the browser interpret `spacebar` as vertical scrolling - similar to the last one, space bar universally means *scroll down* in documents. However, in media players and similar apps, space bar typically means play/pause. That's a much more natural meaning for Replay, so we short-circuit the `body`s normal handler, which will try and scroll things down vertically (I think it scrolls the either the active element or the element under cursor, which often results in the codemirror editor getting scrolled).
- Don't consider `readonly` text inputs to be editable. We have some code that implements the "toggle playing on spacebar logic". It relies on a helper to not activate when the user is typing in, for instance, a comment field. However, the way that codemirror works is that it focuses an invisible `textarea` tag, so that it can manage focus like a normal textfield. When you put it in `readonly` mode it is... well... read-only, and in that case, we want that `play/pause` behavior, even if codemirror is the currently focused element, so I've adjusted that helper function to only consider inputs and text areas to be editable when they are not read-only.
- I've also added a default to `lastExecutionPoint` of `0`. I'm somewhat neutral on this. My general reason for this is that it's nice to have type consistency across all states, so if the null-ish object for that type makes sense, initialize with that, rather than `null` and then have to check for `null` everywhere. This doesn't always work but it seems like it makes sense here.

Fixes https://github.com/RecordReplay/devtools/issues/3773
Fixes https://github.com/RecordReplay/devtools/issues/4137