### PR TITLE
Remove code for catching and displaying dev errors on the DOM

### DIFF
--- a/src/ui/components/ErrorBoundary.tsx
+++ b/src/ui/components/ErrorBoundary.tsx
@@ -5,7 +5,6 @@ import { UnexpectedError } from "ui/state/app";
 import { getUnexpectedError } from "ui/reducers/app";
 import { setUnexpectedError } from "ui/actions/session";
 import BlankScreen from "./shared/BlankScreen";
-import { isDevelopment } from "ui/utils/environment";
 
 export const ReplayUpdatedError: UnexpectedError = {
   message: "Replay updated",
@@ -16,22 +15,15 @@ export const ReplayUpdatedError: UnexpectedError = {
 class ErrorBoundary extends Component<PropsFromRedux & { children: ReactNode }> {
   componentDidCatch(error: any, errorInfo: any) {
     const { setUnexpectedError } = this.props;
-    if (isDevelopment()) {
+
+    if (error.name === "ChunkLoadError") {
+      setUnexpectedError(ReplayUpdatedError, true);
+    } else {
       setUnexpectedError({
-        message: error.message,
-        content: errorInfo.componentStack,
+        message: "Unexpected error",
+        content: "An unexpected error occurred. Please refresh the page.",
         action: "refresh",
       });
-    } else {
-      if (error.name === "ChunkLoadError") {
-        setUnexpectedError(ReplayUpdatedError, true);
-      } else {
-        setUnexpectedError({
-          message: "Unexpected error",
-          content: "An unexpected error occurred. Please refresh the page.",
-          action: "refresh",
-        });
-      }
     }
   }
 

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -4,7 +4,6 @@ import Modal from "ui/components/shared/NewModal";
 import { connect, ConnectedProps } from "react-redux";
 import * as selectors from "ui/reducers/app";
 import { UIState } from "ui/state";
-import BlankScreen from "./BlankScreen";
 import classNames from "classnames";
 import { ExpectedError, UnexpectedError } from "ui/state/app";
 import { getRecordingId, isDevelopment } from "ui/utils/environment";
@@ -113,33 +112,8 @@ interface ErrorProps {
   error: ExpectedError | UnexpectedError;
 }
 
-function DevelopmentError({ error }: ErrorProps) {
-  const { message, content } = error;
-  return (
-    <section className="w-full m-auto bg-white shadow-lg rounded-lg overflow-hidden text-base">
-      <div className="p-12 space-y-12 items-center flex flex-col">
-        <div className="space-y-4 place-content-center">
-          <img className="w-12 h-12 mx-auto" src="/images/logo.svg" />
-        </div>
-        <div className="text-center space-y-3">
-          {message ? <div className="font-bold text-lg">{message}</div> : null}
-          {content ? (
-            <div className="text-gray-500 text-left">
-              <pre>{content}</pre>
-            </div>
-          ) : null}
-        </div>
-      </div>
-    </section>
-  );
-}
-
 function Error({ error }: ErrorProps) {
   const { action, message, content } = error;
-
-  if (isDevelopment()) {
-    return <DevelopmentError error={error} />;
-  }
 
   return (
     <Dialog


### PR DESCRIPTION
Fix #4221.

This undoes the changes from https://github.com/RecordReplay/devtools/commit/a17cda631db583d50295ea1618e55f9294dc8f2c. Those are now redundant since nextjs does the exact same thing for us.