### PR TITLE
Add tests for the onboarding util

### DIFF
--- a/test/ui/utils/onboarding.test.js
+++ b/test/ui/utils/onboarding.test.js
@@ -1,0 +1,29 @@
+const { singleInvitation, firstReplay } = require("ui/utils/onboarding");
+const { Nag } = require("ui/hooks/users");
+
+describe("singleInvitation", () => {
+  test("should return false if there's more than one invitation", () => {
+    const invitationCount = 2;
+    const workspaceCount = 0;
+
+    expect(singleInvitation(invitationCount, workspaceCount)).toBe(false);
+  });
+  test("should return false if there are no invitations", () => {
+    const invitationCount = 0;
+    const workspaceCount = 0;
+
+    expect(singleInvitation(invitationCount, workspaceCount)).toBe(false);
+  });
+  test("should return false if the user is already in a workspace", () => {
+    const invitationCount = 1;
+    const workspaceCount = 1;
+
+    expect(singleInvitation(invitationCount, workspaceCount)).toBe(false);
+  });
+});
+
+describe("firstReplay", () => {
+  test("should return false if the user has already seen (or dismissed) the first replay nag", () => {
+    expect(firstReplay([Nag.FIRST_REPLAY_2]).toBe(false));
+  });
+});


### PR DESCRIPTION
Follow up to #4416. Pulled it out to get the new onboarding changes in effect before PST wakes up!

@jcmorrow This isn't ready yet.