### PR TITLE
Faster full-project search

### DIFF
--- a/src/devtools/client/debugger/src/actions/project-text-search.js
+++ b/src/devtools/client/debugger/src/actions/project-text-search.js
@@ -80,13 +80,18 @@ export function searchSources(cx, query) {
     const validSources = getSourceList(getState()).filter(
       source => !ThreadFront.isMinifiedSource(source.id) && !isThirdParty(source)
     );
-    for (const source of validSources) {
-      if (cancelled) {
-        return;
-      }
-      await dispatch(loadSourceText({ cx, source }));
-      await dispatch(searchSource(cx, source.id, query));
-    }
+    await Promise.all(
+      validSources.map(async source => {
+        if (cancelled) {
+          return;
+        }
+        await dispatch(loadSourceText({ cx, source }));
+        if (cancelled) {
+          return;
+        }
+        await dispatch(searchSource(cx, source.id, query));
+      })
+    );
     dispatch(updateSearchStatus(cx, statusType.done));
   };
 


### PR DESCRIPTION
Related to #3852 

I was poking through the project search code to get familiar with how it works today, and I noticed that the redux action loads each source in sequence before we search it. For kicks, I tried loading the sources in parallel instead.

On a cold-cache, that made a _huge_ difference in the time to search a Replay-Replay. I think there would still be benefits to moving search to the backend, but maybe this could be a helpful very-short-term change?

I made a replay, but unfortunately both versions take about the same amount of time when the replay browser is recording a replay (I guess there's probably some overhead to recording?). You can better observe the difference regular screen captures.

### This branch
https://user-images.githubusercontent.com/478109/140329460-8f4a7b83-b7d5-4c49-aa88-f89ca346ea17.mov

### master
https://user-images.githubusercontent.com/478109/140329928-fed9995f-8ca2-4f9e-b066-6771fa2ef2e9.mov

