### PR TITLE
Left sidebar follow up polish

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/SecondaryPanes.css
@@ -9,7 +9,6 @@
   flex-direction: column;
   flex: 1;
   white-space: nowrap;
-  background-color: var(--theme-sidebar-background);
   --breakpoint-expression-right-clear-space: 36px;
 }
 

--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -3,7 +3,6 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .accordion {
-  background-color: var(--chrome);
   width: 100%;
   list-style-type: none;
   padding: 0px;
@@ -71,9 +70,4 @@
   overflow-y: auto;
   height: 100%;
   background-color: white;
-}
-
-.accordion > .collapsed:last-child > ._header {
-  border-bottom-left-radius: 0.5rem;
-  border-bottom-right-radius: 0.5rem;
 }

--- a/src/devtools/client/shared/components/Accordion.css
+++ b/src/devtools/client/shared/components/Accordion.css
@@ -13,7 +13,6 @@
    * This can give it a focus outline when clicked, which we don't want.
    * The container itself is not in the focus order at all. */
   outline: none;
-  background-color: var(--chrome);
 }
 
 .accordion-header {

--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -199,7 +199,7 @@ function CommentCard({
             />
           </FocusContext.Provider>
         ) : (
-          <div className="border-transparent border">
+          <div className="border-transparent border pl-1">
             <button
               className="w-1/2 text-left text-gray-400 hover:text-primaryAccent focus:outline-none focus:text-primaryAccent"
               onClick={() => {

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -110,7 +110,7 @@ const TipTapEditor = ({
       }}
     >
       <EditorContent
-        className={classNames("outline-none w-full rounded-md py-1 transition border", {
+        className={classNames("outline-none w-full rounded-md p-1 transition border", {
           "bg-white": editable,
           "border-gray-400": editable,
           "border-transparent": !editable,

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -45,7 +45,7 @@ function SidePanel({ selectedPrimaryPanel }: SidePanelProps) {
     );
   }
 
-  return <div className="rounded-lg overflow-hidden w-full mr-2">{sidepanel}</div>;
+  return <div className="rounded-lg overflow-hidden w-full mr-2 bg-white">{sidepanel}</div>;
 }
 
 const connector = connect((state: UIState) => ({

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -35,7 +35,7 @@ function Transcript({ pendingComment }: PropsFromRedux) {
       </div>
       <div className="transcript-list flex-grow overflow-auto overflow-x-hidden flex flex-col items-center bg-white h-full text-xs">
         {displayedComments.length > 0 ? (
-          <div className="overflow-auto w-full flex-grow bg-chrome">
+          <div className="overflow-auto w-full flex-grow bg-white">
             <div className="rounded-b-lg overflow-hidden">
               {sortedComments.map((comment, i) => {
                 return <CommentCard comments={sortedComments} comment={comment} key={keys[i]} />;

--- a/src/ui/components/shared/CommentTool.tsx
+++ b/src/ui/components/shared/CommentTool.tsx
@@ -72,8 +72,9 @@ function CommentTool({
   executionPoint,
   comments,
   canvas,
-  setPendingComment,
   createFrameComment,
+  setPendingComment,
+  setSelectedPrimaryPanel,
 }: CommentToolProps) {
   const [mousePosition, setMousePosition] = useState<Coordinates | null>(null);
   const recordingId = useGetRecordingId();
@@ -141,6 +142,7 @@ function CommentTool({
       newComment.comment.position = mouseEventCanvasPosition(e);
 
       setPendingComment(newComment);
+      setSelectedPrimaryPanel("comments");
     }
   };
   const onMouseMove = (e: MouseEvent) => setMousePosition(mouseEventCanvasPosition(e));
@@ -196,6 +198,7 @@ const connector = connect(
   {
     setPendingComment: actions.setPendingComment,
     createFrameComment: actions.createFrameComment,
+    setSelectedPrimaryPanel: actions.setSelectedPrimaryPanel,
   }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;


### PR DESCRIPTION
Fix #4380, fix #3200.

Item | Screenshot
--- | ---
Comments pane should be full height (replay) | ![image](https://user-images.githubusercontent.com/15959269/140835871-0f792efe-ee7b-4969-a97a-192733748488.png)
Pause panel should be full height (replay) | ![image](https://user-images.githubusercontent.com/15959269/140835918-079880b1-2980-4a44-a29c-68c21150445e.png)
Comment editor should have left padding (replay) | ![image](https://user-images.githubusercontent.com/15959269/140836133-ffa18ea0-29a8-405c-95d3-ad59318b57e3.png)
Revisit comment background colors (replay) | https://user-images.githubusercontent.com/15959269/140836214-d65d5927-af04-46e0-908b-88e529b5cc2b.mov
Move marker should re-open the comments pane | https://user-images.githubusercontent.com/15959269/140836280-5187386c-fd57-49f2-8920-a7c82482b5d2.mov
 