### PR TITLE
Fix timeline inconsistency (#4289)

### DIFF
--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -139,7 +139,7 @@ class Timeline extends Component<PropsFromRedux> {
     if (hoverTime != null && !clickedOnCommentMarker) {
       const event = mostRecentPaintOrMouseEvent(mouseTime);
       if (event && event.point) {
-        if (!seek(event.point, mouseTime, false)) {
+        if (!seek(event.point, event.time, false)) {
           // if seeking to the new point failed because it is in an unloaded region,
           // we reset the timeline to the current time
           setTimelineToTime(ThreadFront.currentTime, true);


### PR DESCRIPTION
When the user clicks on the Timeline, we look for the last paint or mouse event before that point in time and seek to the execution point of that event. But we only used the execution point from that event, not the time. This led to an inconsistent time/executionPoint pair used in the frontend (and also saved in comments).