### PR TITLE
More network monitor changes

### DIFF
--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -21,11 +21,12 @@ export const NetworkMonitor = ({ seek, requests, events, currentTime }: PropsFro
       endPanel={selectedRequest ? <RequestDetails request={selectedRequest} /> : <div />}
       startPanel={
         <RequestTable
-          onClick={setSelectedRequest}
-          seek={seek}
-          requests={requests}
-          events={events}
           currentTime={currentTime}
+          events={events}
+          onClick={setSelectedRequest}
+          requests={requests}
+          seek={seek}
+          selectedRequest={selectedRequest}
         />
       }
       vert={true}

--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -6,10 +6,8 @@ import {
   RequestResponseEvent,
   TimeStampedPoint,
 } from "@recordreplay/protocol";
-import { zipObject } from "lodash";
 import keyBy from "lodash/keyBy";
 import { compareNumericStrings } from "protocol/utils";
-import { UrlCopy } from "../shared/SharingModal/ReplayLink";
 
 export type RequestSummary = {
   domain: string;


### PR DESCRIPTION
- Make the filter sticky
- When jumping to a request that has a triggerPoint, also jump to that
  pause/source location
- When clicking on a request that *does not* have a triggerPoint, do
  seek on the timeline, but leave the pause/source location alone.

One quick note on the className calculation in here: it looks like it's
really complicated, but it's really just an awkward calculation. This is
primarily because requests can be at the same time, and in that case
doing a naive "first row where time is greater than currentTime"
calculation can end up with a frustrating user interaction where you
click row 4 but the line only jumps to row 3 (because they share a time
so both are the "first row in the future"). I am all for making this
calculation easier to understand, but this is the best I have for right
now!

https://user-images.githubusercontent.com/5903784/142697878-53d15d54-1267-4d35-8b49-1f0a0bb3d915.mp4


