### PR TITLE
Refactor the code for painting screenshots (#4373) (#4395)

### DIFF
--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -86,12 +86,10 @@ class Timeline extends Component<PropsFromRedux> {
     if (!this.$progressBar) {
       return;
     }
-    const { hideTooltip, currentTime } = this.props;
     const isHovered = window.elementIsHovered(this.$progressBar);
     if (!isHovered) {
       window.clearInterval(this.hoverInterval);
       this.hoverInterval = undefined;
-      hideTooltip();
     }
   };
 
@@ -421,7 +419,6 @@ const connector = connect(
   }),
   {
     setTimelineToTime: actions.setTimelineToTime,
-    hideTooltip: actions.hideTooltip,
     setTimelineState: actions.setTimelineState,
     updateTimelineDimensions: actions.updateTimelineDimensions,
     seek: actions.seek,

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -12,10 +12,7 @@ function initialTimelineState(): TimelineState {
     unprocessedRegions: [],
     shouldAnimate: true,
     recordingDuration: null,
-    screenShot: null,
     timelineDimensions: { left: 1, top: 1, width: 1 },
-    mouse: null,
-    tooltip: null,
     hoveredItem: null,
     trimRegion: null,
   };
@@ -37,10 +34,6 @@ export default function update(
     case "set_playback_stalled": {
       const playback = state.playback ? { ...state.playback, stalled: action.stalled } : null;
       return { ...state, playback };
-    }
-
-    case "update_tooltip": {
-      return { ...state, tooltip: action.tooltip };
     }
 
     case "set_hovered_item": {
@@ -68,10 +61,7 @@ export const getPlayback = (state: UIState) => state.timeline.playback;
 export const isPlaybackStalled = (state: UIState) => state.timeline.playback?.stalled || false;
 export const getUnprocessedRegions = (state: UIState) => state.timeline.unprocessedRegions;
 export const getRecordingDuration = (state: UIState) => state.timeline.recordingDuration;
-export const getScreenShot = (state: UIState) => state.timeline.screenShot;
-export const getMouse = (state: UIState) => state.timeline.mouse;
 export const getTimelineDimensions = (state: UIState) => state.timeline.timelineDimensions;
-export const getTooltip = (state: UIState) => state.timeline.tooltip;
 export const getHoveredItem = (state: UIState) => state.timeline.hoveredItem;
 export const getPlaybackPrecachedTime = (state: UIState) => state.timeline.playbackPrecachedTime;
 export const getTrimRegion = (state: UIState) => state.timeline.trimRegion;

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -1,9 +1,4 @@
-import { ScreenShot, TimeRange, Location, MouseEventKind } from "@recordreplay/protocol";
-import { MouseAndClickPosition } from "../../protocol/graphics";
-
-export interface Tooltip {
-  left: number;
-}
+import { TimeRange, Location } from "@recordreplay/protocol";
 
 export interface ZoomRegion {
   endTime: number;
@@ -25,15 +20,12 @@ export interface TimelineState {
     stalled?: boolean;
   } | null;
   playbackPrecachedTime: number;
-  screenShot: ScreenShot | null;
-  mouse: MouseAndClickPosition | null | undefined;
   recordingDuration: number | null;
   zoomRegion: ZoomRegion;
   timelineDimensions: { width: number; left: number; top: number };
   hoverTime: number | null;
   unprocessedRegions: TimeRange[];
   shouldAnimate: boolean;
-  tooltip: Tooltip | null;
   hoveredItem: HoveredItem | null;
   trimRegion: { startTime: number; endTime: number } | null;
 }


### PR DESCRIPTION
Painting screenshots after seeking to a new pause was handled in 2 places: `ui/actions/timeline.ts` for recorded screenshots and `protocol/graphics.ts` for repainted screenshots. This PR consolidates the logic in `protocol/graphics.ts` and
- fixes #4373
- fixes #4395 
- removes some properties from redux that were not used anymore