### PR TITLE
Fix events overflow

### DIFF
--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -13,6 +13,11 @@
   height: 100%;
 }
 
+.accordion > li {
+  display: flex;
+  flex-direction: column;
+}
+
 .accordion ._header {
   background-color: #fff;
   display: flex;

--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -73,6 +73,5 @@
 .accordion ._content {
   font-size: var(--theme-body-font-size);
   overflow-y: auto;
-  height: 100%;
   background-color: white;
 }


### PR DESCRIPTION
There's an overflow issue in the events panel that's causing the last part to be pushed down. Likely related to `height: 100%`.

Replay with a lot of events that's nice to test this with: https://app.replay.io/recording/fc8dade7-d55c-41aa-8f34-8476f809f5d4

Before: 
![image](https://user-images.githubusercontent.com/15959269/141844121-2a6c1912-4a2e-49a5-b84c-a65b693af94d.png)

After: 
![image](https://user-images.githubusercontent.com/15959269/141845089-a118d1d7-6ec6-4951-843c-d9e2326ae73c.png)

Demo:

https://user-images.githubusercontent.com/15959269/141844629-751e03d2-c712-4629-9866-05de6bdb2716.mov

 
