### PR TITLE
Fix semgrep in PRs

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,16 +1,16 @@
 on:
-  pull_request: {}
+  pull_request_target: {}
   push:
     branches:
-    - main
-    - master
+      - main
+      - master
 name: Semgrep
 jobs:
   semgrep:
     name: Scan
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: returntocorp/semgrep-action@v1
-      with:
-        publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
+      - uses: actions/checkout@v2
+      - uses: returntocorp/semgrep-action@v1
+        with:
+          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
Semgrep needs access to the repo's secrets to run, but since this is a public repo, [we can't grant access to secrets from PR's](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#accessing-secrets). Changing to `pull_request_target` runs the job - but in the context of the targeted main branch. This means you can't try out semgrep changes on a PR run, but it will work otherwise.