### PR TITLE
CommentTool wont unfocus a CommentEditor

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -36,7 +36,7 @@ function CommentEditor({
   );
 
   return (
-    <div className="comment-input-container">
+    <div className="comment-input-container" data-commentid={comment.id}>
       <div className={classNames("comment-input")}>
         <FocusContext.Consumer>
           {({ autofocus, blur, close, isFocused }) => (

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -12,6 +12,10 @@ import TipTapEditor from "./TipTapEditor";
 import { FocusContext } from "../CommentCard";
 import classNames from "classnames";
 
+export function getCommentEditorDOMId(comment: Comment | Reply) {
+  return `comment-editor-${comment.id}`;
+}
+
 type CommentEditorProps = PropsFromRedux & {
   comment: Comment | Reply;
   editable: boolean;
@@ -36,7 +40,7 @@ function CommentEditor({
   );
 
   return (
-    <div className="comment-input-container" data-commentid={comment.id}>
+    <div className="comment-input-container" id={getCommentEditorDOMId(comment)}>
       <div className={classNames("comment-input")}>
         <FocusContext.Consumer>
           {({ autofocus, blur, close, isFocused }) => (

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -11,6 +11,7 @@ import { Canvas } from "ui/state/app";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import useAuth0 from "ui/utils/useAuth0";
 import { useGetUserId } from "ui/hooks/users";
+import { getCommentEditorDOMId } from "../Comments/TranscriptComments/CommentEditor/CommentEditor";
 
 const mouseEventCanvasPosition = (e: MouseEvent) => {
   const canvas = document.getElementById("graphics");
@@ -104,13 +105,15 @@ function CommentTool({
     }
   };
   const onMouseDown = (evt: MouseEvent) => {
-    const focusedCommentEditor = document.activeElement?.closest("[data-commentid]");
-    if (
-      focusedCommentEditor instanceof HTMLElement &&
-      focusedCommentEditor.dataset.commentid === pendingComment?.comment.id
-    ) {
-      // If the current active element is the comment editor for the pending comment,
-      // comment tool clicks should not take focus from the editor.
+    if (!pendingComment || !document.activeElement) {
+      return;
+    }
+
+    const pendingCommentEditorId = getCommentEditorDOMId(pendingComment.comment);
+    const isEditorFocused = !!document.activeElement.closest(`#${pendingCommentEditorId}`);
+
+    // If the pending comment's editor is focused, comment tool clicks should not take focus from it.
+    if (isEditorFocused) {
       evt.preventDefault();
     }
   };

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -86,6 +86,7 @@ function CommentTool({
 
     if (videoNode) {
       videoNode.classList.add("location-marker");
+      videoNode.addEventListener("mousedown", onMouseDown);
       videoNode.addEventListener("mouseup", onClickInCanvas);
       videoNode.addEventListener("mousemove", onMouseMove);
       videoNode.addEventListener("mouseleave", onMouseLeave);
@@ -96,9 +97,21 @@ function CommentTool({
 
     if (videoNode) {
       videoNode.classList.remove("location-marker");
+      videoNode.addEventListener("mousedown", onMouseDown);
       videoNode.removeEventListener("mouseup", onClickInCanvas);
       videoNode.removeEventListener("mousemove", onMouseMove);
       videoNode.removeEventListener("mouseleave", onMouseLeave);
+    }
+  };
+  const onMouseDown = (evt: MouseEvent) => {
+    const focusedCommentEditor = document.activeElement?.closest("[data-commentid]");
+    if (
+      focusedCommentEditor instanceof HTMLElement &&
+      focusedCommentEditor.dataset.commentid === pendingComment?.comment.id
+    ) {
+      // If the current active element is the comment editor for the pending comment,
+      // comment tool clicks should not take focus from the editor.
+      evt.preventDefault();
     }
   };
   const onClickInCanvas = async (e: MouseEvent) => {

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -110,6 +110,7 @@ function CommentTool({
     }
 
     const pendingCommentEditorId = getCommentEditorDOMId(pendingComment.comment);
+    // this uses `[id="..."]` because comment ids can have "="s in them!
     const isEditorFocused = !!document.activeElement.closest(`[id="${pendingCommentEditorId}"]`);
 
     // If the pending comment's editor is focused, comment tool clicks should not take focus from it.

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -11,7 +11,7 @@ import { Canvas } from "ui/state/app";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import useAuth0 from "ui/utils/useAuth0";
 import { useGetUserId } from "ui/hooks/users";
-import { getCommentEditorDOMId } from "../Comments/TranscriptComments/CommentEditor/CommentEditor";
+import { getCommentEditorDOMId } from "ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor";
 
 const mouseEventCanvasPosition = (e: MouseEvent) => {
   const canvas = document.getElementById("graphics");

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -110,7 +110,7 @@ function CommentTool({
     }
 
     const pendingCommentEditorId = getCommentEditorDOMId(pendingComment.comment);
-    const isEditorFocused = !!document.activeElement.closest(`#${pendingCommentEditorId}`);
+    const isEditorFocused = !!document.activeElement.closest(`[id="${pendingCommentEditorId}"]`);
 
     // If the pending comment's editor is focused, comment tool clicks should not take focus from it.
     if (isEditorFocused) {

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -98,7 +98,7 @@ function CommentTool({
 
     if (videoNode) {
       videoNode.classList.remove("location-marker");
-      videoNode.addEventListener("mousedown", onMouseDown);
+      videoNode.removeEventListener("mousedown", onMouseDown);
       videoNode.removeEventListener("mouseup", onClickInCanvas);
       videoNode.removeEventListener("mousemove", onMouseMove);
       videoNode.removeEventListener("mouseleave", onMouseLeave);


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/devtools/issues/4259
Related to https://github.com/RecordReplay/devtools/pull/4220

If you are creating or editing a comment and click the video area to move the comment marker, the comment text box should not lose focus.

Replay: https://app.replay.io/recording/7cd8db62-d8fe-4fc2-b154-9eea1d894d39