### PR TITLE
Fix the keyboard shortcut for opening file search

### DIFF
--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -34,7 +34,6 @@ const { appinfo } = Services;
 
 const isMacOS = appinfo.OS === "Darwin";
 
-import ProjectSearch from "./ProjectSearch";
 import Editor from "./Editor";
 import WelcomeBox from "./WelcomeBox";
 import EditorTabs from "./Editor/Tabs";

--- a/src/devtools/client/debugger/src/components/ProjectSearch.js
+++ b/src/devtools/client/debugger/src/components/ProjectSearch.js
@@ -92,15 +92,15 @@ export class ProjectSearch extends Component {
   }
 
   componentDidMount() {
-    const { globalShortcuts, shortcuts } = this.context;
-    globalShortcuts.on("CmdOrCtrl+Shift+F", this.toggleProjectTextSearch);
-    shortcuts.on("Enter", this.onEnterPress);
+    const { shortcuts } = this.context;
+    // Todo: Fix the way we handle keyboard events here. -jvv
+    shortcuts?.on("Enter", this.onEnterPress);
   }
 
   componentWillUnmount() {
-    const { globalShortcuts, shortcuts } = this.context;
-    globalShortcuts.off("CmdOrCtrl+Shift+F", this.toggleProjectTextSearch);
-    shortcuts.off("Enter", this.onEnterPress);
+    const { shortcuts } = this.context;
+    // Todo: Fix the way we handle keyboard events here. -jvv
+    shortcuts?.off("Enter", this.onEnterPress);
   }
 
   componentDidUpdate(prevProps) {
@@ -345,7 +345,6 @@ export class ProjectSearch extends Component {
   }
 }
 ProjectSearch.contextTypes = {
-  globalShortcuts: PropTypes.object,
   shortcuts: PropTypes.object,
 };
 

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -28,7 +28,6 @@ import LoomModal from "./shared/LoomModal";
 import NewAttachment from "./shared/NewAttachment";
 import DownloadReplayPromptModal from "./shared/OnboardingModal/DownloadReplayPromptModal";
 import classNames from "classnames";
