### PR TITLE
Rework breakpoint panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "@recordreplay/playwright": "^1.10.3",
         "@recordreplay/recordings-cli": "^0.3.1",
         "@types/classnames": "^2.2.11",
+        "@types/codemirror": "^5.60.5",
         "@types/escape-html": "^1.0.1",
         "@types/lodash": "^4.14.168",
         "@types/logrocket-react": "^3.0.0",
@@ -3737,6 +3738,15 @@
       "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==",
       "dev": true
     },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.5",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.5.tgz",
+      "integrity": "sha512-TiECZmm8St5YxjFUp64LK0c8WU5bxMDt9YaAek1UqUb9swrSCoJhh92fWu1p3mTEqlHjhB5sY7OFBhWroJXZVg==",
+      "dev": true,
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -4070,6 +4080,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+      "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/unist": {
       "version": "2.0.3",
@@ -23164,6 +23183,15 @@
       "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==",
       "dev": true
     },
+    "@types/codemirror": {
+      "version": "5.60.5",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.5.tgz",
+      "integrity": "sha512-TiECZmm8St5YxjFUp64LK0c8WU5bxMDt9YaAek1UqUb9swrSCoJhh92fWu1p3mTEqlHjhB5sY7OFBhWroJXZVg==",
+      "dev": true,
+      "requires": {
+        "@types/tern": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -23499,6 +23527,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "@types/tern": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+      "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
     },
     "@types/unist": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@recordreplay/playwright": "^1.10.3",
     "@recordreplay/recordings-cli": "^0.3.1",
     "@types/classnames": "^2.2.11",
+    "@types/codemirror": "^5.60.5",
     "@types/escape-html": "^1.0.1",
     "@types/lodash": "^4.14.168",
     "@types/logrocket-react": "^3.0.0",

--- a/src/devtools/client/debugger/src/actions/types/ASTAction.js
+++ b/src/devtools/client/debugger/src/actions/types/ASTAction.js
@@ -1,5 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-
-//

--- a/src/devtools/client/debugger/src/actions/types/BreakpointAction.js
+++ b/src/devtools/client/debugger/src/actions/types/BreakpointAction.js
@@ -1,5 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-
-//

--- a/src/devtools/client/debugger/src/actions/types/PauseAction.js
+++ b/src/devtools/client/debugger/src/actions/types/PauseAction.js
@@ -1,5 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-
-//

--- a/src/devtools/client/debugger/src/actions/types/PreviewAction.js
+++ b/src/devtools/client/debugger/src/actions/types/PreviewAction.js
@@ -1,5 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-
-//

--- a/src/devtools/client/debugger/src/actions/types/SourceAction.js
+++ b/src/devtools/client/debugger/src/actions/types/SourceAction.js
@@ -1,5 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-
-//

--- a/src/devtools/client/debugger/src/actions/types/SourceActorAction.js
+++ b/src/devtools/client/debugger/src/actions/types/SourceActorAction.js
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-
-//
-
-import {} from "../utils/middleware/promise";

--- a/src/devtools/client/debugger/src/actions/types/UIAction.js
+++ b/src/devtools/client/debugger/src/actions/types/UIAction.js
@@ -1,5 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-
-//

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -8,42 +8,36 @@
 }
 
 .breakpoint-panel-wrapper > :first-child {
-  max-width: 500px;
-  min-width: 300px;
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }
 
 .breakpoint-panel-wrapper > :last-child {
-  max-width: 500px;
-  min-width: 300px;
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
 }
 
 .breakpoint-panel {
-  cursor: initial;
-  position: relative;
-  display: flex;
-  flex-direction: column;
   background: var(--theme-toolbar-background);
   border: 1px solid var(--theme-splitter-color);
   color: var(--theme-toolbar-color);
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.breakpoint-panel .button-container {
+  padding: 8px;
 }
 
 .breakpoint-panel button {
-  height: 100%;
   border-radius: 4px;
+  align-self: center;
   line-height: 16px;
 }
 
 .breakpoint-panel .paused-add-comment {
   background-color: var(--secondary-accent);
-}
-
-.breakpoint-panel .edit-actions button {
-  padding: 4px 8px;
 }
 
 .breakpoint-panel .action {
@@ -53,108 +47,55 @@
 }
 
 .breakpoint-panel .summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px;
-  color: var(--grey-50);
   border-bottom: 1px solid var(--theme-splitter-color);
+  color: var(--grey-50);
+  display: flex;
+  justify-content: space-between;
 }
 
