### PR TITLE
Change the way we're tracking upload waiting time to be sent to honeycomb

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -248,9 +248,6 @@ export function setDisplayedLoadingProgress(
 }
 
 export function setLoadingFinished(finished: boolean): SetLoadingFinishedAction {
-  if (finished) {
-    trackTiming("kpi-time-to-view-replay");
-  }
   return { type: "set_loading_finished", finished };
 }
 

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -6,7 +6,7 @@ import Modal from "ui/components/shared/NewModal";
 import { Recording, UserSettings } from "ui/types";
 import { LoadingScreen } from "../shared/BlankScreen";
 import { useGetRecordingId } from "ui/hooks/recordings";
-import { trackEvent, trackTiming } from "ui/utils/telemetry";
+import { trackEvent } from "ui/utils/telemetry";
 import Sharing, { MY_LIBRARY } from "./Sharing";
 import { Privacy, ToggleShowPrivacyButton } from "./Privacy";
 import MaterialIcon from "../shared/MaterialIcon";
@@ -158,7 +158,6 @@ export default function UploadScreen({ recording, userSettings, onUpload }: Uplo
     setStatus("saving");
     const workspaceId = selectedWorkspaceId == "" ? null : selectedWorkspaceId;
 
-    trackTiming("kpi-time-to-view-replay");
     trackEvent("create replay", { isDemo: isDemoReplay(recording) });
     startUploadWaitTracking();
 

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -3,7 +3,7 @@ import mixpanel, { Dict } from "mixpanel-browser";
 import { ViewMode } from "ui/state/app";
 import { getRecordingId, isReplayBrowser, skipTelemetry } from "./environment";
 import { prefs } from "./prefs";
-import { TelemetryUser } from "./telemetry";
+import { TelemetryUser, trackTiming } from "./telemetry";
 
 const QA_EMAIL_ADDRESSES = ["mock@user.io"];
 
@@ -73,9 +73,16 @@ export const endMixpanelSession = (reason: string) => () =>
 export const trackViewMode = (viewMode: ViewMode) =>
   trackMixpanelEvent(viewMode == "dev" ? "visit devtools" : "visit viewer");
 
-export const startUploadWaitTracking = () => mixpanel.time_event("upload_recording");
-export const endUploadWaitTracking = (sessionId: SessionId) =>
+export const startUploadWaitTracking = () => {
+  // This one gets tracked in Honeycomb.
+  trackTiming("kpi-time-to-view-replay");
+  mixpanel.time_event("upload_recording");
+};
+export const endUploadWaitTracking = (sessionId: SessionId) => {
+  // This one gets tracked in Honeycomb.
+  trackTiming("kpi-time-to-view-replay");
   trackMixpanelEvent("upload_recording", { sessionId });
+};
 
 function setupSessionEndListener() {
   window.addEventListener("beforeunload", endMixpanelSession("unloaded"));

--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -99,9 +99,8 @@ export function trackTiming(event: string, properties: any = {}) {
   } else {
     duration = Date.now() - timings[event];
     delete timings[event];
+    sendTelemetryEvent(event, { duration, ...properties });
   }
-
-  sendTelemetryEvent(event, { duration, ...properties });
 }
 
 export const trackEvent = trackMixpanelEvent;


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/ops/issues/326.

We were getting unexpected data in Honeycomb from this tracker, so I'm switching it to fire the same way that our current mixpanel tracker does.