-import KeyboardShortcuts from "./KeyboardShortcuts";
 
 function AppModal({ modal }: { modal: ModalType }) {
   switch (modal) {
@@ -123,7 +122,6 @@ function App({ children, fontLoading, modal, theme }: AppProps) {
       {modal ? <AppModal modal={modal} /> : null}
       <ConfirmRenderer />
       <AppErrors />
-      <KeyboardShortcuts />
     </div>
   );
 }

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -28,6 +28,7 @@ import LoomModal from "./shared/LoomModal";
 import NewAttachment from "./shared/NewAttachment";
 import DownloadReplayPromptModal from "./shared/OnboardingModal/DownloadReplayPromptModal";
 import classNames from "classnames";
+import KeyboardShortcuts from "./KeyboardShortcuts";
 
 function AppModal({ modal }: { modal: ModalType }) {
   switch (modal) {
@@ -122,6 +123,7 @@ function App({ children, fontLoading, modal, theme }: AppProps) {
       {modal ? <AppModal modal={modal} /> : null}
       <ConfirmRenderer />
       <AppErrors />
+      <KeyboardShortcuts />
     </div>
   );
 }

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -10,6 +10,7 @@ import NonDevView from "./Views/NonDevView";
 import WaitForReduxSlice from "./WaitForReduxSlice";
 
 import { endUploadWaitTracking } from "ui/utils/mixpanel";
+import KeyboardShortcuts from "./KeyboardShortcuts";
 
 const DevView = React.lazy(() => import("./Views/DevView"));
 
@@ -43,6 +44,7 @@ function _DevTools({
     <>
       <Header />
       {viewMode == "dev" ? <DevView /> : <NonDevView />}
+      <KeyboardShortcuts />
     </>
   );
 }

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -15,11 +15,19 @@ function setupShortcuts() {
 
 const globalShortcuts = setupShortcuts();
 
-function KeyboardShortcuts({ setSelectedPrimaryPanel }: PropsFromRedux) {
+function KeyboardShortcuts({ viewMode, setSelectedPrimaryPanel, setViewMode }: PropsFromRedux) {
+  const openFileSearch = () => {
+    if (viewMode !== "dev") {
+      setViewMode("dev");
+    }
+
+    setSelectedPrimaryPanel("search");
+  };
+
   useEffect(() => {
     if (!globalShortcuts) return;
 
-    globalShortcuts.on("CmdOrCtrl+Shift+F", () => setSelectedPrimaryPanel("search"));
+    globalShortcuts.on("CmdOrCtrl+Shift+F", openFileSearch);
   }, []);
 
   return null;
@@ -28,8 +36,9 @@ function KeyboardShortcuts({ setSelectedPrimaryPanel }: PropsFromRedux) {
 const connector = connect(
   (state: UIState) => ({
     selectedPrimaryPanel: selectors.getSelectedPrimaryPanel(state),
+    viewMode: selectors.getViewMode(state),
   }),
-  { setSelectedPrimaryPanel: actions.setSelectedPrimaryPanel }
+  { setSelectedPrimaryPanel: actions.setSelectedPrimaryPanel, setViewMode: actions.setViewMode }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(KeyboardShortcuts);

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import KeyShortcuts from "devtools/client/shared/key-shortcuts";
+import { usesWindow } from "ssr";
+import { connect, ConnectedProps } from "react-redux";
+import { UIState } from "ui/state";
+import { selectors } from "ui/reducers";
+import { actions } from "ui/actions";
+
+function setupShortcuts() {
+  return usesWindow(win => {
+    if (!win) return null;
+    return new KeyShortcuts({ window: win, target: win.document });
+  });
+}
+
+const globalShortcuts = setupShortcuts();
+
+function KeyboardShortcuts({ setSelectedPrimaryPanel }: PropsFromRedux) {
+  useEffect(() => {
+    if (!globalShortcuts) return;
+
+    globalShortcuts.on("CmdOrCtrl+Shift+F", () => setSelectedPrimaryPanel("search"));
+  }, []);
+
+  return null;
+}
+
+const connector = connect(
+  (state: UIState) => ({
+    selectedPrimaryPanel: selectors.getSelectedPrimaryPanel(state),
+  }),
+  { setSelectedPrimaryPanel: actions.setSelectedPrimaryPanel }
+);
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(KeyboardShortcuts);

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -24,11 +24,17 @@ function KeyboardShortcuts({ viewMode, setSelectedPrimaryPanel, setViewMode }: P
     setSelectedPrimaryPanel("search");
   };
 
+  // The shortcuts have to be reassigned every time the dependencies change,
+  // otherwise we end up with a stale prop.
   useEffect(() => {
     if (!globalShortcuts) return;
 
     globalShortcuts.on("CmdOrCtrl+Shift+F", openFullTextSearch);
-  }, []);
+
+    return () => {
+      globalShortcuts.off("CmdOrCtrl+Shift+F", openFullTextSearch);
+    };
+  }, [viewMode]);
 
   return null;
 }

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -16,7 +16,7 @@ function setupShortcuts() {
 const globalShortcuts = setupShortcuts();
 
 function KeyboardShortcuts({ viewMode, setSelectedPrimaryPanel, setViewMode }: PropsFromRedux) {
-  const openFileSearch = () => {
+  const openFullTextSearch = () => {
     if (viewMode !== "dev") {
       setViewMode("dev");
     }
@@ -27,7 +27,7 @@ function KeyboardShortcuts({ viewMode, setSelectedPrimaryPanel, setViewMode }: P
   useEffect(() => {
     if (!globalShortcuts) return;
 
-    globalShortcuts.on("CmdOrCtrl+Shift+F", openFileSearch);
+    globalShortcuts.on("CmdOrCtrl+Shift+F", openFullTextSearch);
   }, []);
 
   return null;


### PR DESCRIPTION
This gets us a natural Cmd+Shift+F keyboard shortcut to pop open full text search, regardless of which view (devtools/viewer) you're in.