### PR TITLE
Track E2E test finish successes as either 0 or 1

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -318,7 +318,7 @@ async function runTestViewer(path, local, timeout, env) {
       }
     }
 
-    sendTelemetryEvent("E2EFinished", { success: false, local, why });
+    sendTelemetryEvent("E2EFinished", { success: 0, local, why });
 
     failures.push(`Failed test: ${local} ${why}`);
     console.log(`[${elapsedTime()}] Test failed: ${why}`);
@@ -348,7 +348,7 @@ async function runTestViewer(path, local, timeout, env) {
       } else if (!passed) {
         logFailure("Exited without passing test");
       } else {
-        sendTelemetryEvent("E2EFinished", { success: true, local });
+        sendTelemetryEvent("E2EFinished", { success: 1, local });
       }
     }
     resolve();


### PR DESCRIPTION
Using 0 and 1 will help us compute an average. 