### PR TITLE
Replace window.confirms with the replay-confirm dialog

### DIFF
--- a/src/ui/components/Library/BatchActionDropdown.tsx
+++ b/src/ui/components/Library/BatchActionDropdown.tsx
@@ -11,6 +11,22 @@ import MaterialIcon from "../shared/MaterialIcon";
 import classNames from "classnames";
 import PortalDropdown from "../shared/PortalDropdown";
 import MoveRecordingMenu from "./MoveRecordingMenu";
+import { useConfirm } from "../shared/Confirm";
+
+const getConfirmOptions = (count: number) => {
+  if (count === 1) {
+    return {
+      message: "Delete replay?",
+      description: `This action will permanently delete this replay.`,
+      acceptLabel: "Delete replay",
+    };
+  }
+  return {
+    message: `Delete ${count} replays?`,
+    description: `This action will permanently delete ${count} replays`,
+    acceptLabel: "Delete replays",
+  };
+};
 
 type BatchActionDropdownProps = PropsFromRedux & {
   selectedIds: RecordingId[];
@@ -26,23 +42,20 @@ function BatchActionDropdown({
   const [expanded, setExpanded] = useState(false);
   const updateRecordingWorkspace = hooks.useUpdateRecordingWorkspace();
   const deleteRecording = hooks.useDeleteRecordingFromLibrary();
+  const { confirmDestructive } = useConfirm();
 
   if (loading) {
     return null;
   }
 
   const deleteSelectedIds = () => {
-    const count = selectedIds.length;
-    const message = `This action will permanently delete ${count == 1 ? "this" : count} replay${
-      count == 1 ? "" : "s"
-    }. \n\nAre you sure you want to proceed?`;
-
-    if (window.confirm(message)) {
-      selectedIds.forEach(recordingId => deleteRecording(recordingId, currentWorkspaceId));
-      setSelectedIds([]);
-    }
-
-    setExpanded(false);
+    confirmDestructive(getConfirmOptions(selectedIds.length)).then(confirmed => {
+      if (confirmed) {
+        selectedIds.forEach(recordingId => deleteRecording(recordingId, currentWorkspaceId));
+        setSelectedIds([]);
+      }
+      setExpanded(false);
+    });
   };
   const updateRecordings = (targetWorkspaceId: WorkspaceId | null) => {
     selectedIds.forEach(recordingId =>

--- a/src/ui/components/Library/PendingTeamPrompt.tsx
+++ b/src/ui/components/Library/PendingTeamPrompt.tsx
@@ -7,6 +7,7 @@ import { connect, ConnectedProps } from "react-redux";
 import * as selectors from "ui/reducers/app";
 import * as actions from "ui/actions/app";
 import { UIState } from "ui/state";
+import { useConfirm } from "../shared/Confirm";
 
 type PendingTeamPromptProps = PropsFromRedux & { workspace: PendingWorkspaceInvitation };
 
@@ -18,16 +19,22 @@ function PendingTeamPrompt({ workspace, setWorkspaceId }: PendingTeamPromptProps
   const declinePendingInvitation = hooks.useRejectPendingInvitation(onDeclineCompleted);
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
 
+  const { confirmDestructive } = useConfirm();
+
   const handleAccept = () => {
     acceptPendingInvitation({ variables: { workspaceId: id } });
     setLoading(true);
   };
   const handleDecline = () => {
-    const message = "Are you sure you want to decline this invitation?";
-    if (window.confirm(message)) {
-      declinePendingInvitation({ variables: { workspaceId: id } });
-      setLoading(true);
-    }
+    confirmDestructive({
+      message: "Are you sure you want to decline this invitation?",
+      acceptLabel: "Decline invitation",
+    }).then(confirmed => {
+      if (confirmed) {
+        declinePendingInvitation({ variables: { workspaceId: id } });
+        setLoading(true);
+      }
+    });
   };
   function onDeclineCompleted() {
     setWorkspaceId(null);

--- a/src/ui/components/Library/RecordingOptionsDropdown.tsx
+++ b/src/ui/components/Library/RecordingOptionsDropdown.tsx
@@ -12,6 +12,7 @@ import { Dropdown, DropdownDivider, DropdownItem } from "./LibraryDropdown";
 import PortalDropdown from "../shared/PortalDropdown";
 import classNames from "classnames";
 import MoveRecordingMenu from "./MoveRecordingMenu";
+import { useConfirm } from "../shared/Confirm";
 
 type RecordingOptionsDropdownProps = PropsFromRedux & {
   recording: Recording;
@@ -29,6 +30,7 @@ function RecordingOptionsDropdown({
   const updateRecordingWorkspace = hooks.useUpdateRecordingWorkspace();
   const updateIsPrivate = hooks.useUpdateIsPrivate();
   const recordingId = recording.id;
+  const { confirmDestructive } = useConfirm();
 
   const toggleIsPrivate = () => {
     setIsPrivate(!isPrivate);
@@ -36,13 +38,17 @@ function RecordingOptionsDropdown({
     setExpanded(false);
   };
   const onDeleteRecording = (recordingId: RecordingId) => {
-    const message =
-      "This action will permanently delete this replay. \n\nAre you sure you want to proceed?";
-
-    if (window.confirm(message)) {
-      deleteRecording(recordingId, currentWorkspaceId);
-    }
-    setExpanded(false);
+    confirmDestructive({
+      message: "Delete replay?",
+      description:
+        "This action will permanently delete this replay. \n\nAre you sure you want to proceed?",
+      acceptLabel: "Delete replay",
+    }).then(confirmed => {
+      if (confirmed) {
+        deleteRecording(recordingId, currentWorkspaceId);
+      }
+      setExpanded(false);
+    });
   };
   const updateRecording = (targetWorkspaceId: WorkspaceId | null) => {
     updateRecordingWorkspace(recordingId, currentWorkspaceId, targetWorkspaceId);

--- a/src/ui/components/shared/APIKeys.tsx
+++ b/src/ui/components/shared/APIKeys.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ApiKey, ApiKeyResponse, ApiKeyScope } from "ui/types";
+import { useConfirm } from "./Confirm";
 
 import TextInput from "./Forms/TextInput";
 import MaterialIcon from "./MaterialIcon";
@@ -57,6 +58,7 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
 }
 
 function ApiKeyList({ apiKeys, onDelete }: { apiKeys: ApiKey[]; onDelete: (id: string) => void }) {
+  const { confirmDestructive } = useConfirm();
   if (apiKeys.length === 0) return null;
 
   return (
@@ -77,12 +79,16 @@ function ApiKeyList({ apiKeys, onDelete }: { apiKeys: ApiKey[]; onDelete: (id: s
               <button
                 className="inline-flex items-center p-2.5 text-sm shadow-sm leading-4 rounded-md bg-gray-100 text-red-500 hover:text-red-700 focus:outline-none focus:text-red-700"
                 onClick={() => {
-                  const message =
-                    "This action will permanently delete this API key. \n\nAre you sure you want to proceed?";
-
-                  if (window.confirm(message)) {
-                    onDelete(apiKey.id);
-                  }
+                  confirmDestructive({
+                    message: "Delete API key?",
+                    description:
+                      "This action will permanently delete this API key. \n\nAre you sure you want to proceed?",
+                    acceptLabel: "Delete API key",
+                  }).then(confirmed => {
+                    if (confirmed) {
+                      onDelete(apiKey.id);
+                    }
+                  });
                 }}
               >
                 Delete

--- a/src/ui/components/shared/Button.tsx
+++ b/src/ui/components/shared/Button.tsx
@@ -69,7 +69,10 @@ function getColorClasses(color: Colors, style: ButtonStyles) {
 export function getButtonClasses(color: Colors, style: ButtonStyles, size: ButtonSizes) {
   const standardClasses = STANDARD_CLASSES[size];
   const colorClasses = getColorClasses(color, style);
-  const focusClasses = "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500";
+  const focusClasses = `focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-${getColorCode(
+    color,
+    500
+  )}`;
 
   return classNames(standardClasses, colorClasses, focusClasses);
 }

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceMember.tsx
@@ -7,6 +7,7 @@ import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
 import MaterialIcon from "../MaterialIcon";
 import { AvatarImage } from "ui/components/Avatar";
+import { useConfirm } from "../Confirm";
 
 type WorkspaceMemberProps = {
   member: WorkspaceUser;
@@ -135,14 +136,19 @@ export function NonRegisteredWorkspaceMember({
 }) {
   const deleteUserFromWorkspace = hooks.useDeleteUserFromWorkspace();
   const [expanded, setExpanded] = useState(false);
+  const { confirmDestructive } = useConfirm();
 
   const handleDelete = () => {
     setExpanded(false);
-    const message = `Are you sure you want to remove ${member.email} from this team?`;
-
-    if (window.confirm(message)) {
-      deleteUserFromWorkspace({ variables: { membershipId: member.membershipId } });
-    }
+    confirmDestructive({
+      message: "Remove team member?",
+      description: `Are you sure you want to remove ${member.email} from this team?`,
+      acceptLabel: "Remove them",
+    }).then(confirmed => {
+      if (confirmed) {
+        deleteUserFromWorkspace({ variables: { membershipId: member.membershipId } });
+      }
+    });
   };
 
   return (


### PR DESCRIPTION
Fixes #4374 

Took a few minutes to replace the rest of our window.confirms with the new confirmation dialog!

For example...
<img width="584" alt="Screen Shot 2021-11-11 at 11 18 52 AM" src="https://user-images.githubusercontent.com/478109/141333184-a63386ee-fb76-432a-bef4-61f3ac857183.png">

Very open to feedback on the copy here!