### PR TITLE
Only round out the borders for the accordion's last child if it's not expanded

### DIFF
--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -73,7 +73,7 @@
   background-color: white;
 }
 
-.accordion > *:last-child > ._header {
+.accordion > .collapsed:last-child > ._header {
   border-bottom-left-radius: 0.5rem;
   border-bottom-right-radius: 0.5rem;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15959269/140590520-9e62b481-0fd2-4768-95ed-37b48149ff70.png)
![image](https://user-images.githubusercontent.com/15959269/140590543-895f2552-d42a-4b58-b13a-dca5c2a7494e.png)
