### PR TITLE
Don't connect material-icons to the store

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -18,7 +18,8 @@ body {
   border: 2px solid black !important;
 }
 
-#__next {
+#__next,
+#app-container {
   display: flex;
   position: relative;
   flex-direction: column;

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import useAuth0 from "ui/utils/useAuth0";
+import classNames from "classnames";
 
 import AppErrors from "./shared/Error";
 import LoginModal from "./shared/LoginModal";
@@ -70,7 +71,7 @@ function AppModal({ modal }: { modal: ModalType }) {
   }
 }
 
-function App({ theme, modal, children }: AppProps) {
+function App({ children, fontLoading, modal, theme }: AppProps) {
   const auth = useAuth0();
   const userInfo = useGetUserInfo();
 
@@ -108,16 +109,17 @@ function App({ theme, modal, children }: AppProps) {
   }
 
   return (
-    <>
+    <div id="app-container" className={classNames({ "font-loading": fontLoading })}>
       {children}
       {modal ? <AppModal modal={modal} /> : null}
       <ConfirmRenderer />
       <AppErrors />
-    </>
+    </div>
   );
 }
 
 const connector = connect((state: UIState) => ({
+  fontLoading: selectors.getFontLoading(state),
   theme: selectors.getTheme(state),
   modal: selectors.getModal(state),
 }));

--- a/src/ui/components/shared/MaterialIcon.css
+++ b/src/ui/components/shared/MaterialIcon.css
@@ -1,3 +1,3 @@
-.material-icons.invisible {
+.font-loading .material-icons {
   visibility: hidden;
 }


### PR DESCRIPTION
I'm all for many small connected components, rather than massive
containers that have to pass things down through 50 layers, but it seems
a little ridiculous to me that each icon is individually `connect`ed to
the redux store.

I'm not sure if the #app-container addition is the right way to do this,
but I actually found it difficult to add a class to the highest level.
If anybody has suggestions there lmk.