### PR TITLE
Add a download replay modal for first-time users landing on the library in a non-firefox browser

### DIFF
--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -24,6 +24,7 @@ import TrimmingModal from "./shared/TrimmingModal/TrimmingModal";
 import { migratePrefToSettings } from "ui/hooks/settings";
 import { ConfirmRenderer } from "./shared/Confirm";
 import PrivacyModal from "./shared/PrivacyModal";
+import DownloadReplayPromptModal from "./shared/OnboardingModal/DownloadReplayPromptModal";
 
 function AppModal({ modal }: { modal: ModalType }) {
   switch (modal) {
@@ -53,6 +54,9 @@ function AppModal({ modal }: { modal: ModalType }) {
     }
     case "first-replay": {
       return <FirstReplayModal />;
+    }
+    case "download-replay": {
+      return <DownloadReplayPromptModal />;
     }
     case "trimming": {
       return <TrimmingModal />;

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -16,7 +16,12 @@ import ViewerRouter from "./ViewerRouter";
 import { TextInput } from "../shared/Forms";
 import LaunchButton from "../shared/LaunchButton";
 import { trackEvent } from "ui/utils/telemetry";
-import { firstReplay, hasTeamInvitationCode, singleInvitation } from "ui/utils/onboarding";
+import {
+  downloadReplay,
+  firstReplay,
+  hasTeamInvitationCode,
+  singleInvitation,
+} from "ui/utils/onboarding";
 
 function isUnknownWorkspaceId(
   id: string | null,
@@ -132,6 +137,7 @@ function Library({
 }: LibraryProps) {
   const [searchString, setSearchString] = useState("");
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
+  const dismissNag = hooks.useDismissNag();
 
   useEffect(function handleDeletedTeam() {
     // After rendering null, update the workspaceId to display the user's library
@@ -145,6 +151,9 @@ function Library({
     if (singleInvitation(pendingWorkspaces?.length || 0, workspaces.length)) {
       trackEvent("onboarding.team_invite");
       setModal("single-invite");
+    } else if (downloadReplay(nags, dismissNag)) {
+      trackEvent("onboarding.download_replay_prompt");
+      setModal("download-replay");
     } else if (firstReplay(nags)) {
       trackEvent("onboarding.demo_replay_prompt");
       setModal("first-replay");

--- a/src/ui/components/shared/Onboarding/index.tsx
+++ b/src/ui/components/shared/Onboarding/index.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import React, {
   Dispatch,
   MouseEventHandler,
+  ReactNode,
   SetStateAction,
   useContext,
   useEffect,
@@ -55,11 +56,7 @@ export function OnboardingHeader({ children }: { children: string }) {
   return <div className="text-5xl font-extrabold">{children}</div>;
 }
 
-export function OnboardingBody({
-  children,
-}: {
-  children: string | React.ReactChild | React.ReactChild[];
-}) {
+export function OnboardingBody({ children }: { children: string | ReactNode }) {
   return <div className="text-center">{children}</div>;
 }
 

--- a/src/ui/components/shared/OnboardingModal/DownloadReplayModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/DownloadReplayModal.tsx
@@ -1,0 +1,95 @@
+import React, { ReactNode, useState } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { actions } from "ui/actions";
+import { removeUrlParameters } from "ui/utils/environment";
+import { trackEvent } from "ui/utils/telemetry";
+import { PrimaryLgButton, SecondaryLgButton } from "../Button";
+import { DownloadingPage } from "../Onboarding/DownloadingPage";
+import { DownloadPage } from "../Onboarding/DownloadPage";
+import {
+  OnboardingActions,
+  OnboardingBody,
+  OnboardingContent,
+  OnboardingHeader,
+  OnboardingModalContainer,
+} from "../Onboarding/index";
+
+function InitialScreen({
+  onSkipToLibrary,
+  onNext,
+  children,
+}: {
+  onSkipToLibrary: () => void;
+  onNext: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <>
+      <OnboardingHeader>Welcome to Replay</OnboardingHeader>
+      <OnboardingBody>{children}</OnboardingBody>
+      <OnboardingActions>
+        <SecondaryLgButton color="blue" onClick={onSkipToLibrary}>
+          Skip
+        </SecondaryLgButton>
+        <PrimaryLgButton color="blue" onClick={onNext}>
+          {`Download Replay`}
+        </PrimaryLgButton>
+      </OnboardingActions>
+    </>
+  );
+}
+
+function DownloadReplayModal({ hideModal, children }: PropsFromRedux & { children: ReactNode }) {
+  const [current, setCurrent] = useState<number>(1);
+  const [randomNumber, setRandomNumber] = useState<number>(Math.random());
+
+  const onSkipToLibrary = () => {
+    removeUrlParameters();
+    trackEvent("skipped-replay-download");
+    hideModal();
+  };
+  const onNext = () => {
+    setCurrent(current + 1);
+    setRandomNumber(Math.random());
+  };
+  const onFinished = () => {
+    removeUrlParameters();
+    trackEvent("finished-onboarding");
+    hideModal();
+  };
+
+  let content;
+
+  if (current === 1) {
+    content = (
+      <InitialScreen
+        {...{
+          onSkipToLibrary,
+          onNext,
+          hideModal,
+        }}
+      >
+        {children}
+      </InitialScreen>
+    );
+  } else if (current === 2) {
+    content = <DownloadPage {...{ onNext, onSkipToLibrary }} />;
+  } else if (current === 3) {
+    content = <DownloadingPage {...{ onFinished }} />;
+  } else {
+    content = <div>hello</div>;
+  }
+
+  return (
+    <OnboardingModalContainer {...{ randomNumber }}>
+      <OnboardingContent>{content}</OnboardingContent>
+    </OnboardingModalContainer>
+  );
+}
+
+const connector = connect(() => ({}), {
+  hideModal: actions.hideModal,
+  setWorkspaceId: actions.setWorkspaceId,
+});
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(DownloadReplayModal);

--- a/src/ui/components/shared/OnboardingModal/DownloadReplayPromptModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/DownloadReplayPromptModal.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import DownloadReplayModal from "./DownloadReplayModal";
+
+export default function DownloadReplayPromptModal() {
+  return (
+    <DownloadReplayModal>{`To start making recordings, you'll have to download the Replay browser. Would you like to go that team, or download Replay?`}</DownloadReplayModal>
+  );
+}

--- a/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
@@ -4,19 +4,9 @@ import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
 import hooks from "ui/hooks";
 import { PendingWorkspaceInvitation } from "ui/types";
-import { removeUrlParameters } from "ui/utils/environment";
-import { trackEvent } from "ui/utils/telemetry";
-import { PrimaryLgButton, SecondaryLgButton } from "../Button";
-import { DownloadingPage } from "../Onboarding/DownloadingPage";
-import { DownloadPage } from "../Onboarding/DownloadPage";
-import {
-  OnboardingActions,
-  OnboardingBody,
-  OnboardingContent,
-  OnboardingHeader,
-  OnboardingModalContainer,
-} from "../Onboarding/index";
+import { OnboardingContent, OnboardingModalContainer } from "../Onboarding/index";
 import Spinner from "../Spinner";
+import DownloadReplayModal from "./DownloadReplayModal";
 
 function ModalLoader() {
   return (
@@ -71,90 +61,24 @@ function AutoAccept(props: SingleInviteModalProps) {
   return <SingleInviteModal {...props} />;
 }
 
-function InitialScreen({
-  onSkipToLibrary,
-  onNext,
-  name,
-  inviterEmail,
-}: {
-  onSkipToLibrary: () => void;
-  onNext: () => void;
-  name: string | null;
-  inviterEmail: string | null;
-}) {
-  return (
-    <>
-      <OnboardingHeader>Welcome to Replay</OnboardingHeader>
-      <OnboardingBody>
-        {`You've been added to the team `}
-        <strong>{name}</strong>
-        {` by `}
-        <strong>{inviterEmail}</strong>
-        {`. Would you like to go that team, or download Replay?`}
-      </OnboardingBody>
-      <OnboardingActions>
-        <SecondaryLgButton color="blue" onClick={onSkipToLibrary}>
-          {`Go to ${name}`}
-        </SecondaryLgButton>
-        <PrimaryLgButton color="blue" onClick={onNext}>
-          {`Download Replay`}
-        </PrimaryLgButton>
-      </OnboardingActions>
-    </>
-  );
-}
-
 type SingleInviteModalProps = PropsFromRedux & {
   workspace: PendingWorkspaceInvitation;
 };
 
 // This modal is used whenever a user is invited to Replay via a team invitation,
 // and there's only one outstanding team invitation for that user. This should guide them
-// through 1) creating a team, and/or 2) downloading the Replay browser.
-function SingleInviteModal({ hideModal, workspace }: SingleInviteModalProps) {
-  const [current, setCurrent] = useState<number>(1);
-  const [randomNumber, setRandomNumber] = useState<number>(Math.random());
+// through downloading the Replay browser next.
+function SingleInviteModal({ workspace }: SingleInviteModalProps) {
   const { name, inviterEmail } = workspace;
 
-  const onSkipToLibrary = () => {
-    removeUrlParameters();
-    trackEvent("skipped-replay-download");
-    hideModal();
-  };
-  const onNext = () => {
-    setCurrent(current + 1);
-    setRandomNumber(Math.random());
-  };
-  const onFinished = () => {
-    removeUrlParameters();
-    trackEvent("finished-onboarding");
-    hideModal();
-  };
-
-  const props = {
-    onSkipToLibrary,
-    onNext,
-    name,
-    inviterEmail,
-    hideModal,
-  };
-
-  let content;
-
-  if (current === 1) {
-    content = <InitialScreen {...props} />;
-  } else if (current === 2) {
-    content = <DownloadPage {...{ onNext, onSkipToLibrary }} />;
-  } else if (current === 3) {
-    content = <DownloadingPage {...{ onFinished }} />;
-  } else {
-    content = <div>hello</div>;
-  }
-
   return (
-    <OnboardingModalContainer {...{ randomNumber }}>
-      <OnboardingContent>{content}</OnboardingContent>
-    </OnboardingModalContainer>
+    <DownloadReplayModal>
+      {`You've been added to the team `}
+      <strong>{name}</strong>
+      {` by `}
+      <strong>{inviterEmail}</strong>
+      {`. Would you like to go that team, or download Replay?`}
+    </DownloadReplayModal>
   );
 }
 

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -50,6 +50,7 @@ export enum Nag {
   FIRST_BREAKPOINT_REMOVED = "first_breakpoint_removed",
   FIRST_CONSOLE_NAVIGATE = "first_console_navigate",
   FIRST_GUTTER_CLICK = "first_gutter_click",
+  DOWNLOAD_REPLAY = "download_replay",
 }
 
 export enum EmailSubscription {

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -31,6 +31,7 @@ export type ModalType =
   | "single-invite"
   | "browser-launch"
   | "first-replay"
+  | "download-replay"
   | "trimming"
   | "privacy";
 export type WorkspaceId = string;

--- a/src/ui/utils/onboarding.ts
+++ b/src/ui/utils/onboarding.ts
@@ -12,12 +12,27 @@ export const isTeamReferral = () => isTeamMemberInvite() || hasTeamInvitationCod
 
 // This is for the user onboarding flow where the user signs up for Replay using
 // a Replay team invite that they received in their email.
-export const singleInvitation = (invitations: number, workspaces: number) =>
+export const singleInvitation = (invitations: number, workspaces: number): boolean =>
   invitations === 1 && workspaces === 0;
 
 // This is for the user onboarding flow where the user opens the Replay
 // browser for the first time. It teaches them how to create their first replay.
-export function firstReplay(nags: Nag[]) {
-  if (isTeamReferral()) return false;
+export function firstReplay(nags: Nag[]): boolean {
+  if (isTeamReferral()) {
+    return false;
+  }
+
   return shouldShowNag(nags, Nag.FIRST_REPLAY_2) && isReplayBrowser();
+}
+
+// This is for the user onboarding flow where the user first opens the replay app
+// and it's not in the Replay browser. This will prompt them to download Replay.
+export function downloadReplay(nags: Nag[], dismissNag: (nag: Nag) => void): boolean {
+  if (isReplayBrowser()) {
+    dismissNag(Nag.DOWNLOAD_REPLAY);
+
+    return false
+  }
+
+  return shouldShowNag(nags, Nag.DOWNLOAD_REPLAY);
 }


### PR DESCRIPTION
When new users sign up for Replay and land in the library while in the Chrome browser, they often get stuck. If they weren't invited to a team, then there's nothing for them to take a look at. 

Ideally they'd end up downloading the replay button with our Launch Replay button in the top right. We don't have tracking for that yet (to be added shortly), but there's no indication that that helps unstuck people and send them over to the replay browser.

This is a heavy-handed approach to making sure that nobody gets stuck in a non-replay browser, which we do by making the replay browser download link very obvious.

![image](https://user-images.githubusercontent.com/15959269/141154093-c6bbbd5f-7ab7-4bca-a982-ae4bc7ef6d3c.png)
