### PR TITLE
Refactor useDismissNag

### DIFF
--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -113,13 +113,14 @@ export function useDismissNag() {
   const [dismissNag, { error }] = useMutation(DISMISS_NAG, {
     refetchQueries: ["GetUser"],
   });
+  const { nags } = useGetUserInfo();
 
   if (error) {
     console.error("Apollo error while updating the user's nags:", error);
   }
 
   return (nag: Nag) => {
-    if (isTest()) {
+    if (!nags || nags.includes(nag)) {
       return;
     }
 


### PR DESCRIPTION
We're currently using an `isTest()` flag here. We can skip checking the app's being run as a test if we just bail from dismissing nags if nags is undefined.

This also add an additional condition to keep us from hitting the server repeatedly for nags that have already been dismissed.