### PR TITLE
Dismiss the download replay nag if the user has already downloaded replay via the team member onboarding flow

### DIFF
--- a/src/ui/components/shared/Onboarding/DownloadingPage.tsx
+++ b/src/ui/components/shared/Onboarding/DownloadingPage.tsx
@@ -1,8 +1,16 @@
-import React from "react";
+import React, { useEffect } from "react";
+import hooks from "ui/hooks";
+import { Nag } from "ui/hooks/users";
 import { PrimaryLgButton } from "../Button";
 import { OnboardingActions, OnboardingBody, OnboardingHeader } from "../Onboarding/index";
 
 export function DownloadingPage({ onFinished }: { onFinished: () => void }) {
+  const dismissNag = hooks.useDismissNag();
+
+  useEffect(() => {
+    dismissNag(Nag.DOWNLOAD_REPLAY);
+  }, []);
+
   return (
     <>
       <OnboardingHeader>Downloading Replay ...</OnboardingHeader>

--- a/src/ui/utils/onboarding.ts
+++ b/src/ui/utils/onboarding.ts
@@ -31,7 +31,7 @@ export function downloadReplay(nags: Nag[], dismissNag: (nag: Nag) => void): boo
   if (isReplayBrowser()) {
     dismissNag(Nag.DOWNLOAD_REPLAY);
 
-    return false
+    return false;
   }
 
   return shouldShowNag(nags, Nag.DOWNLOAD_REPLAY);


### PR DESCRIPTION
Fix #4528.

This makes sure that we dismiss the nag responsible for showing the download replay prompt. This only used to happen once we see the user use the app using the replay browser. This now makes sure we dismiss the nag once the user hits the screen after they start the replay download.