### PR TITLE
Force fetching recording from server

### DIFF
--- a/src/ui/components/Library/RecordingRow.tsx
+++ b/src/ui/components/Library/RecordingRow.tsx
@@ -75,7 +75,7 @@ function RecordingRow({
     }
 
     loadReplayPrefs(recording.id);
-    router.push(url);
+    window.location.href = url;
   };
   const toggleChecked = () => {
     if (selected) {


### PR DESCRIPTION
There are a few errors that seem to stem from failing to clean up some module-scoped data (thread event listeners, screenshot cache). This likely resolves these but does make the UI a bit clunky (e.g. flash of white screen while fetching the HTML).

https://user-images.githubusercontent.com/788456/140842897-056bf3d4-c37c-4bac-8721-9d9f5146d018.mp4


