### PR TITLE
Convert context error to a warning

### DIFF
--- a/src/devtools/client/debugger/src/utils/context.js
+++ b/src/devtools/client/debugger/src/utils/context.js
@@ -36,6 +36,6 @@ export function validateContext(state, cx) {
   validateNavigateContext(state, cx);
   const newcx = getThreadContext(state);
   if (cx.pauseCounter && cx.pauseCounter != newcx.pauseCounter) {
-    throw new ContextError("Current thread has paused or resumed");
+    console.warn("Current thread has paused or resumed");
   }
 }


### PR DESCRIPTION
I've ignored context error for the past year because it no longer makes sense in a Replay world. Converting it to a warning now that we're in Next and Next takes unhandled errors seriously. I think we can safely remove this logic too.