### PR TITLE
Fix highlighter and node picker when screenshots are scaled

### DIFF
--- a/src/devtools/server/actors/highlighters/box-model.js
+++ b/src/devtools/server/actors/highlighters/box-model.js
@@ -24,7 +24,7 @@ const nodeConstants = require("devtools/shared/dom-node-constants");
 const { LocalizationHelper } = require("devtools/shared/l10n");
 const STRINGS_URI = "devtools/shared/locales/highlighters.properties";
 const L10N = new LocalizationHelper(STRINGS_URI);
-const { refreshGraphics } = require("protocol/graphics");
+const { refreshGraphics, getDevicePixelRatio } = require("protocol/graphics");
 
 // Note that the order of items in this array is important because it is used
 // for drawing the BoxModelHighlighter's path elements correctly.
@@ -32,6 +32,22 @@ const BOX_MODEL_REGIONS = ["margin", "border", "padding", "content"];
 const BOX_MODEL_SIDES = ["top", "right", "bottom", "left"];
 // Width of boxmodelhighlighter guides
 const GUIDE_STROKE_WIDTH = 1;
+
+function scaleQuad({ p1, p2, p3, p4 }, scale) {
+  return {
+    p1: scaleCoordinates(p1, scale),
+    p2: scaleCoordinates(p2, scale),
+    p3: scaleCoordinates(p3, scale),
+    p4: scaleCoordinates(p4, scale),
+  };
+}
+
+function scaleCoordinates({ x, y }, scale) {
+  return {
+    x: x / scale,
+    y: y / scale,
+  };
+}
 
 /**
  * The BoxModelHighlighter draws the box model regions on top of a node.
@@ -521,7 +537,8 @@ class BoxModelHighlighter extends AutoRefreshHighlighter {
   }
 
   _getBoxPathCoordinates(boxQuad, nextBoxQuad) {
-    const { p1, p2, p3, p4 } = boxQuad;
+    const scale = getDevicePixelRatio();
+    const { p1, p2, p3, p4 } = scaleQuad(boxQuad, scale);
 
     let path;
     if (!nextBoxQuad || !this.options.onlyRegionArea) {
@@ -549,7 +566,7 @@ class BoxModelHighlighter extends AutoRefreshHighlighter {
         p4.y;
     } else {
       // Otherwise, just draw the region itself, not a filled rectangle.
-      const { p1: np1, p2: np2, p3: np3, p4: np4 } = nextBoxQuad;
+      const { p1: np1, p2: np2, p3: np3, p4: np4 } = scaleQuad(nextBoxQuad, scale);
       path =
         "M" +
         p1.x +
@@ -711,6 +728,8 @@ class BoxModelHighlighter extends AutoRefreshHighlighter {
       return false;
     }
 
+    const scale = getDevicePixelRatio();
+    point = point / scale;
     if (side === "top" || side === "bottom") {
       guide.setAttribute("x1", "0");
       guide.setAttribute("y1", point + "");

--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -5,7 +5,6 @@ import { actions } from "ui/actions";
 import { EventEmitter } from "protocol/utils";
 import classnames from "classnames";
 import { ThreadFront } from "protocol/thread";
-import { getDevicePixelRatio } from "protocol/graphics";
 import Highlighter from "highlighter/highlighter";
 
 export const nodePicker: any = {};
@@ -87,14 +86,10 @@ class NodePicker extends React.Component<PropsFromRedux, NodePickerState> {
     }
 
     const scale = bounds.width / canvas.offsetWidth;
-    const pixelRatio = getDevicePixelRatio();
-    if (!pixelRatio) {
-      return null;
-    }
 
     return {
-      x: (e.clientX - bounds.left) / scale / pixelRatio,
-      y: (e.clientY - bounds.top) / scale / pixelRatio,
+      x: (e.clientX - bounds.left) / scale,
+      y: (e.clientY - bounds.top) / scale,
     };
   }
 


### PR DESCRIPTION
https://app.replay.io/recording/ac28b258-800b-42f0-be73-b0bbb04c6011 is a recording with scaled screenshots because it was recorded on a retina display (I think). See how highlighting elements and using the node picker is way off.
But in https://devtools-oa8akoob9-recordreplay.vercel.app/recording/ac28b258-800b-42f0-be73-b0bbb04c6011 it works.