### PR TITLE
Rename the breakpoint pane to print statements pane

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/index.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/index.js
@@ -73,7 +73,7 @@ class SecondaryPanes extends Component {
     const { shouldLogExceptions, logExceptions } = this.props;
 
     return {
-      header: "Breakpoints",
+      header: "Print Statements",
       className: "breakpoints-pane",
       component: (
         <Breakpoints shouldLogExceptions={shouldLogExceptions} logExceptions={logExceptions} />


### PR DESCRIPTION
Fix #4500.

![image](https://user-images.githubusercontent.com/15959269/141889250-f6af6644-c536-4bd4-84cc-e3b6dfcea38e.png)
