### PR TITLE
WIP: New search results

### DIFF
--- a/src/devtools/client/debugger/src/actions/project-text-search.js
+++ b/src/devtools/client/debugger/src/actions/project-text-search.js
@@ -11,7 +11,7 @@
 
 import { isFulfilled } from "../utils/async-value";
 import { findSourceMatches } from "../workers/search";
-import { getSource, getSourceList, getSourceContent } from "../selectors";
+import { getSource, getSources, getSourceList, getSourceContent } from "../selectors";
 import { isThirdParty } from "../utils/source";
 import { loadSourceText } from "./sources/loadSourceText";
 import {
@@ -20,6 +20,7 @@ import {
   getTextSearchStatus,
 } from "../reducers/project-text-search";
 import { ThreadFront } from "protocol/thread";
+import { groupBy } from "lodash";
 
 export function addSearchQuery(cx, query) {
   return { type: "ADD_QUERY", cx, query };
@@ -34,6 +35,14 @@ export function addSearchResult(cx, sourceId, filepath, matches) {
     type: "ADD_SEARCH_RESULT",
     cx,
     result: { sourceId, filepath, matches },
+  };
+}
+
+export function addSearchResults(cx, results) {
+  return {
+    type: "ADD_SEARCH_RESULTS",
+    cx,
+    results,
   };
 }
 
@@ -77,16 +86,44 @@ export function searchSources(cx, query) {
     await dispatch(clearSearchResults(cx));
     await dispatch(addSearchQuery(cx, query));
     dispatch(updateSearchStatus(cx, statusType.fetching));
-    const validSources = getSourceList(getState()).filter(
-      source => !ThreadFront.isMinifiedSource(source.id) && !isThirdParty(source)
-    );
-    for (const source of validSources) {
-      if (cancelled) {
-        return;
-      }
-      await dispatch(loadSourceText({ cx, source }));
-      await dispatch(searchSource(cx, source.id, query));
-    }
+    // const validSources = getSourceList(getState()).filter(
+    //   source => !ThreadFront.isMinifiedSource(source.id) && !isThirdParty(source)
+    // );
+    // for (const source of validSources) {
+    //   if (cancelled) {
+    //     return;
+    //   }
+    //   await dispatch(loadSourceText({ cx, source }));
+    //   await dispatch(searchSource(cx, source.id, query));
+    // }
+    await ThreadFront.searchSources({ query }, matches => {
+      console.info(matches);
+      const sources = getSources(getState());
+      const bestResults = matches.filter(
+        match => !ThreadFront.isMinifiedSource(match.location.sourceId)
+      );
+      const resultsBySource = groupBy(bestResults, res => res.location.sourceId);
+      const results = Object.entries(resultsBySource).map(([sourceId, matches]) => {
+        return {
+          sourceId,
+          filepath: sources.values[sourceId]?.url,
+          matches: matches.map(match => {
+            const matchStr = [...match.context]
+              .slice(match.contextStart.column, match.contextEnd.column)
+              .join("");
+            return {
+              column: match.location.column,
+              line: match.location.line,
+              sourceId,
+              match: matchStr,
+              matchIndex: match.context.indexOf(matchStr),
+              value: match.context,
+            };
+          }),
+        };
+      });
+      dispatch(addSearchResults(cx, results));
+    });
     dispatch(updateSearchStatus(cx, statusType.done));
   };
 

--- a/src/devtools/client/debugger/src/reducers/project-text-search.js
+++ b/src/devtools/client/debugger/src/reducers/project-text-search.js
@@ -43,6 +43,17 @@ function update(state = initialProjectTextSearchState(), action) {
         matches: action.result.matches.map(m => ({ type: "MATCH", ...m })),
       };
       return { ...state, results: [...state.results, result] };
+    case "ADD_SEARCH_RESULTS":
+      if (action.results.length === 0) {
+        return state;
+      }
+
+      const formattedResults = action.results.map(result => ({
+        type: "RESULT",
+        ...result,
+        matches: result.matches.map(m => ({ type: "MATCH", ...m })),
+      }));
+      return { ...state, results: [...state.results, ...formattedResults] };
 
     case "UPDATE_STATUS":
       const ongoingSearch = action.status == statusType.fetching ? state.ongoingSearch : null;


### PR DESCRIPTION
This connects the new search results to the old redux actions.

Updated replay: https://app.replay.io/recording/da07290b-ad40-487c-9a68-0903e68230e1

I figured doing it at the redux level was the easiest way to do it.

@jaril suggested we explore doing the same thing in the component without redux at all. That might be nice so we can delete a bunch of redux code. That's over in this [branch](https://github.com/colbyr/devtools/tree/new-search-results) but TBH I'm not sure if that's working right.

![Kapture 2021-11-17 at 20 00 12](https://user-images.githubusercontent.com/478109/142331881-bb863f27-20f2-471e-9453-bcf4e24d3826.gif)
