### PR TITLE
Borderless UI follow up fixes

### DIFF
--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -162,7 +162,7 @@ class Debugger extends Component {
     const horizontal = this.isHorizontal();
 
     return (
-      <div className="editor-pane pt-2 overflow-hidden rounded-lg">
+      <div className="editor-pane overflow-hidden rounded-lg">
         <div className="editor-container relative">
           {!isDemo() && <EditorTabs horizontal={horizontal} />}
           <Redacted>

--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -72,3 +72,8 @@
   height: 100%;
   background-color: white;
 }
+
+.accordion > *:last-child > ._header {
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}

--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -493,17 +493,15 @@ export function refreshGraphics() {
   const cx = canvas.getContext("2d")!;
   const bounds = calculateBounds(video.getBoundingClientRect(), image);
 
-  const LAYOUT_MARGIN = 10;
-
   if (bounds) {
-    canvas.width = bounds.width - LAYOUT_MARGIN * 2;
-    canvas.height = bounds.height - LAYOUT_MARGIN * 2;
-    graphicsVideo.style.width = bounds.width - LAYOUT_MARGIN * 2 + "px";
-    graphicsVideo.style.height = bounds.height - LAYOUT_MARGIN * 2 + "px";
+    canvas.width = bounds.width * 2;
+    canvas.height = bounds.height * 2;
+    graphicsVideo.style.width = bounds.width * 2 + "px";
+    graphicsVideo.style.height = bounds.height * 2 + "px";
 
     canvas.style.transform = graphicsVideo.style.transform = `scale(${bounds.scale})`;
-    canvas.style.left = graphicsVideo.style.left = String(bounds.left + LAYOUT_MARGIN) + "px";
-    canvas.style.top = graphicsVideo.style.top = String(bounds.top + LAYOUT_MARGIN) + "px";
+    canvas.style.left = graphicsVideo.style.left = String(bounds.left) + "px";
+    canvas.style.top = graphicsVideo.style.top = String(bounds.top) + "px";
     if (image) {
       cx.drawImage(image, 0, 0);
     }

--- a/src/ui/components/Avatar.module.css
+++ b/src/ui/components/Avatar.module.css
@@ -8,6 +8,7 @@
   width: 24px;
   border-radius: 50%;
   box-shadow: 0 0 0 2px var(--chrome);
+  overflow: hidden;
 }
 
 .avatar:not(.authenticated):not(:last-child) {

--- a/src/ui/components/Header/Header.module.css
+++ b/src/ui/components/Header/Header.module.css
@@ -1,6 +1,5 @@
 .header {
   background-color: var(--chrome);
-  border-bottom: 1px solid var(--theme-splitter-color);
   height: 50px;
   display: flex;
   align-items: center;

--- a/src/ui/components/Header/ShareButton.tsx
+++ b/src/ui/components/Header/ShareButton.tsx
@@ -16,7 +16,7 @@ function ShareButton({ setModal }: PropsFromRedux) {
     <button
       type="button"
       onClick={onClick}
-      className="flex items-center space-x-1.5 px-4 py-1.5 rounded-lg text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent h-8 mr-0 sharebutton"
+      className="flex items-center space-x-1.5 px-4 py-4 rounded-lg text-white bg-primaryAccent hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primaryAccent h-8 mr-0 sharebutton"
     >
       <MaterialIcon style={{ fontSize: "16px" }}>ios_share</MaterialIcon>
       <div>Share</div>

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -45,7 +45,7 @@ function SidePanel({ selectedPrimaryPanel }: SidePanelProps) {
     );
   }
 
-  return <div className="rounded-lg overflow-hidden w-full mt-2">{sidepanel}</div>;
+  return <div className="rounded-lg overflow-hidden w-full mr-2">{sidepanel}</div>;
 }
 
 const connector = connect((state: UIState) => ({

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -80,7 +80,7 @@ function Toolbar({
   }
 
   return (
-    <div className="toolbox-toolbar-container flex flex-col items-center justify-between p-1.5 pb-4">
+    <div className="toolbox-toolbar-container flex flex-col items-center justify-between p-2 pb-4">
       <div id="toolbox-toolbar">
         <div
           className={classnames("toolbar-panel-button comments", {

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -57,7 +57,7 @@ function Video({
   const showCommentTool = isPaused && !isNodeTarget && !isNodePickerActive;
 
   return (
-    <div id="video" className="bg-toolbarBackground mt-2">
+    <div id="video" className="bg-toolbarBackground">
       <div className="absolute w-full h-full flex items-center justify-center bg-chrome">
         <ReplayLogo size="sm" color="gray" />
       </div>

--- a/src/ui/components/Views/NonDevView.tsx
+++ b/src/ui/components/Views/NonDevView.tsx
@@ -56,7 +56,7 @@ function NonDevView({ updateTimelineDimensions, sidePanelCollapsed }: PropsFromR
           maxSize={sidePanelCollapsed ? "0" : "80%"}
           minSize={sidePanelCollapsed ? "0" : "240px"}
           onControlledPanelResized={handleMove}
-          splitterSize={16}
+          splitterSize={1}
           style={{ width: "100%", overflow: "hidden" }}
           vert={true}
         />


### PR DESCRIPTION
Fix #4309.

1) 8px vertical border between the video and the sidepanels
![image](https://user-images.githubusercontent.com/15959269/140440530-355748b2-e73e-4937-9320-d3aab398e6c5.png)
2) Made the share button height ~32px. This isn't quite the same as 34px as the view toggle, but because of the gray border the view toggle looks a tad smaller than it actually does and this ends up looking 👌. Thoughts welcome.
![image](https://user-images.githubusercontent.com/15959269/140440760-ccb588cc-869a-4d62-92aa-dad4a31fca8f.png)
3) Can't reproduce this one.
4) Made the padding around the toolbar 8px.
![image](https://user-images.githubusercontent.com/15959269/140440800-4dc94da5-fedc-4038-8998-5425f4cc2e8a.png)
5) Made an executive decision on the border underneath the header and made it thinner so it's more consistent with the other gaps. Otherwise it ended up looking too thick. 
![image](https://user-images.githubusercontent.com/15959269/140440902-689c57d1-3db5-4df2-8c30-ddb180ac0cc4.png)


@jonbell-lot23 I'll leave the decision re: #2 and #5 to you. Let me know what you think!