### PR TITLE
Comment spacing

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -62,7 +62,7 @@ function CommentItemHeader({
           {comment.user.name}
         </span>
         <span
-          className="overflow-hidden overflow-ellipsis whitespace-pre flex-shrink-0 opacity-50"
+          className="overflow-hidden overflow-ellipsis whitespace-pre flex-shrink-0 text-gray-400"
           title={relativeDate}
         >
           {relativeDate}
@@ -160,8 +160,8 @@ function CommentCard({
   return (
     <div
       className={classNames(
-        `mx-auto relative w-full border-b last:border-b-0 border-gray-300 cursor-pointer transition`,
-        hoveredComment === comment.id ? "bg-toolbarBackground" : "bg-white"
+        `mx-auto relative w-full border-b last:border-b-0 border-gray-300 cursor-pointer transition bg-white`
+        // hoveredComment === comment.id ? "bg-toolbarBackground" : "bg-white"
       )}
       onMouseDown={e => {
         seekToComment(comment);
@@ -199,9 +199,9 @@ function CommentCard({
             />
           </FocusContext.Provider>
         ) : (
-          <div className="pl-2 py-1 border-transparent border">
+          <div className="border-transparent border">
             <button
-              className="w-1/2 text-left hover:text-primaryAccent focus:outline-none focus:text-primaryAccent"
+              className="w-1/2 text-left text-gray-400 hover:text-primaryAccent focus:outline-none focus:text-primaryAccent"
               onClick={() => {
                 setIsEditorOpen(true);
                 setIsFocused(true);

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -110,7 +110,7 @@ const TipTapEditor = ({
       }}
     >
       <EditorContent
-        className={classNames("outline-none w-full rounded-md py-1 px-2 transition border", {
+        className={classNames("outline-none w-full rounded-md py-1 transition border", {
           "bg-white": editable,
           "border-gray-400": editable,
           "border-transparent": !editable,


### PR DESCRIPTION

<img width="410" alt="Screen Shot 2021-11-06 at 5 38 51 PM" src="https://user-images.githubusercontent.com/254562/140628007-1b77ef45-801a-4d40-a2fc-c2a5075122d7.png">


- aligns the comment text
- removes the comment hover background. We should re-evaluate, but with the current ui it too similar to chrome
- makes the reply button consistent with relative date

These changes line up with frame.io, but that was not intentional

<img width="363" alt="Screen Shot 2021-11-06 at 5 36 30 PM" src="https://user-images.githubusercontent.com/254562/140627964-3ed0e20e-fa80-44e7-a040-fd064bc497f8.png">

