### PR TITLE
Don't show <prototype> on Proxy objects.

### DIFF
--- a/src/protocol/thread/value.ts
+++ b/src/protocol/thread/value.ts
@@ -353,7 +353,9 @@ export class ValueFront {
           contents: state,
         });
       }
-    } else if (this.className() === "Proxy") {
+    }
+
+    if (this.className() === "Proxy") {
       const result = this.previewProxyState();
       if (result) {
         const { target, handler } = result;
@@ -367,11 +369,12 @@ export class ValueFront {
           contents: target,
         });
       }
+    } else {
+      rv.push({
+        name: "<prototype>",
+        contents: this._object!.preview!.prototypeValue,
+      });
     }
-    rv.push({
-      name: "<prototype>",
-      contents: this._object!.preview!.prototypeValue,
-    });
     return rv;
   }
 


### PR DESCRIPTION
Just thought about this. Proxy's don't really have their own prototype and it's always going to be `null` AFAIK.

Refs https://github.com/RecordReplay/backend/issues/3516