### PR TITLE
Outline perf improvements

### DIFF
--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
@@ -68,12 +68,49 @@ const OutlineFunction = React.memo(function OutlineFunction({ isFocused, func, o
     <li
       className={classnames("outline-list__element", { focused: isFocused })}
       ref={itemRef}
-      onClick={() => onSelect(func)}
+      onClick={onSelect ? () => onSelect(func) : undefined}
     >
       <span className="outline-list__element-icon">λ</span>
       <Redacted className="inline-block">
         <PreviewFunction func={func} />
       </Redacted>
+    </li>
+  );
+});
+
+const OutlineClassFunctions = React.memo(function OutlineClassFunctions({
+  classFunc,
+  classInfo,
+  isFocused,
+  onSelect,
+  children,
+}) {
+  const itemRef = useRef();
+  useEffect(() => {
+    if (isFocused && itemRef.current) {
+      console.info("focus", itemRef.current);
+      itemRef.current.scrollIntoView({ block: "center" });
+    }
+  }, [isFocused]);
+
+  const item = classFunc || classInfo;
+
+  return (
+    <li className="outline-list__class" key={item.name}>
+      <h2
+        className={classnames("", { focused: isFocused })}
+        onClick={() => onSelect(item)}
+        ref={itemRef}
+      >
+        {classFunc ? (
+          <OutlineFunction func={classFunc} isFocused={false} />
+        ) : (
+          <div>
+            <span className="keyword">class</span> {item.name}
+          </div>
+        )}
+      </h2>
+      <ul className="outline-list__class-list">{children}</ul>
     </li>
   );
 });
@@ -179,17 +216,9 @@ export class Outline extends PureComponent {
     const isFocused = focusedItem === item;
 
     return (
-      <li className="outline-list__class" key={klass}>
-        <h2
-          className={classnames("", { focused: isFocused })}
-          onClick={() => this.selectItem(item)}
-        >
-          {classFunc ? this.renderFunction(classFunc) : this.renderClassHeader(klass)}
-        </h2>
-        <ul className="outline-list__class-list">
-          {classFunctions.map(func => this.renderFunction(func))}
-        </ul>
-      </li>
+      <OutlineClassFunctions classFunc={classFunc} classInfo={classInfo} isFocused={isFocused}>
+        {classFunctions.map(func => this.renderFunction(func))}
+      </OutlineClassFunctions>
     );
   }
 

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
@@ -88,7 +88,6 @@ const OutlineClassFunctions = React.memo(function OutlineClassFunctions({
   const itemRef = useRef();
   useEffect(() => {
     if (isFocused && itemRef.current) {
-      console.info("focus", itemRef.current);
       itemRef.current.scrollIntoView({ block: "center" });
     }
   }, [isFocused]);

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
@@ -4,18 +4,14 @@
 
 //
 
-import React, { Component, PureComponent, useEffect, useRef } from "react";
-import { showMenu } from "devtools-contextmenu";
+import React, { Component, useEffect, useRef } from "react";
 import { connect } from "../../utils/connect";
 import { score as fuzzaldrinScore } from "fuzzaldrin-plus";
 const classnames = require("classnames");
 
 import { findClosestEnclosedSymbol } from "../../utils/ast";
-import { copyToTheClipboard } from "../../utils/clipboard";
-import { findFunctionText } from "../../utils/function";
 import { getTruncatedFileName } from "../../utils/source";
 import { Redacted } from "ui/components/Redacted";
-import { trackEvent } from "ui/utils/telemetry";
 
 import actions from "../../actions";
 import {
@@ -113,7 +109,7 @@ const OutlineClassFunctions = React.memo(function OutlineClassFunctions({
     </li>
   );
 });
-export class Outline extends PureComponent {
+export class Outline extends Component {
   state = { filter: "", focusedItem: null };
   scrollContainerRef = null;
   focusedElRef = null;


### PR DESCRIPTION
Related to https://github.com/RecordReplay/devtools/issues/4442

I don't know if I'm going to have time re-write the outline view with `react-window` before EOD tomorrow. I'm gonna try but in the meantime, this fixes the most egregious problems with the one we have now.

Right now every component in the outline scrolls any time you scroll or click in the source panel. For a big module, that update feels real slow (It's extra slow in the video because I turned on highlight component updates). ~Also focusing doesn't work in the panel at all.~

https://user-images.githubusercontent.com/478109/142503738-3cba405c-1ee5-47b9-be14-2bfa1301cc72.mov

This PR memoizes the components that make up the list of functions, and removes props that would've triggered needless rerenders.

(Again the video is artificially janky from highlight component updates)

https://user-images.githubusercontent.com/478109/142504191-3953bcfe-734e-48a5-98a3-a840f5cfa1b6.mov

Replay: https://app.replay.io/recording/1e307651-ae2d-4ddb-a105-9011addf2b58#