### PR TITLE
Improve Elements panel performance (#4224)

### DIFF
--- a/src/devtools/client/inspector/rules/models/element-style.ts
+++ b/src/devtools/client/inspector/rules/models/element-style.ts
@@ -399,12 +399,13 @@ export default class ElementStyle {
       // overridden state has changed for the text property.
       // _hasUpdatedCSSVariable will return true if the declaration contains any
       // of the updated CSS variable names.
-      if (
-        this._updatePropertyOverridden(textProp) ||
-        this._hasUpdatedCSSVariable(textProp, changedVariableNamesSet)
-      ) {
-        textProp.updateEditor();
-      }
+      // if (
+      //   this._updatePropertyOverridden(textProp) ||
+      //   this._hasUpdatedCSSVariable(textProp, changedVariableNamesSet)
+      // ) {
+      //   textProp.updateEditor();
+      // }
+      this._updatePropertyOverridden(textProp);
 
       // For each editor show or hide the inactive CSS icon as needed.
       // if (textProp.editor && this.unusedCssEnabled) {

--- a/src/devtools/client/inspector/rules/rules.js
+++ b/src/devtools/client/inspector/rules/rules.js
@@ -578,6 +578,11 @@ class RulesView {
    * to be refresh (e.g. when print media simulation is toggled).
    */
   async updateElementStyle() {
+    // Updating the style panels can take more than 100ms and blocks the browser from
+    // rendering the updated markup panel, so we add a tiny delay here to give the browser
+    // an opportunity to render.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
     await this.elementStyle.populate();
 
     // const isAddRuleEnabled = this.selection.isElementNode() && !this.selection.isAnonymousNode();

--- a/src/devtools/shared/inspector/css-logic.js
+++ b/src/devtools/shared/inspector/css-logic.js
@@ -129,14 +129,25 @@ exports.isAgentStylesheet = function (sheet) {
  *
  * @param {CSSStyleSheet} sheet the DOM object for the style sheet.
  */
+const shortSourceCache = new Map();
 exports.shortSource = function (sheet) {
   // Use a string like "inline" if there is no source href
   if (!sheet || !sheet.href) {
     return exports.l10n("rule.sourceInline");
   }
 
+  if (shortSourceCache.has(sheet.href)) {
+    return shortSourceCache.get(sheet.href);
+  }
+
+  const shortened = computeShortSource(sheet.href);
+  shortSourceCache.set(sheet.href, shortened);
+  return shortened;
+};
+
+function computeShortSource(href) {
   // If the sheet is a data URL, return a trimmed version of it.
-  const dataUrl = sheet.href.trim().match(/^data:.*?,((?:.|\r|\n)*)$/);
+  const dataUrl = href.trim().match(/^data:.*?,((?:.|\r|\n)*)$/);
   if (dataUrl) {
     return dataUrl[1].length > MAX_DATA_URL_LENGTH
       ? `${dataUrl[1].substr(0, MAX_DATA_URL_LENGTH - 1)}…`
@@ -146,7 +157,7 @@ exports.shortSource = function (sheet) {
   // We try, in turn, the filename, filePath, query string, whole thing
   let url = {};
   try {
-    url = new URL(sheet.href);
+    url = new URL(href);
   } catch (ex) {
     // Some UA-provided stylesheets are not valid URLs.
   }
@@ -163,8 +174,8 @@ exports.shortSource = function (sheet) {
     return url.query;
   }
 
-  return sheet.href;
-};
+  return href;
+}
 
 const TAB_CHARS = "\t";
 const SPACE_CHARS = " ";

--- a/src/ui/utils/sanitize.ts
+++ b/src/ui/utils/sanitize.ts
@@ -18,7 +18,13 @@ const forbiddenClasses: Record<string, any> = {
   NodeBoundsFront,
 };
 
-const excludedActions = ["SET_SYMBOLS", "START_PREVIEW", "COMPLETE_PREVIEW"];
+const excludedActions = [
+  "SET_SYMBOLS",
+  "START_PREVIEW",
+  "COMPLETE_PREVIEW",
+  "UPDATE_RULES",
+  "set_computed_properties",
+];
 
 const loggedCategories = new Set<string>();
 


### PR DESCRIPTION
This PR contains 4 independent changes to improve the performance of the Elements panel:
- adds a tiny delay before updating the style panels to give the browser an opportunity to render the updated markup view
- removes the `_hasUpdatedCSSVariable` check in the `ElementStyle` class that had no effect
- adds a cache to the `shortSource` function
- adds 2 redux actions with a large payload to the list of actions that should not be sanitized