### PR TITLE
Add a `useFeature` hook

### DIFF
--- a/src/devtools/client/debugger/dist/devtools-services.d.ts
+++ b/src/devtools/client/debugger/dist/devtools-services.d.ts
@@ -1,1 +1,2 @@
 export function pref(name: string, value: any): void;
+export const prefs: PrefBranch;

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import classnames from "classnames";
 import hooks from "ui/hooks";
@@ -17,7 +17,6 @@ import { trackEvent } from "ui/utils/telemetry";
 
 import "ui/setup/dynamic/inspector";
 import { ConnectedRequestTable } from "../NetworkMonitor/RequestTable";
-import { features } from "ui/utils/prefs";
 import { UserSettings } from "ui/types";
 
 const InspectorApp = React.lazy(() => import("devtools/client/inspector/components/App"));
@@ -36,6 +35,7 @@ function PanelButtons({
   setSelectedPanel,
 }: PanelButtonsProps) {
   const { userSettings } = hooks.useGetUserSettings();
+  const hasNetwork = hooks.useFeature("network");
 
   const showReact = userSettings.showReact;
   const showElements = userSettings.showElements;
@@ -78,7 +78,7 @@ function PanelButtons({
           <div className="label">React</div>
         </button>
       )}
-      {features.network && (
+      {hasNetwork && (
         <button
           className={classnames("console-panel-button", {
             expanded: selectedPanel === "network",
@@ -112,10 +112,10 @@ function InspectorPanel() {
   );
 }
 
-function getAllowedPanels(settings: UserSettings) {
+function getAllowedPanels(settings: UserSettings, hasNetwork: boolean) {
   const allowedPanels = ["console"];
 
-  if (features.network) {
+  if (hasNetwork) {
     allowedPanels.push("network");
   }
   if (settings.showReact) {
@@ -135,10 +135,11 @@ function SecondaryToolbox({
   hasReactComponents,
 }: PropsFromRedux) {
   const { userSettings } = hooks.useGetUserSettings();
+  const hasNetwork = hooks.useFeature("network");
   const showReact = userSettings.showReact;
   const isNode = recordingTarget === "node";
 
-  if (!getAllowedPanels(userSettings).includes(selectedPanel)) {
+  if (!getAllowedPanels(userSettings, hasNetwork).includes(selectedPanel)) {
     setSelectedPanel("console");
   }
 

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -179,7 +179,7 @@ const getSettings = (internal: boolean): Settings<SettingsTabTitle, CombinedUser
         label: "Network Monitor",
         type: "checkbox",
         key: "enableNetworkMonitor",
-        description: "Network Monitor request table (refresh required)",
+        description: "Network Monitor request table",
         disabled: false,
       },
     ],

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -6,6 +6,9 @@ import { SettingItemKey } from "ui/components/shared/SettingsModal/types";
 import useAuth0 from "ui/utils/useAuth0";
 import type { UserSettings } from "../types";
 import { ADD_USER_API_KEY, DELETE_USER_API_KEY, GET_USER_SETTINGS } from "ui/graphql/settings";
+import { features } from "ui/utils/prefs";
+import { prefs as prefsService } from "devtools-services";
+import { useEffect, useState } from "react";
 
 const emptySettings: UserSettings = {
   apiKeys: [],
@@ -62,6 +65,20 @@ export function useGetUserSettings() {
 
   return { userSettings: convertUserSettings(data), error, loading };
 }
+
+export const useFeature = (prefKey: keyof typeof features) => {
+  const [pref, setPref] = useState(Boolean(features[prefKey]));
+
+  useEffect(() => {
+    const onUpdate = (prefs: any) => {
+      setPref(prefs.getBoolPref(`devtools.features.${prefKey}`));
+    };
+
+    prefsService.addObserver(`devtools.features.${prefKey}`, onUpdate, false);
+  }, [prefKey]);
+
+  return pref;
+};
 
 function convertUserSettings(data: any): UserSettings {
   if (!data?.viewer) {


### PR DESCRIPTION
This sets an observer on our preferences store and allows for a component to refresh when that preference changes. This is used for `features`, but it could easily be expanded to other `prefs`. This allows us to update the secondary toolbox to add or remove the network monitor without refreshing the page.