### PR TITLE
Ignore stripe.js loader error

### DIFF
--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -9,7 +9,11 @@ import { initializeMixpanel, trackMixpanelEvent } from "./mixpanel";
 const timings: Record<string, number> = {};
 
 export function setupTelemetry() {
-  const ignoreList = ["Current thread has paused or resumed", "Current thread has changed"];
+  const ignoreList = [
+    "Current thread has paused or resumed",
+    "Current thread has changed",
+    "Failed to load Stripe.js",
+  ];
   // We always initialize mixpanel here. This allows us to force enable mixpanel events even if
   // telemetry events are being skipped for any reason, e.g. development, test, etc.
   initializeMixpanel();


### PR DESCRIPTION
There's some additional context in https://github.com/stripe/stripe-js/issues/26 but there doesn't seem to be a way to handle this error to avoid the promise rejection so I'm suppressing it from Sentry instead.