### PR TITLE
Allow embedded links to be copied and pasted

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/githubLink.ts
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/githubLink.ts
@@ -5,7 +5,7 @@ export interface GitHubLinkOptions {
   HTMLAttributes: Record<string, any>;
 }
 
-export const inputRegex = /(https:\/\/github.com\/(.*)\/(.*)\/(.*)\/(\d+))/g;
+export const inputRegex = /(https:\/\/github.com\/(.*)\/(.*)\/(.*)\/(\d+)[^ ]*)/g;
 
 const getAttributes = (match: string[]) => {
   const [href, , org, repo, subpath, id] = match;
@@ -50,16 +50,19 @@ export const GitHubLink = Node.create<GitHubLinkOptions>({
   inline: true,
 
   parseHTML() {
-    return [{ tag: "a[href]" }];
+    return [{ tag: "a[data-github-link]" }];
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    console.log(node);
     return [
       "a",
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+      mergeAttributes({ "data-github-link": "" }, this.options.HTMLAttributes, HTMLAttributes),
       `${node.attrs.org}/${node.attrs.repo}#${node.attrs.id}`,
     ];
+  },
+
+  renderText({ node }) {
+    return node.attrs.href;
   },
 
   addInputRules() {

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/replayLink.ts
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/replayLink.ts
@@ -5,7 +5,7 @@ export interface ReplayLinkOptions {
   HTMLAttributes: Record<string, any>;
 }
 
-export const inputRegex = /(https:\/\/app.replay.io\/recording\/(.*)\?.*)/g;
+export const inputRegex = /(https:\/\/app.replay.io\/recording\/([a-zA-z0-9\-]{36})[^ ]*)/g;
 
 const getAttributes = (match: string[]) => {
   const [href, , recordingId] = match;
@@ -18,7 +18,7 @@ const getAttributes = (match: string[]) => {
 // More info at:
 // https://www.notion.so/replayio/TipTap-Editor-0021afbf0c0e458793eba4c98cbbb47e#5a47e9da0c5d4fd1bd57436b0a48294c
 export const ReplayLink = Node.create<ReplayLinkOptions>({
-  name: "Replay-link",
+  name: "replay-link",
 
   priority: 100,
 
@@ -44,16 +44,20 @@ export const ReplayLink = Node.create<ReplayLinkOptions>({
   inline: true,
 
   parseHTML() {
-    return [{ tag: "a[href]" }];
+    return [{ tag: "a[data-replay-link]" }];
   },
 
   renderHTML({ node, HTMLAttributes }) {
     const firstPart = node.attrs.recordingId?.split("-")?.[0] || "";
     return [
       "a",
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+      mergeAttributes({ "data-replay-link": "" }, this.options.HTMLAttributes, HTMLAttributes),
       `replay#${firstPart}`,
     ];
+  },
+
+  renderText({ node }) {
+    return node.attrs.href;
   },
 
   addInputRules() {

--- a/test/ui/components/Comments/TranscriptComments/CommentEditor/githubLink.test.js
+++ b/test/ui/components/Comments/TranscriptComments/CommentEditor/githubLink.test.js
@@ -12,4 +12,20 @@ describe("GitHubLink", () => {
       "https://github.com/RecordReplay/devtools/issues/3926",
     ]);
   });
+
+  test("when the link has other text on both sides it only matches the link", () => {
+    expect(
+      "Beginning https://github.com/RecordReplay/devtools/issues/3926 end".match(inputRegex)
+    ).toEqual(["https://github.com/RecordReplay/devtools/issues/3926"]);
+  });
+
+  test("when the link has query params it matches them but not in the ID", () => {
+    expect(
+      [
+        ..."Beginning https://github.com/RecordReplay/devtools/issues/3926?foo end".matchAll(
+          inputRegex
+        ),
+      ][0]
+    ).toContain("https://github.com/RecordReplay/devtools/issues/3926?foo", "3926");
+  });
 });


### PR DESCRIPTION
There were a couple of weird issues with the regexes we were using when they were pasted in the middle of content. This is probably a rare case but it's nice to handle it correctly. We will now not match a malformed Replay URL, which should help users realize that their link isn't fully copied in the case that they try and paste an incomplete URL. We also render text correctly, so you can paste *from* a replay comment and get the link back. For example:

https://user-images.githubusercontent.com/5903784/139773469-4d3ae80a-b5e1-4d5a-92fc-c124257a180e.mp4

Copying a smart link from one comment and pasting it into another comment now *also* works. The problem here was that I had set up our `parseHTML` matcher to `a[href]`, which means that if you pasted *any* HTML that had a valid link in it, TipTap would try and interpret that as a GitHub link. Now, we use `a[data-github-link]` and when we `renderHTML` we make sure that all github links have that data attribute (and Replay links get a similar `data-replay-link` attribute). Again, the mention extension was  indispensable in figuring out why this was broken. I find that reading other extension code almost always answers my TipTap questions.

Fixes #4258 