### PR TITLE
Add a request detail view to the network tab

### DIFF
--- a/src/devtools/client/shared/components/splitter/SplitBox.js
+++ b/src/devtools/client/shared/components/splitter/SplitBox.js
@@ -223,14 +223,8 @@ class SplitBox extends Component {
   // eslint-disable-next-line complexity
   render() {
     const { endPanelControl, splitterSize, vert } = this.state;
-    const {
-      startPanel,
-      endPanel,
-      minSize,
-      maxSize,
-      onSelectContainerElement,
-      initialSize,
-    } = this.props;
+    const { startPanel, endPanel, minSize, maxSize, onSelectContainerElement, initialSize } =
+      this.props;
 
     const style = Object.assign(
       {

--- a/src/devtools/client/webconsole/components/FilterBar/FilterBar.js
+++ b/src/devtools/client/webconsole/components/FilterBar/FilterBar.js
@@ -24,8 +24,8 @@ const { FILTERBAR_DISPLAY_MODES, MESSAGE_TYPE } = require("devtools/client/webco
 
 // Additional Components
 const { Events } = require("devtools/client/webconsole/components/FilterBar/Events");
-const ConsoleSettings = require("devtools/client/webconsole/components/FilterBar/ConsoleSettings")
-  .default;
+const ConsoleSettings =
+  require("devtools/client/webconsole/components/FilterBar/ConsoleSettings").default;
 
 const SearchBox = createFactory(require("devtools/client/shared/components/SearchBox"));
 const { isDemo } = require("ui/utils/environment");
@@ -124,6 +124,9 @@ class FilterBar extends Component {
       const filterButtonsToolbar = this.wrapperNode.querySelector(
         ".webconsole-filterbar-secondary"
       );
+      if (!filterButtonsToolbar) {
+        return;
+      }
 
       const buttonMargin = 5;
       const filterButtonsToolbarWidth = Array.from(filterButtonsToolbar.children).reduce(

--- a/src/stories/NetworkMonitor/NetworkMonitor.stories.tsx
+++ b/src/stories/NetworkMonitor/NetworkMonitor.stories.tsx
@@ -2,17 +2,15 @@ import React, { ComponentProps } from "react";
 
 import { Story, Meta } from "@storybook/react";
 
-import RequestTable from "ui/components/NetworkMonitor/RequestTable";
+import NetworkMonitor from "ui/components/NetworkMonitor";
 import { requestProps } from "./utils";
 
 export default {
-  title: "Network Monitor/Request Table",
-  component: RequestTable,
+  title: "Network Monitor/Network Monitor",
+  component: NetworkMonitor,
 } as Meta;
 
-const Template: Story<ComponentProps<typeof RequestTable>> = args => <RequestTable {...args} />;
-
-export const Loaded = Template.bind({});
+const Template: Story<ComponentProps<typeof NetworkMonitor>> = args => <NetworkMonitor {...args} />;
 
 const requests = [
   requestProps("1", "https://app.replay.io/graphql", 200),
@@ -21,9 +19,10 @@ const requests = [
   requestProps("4", "https://app.replay.io/graphql", 400),
 ];
 
-Loaded.args = {
+export const Basic = Template.bind({});
+
+Basic.args = {
   currentTime: 3,
   events: requests.flatMap(r => r.events),
   requests: requests.map(r => r.info),
-  seek: (point: string, time: number, hasFrames: boolean, pauseId?: string | undefined) => false,
 };

--- a/src/stories/NetworkMonitor/RequestDetail.stories.tsx
+++ b/src/stories/NetworkMonitor/RequestDetail.stories.tsx
@@ -1,0 +1,79 @@
+import React, { ComponentProps } from "react";
+
+import { Story, Meta } from "@storybook/react";
+
+import RequestDetails from "ui/components/NetworkMonitor/RequestDetails";
+import { requestProps } from "./utils";
+
+export default {
+  title: "Network Monitor/Request Details",
+  component: RequestDetails,
+} as Meta;
+
+const Template: Story<ComponentProps<typeof RequestDetails>> = args => (
+  <div style={{ height: "300px", overflow: "hidden" }}>
+    <RequestDetails {...args} />
+  </div>
+);
+
+const request = requestProps("1", "https://app.replay.io/graphql", 200);
+
+export const Basic = Template.bind({});
+
+Basic.args = {
+  request: {
+    domain: "assets.website-files.com",
+    end: 984,
+    requestHeaders: [
+      { name: "Host", value: "assets.website-files.com" },
+      {
+        name: "User-Agent",
+        value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.16; rv:86.0) Gecko/20100101 Firefox/86.0",
+      },
+      {
+        name: "Accept",
+        value: "application/font-woff2;q=1.0,application/font-woff;q=0.9,*/*;q=0.8",
+      },
+      { name: "Accept-Language", value: "en-US,en;q=0.5" },
+      { name: "Accept-Encoding", value: "identity" },
+      {
+        name: "Referer",
+        value:
+          "https://assets.website-files.com/613b96978e0f483f60fbb8c0/css/replay-new.2b6f812de.min.css",
+      },
+      { name: "Origin", value: "https://www.replay.io" },
+    ],
+    responseHeaders: [
+      { name: "content-type", value: "application/octet-stream" },
+      { name: "content-length", value: "34616" },
+      { name: "date", value: "Sun, 31 Oct 2021 02:21:10 GMT" },
+      { name: "access-control-allow-origin", value: "*" },
+      { name: "access-control-allow-methods", value: "GET, HEAD" },
+      { name: "access-control-max-age", value: "3000" },
+      { name: "last-modified", value: "Fri, 10 Sep 2021 17:32:10 GMT" },
+      { name: "etag", value: '"788e7c705c377d9e08875341f0e860cb"' },
+      { name: "x-amz-server-side-encryption", value: "AES256" },
+      { name: "cache-control", value: "max-age=31536000, must-revalidate" },
+      { name: "x-amz-version-id", value: "fBeMx982MEOHJMFLP04t2lw.U.zSo4X1" },
+      { name: "accept-ranges", value: "bytes" },
+      { name: "server", value: "AmazonS3" },
+      {
+        name: "vary",
+        value: "Origin,Access-Control-Request-Headers,Access-Control-Request-Method",
+      },
+      { name: "x-cache", value: "Hit from cloudfront" },
+      { name: "via", value: "1.1 063a9ddbb93cf698306df937132cd318.cloudfront.net (CloudFront)" },
+      { name: "x-amz-cf-pop", value: "SFO5-C1" },
+      { name: "x-amz-cf-id", value: "QS6mG12CzDHHvoioQG6iRZYbDdju5-BSCkQOxrIIrmldKkXVoqLSCw==" },
+      { name: "age", value: "936035" },
+      { name: "X-Firefox-Spdy", value: "h2" },
+    ],
+    method: "GET",
+    name: "613b96978e0f48b736fbb935_SpaceGrotesk-Bold.woff2",
+    point: { point: "1947111322047004550402308086694092", time: 984 },
+    status: 200,
+    start: 984,
+    time: 166,
+    url: "https://assets.website-files.com/613b96978e0f483f60fbb8c0/613b96978e0f48b736fbb935_SpaceGrotesk-Bold.woff2",
+  },
+};

--- a/src/stories/NetworkMonitor/utils.ts
+++ b/src/stories/NetworkMonitor/utils.ts
@@ -1,4 +1,4 @@
-import { RequestEvent, RequestInfo, RequestEventInfo } from "@recordreplay/protocol";
+import { RequestInfo, RequestEventInfo } from "@recordreplay/protocol";
 
 export const eventsFor = (
   id: string,
@@ -13,7 +13,19 @@ export const eventsFor = (
       event: {
         kind: "request",
         requestCause: "app.js:31",
-        requestHeaders: [],
+        requestHeaders: [
+          { name: "Host", value: "www.paypal.com" },
+          {
+            name: "User-Agent",
+            value:
+              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.16; rv:86.0) Gecko/20100101 Firefox/86.0",
+          },
+          { name: "Accept", value: "application/json" },
+          { name: "Accept-Language", value: "en-US,en;q=0.5" },
+          { name: "Accept-Encoding", value: "gzip, deflate, br" },
+          { name: "content-type", value: "application/json" },
+          { name: "Content-Length", value: "1440" },
+        ],
         requestMethod: method,
         requestUrl: url,
       },
@@ -24,7 +36,32 @@ export const eventsFor = (
       event: {
         kind: "response",
         responseFromCache: false,
-        responseHeaders: [],
+        responseHeaders: [
+          { name: "cache-control", value: "max-age=0, no-cache, no-store, must-revalidate" },
+          { name: "content-type", value: "image/gif" },
+          { name: "expires", value: "Sat, 13 Nov 2021 16:05:38 GMT" },
+          {
+            name: "p3p",
+            value:
+              'policyref="https://t.paypal.com/w3c/p3p.xml",CP="CAO IND OUR SAM UNI STA COR COM"',
+          },
+          { name: "paypal-debug-id", value: "f5f7b78d1f30e" },
+          { name: "pragma", value: "no-cache" },
+          { name: "accept-ranges", value: "bytes" },
+          { name: "via", value: "1.1 varnish, 1.1 varnish" },
+          { name: "date", value: "Sat, 13 Nov 2021 16:05:38 GMT" },
+          {
+            name: "strict-transport-security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          { name: "x-served-by", value: "cache-lax10625-LGB, cache-pao17450-PAO" },
+          { name: "x-cache", value: "MISS, MISS" },
+          { name: "x-cache-hits", value: "0, 0" },
+          { name: "x-timer", value: "S1636819538.108041,VS0,VE84" },
+          { name: "set-cookie", value: "x-cdn=0033; Domain=paypal.com; Path=/; Secure" },
+          { name: "content-length", value: "42" },
+          { name: "X-Firefox-Spdy", value: "h2" },
+        ],
         responseProtocolVersion: "1",
         responseStatus: status,
         responseStatusText: "test",

--- a/src/ui/components/NetworkMonitor/RequestDetails.module.css
+++ b/src/ui/components/NetworkMonitor/RequestDetails.module.css
@@ -1,0 +1,34 @@
+.requestDetails {
+  background: white;
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+  height: 100%;
+}
+
+.headerTable {
+  display: flex;
+  flex: 1 1 0;
+  overflow: scroll;
+}
+
+h2.title {
+  flex: 0 0 auto;
+}
+
+.row {
+  white-space: nowrap;
+}
+
+.request {
+  flex: 0 0 auto;
+  display: flex;
+}
+
+.method {
+  font-weight: bold;
+}
+
+.status {
+  font-weight: bold;
+}

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -1,0 +1,103 @@
+import React, { useMemo, useState } from "react";
+import { RequestSummary } from "./utils";
+import styles from "./RequestDetails.module.css";
+import classNames from "classnames";
+import sortBy from "lodash/sortBy";
+import Status from "./Status";
+
+interface Detail {
+  name: string;
+  value: string;
+}
+
+const DetailTable = ({ className, details }: { className?: string; details: Detail[] }) => {
+  return (
+    <div className={className}>
+      <div className={classNames("text-gray-400 px-4 flex flex-col")}>
+        {details.map(h => (
+          <div title={h.name} className={classNames(styles.row, styles.value)} key={h.name}>
+            {h.name}
+          </div>
+        ))}
+      </div>
+      <div className="flex flex-col">
+        {details.map(h => (
+          <div title={h.value} className={classNames(styles.row, styles.value)} key={h.name}>
+            {h.value}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const TriangleToggle = ({ open }: { open: boolean }) => (
+  <span
+    className={classNames("p-3 select-none img arrow", { expanded: open })}
+    style={{ marginInlineEnd: "4px" }}
+  />
+);
+
+const RequestDetails = ({ request }: { request: RequestSummary }) => {
+  const [requestExpanded, setRequestExpanded] = useState(true);
+  const [requestHeadersExpanded, setRequestHeadersExpanded] = useState(true);
+  const [responseHeadersExpanded, setResponseHeadersExpanded] = useState(true);
+
+  const requestHeaders = useMemo(
+    () => sortBy(request?.requestHeaders, r => r.name.toLowerCase()),
+    [request]
+  );
+  const responseHeaders = useMemo(
+    () => sortBy(request?.responseHeaders, r => r.name.toLowerCase()),
+    [request]
+  );
+
+  if (!request) {
+    return null;
+  }
+
+  return (
+    <div className={classNames("border-l w-full", styles.requestDetails)}>
+      <div
+        className={classNames("flex items-center py-1 whitespace-nowrap cursor-pointer")}
+        onClick={() => setRequestExpanded(!requestExpanded)}
+      >
+        <TriangleToggle open={requestExpanded} />
+        <Status value={request.status} />
+        &nbsp;<span className={styles.method}>{request.method}</span>&nbsp;
+        <span className={classNames("text-gray-400", styles.url)}>{request.url}</span>
+      </div>
+      {requestExpanded && (
+        <DetailTable
+          className={classNames("py-1", styles.request)}
+          details={[
+            { name: "Start", value: `${request.start}ms` },
+            { name: "End", value: `${request.end}ms` },
+          ]}
+        />
+      )}
+      <h2
+        className={classNames("py-1 border-t cursor-pointer", styles.title)}
+        onClick={() => setRequestHeadersExpanded(!requestHeadersExpanded)}
+      >
+        <TriangleToggle open={requestHeadersExpanded} />
+        Request Headers
+      </h2>
+      {requestHeadersExpanded && (
+        <DetailTable className={styles.headerTable} details={requestHeaders} />
+      )}
+      <h2
+        className={classNames("py-1 border-t cursor-pointer", styles.title)}
+        onClick={() => setResponseHeadersExpanded(!responseHeadersExpanded)}
+      >
+        <TriangleToggle open={responseHeadersExpanded} />
+        Response Headers
+      </h2>
+      {responseHeadersExpanded && (
+        <DetailTable className={styles.headerTable} details={responseHeaders} />
+      )}
+    </div>
+  );
+};
+
+export default RequestDetails;

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -1,0 +1,47 @@
+import SplitBox from "devtools/client/shared/components/splitter/SplitBox";
+import React, { useState } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { actions } from "ui/actions";
+import { getEvents, getRequests } from "ui/reducers/network";
+import { getCurrentTime } from "ui/reducers/timeline";
+import { UIState } from "ui/state";
+import RequestDetails from "./RequestDetails";
+import RequestTable from "./RequestTable";
+import { RequestSummary } from "./utils";
+
+export const NetworkMonitor = ({ seek, requests, events, currentTime }: PropsFromRedux) => {
+  const [selectedRequest, setSelectedRequest] = useState<RequestSummary>();
+
+  return (
+    <SplitBox
+      className="max-h-full"
+      initialSize="50%"
+      minSize={selectedRequest ? "20%" : "100%"}
+      maxSize={selectedRequest ? "80%" : "100%"}
+      endPanel={selectedRequest ? <RequestDetails request={selectedRequest} /> : <div />}
+      startPanel={
+        <RequestTable
+          onClick={setSelectedRequest}
+          seek={seek}
+          requests={requests}
+          events={events}
+          currentTime={currentTime}
+        />
+      }
+      vert={true}
+      splitterSize={8}
+    />
+  );
+};
+
+const connector = connect(
+  (state: UIState) => ({
+    events: getEvents(state),
+    requests: getRequests(state),
+    currentTime: getCurrentTime(state),
+  }),
+  { seek: actions.seek }
+);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default connector(NetworkMonitor);

--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -88,10 +88,20 @@ overflows its container (https://drafts.csswg.org/css-flexbox-1/#min-size-auto) 
   display: flex;
   flex-direction: column;
   flex: 1;
+  height: 100%;
 }
 
 .secondary-toolbox .toolbox-bottom-panels .toolbox-panel {
   flex: 1;
   min-height: 0;
   height: 100%;
+}
+
+.secondary-toolbox .splitter {
+  background: white;
+}
+
+.secondary-toolbox .splitter:hover,
+.secondary-toolbox .splitter:active {
+  background: var(--tab-hover-color);
 }

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -16,8 +16,9 @@ import ToolboxOptions from "./ToolboxOptions";
 import { trackEvent } from "ui/utils/telemetry";
 
 import "ui/setup/dynamic/inspector";
-import { ConnectedRequestTable } from "../NetworkMonitor/RequestTable";
 import { UserSettings } from "ui/types";
+import NetworkMonitor from "../NetworkMonitor";
+import classNames from "classnames";
 
 const InspectorApp = React.lazy(() => import("devtools/client/inspector/components/App"));
 
@@ -112,13 +113,17 @@ function InspectorPanel() {
   );
 }
 
-function getAllowedPanels(settings: UserSettings, hasNetwork: boolean) {
+function getAllowedPanels(
+  settings: UserSettings,
+  hasNetwork: boolean,
+  hasReactComponents: boolean
+) {
   const allowedPanels = ["console"];
 
   if (hasNetwork) {
     allowedPanels.push("network");
   }
-  if (settings.showReact) {
+  if (settings.showReact && hasReactComponents) {
     allowedPanels.push("react-components");
   }
   if (settings.showElements) {
@@ -136,10 +141,9 @@ function SecondaryToolbox({
 }: PropsFromRedux) {
   const { userSettings } = hooks.useGetUserSettings();
   const hasNetwork = hooks.useFeature("network");
-  const showReact = userSettings.showReact;
   const isNode = recordingTarget === "node";
 
-  if (!getAllowedPanels(userSettings, hasNetwork).includes(selectedPanel)) {
+  if (!getAllowedPanels(userSettings, hasNetwork, hasReactComponents).includes(selectedPanel)) {
     setSelectedPanel("console");
   }
 
@@ -157,12 +161,22 @@ function SecondaryToolbox({
         </header>
       )}
       <Redacted className="secondary-toolbox-content text-xs">
-        {selectedPanel === "network" && <ConnectedRequestTable />}
-        {selectedPanel === "console" ? <ConsolePanel /> : null}
-        {selectedPanel === "inspector" ? <InspectorPanel /> : null}
-        {showReact && hasReactComponents && selectedPanel === "react-components" ? (
+        {/* {selectedPanel === "network" && <NetworkMonitor />} */}
+        <div className={classNames("h-full", { hidden: selectedPanel !== "network" })}>
+          <NetworkMonitor />
+        </div>
+        {/* {selectedPanel === "console" ? <ConsolePanel /> : null} */}
+        <div className={classNames("h-full", { hidden: selectedPanel !== "console" })}>
+          <ConsolePanel />
+        </div>
+        {/* {selectedPanel === "inspector" ? <InspectorPanel /> : null} */}
+        <div className={classNames("h-full", { hidden: selectedPanel !== "inspector" })}>
+          <InspectorPanel />
+        </div>
+        {/* {selectedPanel === "react-components" ? <ReactDevtoolsPanel /> : null} */}
+        <div className={classNames("h-full", { hidden: selectedPanel !== "react-components" })}>
           <ReactDevtoolsPanel />
-        ) : null}
+        </div>
       </Redacted>
     </div>
   );


### PR DESCRIPTION
### Changes
- Add a `RequestDetail` component that will show a more detailed view of the selected request
- Put that detail view into a SplitBox in the Network tab
- Change all tabs in the SecondaryToolbox to toggle their visibility, rather than their presence in the DOM, so that it's more likely to keep state as people are switching tabs.
- Add headers to the storybook mock data
- Try and get storybook to work with request table and request detail components. One frustrating thing about Storybook is that when it doesn't work it just... doesn't work. The components don't appear in the sidebar, but there are no errors, or any signal about what's wrong. The only thing I've realized here is that calling `connect` in a file can break Storybook *even if the component you are important from that file *isn't* the connected component. I'm not digging further into this right now, it's just not worth the rabbit hole 🐰 .

### Video

https://user-images.githubusercontent.com/5903784/142294108-3b2a6e46-80ee-46e2-b020-d53c82d95ea6.mp4


