### PR TITLE
Don't redraw the current screenshot if it hasn't been replaced earlier (#4496)

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -15,6 +15,7 @@ import {
 } from "protocol/graphics";
 import {
   getCurrentTime,
+  getHoveredItem,
   getHoverTime,
   getPlayback,
   getTrimRegion,
@@ -480,7 +481,11 @@ export function setHoveredItem(hoveredItem: HoveredItem): UIThunkAction {
 }
 
 export function clearHoveredItem(): UIThunkAction {
-  return ({ dispatch }) => {
+  return ({ dispatch, getState }) => {
+    const hoveredItem = getHoveredItem(getState());
+    if (!hoveredItem) {
+      return;
+    }
     dispatch({ type: "set_hovered_item", hoveredItem: null });
     dispatch(setTimelineToTime(null));
   };


### PR DESCRIPTION
`clearHoveredItem()` triggers redrawing the current screenshot because it may have been replaced earlier in `setHoveredItem()`. Since `setTimelineToTime()` only draws _recorded_ screenshots, this will replace a repainted screenshot.
The redrawing logic is only necessary if the user has enabled one of the hover features (which are disabled by default).
This PR will only disable the redrawing in case the hover features are disabled. If one of the hover features is enabled, the user will still notice a bug: after hovering, the screenshot will be replaced with the current _recorded_ screenshot instead of the current _repainted_ screenshot. I didn't want to spend time fixing this because I think we should probably remove the hover features instead.