### PR TITLE
Keep pause info panels from expanding to full height when expanded

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/SecondaryPanes.css
@@ -39,10 +39,6 @@
   flex-direction: column;
 }
 
-.secondary-panes .accordion li {
-  display: contents;
-}
-
 .secondary-panes-wrapper .accordion li:last-child ._content {
   border-bottom: 0;
 }


### PR DESCRIPTION
Fix #3200.

![image](https://user-images.githubusercontent.com/15959269/140835947-d0474e3e-c66a-45ca-bdc2-e6a611372a20.png)