### PR TITLE
Nicer default editor screen

### DIFF
--- a/src/devtools/client/debugger/src/components/WelcomeBox.css
+++ b/src/devtools/client/debugger/src/components/WelcomeBox.css
@@ -32,21 +32,31 @@
   overflow: hidden;
   text-overflow: ellipsis;
   cursor: pointer;
+  width: 100%;
+}
+
+.welcomebox__searchSources,
+.welcomebox__searchProject,
+.welcomebox__allShortcuts
+{
+  background-color: #ececec;
+  margin: 15px 0;
+  border-radius: 8px;
+  display: block;
+  font-size: 15px;
 }
 
 .welcomebox__searchSources:hover,
 .welcomebox__searchProject:hover,
 .welcomebox__allShortcuts:hover {
-  color: var(--theme-body-color);
+  background-color: #ddd;
 }
 
 .shortcutKey {
   direction: ltr;
   text-align: right;
   padding-right: 10px;
-  font-size: 14px;
   line-height: 18px;
-  color: var(--theme-body-color);
 }
 
 .shortcutKey:dir(rtl) {
@@ -62,14 +72,14 @@
 .shortcutLabel {
   text-align: start;
   padding-left: 10px;
-  font-size: 14px;
   line-height: 18px;
 }
 
 .shortcutFunction {
   margin: 0 auto;
-  color: var(--theme-comment);
   display: table;
+  min-width: 300px;
+  max-width: 400px;
 }
 
 .shortcutFunction p {
@@ -78,6 +88,6 @@
 
 .shortcutFunction .shortcutKey,
 .shortcutFunction .shortcutLabel {
-  padding: 10px 5px;
+  padding: 10px 15px;
   display: table-cell;
 }

--- a/src/devtools/client/debugger/src/components/WelcomeBox.css
+++ b/src/devtools/client/debugger/src/components/WelcomeBox.css
@@ -37,9 +37,8 @@
 
 .welcomebox__searchSources,
 .welcomebox__searchProject,
-.welcomebox__allShortcuts
-{
-  background-color: #ececec;
+.welcomebox__allShortcuts {
+  background-color: var(--chrome);
   margin: 15px 0;
   border-radius: 8px;
   display: block;
@@ -49,7 +48,7 @@
 .welcomebox__searchSources:hover,
 .welcomebox__searchProject:hover,
 .welcomebox__allShortcuts:hover {
-  background-color: #ddd;
+  background-color: var(--theme-tab-background);
 }
 
 .shortcutKey {

--- a/src/devtools/client/debugger/src/components/WelcomeBox.js
+++ b/src/devtools/client/debugger/src/components/WelcomeBox.js
@@ -18,45 +18,45 @@ function WelcomeBox({ setActiveSearch, openQuickOpen, toggleShortcutsModal }) {
     <div className="welcomebox">
       <div className="alignlabel">
         <div className="shortcutFunction">
-          <p
+          <div
             className="welcomebox__searchSources"
             role="button"
             tabIndex="0"
             onClick={() => openQuickOpen()}
           >
-            <span className="shortcutKey">{formatKeyShortcut("CmdOrCtrl+p")}</span>
             <span className="shortcutLabel">{"%S Go to file".substring(2)}</span>
-          </p>
+            <span className="shortcutKey">{formatKeyShortcut("CmdOrCtrl+P")}</span>
+          </div>
 
           {userSettings.enableGlobalSearch && (
-            <p
+            <div
               className="welcomebox__searchSources"
               role="button"
               tabIndex="0"
               onClick={() => openQuickOpen("@", true)}
             >
-              <span className="shortcutKey">{formatKeyShortcut("CmdOrCtrl+o")}</span>
               <span className="shortcutLabel">{"%S Search functions".substring(2)}</span>
-            </p>
+              <span className="shortcutKey">{formatKeyShortcut("CmdOrCtrl+O")}</span>
+            </div>
           )}
-          <p
+          <div
             className="welcomebox__searchProject"
             role="button"
             tabIndex="0"
             onClick={setActiveSearch.bind(null, "project")}
           >
-            <span className="shortcutKey">{formatKeyShortcut("CmdOrCtrl+Shift+f")}</span>
             <span className="shortcutLabel">{"%S Find in files".substring(2)}</span>
-          </p>
-          <p
+            <span className="shortcutKey">{formatKeyShortcut("CmdOrCtrl+Shift+F")}</span>
+          </div>
+          <div
             className="welcomebox__allShortcuts"
             role="button"
             tabIndex="0"
             onClick={() => toggleShortcutsModal()}
           >
-            <span className="shortcutKey">{formatKeyShortcut("CmdOrCtrl+/")}</span>
             <span className="shortcutLabel">{"Show all shortcuts"}</span>
-          </p>
+            <span className="shortcutKey">{formatKeyShortcut("CmdOrCtrl+/")}</span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -33,6 +33,7 @@
 
 :root {
   --monospace-font-family: Menlo, Consolas, monospace;
+  font-family: Inter;
 }
 
 /**
@@ -180,6 +181,11 @@ button::selection {
   right: 0;
   bottom: 0;
   z-index: -1;
+}
+
+.shortcutFunction p
+{
+  border: 1px solid red;
 }
 
 /* Rest of the dark and light theme */


### PR DESCRIPTION
We're going to be doing more work on this page, and this is our first revision.

Old design:
<img width="372" alt="image" src="https://user-images.githubusercontent.com/9154902/142349451-9f8f7b3d-aa1e-43e5-8de2-2c20e5e72a9c.png">

New design:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/9154902/142349472-245a13fa-2946-41c6-a91d-d9168f0091bc.png">


