### PR TITLE
Double click to edit comments

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
@@ -4,6 +4,7 @@ import hooks from "ui/hooks";
 import { actions } from "ui/actions";
 import CommentEditor from "./CommentEditor";
 import { Comment, Reply } from "ui/state/comments";
+import { useGetUserId } from "ui/hooks/users";
 
 type ExistingCommentEditorProps = PropsFromRedux & {
   comment: Comment | Reply;
@@ -15,8 +16,10 @@ function ExistingCommentEditor({
   comment,
   clearPendingComment,
   editable,
+  editItem,
   type,
 }: ExistingCommentEditorProps) {
+  const { userId } = useGetUserId();
   const updateComment = hooks.useUpdateComment();
   const updateCommentReply = hooks.useUpdateCommentReply();
 
@@ -29,10 +32,23 @@ function ExistingCommentEditor({
     clearPendingComment();
   };
 
-  return <CommentEditor editable={editable} comment={comment} handleSubmit={handleSubmit} />;
+  return (
+    <div
+      onDoubleClick={() => {
+        if (comment.user.id === userId) {
+          editItem(comment);
+        }
+      }}
+    >
+      <CommentEditor editable={editable} comment={comment} handleSubmit={handleSubmit} />
+    </div>
+  );
 }
 
-const connector = connect(null, { clearPendingComment: actions.clearPendingComment });
+const connector = connect(null, {
+  clearPendingComment: actions.clearPendingComment,
+  editItem: actions.editItem,
+});
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 export default connector(ExistingCommentEditor);

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -103,18 +103,18 @@ const TipTapEditor = ({
   return (
     <div
       className="w-full"
-      onClick={e => {
+      onMouseDown={e => {
         if (editable) {
           e.stopPropagation();
         }
       }}
     >
       <EditorContent
-        className={classNames("outline-none w-full rounded-md py-1 px-2 transition", {
+        className={classNames("outline-none w-full rounded-md py-1 px-2 transition border", {
           "bg-white": editable,
           "border-gray-400": editable,
+          "border-transparent": !editable,
           "cursor-text": editable,
-          border: editable,
         })}
         editor={editor}
         onBlur={() => {


### PR DESCRIPTION
This is another little piece of polish on comments, and so far in my local testing it feels *great*. One additional change: keep a border on the TipTap editors at all times, so that they don't jump in height by two pixels when going from uneditable -> editable.

### Preview

https://user-images.githubusercontent.com/5903784/139759444-bd6dcf4e-4406-490b-b5fa-6077bede274a.mp4

