### PR TITLE
Simplify Mixpanel code

### DIFF
--- a/src/protocol/socket.ts
+++ b/src/protocol/socket.ts
@@ -14,6 +14,7 @@ import { UIStore } from "ui/actions";
 import { Action, Dispatch } from "redux";
 import { isMock, mockEnvironment, waitForMockEnvironment } from "ui/utils/environment";
 import { UnexpectedError } from "ui/state/app";
+import { endMixpanelSession } from "ui/utils/mixpanel";
 
 interface Message {
   id: number;
@@ -152,11 +153,14 @@ function onSocketMessage(evt: MessageEvent<any>) {
   }
 }
 
-const disconnectedError: UnexpectedError = {
-  message: "Are you still there?",
-  content: "Replays disconnect after 5 minutes to reduce server load. Ready when you are!",
-  action: "refresh",
-};
+export function getDisconnectionError(): UnexpectedError {
+  endMixpanelSession();
+  return {
+    message: "Are you still there?",
+    content: "Replays disconnect after 5 minutes to reduce server load. Ready when you are!",
+    action: "refresh",
+  };
+}
 
 function onSocketClose() {
   return ({ dispatch }: { dispatch: Dispatch<Action> }) => {
@@ -164,7 +168,7 @@ function onSocketClose() {
     gSocketOpen = false;
 
     if (!willClose) {
-      dispatch(setUnexpectedError(disconnectedError, true));
+      dispatch(setUnexpectedError(getDisconnectionError(), true));
     }
   };
 }
@@ -186,7 +190,7 @@ function onSocketError(evt: Event) {
         })
       );
     } else {
-      dispatch(setUnexpectedError(disconnectedError, true));
+      dispatch(setUnexpectedError(getDisconnectionError(), true));
     }
   };
 }

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -3,7 +3,7 @@ import { bootstrapStore } from "./store";
 import { registerStoreObserver, updatePrefs } from "./prefs";
 import { setupAppHelper } from "./helpers";
 import { setupDOMHelpers } from "./dom";
-import { maybeDisableMixpanel, setTelemetryContext, setupTelemetry } from "ui/utils/telemetry";
+import { setTelemetryContext, setupTelemetry } from "ui/utils/telemetry";
 import { UIStore } from "ui/actions";
 import { getInitialAppState, getTheme, getWorkspaceId } from "ui/reducers/app";
 import { setFontLoading, setModal, setWorkspaceId } from "ui/actions/app";
@@ -14,6 +14,7 @@ import { getUserInfo } from "ui/hooks/users";
 import { getUserSettings } from "ui/hooks/settings";
 import { isTest } from "ui/utils/environment";
 import { initLaunchDarkly } from "ui/utils/launchdarkly";
