### PR TITLE
Append a narrow classname to the editor pane when the width is <240px

### DIFF
--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import React, { Component, useEffect, useState, useRef } from "react";
+import React, { Component, useEffect, useState, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
 
 import { connect } from "../utils/connect";
@@ -34,7 +34,6 @@ const { appinfo } = Services;
 
 const isMacOS = appinfo.OS === "Darwin";
 
-import ProjectSearch from "./ProjectSearch";
 import Editor from "./Editor";
 import WelcomeBox from "./WelcomeBox";
 import EditorTabs from "./Editor/Tabs";
@@ -44,27 +43,19 @@ import SidePanel from "ui/components/SidePanel";
 import { waitForEditor } from "../utils/editor/create-editor";
 import { isDemo } from "ui/utils/environment";
 import { ReplayUpdatedError } from "ui/components/ErrorBoundary";
+import useWidthObserver from "ui/utils/useWidthObserver";
 import classNames from "classnames";
 
-var resizeObserver;
-
 const EditorPane = ({ children }) => {
-  const [width, setWidth] = useState(null);
-  const paneNode = useRef();
-
-  useEffect(() => {
-    resizeObserver = new ResizeObserver(() => {
-      const newWidth = paneNode.current.getBoundingClientRect().width;
-      setWidth(newWidth);
-    });
-
-    resizeObserver.observe(paneNode.current);
-  }, []);
+  const [paneNode, setPanelNode] = useState(null);
+  const nodeWidth = useWidthObserver(paneNode);
 
   return (
     <div
-      className={classNames("editor-pane overflow-hidden rounded-lg", { narrow: width < 240 })}
-      ref={paneNode}
+      className={classNames("editor-pane overflow-hidden rounded-lg", {
+        narrow: nodeWidth && nodeWidth < 240,
+      })}
+      ref={node => setPanelNode(node)}
     >
       <div className="editor-container relative">{children}</div>
     </div>

--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -44,12 +44,32 @@ import SidePanel from "ui/components/SidePanel";
 import { waitForEditor } from "../utils/editor/create-editor";
 import { isDemo } from "ui/utils/environment";
 import { ReplayUpdatedError } from "ui/components/ErrorBoundary";
+import classNames from "classnames";
 
-const EditorPane = ({ children }) => (
-  <div className="editor-pane overflow-hidden rounded-lg">
-    <div className="editor-container relative">{children}</div>
-  </div>
-);
+var resizeObserver;
+
+const EditorPane = ({ children }) => {
+  const [width, setWidth] = useState(null);
+  const paneNode = useRef();
+
+  useEffect(() => {
+    resizeObserver = new ResizeObserver(() => {
+      const newWidth = paneNode.current.getBoundingClientRect().width;
+      setWidth(newWidth);
+    });
+
+    resizeObserver.observe(paneNode.current);
+  }, []);
+
+  return (
+    <div
+      className={classNames("editor-pane overflow-hidden rounded-lg", { narrow: width < 240 })}
+      ref={paneNode}
+    >
+      <div className="editor-container relative">{children}</div>
+    </div>
+  );
+};
 
 class Debugger extends Component {
   state = {

--- a/src/ui/utils/useWidthObserver.ts
+++ b/src/ui/utils/useWidthObserver.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+var resizeObserver;
+
+// Set the element to be observed in the component's state, and pass it into this
+// hook so that it returns the width of the element whenever it's resized.
+export default function useWidthObserver(node: HTMLElement) {
+  const [width, setWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!node) return;
+
+    resizeObserver = new ResizeObserver(() => {
+      const newWidth = node.getBoundingClientRect().width;
+      setWidth(newWidth);
+    });
+
+    resizeObserver.observe(node);
+  }, [node]);
+
+  return width;
+}


### PR DESCRIPTION
Fix #4574.

This adds a classname that we can use as a breakpoint for when the editor pane gets too narrow, so that the suggested actions aren't cut off.