### PR TITLE
Add new mixpanel trackers

### DIFF
--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -170,6 +170,7 @@ export default function UploadScreen({ recording, userSettings, onUpload }: Uplo
   };
   const onDiscard = () => {
     setStatus("deleting");
+    trackEvent("discard replay", { isDemo: isDemoReplay(recording) });
     window.onbeforeunload = null;
     deleteRecording({ variables: { recordingId } });
   };

--- a/src/ui/components/shared/SharingModal/ReplayLink.tsx
+++ b/src/ui/components/shared/SharingModal/ReplayLink.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from "react";
 import { RecordingId } from "@recordreplay/protocol";
+import { trackEvent } from "ui/utils/telemetry";
 
 export function CopyButton({ recordingId }: { recordingId: RecordingId }) {
   const [showCopied, setShowCopied] = useState(false);
@@ -8,6 +9,7 @@ export function CopyButton({ recordingId }: { recordingId: RecordingId }) {
 
   const onClick = () => {
     navigator.clipboard.writeText(url);
+    trackEvent("copy replay link");
 
     if (timeoutKey.current) {
       clearTimeout(timeoutKey.current);


### PR DESCRIPTION
This adds trackers for two actions:
- when a user copies the link from the sharing modal
- when a user discards a replay from the upload screen

[Rationale](https://www.notion.so/replayio/202111120656-11-11-Onboarding-Rundown-a772d37f34c14c58bd0e28b1306d0778)