### PR TITLE
Add `waitingFor` and fix two specs

### DIFF
--- a/test/mock/scripts/unload-recording-01.ts
+++ b/test/mock/scripts/unload-recording-01.ts
@@ -1,6 +1,7 @@
 // Check that unloaded regions in the recording are reflected in the UI.
 
-import { runTest, devtoolsURL, waitUntil } from "../src/runTest";
+import { runTest, devtoolsURL } from "../src/runTest";
+import { waitUntil } from "../../../src/test/harness";
 import { installMockEnvironment, MockHandlerHelpers } from "../src/mockEnvironment";
 import { v4 as uuid } from "uuid";
 import {
@@ -41,14 +42,18 @@ const messageHandlers = {
   ...basicMessageHandlers(),
   "Session.listenForLoadChanges": (params: any, h: MockHandlerHelpers) => {
     h.emitEvent("Session.loadedRegions", {
-      loaded: [{
-        begin: { point: "50000", time: 50000 },
-        end: h.bindings.endpoint,
-      }],
-      loading: [{
-        begin: { point: "50000", time: 50000 },
-        end: h.bindings.endpoint,
-      }],
+      loaded: [
+        {
+          begin: { point: "50000", time: 50000 },
+          end: h.bindings.endpoint,
+        },
+      ],
+      loading: [
+        {
+          begin: { point: "50000", time: 50000 },
+          end: h.bindings.endpoint,
+        },
+      ],
     });
     return new Promise(resolve => {});
   },

--- a/test/scripts/breakpoints-07.js
+++ b/test/scripts/breakpoints-07.js
@@ -9,12 +9,15 @@
 
     Test.app.actions.openQuickOpen();
     Test.app.actions.setQuickOpenQuery("bundle");
-    await Test.waitUntil(() => {
-      const foundSourceUrls = [...document.querySelectorAll("#result-list .title")].map(
-        el => el.textContent
-      );
-      return JSON.stringify(foundSourceUrls) === '["bundle_input.js"]';
-    });
+    await Test.waitUntil(
+      () => {
+        const foundSourceUrls = [...document.querySelectorAll("#result-list .title")].map(
+          el => el.textContent
+        );
+        return JSON.stringify(foundSourceUrls) === '["bundle_input.js"]';
+      },
+      { waitingFor: "bundle_input.js to be present in source urls" }
+    );
     Test.app.actions.closeQuickOpen();
 
     await Test.addBreakpoint("bundle_input.js", 5);
@@ -25,7 +28,7 @@
     await Test.rewindToLine(5);
     await checkBreakpointPanel(1);
 
-    closeEditor();
+    await closeEditor();
     // click the first source link in the console
     document.querySelectorAll(".webconsole-output .frame-link-source")[0].click();
     await checkBreakpointPanel(1);
@@ -46,7 +49,8 @@
     Test.app.actions.setViewMode("dev");
 
     await Test.waitUntil(
-      () => document.querySelectorAll(".breakpoints-list .breakpoint").length === 1
+      () => document.querySelectorAll(".breakpoints-list .breakpoint").length === 1,
+      { waitingFor: "a breakpoint to be present" }
     );
 
     Test.finish();
@@ -54,21 +58,26 @@
 })();
 
 async function checkBreakpointPanel(selectedBreakpoint) {
-  await Test.waitUntil(() => {
-    const statusElement = document.querySelector(".breakpoint-navigation-status-container");
-    return statusElement && statusElement.textContent === `${selectedBreakpoint}/2`;
-  });
+  await Test.waitUntil(
+    () => {
+      const statusElement = document.querySelector(".breakpoint-navigation-status-container");
+      return statusElement && statusElement.textContent === `${selectedBreakpoint}/2`;
+    },
+    { waitingFor: `${selectedBreakpoint}/2 to be selected` }
+  );
 }
 
 async function checkDebugLine() {
-  await Test.waitUntil(() =>
-    document.querySelector(".editor-pane .CodeMirror-code .new-debug-line")
+  await Test.waitUntil(
+    () => document.querySelector(".editor-pane .CodeMirror-code .new-debug-line"),
+    { waitingFor: "new debug line to be present" }
   );
 }
 
 async function closeEditor() {
   document.querySelector(".source-tabs .close").click();
   await Test.waitUntil(
-    () => document.querySelector(".breakpoint-navigation-status-container") === null
+    () => document.querySelector(".breakpoint-navigation-status-container") === null,
+    { waitingFor: "source tab to close" }
   );
 }

--- a/test/scripts/react_devtools.js
+++ b/test/scripts/react_devtools.js
@@ -8,31 +8,41 @@ Test.describe(`Test React DevTools.`, async () => {
   await Test.warpToMessage("Initial list");
 
   await Test.selectReactDevTools();
-  await Test.waitUntil(() => getComponents().length === 3);
+  await Test.waitUntil(() => getComponents().length === 3, {
+    waitingFor: "There to be 3 components in ReactDevTools",
+  });
 
   await Test.selectConsole();
   await Test.warpToMessage("Added an entry");
 
   await Test.selectReactDevTools();
-  await Test.waitUntil(() => getComponents().length === 4);
+  await Test.waitUntil(() => getComponents().length === 4, {
+    waitingFor: "There to be 4 components in ReactDevTools",
+  });
 
   await Test.selectConsole();
   await Test.warpToMessage("Removed an entry");
 
   await Test.selectReactDevTools();
-  await Test.waitUntil(() => getComponents().length === 3);
+  await Test.waitUntil(() => getComponents().length === 3, {
+    waitingFor: "There to be 3 components in ReactDevTools",
+  });
 
   const rootComponent = getComponents()[0];
 
   rootComponent.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
   await Test.checkHighlighterVisible(true);
-  await Test.checkHighlighterShape("M40,16 L140,16 L140,35 L40,35");
+  await Test.checkHighlighterShape("M40,16 L140,16 L140,36 L40,36");
 
   rootComponent.parentElement.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
-  await Test.waitUntil(() => getInspectedItem("State"));
+  await Test.waitUntil(() => getInspectedItem("State"), {
+    waitingFor: "State to be the inspectedItem",
+  });
 
   getInspectedItem("State").parentElement.firstChild.click();
-  await Test.waitUntil(() => getInspectedItem("0"));
+  await Test.waitUntil(() => getInspectedItem("0"), { waitingFor: "0 to be the inspected item" });
   getInspectedItem("0").parentElement.firstChild.click();
-  await Test.waitUntil(() => getInspectedItem("key") && getInspectedItem("text"));
+  await Test.waitUntil(() => getInspectedItem("key") && getInspectedItem("text"), {
+    waitingFor: "key and text to be the inspected items",
+  });
 });


### PR DESCRIPTION
### Changes

- Add a waitingFor field to the waitUntil method used in tests. It's really frustrating when a test fails and all it says is timed out. Like... timed out while waiting for what? Test failures should guide you to the place of failure as quickly as possible.
- Log the time that tests take. We started with a lot of timeouts. I fixed them, but sometimes it was hard to see what tests were timing out. Now, when a test completes, we emit some test stats. Eventually, it might be nice to just like... use a real test runner... but this is fine for now.