### PR TITLE
Get recording ID from the URL

### DIFF
--- a/pages/recording/[id].tsx
+++ b/pages/recording/[id].tsx
@@ -5,13 +5,15 @@ import { getAccessibleRecording } from "ui/actions/session";
 import { Recording as RecordingInfo } from "ui/types";
 import { useGetRecordingId } from "ui/hooks/recordings";
 import { LoadingScreen } from "ui/components/shared/BlankScreen";
+import { useRouter } from "next/router";
 import Upload from "./upload";
 import DevTools from "ui/components/DevTools";
 import setup from "ui/setup/dynamic/devtools";
 
 function Recording({ getAccessibleRecording }: PropsFromRedux) {
+  const router = useRouter();
   const store = useStore();
-  const recordingId = useGetRecordingId();
+  const recordingId = router.query.id;
   const [recording, setRecording] = useState<RecordingInfo | null>();
   const [uploadComplete, setUploadComplete] = useState(false);
   useEffect(() => {


### PR DESCRIPTION
This seems to work just fine locally, @ryanjduffy maybe you have the best context on whether this is a bad idea or not? 

For context, here is the issue we are dealing with in tests:

https://app.replay.io/recording/e96100a3-dcb1-4427-9817-5f2dbe627918