### PR TITLE
QuickOpen: exclude webpack-internal files from sources search

### DIFF
--- a/src/devtools/client/debugger/src/utils/quick-open.js
+++ b/src/devtools/client/debugger/src/utils/quick-open.js
@@ -137,6 +137,10 @@ export function formatSources(sources, tabUrls) {
   for (let i = 0; i < sources.length; ++i) {
     const source = sources[i];
 
+    if (!source.url || source.url.includes("webpack-internal") || source.url.includes(".css")) {
+      continue;
+    }
+
     if (!!source.relativeUrl && !isPretty(source) && !sourceURLs.has(source.url)) {
       formattedSources.push(formatSourcesForList(source, tabUrls));
       sourceURLs.add(source.url);


### PR DESCRIPTION
fixes #4493

excludes webpack internal files and css files which are also webpack artifacts that aren't useful most of the time