### PR TITLE
Delay session start until after we have the user's info

### DIFF
--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -11,10 +11,7 @@ const enableMixpanel = () => (mixpanelDisabled = false);
 const disableMixpanel = () => (mixpanelDisabled = true);
 
 export function initializeMixpanel() {
-  // This init event becomes our Session Start point.
   mixpanel.init("ffaeda9ef8fb976a520ca3a65bba5014");
-  trackMixpanelEvent("session-start");
-  setupSessionEndListener();
 
   // Add the recordingId to the event metadata so we have a cookie crumb
   // trail for following flows in LogRocket.
@@ -32,6 +29,8 @@ export function maybeSetMixpanelContext(userInfo: TelemetryUser) {
 
   if (!shouldDisableMixpanel || forceEnableMixpanel) {
     enableMixpanel();
+    trackMixpanelEvent("session_start");
+    setupSessionEndListener();
     setMixpanelContext(userInfo);
   } else {
     disableMixpanel();
@@ -62,7 +61,7 @@ export function setMixpanelContext({ id, email }: TelemetryUser) {
   }
 }
 
-export const endMixpanelSession = () => trackMixpanelEvent("session-end");
+export const endMixpanelSession = () => trackMixpanelEvent("session_end");
 export const trackViewMode = (viewMode: ViewMode) =>
   trackMixpanelEvent(viewMode == "dev" ? "visit devtools" : "visit viewer");
 


### PR DESCRIPTION
Originally thought it was a good idea to start the session as soon as possible to maximize the number of events that we can track. But this complicates the track vs don't track logic. This simplifies it and just starts the session once we have all the information we need to know whether we should track the user or not.

Changed the event name to `session_start` and `session_end` so we can exclude the old events (`session-start`, `session-end`).