### PR TITLE
Only show tips when we're loading a recording

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -144,7 +144,7 @@ const AppRouting = ({ Component, pageProps }: AppProps) => {
   if (!store) {
     // We hide the tips here since we don't have the store ready yet, which
     // the tips need to work properly.
-    return <BlankProgressScreen progress={null} hideTips />;
+    return <BlankProgressScreen progress={null} />;
   }
 
   if (maintenanceMode) {

--- a/src/ui/components/shared/BlankScreen.tsx
+++ b/src/ui/components/shared/BlankScreen.tsx
@@ -96,13 +96,7 @@ function Logo({ scale = 1 }) {
 }
 
 // White progress screen used for showing the scanning progress of a replay
-export function BlankProgressScreen({
-  progress,
-  hideTips,
-}: {
-  progress: null | number;
-  hideTips?: boolean;
-}) {
+export function BlankProgressScreen({ progress }: { progress: null | number }) {
   return (
     <BlankScreen>
       <div className="m-auto">
@@ -120,7 +114,7 @@ export function BlankProgressScreen({
           </div>
         </div>
       </div>
-      {!hideTips ? <LoadingTip /> : null}
+      {progress ? <LoadingTip /> : null}
     </BlankScreen>
   );
 }


### PR DESCRIPTION
This makes it so we only show the loading tips when we're loading a recording.