### PR TITLE
Nicer text for “are you there?” screen

### DIFF
--- a/src/protocol/socket.ts
+++ b/src/protocol/socket.ts
@@ -156,9 +156,9 @@ function onSocketMessage(evt: MessageEvent<any>) {
 export function getDisconnectionError(): UnexpectedError {
   endMixpanelSession();
   return {
-    message: "Are you still there?",
-    content: "Replays disconnect after 5 minutes to reduce server load. Ready when you are!",
-    action: "refresh",
+    message: "Ready when you are!",
+    content: "Replays disconnect after 5 minutes to reduce server load.",
+    action: "Refresh",
   };
 }
 


### PR DESCRIPTION
Old:
message: "Are you still there?",
content: "Replays disconnect after 5 minutes to reduce server load. Ready when you are!",
action: "refresh",

New:
message: "Ready when you are!",
content: "Replays disconnect after 5 minutes to reduce server load.",
action: "Refresh",

"Are you still there?" sounds like you're concerned that something went wrong. "Ready when you are!" is forward-looking and proactive.