### PR TITLE
Make the sourced accordion into a stacked accordion

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.tsx"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,6 @@
 import "base.css";
+import "image/image.css";
+import "devtools/client/debugger/src/components/shared/AccessibleImage.css";
 import "devtools/client/themes/variables.css";
 import "tailwindcss/tailwind.css";
 import { withRootAttribute } from "storybook-addon-root-attribute";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -51,7 +51,6 @@ import "devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.css
 import "devtools/client/debugger/src/components/SecondaryPanes/Scopes.css";
 import "devtools/client/debugger/src/components/SecondaryPanes/SecondaryPanes.css";
 import "devtools/client/debugger/src/components/shared/AccessibleImage.css";
-import "devtools/client/debugger/src/components/shared/AccessibleImage.css";
 import "devtools/client/debugger/src/components/shared/Accordion.css";
 import "devtools/client/debugger/src/components/shared/Badge.css";
 import "devtools/client/debugger/src/components/shared/BracketArrow.css";

--- a/src/base.css
+++ b/src/base.css
@@ -24,6 +24,7 @@ body {
   --faint-red: rgba(255, 0, 0, 0.5);
   --light-blue: #61cdff;
   --light-grey: #969696;
+  font-family: "Inter", sans-serif;
 }
 
 #__next,
@@ -32,7 +33,6 @@ body {
   color: var(--theme-body-color);
   display: flex;
   flex-direction: column;
-  font-family: "Inter", sans-serif;
   height: 100%;
   position: relative;
   width: 100%;
@@ -47,4 +47,20 @@ img.avatar,
 .avatar img {
   border-radius: 50%;
   background-color: var(--light-grey);
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  background: transparent;
+}
+
+::-webkit-scrollbar-track {
+  border-radius: 8px;
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 8px;
+  background: rgba(113, 113, 113, 0.5);
 }

--- a/src/devtools/client/debugger/src/components/App.css
+++ b/src/devtools/client/debugger/src/components/App.css
@@ -80,19 +80,3 @@ button {
   display: flex;
   height: 100%;
 }
-
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-  background: transparent;
-}
-
-::-webkit-scrollbar-track {
-  border-radius: 8px;
-  background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  border-radius: 8px;
-  background: rgba(113, 113, 113, 0.5);
-}

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
@@ -4,31 +4,10 @@
 
 .sources-panel {
   background-color: var(--theme-sidebar-background);
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  overflow: hidden;
-  position: relative;
 }
 
 .sources-panel * {
   user-select: none;
-}
-
-.sources-pane {
-  display: flex;
-  flex-direction: column;
-  overflow-x: auto;
-  overflow-y: hidden;
-}
-
-div.sources-pane {
-  height: 100%;
-}
-
-.sources-pane.expanded {
-  flex: 1;
-  height: 100%;
 }
 
 .sources-list .img.blackBox {
@@ -36,16 +15,9 @@ div.sources-pane {
   background-color: var(--theme-icon-checked-color);
 }
 
-.sources-list {
-  flex: 1;
-  display: flex;
-  height: 100%;
-}
-
 .sources-list .managed-tree {
   flex: 1;
   display: flex;
-  height: 100%;
   overflow-y: auto;
 }
 
@@ -109,10 +81,6 @@ div.sources-pane {
   user-select: none;
   justify-content: center;
   align-items: center;
-}
-
-.sources-panel .outline {
-  height: 100%;
 }
 
 .source-outline-tabs {

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
@@ -13,35 +13,36 @@ import {
   getContext,
   getSourcesCollapsed,
 } from "../../selectors";
-import { connect } from "../../utils/connect";
-import { prefs } from "../../utils/prefs";
 
 import Outline from "./Outline";
 import SourcesTree from "./SourcesTree";
-import Accordion from "../shared/Accordion";
+import { connect, ConnectedProps } from "react-redux";
+import { UIState } from "ui/state";
+import { prefs } from "devtools/client/webconsole/utils/prefs";
+import Accordion from "ui/components/Accordion";
 
-class PrimaryPanes extends Component {
+class PrimaryPanes extends Component<PropsFromRedux> {
   renderOutline() {
     return {
-      header: "Outline",
       className: "outlines-pane border-t",
       component: <Outline />,
-      opened: prefs.outlineExpanded,
-      onToggle: opened => {
+      header: "Outline",
+      onToggle: (opened: boolean) => {
         prefs.outlineExpanded = opened;
       },
+      collapsed: !prefs.outlineExpanded,
     };
   }
 
   renderSources() {
     return {
-      header: "Sources",
       className: "sources-pane",
       component: <SourcesTree />,
-      opened: !prefs.sourcesCollapsed,
-      onToggle: opened => {
+      header: "Sources",
+      onToggle: () => {
         this.props.toggleSourcesCollapse();
       },
+      collapsed: prefs.sourcesCollapsed,
     };
   }
 
@@ -49,14 +50,11 @@ class PrimaryPanes extends Component {
     return [this.renderSources(), this.renderOutline()];
   }
   render() {
-    const { selectedTab } = this.props;
-    const activeIndex = selectedTab === "sources" ? 0 : 1;
-
     return <Accordion items={this.getItems()} />;
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state: UIState) => {
   return {
     cx: getContext(state),
     selectedTab: getSelectedPrimaryPaneTab(state),
@@ -71,5 +69,7 @@ const connector = connect(mapStateToProps, {
   closeActiveSearch: actions.closeActiveSearch,
   toggleSourcesCollapse: actions.toggleSourcesCollapse,
 });
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
 
 export default connector(PrimaryPanes);

--- a/src/devtools/client/debugger/src/components/shared/Accordion.css
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.css
@@ -75,3 +75,15 @@
   overflow-y: auto;
   background-color: white;
 }
+
+.accordion li {
+  flex: 1;
+  flex-grow: 0;
+  flex-shrink: 1;
+  flex-basis: auto;
+  min-height: fit-content;
+}
+
+.accordion li.expanded {
+  min-height: 20%;
+}

--- a/src/devtools/client/debugger/src/components/shared/Accordion.js
+++ b/src/devtools/client/debugger/src/components/shared/Accordion.js
@@ -3,6 +3,8 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 //
+import classNames from "classnames";
+import { findLastIndex, lastIndexOf } from "lodash";
 import React, { cloneElement, Component } from "react";
 import AccessibleImage from "./AccessibleImage";
 
@@ -29,9 +31,15 @@ class Accordion extends Component {
 
   renderContainer = (item, i) => {
     const { opened } = item;
+    const lastOpenedIndex = i === findLastIndex(this.props.items, item => item.opened);
 
     return (
-      <li className={`${item.className} ${item.opened ? "expanded" : "collapsed"}`} key={i}>
+      <li
+        className={classNames(item.className, item.opened ? "expanded" : "collapsed", {
+          lastOpen: lastOpenedIndex,
+        })}
+        key={i}
+      >
         <h2
           className="_header"
           tabIndex="0"

--- a/src/devtools/client/debugger/src/selectors/index.d.ts
+++ b/src/devtools/client/debugger/src/selectors/index.d.ts
@@ -11,10 +11,14 @@ export interface SelectedFrame {
   location: UrlLocation;
 }
 
-export function getThreadContext(state: UIState): any;
-export function getVisibleSelectedFrame(state: UIState): SelectedFrame | null;
-export function getSourceWithContent(state: UIState, sourceId: string): any;
-export function getPausePreviewLocation(state: UIState): UrlLocation;
+export function getActiveSearch(state: UIState): any;
+export function getContext(state: UIState): any;
 export function getDebugLineLocation(state: UIState): UrlLocation | undefined;
 export function getPaneCollapse(state: UIState): boolean;
+export function getPausePreviewLocation(state: UIState): UrlLocation;
+export function getSelectedPrimaryPaneTab(state: UIState): any;
+export function getSourceWithContent(state: UIState, sourceId: string): any;
+export function getSourcesCollapsed(state: UIState): any;
+export function getThreadContext(state: UIState): any;
+export function getVisibleSelectedFrame(state: UIState): SelectedFrame | null;
 export function hasFrames(state: UIState): boolean;

--- a/src/devtools/client/webconsole/utils/prefs.d.ts
+++ b/src/devtools/client/webconsole/utils/prefs.d.ts
@@ -1,16 +1,18 @@
 export const prefs: {
+  editor: boolean;
+  filterDebug: boolean;
   filterError: boolean;
-  filterWarn: boolean;
   filterInfo: boolean;
   filterLog: boolean;
-  filterDebug: boolean;
   filterNodeModules: boolean;
-  persistLogs: boolean;
+  filterWarn: boolean;
+  inputContext: boolean;
   inputHistoryCount: boolean;
-  editor: boolean;
+  outlineExpanded: boolean;
+  persistLogs: boolean;
+  sourcesCollapsed: boolean;
   timestampMessages: boolean;
   timestampsVisible: boolean;
-  inputContext: boolean;
 };
 
 export function getPrefsService(): {

--- a/src/stories/NetworkMonitor/RequestTable.stories.tsx
+++ b/src/stories/NetworkMonitor/RequestTable.stories.tsx
@@ -10,17 +10,17 @@ export default {
   component: RequestTable,
 } as Meta;
 
-const store = {};
-
 const Template: Story<ComponentProps<typeof RequestTable>> = args => <RequestTable {...args} />;
 
 export const Loaded = Template.bind({});
+
 const requests = [
   requestProps("1", "https://app.replay.io/graphql", 200),
   requestProps("2", "https://app.replay.io/graphql", 500, "POST"),
   requestProps("3", "https://www.replay.io", 301),
   requestProps("4", "https://app.replay.io/graphql", 400),
 ];
+
 Loaded.args = {
   currentTime: 3,
   events: requests.flatMap(r => r.events),

--- a/src/stories/NetworkMonitor/Status.stories.tsx
+++ b/src/stories/NetworkMonitor/Status.stories.tsx
@@ -9,8 +9,6 @@ export default {
   component: Status,
 } as Meta;
 
-const store = {};
-
 const Template: Story<ComponentProps<typeof Status>> = args => <Status {...args} />;
 
 export const Success = Template.bind({});

--- a/src/ui/components/Accordion.module.css
+++ b/src/ui/components/Accordion.module.css
@@ -1,0 +1,46 @@
+.accordion {
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.accordionItemContainer:first-child {
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-top: none;
+}
+
+.accordionItemContainer.open {
+  flex: 0 1 auto;
+  min-height: 20%;
+  overflow-y: scroll;
+}
+
+.accordionItemContainer {
+  border-top-width: 1px;
+}
+
+.accordionItemContainer:not(.open) {
+  flex-shrink: 0;
+}
+
+.accordionItemContainer .header {
+  background: white;
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1.25;
+  padding: 8px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.content:not(.open) {
+  height: 0;
+  overflow: hidden;
+}
+
+.content.open {
+  height: auto;
+}

--- a/src/ui/components/Accordion.stories.tsx
+++ b/src/ui/components/Accordion.stories.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+
+import { Story, Meta } from "@storybook/react";
+
+import Accordion, { AccordionItem } from "ui/components/Accordion";
+
+const lorem = [
+  "Sed ut perspiciatis",
+  "unde omnis iste",
+  "natus error si",
+  "voluptatem accusantium doloremqu",
+  "laudantium, tota",
+  "rem aperiam",
+  "eaque ipsa qua",
+  "ab illo inventor",
+  "veritatis et quas",
+  "architecto beatae vita",
+  "dicta sunt explicab",
+  "Nemo enim ipsa",
+  "voluptatem quia volupta",
+  "sit aspernatur au",
+  "Sed ut perspiciati",
+  "unde omnis iste",
+  "natus error si",
+  "voluptatem accusantium doloremqu",
+  "laudantium, tota",
+  "rem aperiam",
+  "eaque ipsa qua",
+  "ab illo inventor",
+  "veritatis et quas",
+  "architecto beatae vita",
+  "dicta sunt explicab",
+  "Nemo enim ipsa",
+  "voluptatem quia volupta",
+  "sit aspernatur au",
+  "Sed ut perspiciati",
+  "unde omnis iste",
+  "natus error si",
+  "voluptatem accusantium doloremqu",
+  "laudantium, tota",
+  "rem aperiam",
+  "eaque ipsa qua",
+  "ab illo inventor",
+  "veritatis et quas",
+  "architecto beatae vita",
+  "dicta sunt explicab",
+  "Nemo enim ipsa",
+  "voluptatem quia volupta",
+  "sit aspernatur au",
+  "Sed ut perspiciati",
+  "unde omnis iste",
+  "natus error si",
+  "voluptatem accusantium doloremqu",
+  "laudantium, tota",
+  "rem aperiam",
+  "eaque ipsa qua",
+  "ab illo inventor",
+  "veritatis et quas",
+  "architecto beatae vita",
+  "dicta sunt explicab",
+  "Nemo enim ipsa",
+  "voluptatem quia volupta",
+  "sit aspernatur au",
+];
+
+export default {
+  title: "Utilities/Accordion",
+  component: Accordion,
+} as Meta;
+
+const Template: Story<{ items: Partial<AccordionItem & { size: number }>[] }> = args => {
+  let items = args.items?.map((item, i) => {
+    return {
+      header: `Section ${i + 1}`,
+      component: (
+        <ul>
+          {lorem.slice(item.size).map(sentence => (
+            <li className="px-4">{sentence}</li>
+          ))}
+        </ul>
+      ),
+      ...item,
+    };
+  });
+  return (
+    <div
+      style={{
+        maxWidth: "500px",
+        height: "600px",
+        borderRadius: "8px",
+        boxShadow:
+          "0.2px 0px 2.2px rgba(0, 0, 0, 0.02), 0.5px 0px 5.3px rgba(0, 0, 0, 0.028), 0.9px 0px 10px rgba(0, 0, 0, 0.035), 1.6px 0px 17.9px rgba(0, 0, 0, 0.042), 2.9px 0px 33.4px rgba(0, 0, 0, 0.05), 7px 0px 80px rgba(0, 0, 0, 0.07)",
+      }}
+    >
+      <Accordion items={items} />
+    </div>
+  );
+};
+
+export const OverflowingAllOpen = Template.bind({});
+OverflowingAllOpen.args = {
+  items: [{ size: 10 }, { size: 50 }, { size: 20 }],
+};
+
+export const UnderflowingSomeClosed = Template.bind({});
+UnderflowingSomeClosed.args = {
+  items: [{ size: 10 }, { size: 50, collapsed: true }, { size: 20, collapsed: true }],
+};
+
+export const OverflowingSomeClosed = Template.bind({});
+OverflowingSomeClosed.args = {
+  items: [{ size: 10 }, { size: 50, collapsed: true }, { size: 20 }],
+};
+
+export const VeryDifferentLengths = Template.bind({});
+VeryDifferentLengths.args = {
+  items: [{ size: 10 }, { size: 40 }],
+};

--- a/src/ui/components/Accordion.tsx
+++ b/src/ui/components/Accordion.tsx
@@ -1,0 +1,60 @@
+import classNames from "classnames";
+import React, { useState } from "react";
+import styles from "./Accordion.module.css";
+
+export interface AccordionItem {
+  className?: string;
+  component: React.ReactNode;
+  header: string;
+  onToggle?: (open: boolean) => void;
+  collapsed?: boolean;
+}
+
+const Accordion = ({ items }: { items: AccordionItem[] }) => {
+  const [state, setState] = useState(items);
+
+  return (
+    <div
+      className={classNames(
+        styles.accordion,
+        styles[`items-${items.filter(i => !i.collapsed).length}`]
+      )}
+    >
+      {state.map(({ className, onToggle, header, component, collapsed }, i) => {
+        return (
+          <div
+            key={i}
+            className={classNames(className, styles.accordionItemContainer, {
+              [styles.open]: !collapsed,
+            })}
+          >
+            <div
+              className={styles.header}
+              onClick={() => {
+                let newState = [...state];
+                let newValue = !newState[i].collapsed;
+                newState[i].collapsed = newValue;
+                onToggle?.(newValue);
+                setState(newState);
+              }}
+            >
+              <h2>
+                <span
+                  className={classNames("img arrow", { expanded: !collapsed })}
+                  style={{ marginInlineEnd: "4px" }}
+                />
+
+                {header}
+              </h2>
+            </div>
+            <div className={classNames(styles.content, { [styles.open]: !collapsed })}>
+              {component}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default Accordion;

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -5,7 +5,7 @@ import { UIState } from "ui/state";
 import Transcript from "ui/components/Transcript";
 import Events from "ui/components/Events";
 import ReplayInfo from "./Events/ReplayInfo";
-const PrimaryPanes = require("devtools/client/debugger/src/components/PrimaryPanes").default;
+import PrimaryPanes from "devtools/client/debugger/src/components/PrimaryPanes";
 const SecondaryPanes = require("devtools/client/debugger/src/components/SecondaryPanes").default;
 const Accordion = require("devtools/client/debugger/src/components/shared/Accordion").default;
 


### PR DESCRIPTION
This adds a new Accordion class, which shares an interface with the old one, but is IMO considerably simpler. Right now it only has a stacked mode, but it's quite simple to add a non-stacked mode by setting `flex-basis: 0` and `flex-grow: 1` on open children. One thing that I don't love about this design is that the heights use a content basis, which means that if there is any overflow, the shrunken space will be shared evenly by the children, but their final heights will reflect differences in their contents. This means in situations where there are contents with very different heights you will have very uneven heights after shrinking as well. There are a lot of examples in storybook to play around with.

![CleanShot 2021-11-16 at 11 44 54](https://user-images.githubusercontent.com/5903784/142054841-2979bbf1-ad15-4718-88fa-0514f81cef76.png)

![CleanShot 2021-11-16 at 11 44 42](https://user-images.githubusercontent.com/5903784/142054844-69a04e4d-88a7-414c-bbdf-ad8e5126e684.png)

Fixes #3200 (finally)