### PR TITLE
Call preventDefault on cursor key events in the markup panel (#4423)

### DIFF
--- a/src/devtools/client/inspector/markup/actions/markup.ts
+++ b/src/devtools/client/inspector/markup/actions/markup.ts
@@ -175,11 +175,11 @@ export function selectionChanged(
   };
 }
 
-export function selectNode(nodeId: string): UIThunkAction {
+export function selectNode(nodeId: string, reason?: string): UIThunkAction {
   return ({ toolbox }) => {
     const nodeFront = ThreadFront.currentPause?.getNodeFront(nodeId);
     if (nodeFront) {
-      toolbox.selection.setNodeFront(nodeFront);
+      toolbox.selection.setNodeFront(nodeFront, { reason });
     }
   };
 }
@@ -266,7 +266,7 @@ export function onLeftKey(): UIThunkAction {
       if (parentNodeId != null) {
         const parentNodeInfo = getNodeInfo(state, parentNodeId);
         if (parentNodeInfo && parentNodeInfo.type !== DOCUMENT_TYPE_NODE) {
-          dispatch(selectNode(parentNodeId));
+          dispatch(selectNode(parentNodeId, "keyboard"));
         }
       }
     }
@@ -288,11 +288,11 @@ export function onRightKey(): UIThunkAction {
     } else {
       const firstChildId = selectedNodeInfo.children[0];
       if (firstChildId != null) {
-        dispatch(selectNode(firstChildId));
+        dispatch(selectNode(firstChildId, "keyboard"));
         return;
       }
       const nextNodeId = getNextNodeId(state, selectedNodeId);
-      dispatch(selectNode(nextNodeId));
+      dispatch(selectNode(nextNodeId, "keyboard"));
     }
   };
 }
@@ -306,7 +306,7 @@ export function onUpKey(): UIThunkAction {
     }
 
     const previousNodeId = getPreviousNodeId(state, selectedNodeId);
-    dispatch(selectNode(previousNodeId));
+    dispatch(selectNode(previousNodeId, "keyboard"));
   };
 }
 
@@ -319,7 +319,7 @@ export function onDownKey(): UIThunkAction {
     }
 
     const nextNodeId = getNextNodeId(state, selectedNodeId);
-    dispatch(selectNode(nextNodeId));
+    dispatch(selectNode(nextNodeId, "keyboard"));
   };
 }
 
@@ -335,7 +335,7 @@ export function onPageUpKey(): UIThunkAction {
     for (let i = 0; i < 10; i++) {
       previousNodeId = getPreviousNodeId(state, previousNodeId);
     }
-    dispatch(selectNode(previousNodeId));
+    dispatch(selectNode(previousNodeId, "keyboard"));
   };
 }
 
@@ -351,7 +351,7 @@ export function onPageDownKey(): UIThunkAction {
     for (let i = 0; i < 10; i++) {
       nextNodeId = getNextNodeId(state, nextNodeId);
     }
-    dispatch(selectNode(nextNodeId));
+    dispatch(selectNode(nextNodeId, "keyboard"));
   };
 }
 

--- a/src/devtools/client/inspector/markup/components/Nodes.tsx
+++ b/src/devtools/client/inspector/markup/components/Nodes.tsx
@@ -11,7 +11,7 @@ import {
   onUpKey,
 } from "../actions/markup";
 import useKeyShortcuts from "ui/utils/use-key-shortcuts";
-import { cancelBubbling } from "ui/utils/key-shortcuts";
+import { cancelBubbling, preventDefault } from "ui/utils/key-shortcuts";
 import Node from "./Node";
 import { MarkupProps } from "./MarkupApp";
 
@@ -21,12 +21,12 @@ function Nodes(props: MarkupProps & PropsFromRedux) {
   const ref = useRef<HTMLUListElement>(null);
   useKeyShortcuts(
     {
-      Up: cancelBubbling(onUpKey),
-      Down: cancelBubbling(onDownKey),
-      Left: cancelBubbling(onLeftKey),
-      Right: cancelBubbling(onRightKey),
-      PageUp: cancelBubbling(onPageUpKey),
-      PageDown: cancelBubbling(onPageDownKey),
+      Up: cancelBubbling(preventDefault(onUpKey)),
+      Down: cancelBubbling(preventDefault(onDownKey)),
+      Left: cancelBubbling(preventDefault(onLeftKey)),
+      Right: cancelBubbling(preventDefault(onRightKey)),
+      PageUp: cancelBubbling(preventDefault(onPageUpKey)),
+      PageDown: cancelBubbling(preventDefault(onPageDownKey)),
     },
     ref
   );

--- a/src/ui/utils/key-shortcuts.ts
+++ b/src/ui/utils/key-shortcuts.ts
@@ -73,6 +73,13 @@ export function cancelBubbling(listener: KeyboardEventListener): KeyboardEventLi
   };
 }
 
+export function preventDefault(listener: KeyboardEventListener): KeyboardEventListener {
+  return (event: KeyboardEvent) => {
+    event.preventDefault();
+    listener(event);
+  };
+}
+
 function isEditableTag(target: HTMLElement) {
   return ["INPUT", "TEXTAREA"].includes(target.tagName) && target.getAttribute("readonly") === null;
 }


### PR DESCRIPTION
There are 2 reasons why the markup panel scrolls when using the cursor keys: the browser's default action for those keyboard events in a scrollable panel and the Node component [calling](https://github.com/RecordReplay/devtools/blob/15c45a443ca05914d1af5ab4ed8374940158e77b/src/devtools/client/inspector/markup/components/Node.tsx#L70) `scrollIntoView()` on its DOM node.
This PR only disables the first mechanism but also prepares everything to disable the second mechanism: all that is needed is to change the condition [here](https://github.com/RecordReplay/devtools/blob/15c45a443ca05914d1af5ab4ed8374940158e77b/src/devtools/client/inspector/markup/markup.js#L213). But the scrolling introduced by the second mechanism feels right to me.