### PR TITLE
Adjust the search boxes to fit the new UI

### DIFF
--- a/src/devtools/client/debugger/src/components/QuickOpenModal.js
+++ b/src/devtools/client/debugger/src/components/QuickOpenModal.js
@@ -393,7 +393,7 @@ export class QuickOpenModal extends Component {
     const expanded = !!items && items.length > 0;
 
     return (
-      <Modal in={enabled} handleClose={this.closeModal}>
+      <Modal additionalClass={"rounded-lg"} in={enabled} handleClose={this.closeModal}>
         <SearchInput
           query={query}
           hasPrefix={true}

--- a/src/devtools/client/debugger/src/components/shared/SearchInput.css
+++ b/src/devtools/client/debugger/src/components/shared/SearchInput.css
@@ -10,7 +10,7 @@
   flex-shrink: 0;
   min-height: 28px;
   width: 100%;
-  background-color: var(--theme-toolbar-background);
+  background-color: white;
 }
 
 .search-field .img.search {

--- a/src/devtools/client/debugger/src/components/shared/SearchInput.js
+++ b/src/devtools/client/debugger/src/components/shared/SearchInput.js
@@ -216,7 +216,7 @@ class SearchInput extends Component {
     return (
       <div className="search-outline">
         <div
-          className={classnames("search-field", size)}
+          className={classnames("search-field rounded-lg", size)}
           role="combobox"
           aria-haspopup="listbox"
           aria-owns="result-list"

--- a/src/ui/components/shared/Modal.css
+++ b/src/ui/components/shared/Modal.css
@@ -28,7 +28,8 @@
   padding: 20px;
   background: var(--theme-toolbar-background);
   color: var(--theme-toolbar-color);
-  box-shadow: rgba(15, 15, 15, 0.05) 0px 0px 0px 1px, rgba(15, 15, 15, 0.1) 0px 3px 6px, rgba(15, 15, 15, 0.2) 0px 9px 24px;
+  box-shadow: rgba(15, 15, 15, 0.05) 0px 0px 0px 1px, rgba(15, 15, 15, 0.1) 0px 3px 6px,
+    rgba(15, 15, 15, 0.2) 0px 9px 24px;
   animation: dropdownFadeIn ease 200ms;
 }
 
@@ -42,6 +43,10 @@
 }
 
 @keyframes modalFadeIn {
-  0% {opacity:0;}
-  100% {opacity:1;}
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
With the new UI, the search boxes were looking a little out of place.
I've made the backgrounds white, and rounded the edges like the other
panes.

### Before

![CleanShot 2021-11-04 at 18 13 33](https://user-images.githubusercontent.com/5903784/140441912-8cd17c07-ab4d-44bf-b0cb-3f9a156ef911.png)

### After

![CleanShot 2021-11-04 at 18 15 17](https://user-images.githubusercontent.com/5903784/140442000-b91207e9-308f-435d-816a-65b602933f00.png)

