### PR TITLE
Fix highlighter and node picker (again)

### DIFF
--- a/src/devtools/server/actors/highlighters/box-model.js
+++ b/src/devtools/server/actors/highlighters/box-model.js
@@ -24,7 +24,7 @@ const nodeConstants = require("devtools/shared/dom-node-constants");
 const { LocalizationHelper } = require("devtools/shared/l10n");
 const STRINGS_URI = "devtools/shared/locales/highlighters.properties";
 const L10N = new LocalizationHelper(STRINGS_URI);
-const { refreshGraphics, getDevicePixelRatio } = require("protocol/graphics");
+const { refreshGraphics } = require("protocol/graphics");
 
 // Note that the order of items in this array is important because it is used
 // for drawing the BoxModelHighlighter's path elements correctly.
@@ -32,22 +32,6 @@ const BOX_MODEL_REGIONS = ["margin", "border", "padding", "content"];
 const BOX_MODEL_SIDES = ["top", "right", "bottom", "left"];
 // Width of boxmodelhighlighter guides
 const GUIDE_STROKE_WIDTH = 1;
-
-function scaleQuad({ p1, p2, p3, p4 }, scale) {
-  return {
-    p1: scaleCoordinates(p1, scale),
-    p2: scaleCoordinates(p2, scale),
-    p3: scaleCoordinates(p3, scale),
-    p4: scaleCoordinates(p4, scale),
-  };
-}
-
-function scaleCoordinates({ x, y }, scale) {
-  return {
-    x: x / scale,
-    y: y / scale,
-  };
-}
 
 /**
  * The BoxModelHighlighter draws the box model regions on top of a node.
@@ -537,8 +521,7 @@ class BoxModelHighlighter extends AutoRefreshHighlighter {
   }
 
   _getBoxPathCoordinates(boxQuad, nextBoxQuad) {
-    const scale = getDevicePixelRatio();
-    const { p1, p2, p3, p4 } = scaleQuad(boxQuad, scale);
+    const { p1, p2, p3, p4 } = boxQuad;
 
     let path;
     if (!nextBoxQuad || !this.options.onlyRegionArea) {
@@ -566,7 +549,7 @@ class BoxModelHighlighter extends AutoRefreshHighlighter {
         p4.y;
     } else {
       // Otherwise, just draw the region itself, not a filled rectangle.
-      const { p1: np1, p2: np2, p3: np3, p4: np4 } = scaleQuad(nextBoxQuad, scale);
+      const { p1: np1, p2: np2, p3: np3, p4: np4 } = nextBoxQuad;
       path =
         "M" +
         p1.x +
@@ -728,8 +711,6 @@ class BoxModelHighlighter extends AutoRefreshHighlighter {
       return false;
     }
 
-    const scale = getDevicePixelRatio();
-    point = point / scale;
     if (side === "top" || side === "bottom") {
       guide.setAttribute("x1", "0");
       guide.setAttribute("y1", point + "");

--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -116,8 +116,8 @@ const gNavigationEvents: NavigationEvent[] = [];
 // All mouse click events that have occurred in the recording, in order.
 const gMouseClickEvents: MouseEvent[] = [];
 
-// Device pixel ratio used by recording screen shots.
-let gDevicePixelRatio: number;
+// Device pixel ratio used by the current screenshot.
+let gDevicePixelRatio = 1;
 
 function onPaints({ paints }: paintPoints) {
   paints.forEach(({ point, time, screenShots }) => {
@@ -222,10 +222,6 @@ export function setupGraphics(store: UIStore) {
       client.Graphics.getPlaybackVideo({}, sessionId);
       client.Graphics.addPlaybackVideoFragmentListener(param => Video.append(param.fragment));
     }
-
-    client.Graphics.getDevicePixelRatio({}, sessionId).then(({ ratio }) => {
-      gDevicePixelRatio = ratio;
-    });
   });
 
   ThreadFront.on("paused", async ({ point, time }) => {
@@ -424,6 +420,7 @@ export function paintGraphics(
     gDrawImage.src = `data:${screenShot.mimeType};base64,${screenShot.data}`;
   }
   gDrawMouse = mouse || null;
+  gDevicePixelRatio = screenShot?.scale || 1;
   refreshGraphics();
 }
 

--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -5,6 +5,7 @@ import { actions } from "ui/actions";
 import { EventEmitter } from "protocol/utils";
 import classnames from "classnames";
 import { ThreadFront } from "protocol/thread";
+import { getDevicePixelRatio } from "protocol/graphics";
 import Highlighter from "highlighter/highlighter";
 
 export const nodePicker: any = {};
@@ -86,10 +87,14 @@ class NodePicker extends React.Component<PropsFromRedux, NodePickerState> {
     }
 
     const scale = bounds.width / canvas.offsetWidth;
+    const pixelRatio = getDevicePixelRatio();
+    if (!pixelRatio) {
+      return null;
+    }
 
     return {
-      x: (e.clientX - bounds.left) / scale,
-      y: (e.clientY - bounds.top) / scale,
+      x: (e.clientX - bounds.left) / scale / pixelRatio,
+      y: (e.clientY - bounds.top) / scale / pixelRatio,
     };
   }
 


### PR DESCRIPTION
Use the per-screenshot scaling information we get from the backend now.
This reverts #4299 because that PR only worked around wrong scaling information for the recording that I tested with.
