### PR TITLE
Add support for API key auth

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,7 +2,8 @@ import "../src/test-prep";
 import "ui/utils/whatwg-url-fix";
 
 import Head from "next/head";
-import type { AppProps } from "next/app";
+import type { AppContext, AppProps } from "next/app";
+import NextApp from "next/app";
 import React, { useEffect, useState } from "react";
 import { Provider } from "react-redux";
 import { IntercomProvider } from "react-use-intercom";
@@ -135,7 +136,7 @@ import { InstallRouteListener } from "ui/utils/routeListener";
 // _ONLY_ set this flag if you want to disable the frontend entirely
 const maintenanceMode = false;
 
-const AppRouting = ({ Component, pageProps }: AppProps) => {
+const AppRouting = ({ apiKey, Component, pageProps }: AppProps & AuthProps) => {
   const [store, setStore] = useState<Store | null>(null);
   useEffect(() => {
     bootstrapApp().then((store: Store) => setStore(store));
@@ -151,7 +152,7 @@ const AppRouting = ({ Component, pageProps }: AppProps) => {
 
   return (
     <Provider store={store}>
-      <tokenManager.Auth0Provider>
+      <tokenManager.Auth0Provider apiKey={apiKey}>
         <ApolloWrapper>
           <IntercomProvider appId={"k7f741xx"} autoBoot>
             <ConfirmProvider>
@@ -184,6 +185,26 @@ const AppRouting = ({ Component, pageProps }: AppProps) => {
       </tokenManager.Auth0Provider>
     </Provider>
   );
+};
+
+interface AuthProps {
+  apiKey?: string;
+}
+AppRouting.getInitialProps = (appContext: AppContext) => {
+  const props = NextApp.getInitialProps(appContext);
+  const authHeader = appContext.ctx.req?.headers.authorization;
+  const authProps: AuthProps = { apiKey: undefined };
+
+  if (authHeader) {
+    const [scheme, token] = authHeader.split(" ", 2);
+    if (!token || !/^Bearer$/i.test(scheme)) {
+      console.error("Format is Authorization: Bearer [token]");
+    } else {
+      authProps.apiKey = token;
+    }
+  }
+
+  return { ...props, ...authProps };
 };
 
 export default AppRouting;

--- a/src/ui/components/Header/UserOptions.tsx
+++ b/src/ui/components/Header/UserOptions.tsx
@@ -23,8 +23,8 @@ function UserOptions({ setModal, noBrowserItem }: UserOptionsProps) {
 
   const isOwner = hooks.useIsOwner(recordingId || "00000000-0000-0000-0000-000000000000");
   const isCollaborator =
-    isAuthenticated &&
-    hooks.useIsCollaborator(recordingId || "00000000-0000-0000-0000-000000000000");
+    hooks.useIsCollaborator(recordingId || "00000000-0000-0000-0000-000000000000") &&
+    isAuthenticated;
   const showShare = isOwner || isCollaborator;
 
   if (isDeployPreview()) {

--- a/src/ui/components/Library/SidebarFooter.tsx
+++ b/src/ui/components/Library/SidebarFooter.tsx
@@ -6,7 +6,7 @@ import { AvatarImage } from "../Avatar";
 
 function SidebarFooter({ setModal }: PropsFromRedux) {
   const { user } = useAuth0();
-  const { name, picture } = user!;
+  const { name, picture } = user || { name: "", picture: "" };
 
   const handleSettingsClick = () => {
     setModal("settings");

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -50,7 +50,7 @@ function Support() {
 
 function Personal() {
   const { logout, user } = useAuth0();
-  const { name, picture, email } = user!;
+  const { name, picture, email } = user || {};
 
   return (
     <div className="space-y-12">

--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -18,6 +18,7 @@ const clientId: string = usesWindow(win => {
 });
 
 export interface TokenState {
+  apiKey?: boolean;
   loading?: boolean;
   token?: string;
   error?: any;
@@ -43,7 +44,7 @@ class TokenManager {
     // }
   }
 
-  Auth0Provider = ({ children }: { children: ReactNode }) => {
+  Auth0Provider = ({ children, apiKey }: { apiKey?: string; children: ReactNode }) => {
     const router = useRouter();
 
     const onRedirectCallback = (appState: AppState) => {
@@ -74,7 +75,13 @@ class TokenManager {
               return;
             }
 
-            setTimeout(() => this.update(false), 0);
+            setTimeout(() => {
+              if (apiKey) {
+                this.setApiKey(apiKey);
+              } else {
+                this.update(false);
+              }
+            }, 0);
 
             return null;
           }}
@@ -112,6 +119,10 @@ class TokenManager {
       clearTimeout(this.refreshTimeout);
       this.refreshTimeout = undefined;
     }
+  }
+
+  private setApiKey(apiKey: string) {
+    this.setState({ token: apiKey, apiKey: true }, this.deferredState);
   }
 
   private async update(refresh: boolean) {

--- a/src/ui/utils/useAuth0.ts
+++ b/src/ui/utils/useAuth0.ts
@@ -1,5 +1,7 @@
 import { useAuth0 as useOrigAuth0, Auth0ContextInterface } from "@auth0/auth0-react";
+import { useGetUserInfo } from "ui/hooks/users";
 import { isTest, isMock } from "./environment";
+import useToken from "./useToken";
 
 const TEST_AUTH = {
   isLoading: false,
@@ -22,6 +24,25 @@ export type AuthContext = Auth0ContextInterface | typeof TEST_AUTH;
  */
 export default function useAuth0() {
   const auth = useOrigAuth0();
+  const { loading, name, email, picture } = useGetUserInfo();
+  const { token, apiKey } = useToken();
+
+  if (apiKey && token) {
+    return {
+      isLoading: loading,
+      isAuthenticated: true,
+      user: loading
+        ? undefined
+        : {
+            sub: "api-key",
+            name,
+            email,
+            picture,
+          },
+      loginWithRedirect: () => {},
+      logout: () => {},
+    };
+  }
 
   if (isTest() || isMock()) {
     return TEST_AUTH;


### PR DESCRIPTION
## Issue

Google auth uses captcha to protect against bots and automated UI tests struggle with captchas because ... ya know ... they _are_ bots.

## Resolution

* Captures the API key via the request header and passes it to the App in props using the Next.js API: `getInitialProps`.
* Adds plumbing to the auth provider component to use the API key as the token when set and skip any token refreshes
* Fixes up a few places that asserted we have a `user` via auth0 and now may need to wait a tick for the graphql query to resolve

## Notes
We could support other ways to input the api key (e.g. a query string) but it's not designed to be a user-facing feature so the extra friction seems like a feature not a bug. Open to discussion