### PR TITLE
Circular loader

### DIFF
--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -35,13 +35,6 @@
   --monospace-font-family: Menlo, Consolas, monospace;
 }
 
-.progressLoader {
-  position: absolute;
-  bottom: 16px;
-  left: 10px;
-  opacity: 0.4;
-}
-
 /**
   * Customize the dark theme's scrollbar colors to avoid excessive contrast.
   */
@@ -629,6 +622,15 @@ checkbox:-moz-focusring {
   -moz-context-properties: fill;
   fill: var(--theme-icon-dimmed-color);
   transform: rotate(-90deg);
+}
+
+/* global loader */
+
+.progressLoader {
+  position: absolute;
+  z-index: 99;
+  bottom: 14px;
+  left: 8px;
 }
 
 /* Mirror the twisty for rtl direction */

--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -35,6 +35,13 @@
   --monospace-font-family: Menlo, Consolas, monospace;
 }
 
+.progressLoader {
+  position: absolute;
+  bottom: 16px;
+  left: 10px;
+  opacity: 0.4;
+}
+
 /**
   * Customize the dark theme's scrollbar colors to avoid excessive contrast.
   */

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -44,11 +44,11 @@ function IndexingLoader({
   }
 
   return (
-    <div className="w-8 h-8 p-1" title={`Indexing (${progressPercentage.toFixed()}%)`}>
+    <div className="w-9 h-9 p-1" title={`Indexing (${progressPercentage.toFixed()}%)`}>
       <CircularProgressbar
         value={progressPercentage}
         strokeWidth={10}
-        styles={buildStyles({ pathColor: `#000000`, trailColor: `#FFFFFF` })}
+        styles={buildStyles({ pathColor: `#0074E8`, trailColor: `transparent` })}
       />
     </div>
   );
@@ -150,7 +150,7 @@ function Toolbar({
         ) : null}
       </div>
       <div className="flex flex-col space-y-1 items-center progressLoader">
-        {progressPercentage !== 101 && viewMode === "dev" ? (
+        {progressPercentage !== 100 && viewMode === "dev" ? (
           <IndexingLoader {...{ progressPercentage, viewMode }} />
         ) : null}
       </div>

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -48,7 +48,7 @@ function IndexingLoader({
       <CircularProgressbar
         value={progressPercentage}
         strokeWidth={10}
-        styles={buildStyles({ pathColor: `#353535`, trailColor: `#ECECED` })}
+        styles={buildStyles({ pathColor: `#000000`, trailColor: `#FFFFFF` })}
       />
     </div>
   );
@@ -149,8 +149,8 @@ function Toolbar({
           </>
         ) : null}
       </div>
-      <div className="flex flex-col space-y-1 items-center">
-        {progressPercentage !== 100 && viewMode === "dev" ? (
+      <div className="flex flex-col space-y-1 items-center progressLoader">
+        {progressPercentage !== 101 && viewMode === "dev" ? (
           <IndexingLoader {...{ progressPercentage, viewMode }} />
         ) : null}
       </div>


### PR DESCRIPTION
We're trying to make a global loader like this:
![image](https://user-images.githubusercontent.com/9154902/142064649-7555e290-5ec3-4115-bd41-5c8973e9ee27.png)

([Figma link](https://www.figma.com/file/SSr1ljyzF0lCXTL7BX1Whh/Replay-Design-Doc?node-id=8344%3A58248) and [GitHub link](https://github.com/RecordReplay/devtools/issues/4337)

Right now the code sort of works ... but now the play button isn't clickable because the loader is overlapping. We need to fix it with some z-index magic.
