### PR TITLE
Await setting up the store on Recording Page

### DIFF
--- a/pages/recording/[id].tsx
+++ b/pages/recording/[id].tsx
@@ -17,8 +17,8 @@ function Recording({ getAccessibleRecording }: PropsFromRedux) {
   useEffect(() => {
     if (!store) return;
 
-    setup(store);
     async function getRecording() {
+      await setup(store);
       setRecording(await getAccessibleRecording(recordingId));
     }
     getRecording();


### PR DESCRIPTION
I've never seen this happen in production or dev, but it happens quite regularly in test, probably something about how timings are slightly different in the test environment. It resulted in tests where we would visit the correct URL, for an existing recording but get a `"undefined" is not a valid recording ID` error message. The test would then sit there for 4 minutes until it timed out, making it hard to track down where exactly the bug was.

Fixes a significant portion, though not all, of #4438 