### PR TITLE
Remove duplicated mixpanel events

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/index.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/index.js
@@ -227,7 +227,6 @@ export function addBreakpointAtLine(cx, line, shouldLog = false, disabled = fals
       return;
     }
 
-    trackEvent("add breakpoint");
     trackEvent("breakpoint.add");
 
     const breakpointLocation = {

--- a/src/devtools/client/debugger/src/actions/breakpoints/modify.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/modify.js
@@ -250,7 +250,6 @@ export function setBreakpointOptions(cx, location, options = {}) {
 
     // Note: setting a breakpoint's options implicitly enables it.
     breakpoint = { ...breakpoint, disabled: false, options };
-    trackEvent("edit breakpoint");
     trackEvent("breakpoint.edit");
 
     dispatch({

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -174,7 +174,6 @@ class Message extends Component {
 
     let overlayType, label;
     let onRewindClick = () => {
-      trackEvent("console seek");
       trackEvent("console.seek");
       dispatch(
         actions.seek(executionPoint, executionPointTime, executionPointHasFrames, message.pauseId)


### PR DESCRIPTION
We're currently keeping duplicates for these three events after having changed the naming scheme for mixpanel events:
- `breakpoint.add` and `add breakpoint`
- `breakpoint.edit` and `edit breakpoint`
- `console.seek` and `console seek`

I merged those events together in Mixpanel's Lexicon so that they just show up under the current naming scheme (e.g. `breakpoint.add`), so we can get rid of them here.