### PR TITLE
Don't start loading the recording page until our URL params have hydrated

### DIFF
--- a/pages/recording/[id].tsx
+++ b/pages/recording/[id].tsx
@@ -15,14 +15,14 @@ function Recording({ getAccessibleRecording }: PropsFromRedux) {
   const [recording, setRecording] = useState<RecordingInfo | null>();
   const [uploadComplete, setUploadComplete] = useState(false);
   useEffect(() => {
-    if (!store) return;
+    if (!store || !recordingId) return;
 
     async function getRecording() {
       await setup(store);
       setRecording(await getAccessibleRecording(recordingId));
     }
     getRecording();
-  }, [store]);
+  }, [recordingId, store]);
 
   if (!recording || typeof window === "undefined") {
     return <LoadingScreen />;


### PR DESCRIPTION
Follow-up to my misguided attempt in https://github.com/RecordReplay/devtools/pull/4472. This still uses `getRouter` under the hood as @ryanjduffy pointed out, but now we shouldn't get stuck in a 404 state ever.