### PR TITLE
Reenable returning to a route after login

### DIFF
--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -48,7 +48,7 @@ class TokenManager {
 
     const onRedirectCallback = (appState: AppState) => {
       if (appState?.returnTo) {
-        router.replace("/");
+        router.replace(appState?.returnTo);
       }
     };
 


### PR DESCRIPTION
@ryanjduffy You had disabled this for the Next.js migration, but when I just tested it, it seemed to work fine. Did you see any issues that I missed?