+import { maybeSetMixpanelContext } from "ui/utils/mixpanel";
 const FontFaceObserver = require("fontfaceobserver");
 
 declare global {
@@ -55,8 +56,8 @@ export async function bootstrapApp() {
 
     const userInfo = await getUserInfo();
     if (userInfo) {
-      maybeDisableMixpanel(userInfo);
       setTelemetryContext(userInfo);
+      maybeSetMixpanelContext(userInfo);
       maybeAutoOpenModal(store);
 
       if (!getWorkspaceId(store.getState())) {

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -1,0 +1,75 @@
+import mixpanel from "mixpanel-browser";
+import { ViewMode } from "ui/state/app";
+import { getRecordingId } from "./environment";
+import { prefs } from "./prefs";
+import { TelemetryUser } from "./telemetry";
+
+const QA_EMAIL_ADDRESSES = ["mock@user.io"];
+
+export let mixpanelDisabled = false;
+const enableMixpanel = () => (mixpanelDisabled = false);
+const disableMixpanel = () => (mixpanelDisabled = true);
+
+export function initializeMixpanel() {
+  // This init event becomes our Session Start point.
+  mixpanel.init("ffaeda9ef8fb976a520ca3a65bba5014");
+  trackEvent("session-start");
+  setupSessionEndListener();
+
+  // Add the recordingId to the event metadata so we have a cookie crumb
+  // trail for following flows in LogRocket.
+  mixpanel.register({ recordingId: getRecordingId() });
+}
+
+export function maybeSetMixpanelContext(userInfo: TelemetryUser) {
+  const { email, internal } = userInfo;
+  const isQAUser = email && QA_EMAIL_ADDRESSES.includes(email);
+  const isInternal = internal;
+  const shouldDisableMixpanel = isQAUser || isInternal;
+
+  // This gives us an option to log telemetry events in development.
+  const forceEnableMixpanel = prefs.logTelemetryEvent;
+
+  if (!shouldDisableMixpanel || forceEnableMixpanel) {
+    enableMixpanel();
+    setMixpanelContext(userInfo);
+  } else {
+    disableMixpanel();
+  }
+}
+
+export async function trackEvent(event: string, additionalContext?: Object) {
+  if (mixpanelDisabled) {
+    return;
+  }
+
+  const context = { ...additionalContext };
+
+  if (prefs.logTelemetryEvent) {
+    console.log("🔴", event, context);
+  }
+
+  mixpanel.track(event, context);
+}
+
+export function setMixpanelContext({ id, email }: TelemetryUser) {
+  if (id) {
+    mixpanel.identify(id);
+  }
+
+  if (email) {
+    mixpanel.people.set({ $email: email });
+  }
+
+  if (prefs.logTelemetryEvent) {
+    mixpanel.register({ isDevEvent: true });
+  }
+}
+
+export const endMixpanelSession = () => trackEvent("session-end");
+export const trackViewMode = (viewMode: ViewMode) =>
+  trackEvent(viewMode == "dev" ? "visit devtools" : "visit viewer");
+
+function setupSessionEndListener() {
+  window.addEventListener("beforeunload", endMixpanelSession);
+}

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -1,4 +1,4 @@
-import mixpanel from "mixpanel-browser";
+import mixpanel, { Dict } from "mixpanel-browser";
 import { ViewMode } from "ui/state/app";
 import { getRecordingId } from "./environment";
 import { prefs } from "./prefs";
@@ -38,18 +38,14 @@ export function maybeSetMixpanelContext(userInfo: TelemetryUser) {
   }
 }
 
-export async function trackMixpanelEvent(event: string, additionalContext?: Object) {
-  if (mixpanelDisabled) {
-    return;
-  }
-
-  const context = { ...additionalContext };
-
+export async function trackMixpanelEvent(event: string, properties?: Dict) {
   if (prefs.logTelemetryEvent) {
-    console.log("🔴", event, context);
+    console.log("🔴", event, properties);
   }
 
-  mixpanel.track(event, context);
+  if (!mixpanelDisabled) {
+    mixpanel.track(event, properties);
+  }
 }
 
 export function setMixpanelContext({ id, email }: TelemetryUser) {

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -13,7 +13,7 @@ const disableMixpanel = () => (mixpanelDisabled = true);
 export function initializeMixpanel() {
   // This init event becomes our Session Start point.
   mixpanel.init("ffaeda9ef8fb976a520ca3a65bba5014");
-  trackEvent("session-start");
+  trackMixpanelEvent("session-start");
   setupSessionEndListener();
 
   // Add the recordingId to the event metadata so we have a cookie crumb
@@ -38,7 +38,7 @@ export function maybeSetMixpanelContext(userInfo: TelemetryUser) {
   }
 }
 
-export async function trackEvent(event: string, additionalContext?: Object) {
+export async function trackMixpanelEvent(event: string, additionalContext?: Object) {
   if (mixpanelDisabled) {
     return;
   }
@@ -66,9 +66,9 @@ export function setMixpanelContext({ id, email }: TelemetryUser) {
   }
 }
 
-export const endMixpanelSession = () => trackEvent("session-end");
+export const endMixpanelSession = () => trackMixpanelEvent("session-end");
 export const trackViewMode = (viewMode: ViewMode) =>
-  trackEvent(viewMode == "dev" ? "visit devtools" : "visit viewer");
+  trackMixpanelEvent(viewMode == "dev" ? "visit devtools" : "visit viewer");
 
 function setupSessionEndListener() {
   window.addEventListener("beforeunload", endMixpanelSession);

--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -1,19 +1,18 @@
-import mixpanel from "mixpanel-browser";
 import * as Sentry from "@sentry/react";
 import { Integrations } from "@sentry/tracing";
-import { isDevelopment, skipTelemetry } from "./environment";
+import { skipTelemetry } from "./environment";
 import { Recording, Workspace } from "ui/types";
-import { isTest } from "./environment";
 import { prefs } from "./prefs";
 import { UserInfo } from "ui/hooks/users";
+import { initializeMixpanel } from "./mixpanel";
 
-let mixpanelDisabled = false;
 const timings: Record<string, number> = {};
-const QA_EMAIL_ADDRESSES = ["mock@user.io"];
 
 export function setupTelemetry() {
   const ignoreList = ["Current thread has paused or resumed", "Current thread has changed"];
-  mixpanel.init("ffaeda9ef8fb976a520ca3a65bba5014");
+  // We always initialize mixpanel here. This allows us to force enable mixpanel events even if
+  // telemetry events are being skipped for any reason, e.g. development, test, etc.
+  initializeMixpanel();
 
   if (skipTelemetry()) {
     return;
@@ -47,39 +46,16 @@ export function registerRecording({
   if (!recording) {
     return;
   }
-
   Sentry.setContext("recording", { recordingId: recording.id, url: window.location.href });
-
-  if (
-    !prefs.logTelemetryEvent &&
-    (recording.user?.internal || userInfo?.internal || skipTelemetry())
-  ) {
-    mixpanelDisabled = true;
-  } else {
-    mixpanel.register({ recordingId: recording.id });
-  }
 }
 
-type TelemetryUser = {
+export type TelemetryUser = {
   id: string | undefined;
   email: string | undefined;
   internal: boolean;
 };
 
 let telemetryUser: TelemetryUser | undefined;
-let telemetryProperties: any = {};
-
-let workspaceContext: Workspace | undefined;
-
-export function setWorkspaceContext(workspace: Workspace) {
-  workspaceContext = workspace;
-}
-
-export function maybeDisableMixpanel({ email }: TelemetryUser) {
-  if (email && QA_EMAIL_ADDRESSES.includes(email)) {
-    mixpanelDisabled = true;
-  }
-}
 
 export function setTelemetryContext({ id, email, internal }: TelemetryUser) {
   telemetryUser = { id, email, internal };
@@ -90,14 +66,6 @@ export function setTelemetryContext({ id, email, internal }: TelemetryUser) {
     Sentry.setTag("anonymous", false);
   } else {
     Sentry.setTag("anonymous", true);
-  }
-
-  if (!mixpanelDisabled && id) {
-    mixpanel.identify(id);
-  }
-
-  if (!mixpanelDisabled && email) {
-    mixpanel.people.set({ $email: email });
   }
 }
 
@@ -124,24 +92,6 @@ export async function sendTelemetryEvent(event: string, tags: any = {}) {
   } catch (e) {
     console.error(`Couldn't send telemetry event ${event}`, e);
   }
-}
-
-export async function trackEvent(event: string, additionalContext?: Object) {
-  // we should be able to opt-in to logging telemetry events in development
-  if (mixpanelDisabled || (!prefs.logTelemetryEvent && (isTest() || isDevelopment()))) {
-    return;
-  }
-
-  const context = {
-    workspace: workspaceContext?.name || "",
-    ...additionalContext,
-  };
-
-  if (prefs.logTelemetryEvent) {
-    console.log("🔴", event, context);
-  }
-
-  mixpanel.track(event, context);
 }
 
 export function trackTiming(event: string, properties: any = {}) {

--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -4,7 +4,7 @@ import { skipTelemetry } from "./environment";
 import { Recording, Workspace } from "ui/types";
 import { prefs } from "./prefs";
 import { UserInfo } from "ui/hooks/users";
-import { initializeMixpanel } from "./mixpanel";
+import { initializeMixpanel, trackMixpanelEvent } from "./mixpanel";
 
 const timings: Record<string, number> = {};
 
@@ -105,3 +105,5 @@ export function trackTiming(event: string, properties: any = {}) {
 
   sendTelemetryEvent(event, { duration, ...properties });
 }
+
+export const trackEvent = trackMixpanelEvent;


### PR DESCRIPTION
This patch:
- consolidates the way we handle enabling/disabling mixpanel tracking.
- adds a `start-session` and `end-session` events to help make tracking event flows easier.