-.breakpoint-panel .summary .options {
-  font-family: var(--monospace-font-family);
+.breakpoint-panel .statement {
+  align-items: center;
+  display: flex;
+  height: 28px;
+  line-height: 16px;
   overflow: hidden;
-}
-
-.breakpoint-panel .summary .action {
-  visibility: hidden;
-  padding: 4px 4px 4px 8px;
-}
-
-.breakpoint-panel .summary:hover .action {
-  visibility: visible;
-}
-
-.breakpoint-panel .summary:hover .img {
-  background: var(--theme-comment);
-}
-
-.breakpoint-panel .summary button.log,
-.breakpoint-panel .summary button.condition {
-  white-space: nowrap;
-  overflow: hidden;
+  padding: 4px;
+  padding-left: 8px;
   text-overflow: ellipsis;
-  padding: 5px;
-  width: 100%;
+  white-space: nowrap;
 }
 
-span.expression {
-  display: block;
-  text-align: left;
+.breakpoint-panel .statement:first-child {
+  padding-top: 8px;
+}
+
+.breakpoint-panel .statement:last-child {
+  padding-bottom: 8px;
 }
 
 .breakpoint-panel .panel-editor {
-  padding: 8px;
   border-bottom: 1px solid var(--theme-splitter-color);
 }
 
-.breakpoint-panel .header {
-  display: flex;
-}
-
-.breakpoint-panel .header .type {
-  margin-right: 4px;
-}
-
-.breakpoint-panel .header .line {
-  margin-right: 8px;
-}
-
-.breakpoint-panel form label {
-  color: var(--theme-comment);
-  min-width: 48px;
-  margin-right: 8px;
-  text-align: end;
-}
-
-.brekapoint-panel form label .expression {
-  font-family: var(--monospace-font-family);
-}
-
-.breakpoint-panel form .form-row {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.breakpoint-panel form .input-container {
-  position: relative;
-  width: 100%;
-  display: flex;
-  align-items: center;
-}
-
-.breakpoint-panel form .input-container .placeholder-text {
-  position: absolute;
-  color: var(--theme-comment);
-  left: 8px;
-  font-style: italic;
-  color: var(--grey-40);
-  pointer-events: none;
-}
-
 .breakpoint-panel .panel-editor form .CodeMirror {
-  border: 1px solid transparent;
-  display: flex;
-  width: 100%;
   border-radius: 4px;
+  border: 1px solid transparent;
+  color: var(--theme-toolbar-color);
+  display: flex;
   font-family: var(--monospace-font-family);
   font-size: var(--theme-code-font-size);
-  color: var(--theme-toolbar-color);
+  width: 100%;
 }
 
 .breakpoint-panel .panel-editor.conditional form .CodeMirror {
   border: 1px solid #e5e7eb;
+  height: 21px;
+}
+
+.breakpoint-panel form .form-row {
+  align-items: center;
+  height: 28px;
+  display: flex;
 }
 
 .breakpoint-panel .panel-editor form .form-row.invalid .CodeMirror {
@@ -179,50 +120,15 @@ non-editing markup */
   padding: 0px;
 }
 
-.breakpoint-panel .edit-actions {
-  display: flex;
-  flex-grow: 1;
-  align-items: center;
-  align-self: flex-end;
-}
-
-.breakpoint-panel .edit-actions > *:not(:last-child) {
-  margin-right: 8px;
-}
-
-.breakpoint-panel button.save {
-  background: var(--primary-accent);
-  color: white;
-}
-
 .breakpoint-panel button.save:hover {
   background: var(--primary-accent-hover);
   color: white;
 }
 
-.breakpoint-panel button.cancel {
-  border: 1px solid var(--theme-splitter-color);
-  color: var(--theme-comment);
-}
-
 /* Breakpoint Navigation */
 
 .breakpoint-panel .breakpoint-navigation {
-  padding: 6px 8px 6px 6px;
-}
-
-.breakpoint-panel .breakpoint-navigation-timeline-container {
-  margin: 0 4px;
-}
-
-.breakpoint-panel .breakpoint-navigation-timeline {
-  box-sizing: content-box;
-  border-radius: 0px;
-  padding: 2px 0px;
-}
-
-.breakpoint-panel .breakpoint-navigation-status-container {
-  min-width: 50px;
+  padding: 6px;
 }
 
 .breakpoint-panel .breakpoint-navigation-commands .img {
@@ -233,10 +139,6 @@ non-editing markup */
   background: var(--theme-splitter-color);
 }
 
-.breakpoint-panel .breakpoint-navigation-commands button {
-  padding: 2px;
-}
-
 .breakpoint-panel .breakpoint-navigation-commands button:not(.disabled):hover {
   background-color: var(--theme-toolbar-background-hover);
 }
@@ -245,19 +147,22 @@ non-editing markup */
   font-size: 1rem;
 }
 
-.breakpoint-panel .summary:hover .expression {
+.breakpoint-panel .summary .statement:hover .expression {
   background-image: linear-gradient(to right, var(--theme-highlight-purple) 50%, transparent 0%);
   background-position: 1px 14px;
   background-size: 5px 1.5px;
   background-repeat: repeat-x;
 }
 
-.breakpoint-panel .summary:hover {
+.breakpoint-panel .summary.enabled:hover {
   background: hsl(240, 8%, 99%);
+}
+
+.breakpoint-panel .summary .statement:hover {
   cursor: pointer;
 }
 
-.breakpoint-panel .summary:hover .pencil {
+.breakpoint-panel .summary .statement:hover .pencil {
   opacity: 1;
   color: var(--theme-highlight-purple);
 }

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -107,7 +107,6 @@ function Panel({
               breakpoint={breakpoint}
               toggleEditingOff={toggleEditingOff}
               inputToFocus={inputToFocus}
-              setInputToFocus={setInputToFocus}
               showCondition={showCondition}
               setShowCondition={setShowCondition}
             />

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelEditor.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelEditor.tsx
@@ -79,9 +79,12 @@ class PanelEditor extends PureComponent<Props, State> {
 
     return (
       <div
-        className={classnames("panel-editor flex flex-row bg-white space-x-2 items-top", {
-          conditional: showCondition,
-        })}
+        className={classnames(
+          "panel-editor flex items-center flex-row bg-white space-x-2 items-top",
+          {
+            conditional: showCondition,
+          }
+        )}
       >
         <PanelForm
           {...{
@@ -99,10 +102,12 @@ class PanelEditor extends PureComponent<Props, State> {
           setCondition={this.setCondition}
           setConditionSyntaxError={this.setConditionSyntaxError}
         />
-        <SubmitButton
-          handleSetBreakpoint={this.handleSetBreakpoint}
-          disabled={!!logSyntaxError || !!conditionSyntaxError}
-        />
+        <div className="button-container flex items-center">
+          <SubmitButton
+            handleSetBreakpoint={this.handleSetBreakpoint}
+            disabled={!!logSyntaxError || !!conditionSyntaxError}
+          />
+        </div>
       </div>
     );
   }

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelForm.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classnames from "classnames";
-const { PanelInput } = require("./PanelInput");
+import { PanelInput } from "./PanelInput";
 import { parser } from "devtools/client/debugger/src/utils/bootstrap";
 import { trackEvent } from "ui/utils/telemetry";
 
@@ -70,33 +70,29 @@ export default function PanelForm({
   };
 
   return (
-    <div className="flex-grow overflow-hidden">
-      <form className="flex flex-col space-y-1">
-        {showCondition ? (
-          <div className={classnames("form-row")}>
-            <div className="w-6 flex-shrink-0 mr-1">if</div>
-            <PanelInput
-              id="condition"
-              autofocus={inputToFocus == "condition"}
-              defaultValue={condition}
-              onChange={(cm: any) => onConditionChange(cm.getValue().trim())}
-              onEnter={handleSetBreakpoint}
-              onEscape={toggleEditingOff}
-            />
-          </div>
-        ) : null}
+    <form className="pl-2 flex-grow flex flex-col">
+      {showCondition ? (
         <div className={classnames("form-row")}>
-          {showCondition ? <div className="w-6 flex-shrink-0 mr-1">log</div> : null}
+          <div className="w-6 flex-shrink-0 mr-1">if</div>
           <PanelInput
-            id="logpoint"
-            autofocus={inputToFocus == "logValue"}
-            defaultValue={logValue}
-            onChange={(cm: any) => onLogValueChange(cm.getValue().trim())}
+            autofocus={inputToFocus == "condition"}
+            defaultValue={condition}
+            onChange={(cm: any) => onConditionChange(cm.getValue().trim())}
             onEnter={handleSetBreakpoint}
             onEscape={toggleEditingOff}
           />
         </div>
-      </form>
-    </div>
+      ) : null}
+      <div className={classnames("form-row")}>
+        {showCondition ? <div className="w-6 flex-shrink-0 mr-1">log</div> : null}
+        <PanelInput
+          autofocus={inputToFocus == "logValue"}
+          defaultValue={logValue}
+          onChange={(cm: any) => onLogValueChange(cm.getValue().trim())}
+          onEnter={handleSetBreakpoint}
+          onEscape={toggleEditingOff}
+        />
+      </div>
+    </form>
   );
 }

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelInput.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelInput.tsx
@@ -1,24 +1,25 @@
-import React, { useRef, useEffect } from "react";
-import { getCodeMirror } from "devtools/client/debugger/src/utils/editor/create-editor";
+import React, { useRef, useEffect, Key } from "react";
+import CodeMirror, { Editor, EditorFromTextArea, KeyMap } from "codemirror";
+const { getCodeMirror } = require("devtools/client/debugger/src/utils/editor/create-editor");
 
 export function PanelInput({
-  defaultValue,
   autofocus,
-  onBlur,
+  defaultValue,
   onChange,
-  onKeyDown,
   onEnter,
   onEscape,
-  onClick,
-  onMouseOver,
-  onScroll,
-  onGutterClick,
+}: {
+  autofocus: boolean;
+  defaultValue: string;
+  onChange: (cm: Editor) => void;
+  onEnter: (cm: Editor) => void;
+  onEscape: (cm: Editor) => void;
 }) {
   const textAreaNode = useRef(null);
-  const codeMirrorNode = useRef(null);
+  const codeMirrorNode = useRef<EditorFromTextArea | null>(null);
   useEffect(() => {
     requestAnimationFrame(() => {
-      let extraKeys = {
+      let extraKeys: KeyMap = {
         Esc: false,
         "Cmd-F": false,
         "Ctrl-F": false,
@@ -39,11 +40,12 @@ export function PanelInput({
 
       const CodeMirror = getCodeMirror();
       const codeMirror = CodeMirror.fromTextArea(textAreaNode.current, {
-        mode: "javascript",
-        theme: "mozilla",
-        lineNumbers: false,
         autofocus,
         extraKeys,
+        lineNumbers: false,
+        mode: "javascript",
+        scrollbarStyle: null,
+        theme: "mozilla",
       });
 
       const inputValue = defaultValue || "";
@@ -52,32 +54,8 @@ export function PanelInput({
 
       // Set code editor wrapper to be focusable
       codeMirrorWrapper.tabIndex = 0;
-      if (onKeyDown) {
-        codeMirrorWrapper.addEventListener("keydown", e => onKeyDown(e, codeMirror));
-      }
-
-      if (onClick) {
-        codeMirrorWrapper.addEventListener("keydown", e => onClick(e));
-      }
-
-      if (onBlur) {
-        codeMirror.on("blur", e => onBlur(e));
-      }
-
       if (onChange) {
-        codeMirror.on("change", (cm, e) => onChange(cm, e));
-      }
-
-      if (onMouseOver) {
-        codeMirrorWrapper.addEventListener("mouseover", e => onMouseOver(e));
-      }
-
-      if (onScroll) {
-        codeMirror.on("scroll", e => onScroll(e));
-      }
-
-      if (onGutterClick) {
-        codeMirror.on("gutterClick", onGutterClick);
+        codeMirror.on("change", onChange);
       }
 
       codeMirror.setCursor(0, inputValue.length);

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/Condition.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/Condition.tsx
@@ -1,14 +1,15 @@
 import React from "react";
-import { Input } from ".";
 import { SummaryExpression, SummaryExpressionProps } from "./SummaryExpression";
 import SummaryRow from "./SummaryRow";
 
 type ConditionProps = SummaryExpressionProps & {
-  handleClick: (event: React.MouseEvent, input: Input) => void;
+  onClick: () => void;
 };
 
-export default function Condition({ handleClick, ...rest }: ConditionProps) {
-  const expression = <SummaryExpression {...rest} handleClick={e => handleClick(e, "condition")} />;
-
-  return <SummaryRow label={"if"}>{expression}</SummaryRow>;
+export default function Condition({ onClick, ...rest }: ConditionProps) {
+  return (
+    <SummaryRow onClick={onClick} label={"if"}>
+      <SummaryExpression {...rest} />
+    </SummaryRow>
+  );
 }

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/Log.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/Log.tsx
@@ -1,15 +1,13 @@
 import React from "react";
-import { Input } from ".";
 import { SummaryExpression, SummaryExpressionProps } from "./SummaryExpression";
 import SummaryRow from "./SummaryRow";
 
-type LogProps = SummaryExpressionProps & {
-  handleClick?: (event: React.MouseEvent, input: Input) => void;
-  hasCondition: boolean;
-};
+type LogProps = SummaryExpressionProps & { hasCondition: boolean; onClick: () => void };
 
-export default function Log({ handleClick = () => {}, hasCondition, ...rest }: LogProps) {
-  const expression = <SummaryExpression {...rest} handleClick={e => handleClick(e, "logValue")} />;
-
-  return <SummaryRow label={hasCondition ? "log" : null}>{expression}</SummaryRow>;
+export default function Log({ hasCondition, onClick, ...rest }: LogProps) {
+  return (
+    <SummaryRow onClick={onClick} label={hasCondition ? "log" : null}>
+      <SummaryExpression {...rest} />
+    </SummaryRow>
+  );
 }

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/Popup.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/Popup.tsx
@@ -9,7 +9,7 @@ interface PopupProps {
 export default function Popup({ trigger, children }: PopupProps) {
   return (
     <ReactPopup
-      trigger={trigger}
+      trigger={<>{trigger}</>}
       on="hover"
       position="right center"
       mouseEnterDelay={200}

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
@@ -25,72 +25,37 @@ function getSyntaxHighlightedMarkup(string: string) {
 
 function Expression({ value, isEditable }: { value: string; isEditable: boolean }) {
   return (
-    <span className="expression">
-      <span
-        className={
-          isEditable
-            ? "border-b border-dashed border-transparent group-hover:border-primaryAccent"
-            : ""
-        }
-      >
-        <div
-          className="cm-s-mozilla font-mono overflow-hidden whitespace-pre"
-          dangerouslySetInnerHTML={{
-            __html: getSyntaxHighlightedMarkup(value || ""),
-          }}
-        />
-      </span>
-    </span>
+    <div className={classNames({ expression: true })}>
+      <div
+        className="cm-s-mozilla font-mono overflow-hidden whitespace-pre"
+        dangerouslySetInnerHTML={{ __html: getSyntaxHighlightedMarkup(value || "") }}
+      />
+    </div>
   );
 }
 
-export function SummaryExpression({
-  isEditable,
-  handleClick,
-  value,
-}: SummaryExpressionProps & {
-  handleClick: (event: React.MouseEvent) => void;
-}) {
+export function SummaryExpression({ isEditable, value }: SummaryExpressionProps & {}) {
   const { isTeamDeveloper } = hooks.useIsTeamDeveloper();
 
-  return (
-    <button
-      className={classNames(
-        "group flex flex-row items-top space-x-1 p-0.5",
-        !isEditable ? "bg-gray-200 cursor-auto" : "group-hover:text-primaryAccent"
-      )}
-      disabled={!isEditable}
-      onClick={handleClick}
-    >
-      {isEditable ? (
-        <>
-          <span className="expression">
-            <Expression {...{ value, isEditable }} />
-          </span>
-          <MaterialIcon className="opacity-0 pencil" iconSize="xs">
-            edit
-          </MaterialIcon>
-        </>
-      ) : (
-        <>
-          <Popup
-            trigger={
-              <span className="expression">
-                <Expression {...{ value, isEditable }} />
-              </span>
-            }
-          >
-            {isTeamDeveloper ? (
-              <>
-                This log cannot be edited because <br />
-                it was hit {prefs.maxHitsDisplayed}+ times
-              </>
-            ) : (
-              "Editing logpoints is available for Developers in the Team plan"
-            )}
-          </Popup>
-        </>
-      )}
-    </button>
+  return isEditable ? (
+    <div className="flex group hover:text-primaryAccent space-x-1 px-2">
+      <Expression value={value} isEditable={true} />
+      <MaterialIcon className="opacity-0 pencil" iconSize="xs">
+        edit
+      </MaterialIcon>
+    </div>
+  ) : (
+    <div className="bg-gray-200 px-2 rounded-sm">
+      <Popup trigger={<Expression value={value} isEditable={false} />}>
+        {isTeamDeveloper ? (
+          <>
+            This log cannot be edited because <br />
+            it was hit {prefs.maxHitsDisplayed}+ times
+          </>
+        ) : (
+          "Editing logpoints is available for Developers in the Team plan"
+        )}
+      </Popup>
+    </div>
   );
 }

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryRow.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryRow.tsx
@@ -3,13 +3,15 @@ import React from "react";
 export default function SummaryRow({
   children,
   label,
+  onClick,
 }: {
   children: React.ReactElement;
   label: string | null;
+  onClick: () => void;
 }) {
   return (
-    <div className="flex flex-row space-x-1 items-center">
-      {label ? <div className="w-6 flex-shrink-0">{label}</div> : null}
+    <div onClick={onClick} className="statement flex flex-grow">
+      {label ? <div className="w-6">{label}</div> : null}
       {children}
     </div>
   );

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -71,29 +71,28 @@ function BreakpointNavigation({
       ) : (
         <div className="flex-grow" />
       )}
-      <div className="relative">
-        {editing ? (
-          <div className="absolute right-0">
-            <button
-              className={classnames(
-                "rounded-full h-5 w-5 p-px pt-0.5 border",
-                showCondition
-                  ? "border-primaryAccent text-primaryAccent"
-                  : "border-gray-500 text-gray-500"
-              )}
-              style={{ height: "1.25rem", borderRadius: "100%" }}
-              onClick={() => setShowCondition(!showCondition)}
-            >
-              <MaterialIcon>filter_list</MaterialIcon>
-            </button>
-          </div>
-        ) : null}
-        <BreakpointNavigationStatus
-          indexed={indexed}
-          executionPoint={lastExecutionPoint}
-          analysisPoints={analysisPoints}
-          isHidden={editing}
-        />
+      <div className="text-center">
+        {editing && (
+          <button
+            className={classnames(
+              "rounded-full h-5 w-5 p-px pt-0.5 border",
+              showCondition
+                ? "border-primaryAccent text-primaryAccent"
+                : "border-gray-500 text-gray-500"
+            )}
+            style={{ height: "1.25rem", borderRadius: "100%" }}
+            onClick={() => setShowCondition(!showCondition)}
+          >
+            <MaterialIcon>filter_list</MaterialIcon>
+          </button>
+        )}
+        {!editing && (
+          <BreakpointNavigationStatus
+            indexed={indexed}
+            executionPoint={lastExecutionPoint}
+            analysisPoints={analysisPoints}
+          />
+        )}
       </div>
     </div>
   );
@@ -122,7 +121,7 @@ function BreakpointNavigationCommands({ disabled, prev, next, navigateToPoint })
   );
 }
 
-function BreakpointNavigationStatus({ executionPoint, analysisPoints, indexed, isHidden }) {
+function BreakpointNavigationStatus({ executionPoint, analysisPoints, indexed }) {
   let status = "";
   let maxStatusLength = 0;
   if (!indexed) {
@@ -142,12 +141,12 @@ function BreakpointNavigationStatus({ executionPoint, analysisPoints, indexed, i
     maxStatusLength = `${analysisPoints.length}/${analysisPoints.length}`.length;
   }
 
+  console.log({ maxStatusLength });
   return (
     <div className={classnames("breakpoint-navigation-status-container")}>
       <div className="px-3 py-0.5 rounded-2xl text-gray-500 bg-gray-200">
-        <div className="text-center" style={{ minWidth: `${maxStatusLength}ch` }}>
-          {status}
-        </div>
+        <div className="text-center" style={{ minWidth: `${maxStatusLength}ch` }}></div>
+        {status}
       </div>
     </div>
   );


### PR DESCRIPTION
There was a lot of unused CSS here, and also a lot of CSS that was sort of circuitous. I found the best approach was to rip most of it out and then rebuild. When you have click targets that extend outside of their elements and are also close to each other the way that you mark up space becomes *very* important. For instance, the difference between:

![CleanShot 2021-10-29 at 23 01 51](https://user-images.githubusercontent.com/5903784/139522357-d2cac10c-58c4-4399-9be3-f3490a29408a.png)

Where the whole background is a click target for A is *very* different structurally from:

![CleanShot 2021-10-29 at 23 02 47](https://user-images.githubusercontent.com/5903784/139522377-ed3caf81-373a-47b5-8e32-12ef49378cfc.png)

Where the top half is a click target for B and the bottom half is a click target for A. But once you get that structure right, some things become easier. For instance, B is no longer a child of A's click target, so you can remove some `preventDefault` style code, which is a sign that you're moving with the grain rather than against it.

But getting that design right with a minimum of changes as you snap back and forth between editor mode is *hard*. I still haven't eliminated all movement, but I think this is as close to pixel-perfect as it is worth pushing this particular iteration. I think the long term vision for this component should actually be to remove CodeMirror from it. Don't get me wrong, CodeMirror is awesome, but every time we render a conditional break-point we are instantiating two full-blown code editors in JS, when what we *really* want is just a text input tag with some syntax highlighting. Even on a fast computer, you can *feel* the DOM rebuilding itself as it transitions in and out of editor mode. It sort of feels like trying to drive a nail in with a jackhammer. It's not that it won't work, it just doesn't feel like the right tool for the job.

### Before


https://user-images.githubusercontent.com/5903784/139524082-e6fb541b-2aa0-4b11-909d-88554c92d8e3.mp4


### After

https://user-images.githubusercontent.com/5903784/139522602-112a2f67-718b-4504-bdd2-cf9b07554954.mp4

Fixes https://github.com/RecordReplay/devtools/issues/4119 except for the part about keeping console statements around, which was a "nice to have". Let's make a follow-on issue for that that we can pick up as part of console work!
