### PR TITLE
Fix breakpoint overflow in statement

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -53,15 +53,18 @@
   justify-content: space-between;
 }
 
+.breakpoint-panel .statements-container {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .breakpoint-panel .statement {
   align-items: center;
   display: flex;
   height: 28px;
   line-height: 16px;
-  overflow: hidden;
   padding: 4px;
   padding-left: 8px;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
This is the same fix as #4274, but this time for the view when *not*
editing.

### Before

![CleanShot 2021-11-02 at 19 21 47](https://user-images.githubusercontent.com/5903784/140001820-b8abd00c-5a9e-4f0f-a81d-dcf8a3007e05.png)

### After

![CleanShot 2021-11-02 at 19 21 25](https://user-images.githubusercontent.com/5903784/140001824-5ee90a83-807d-45e6-813d-ef5d25adfad3.png)