### PR TITLE
Strip the semicolon from doc types

### DIFF
--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -59,7 +59,7 @@ const documentType = (headers: Header[]): string => {
   const contentType =
     headers.find(h => h.name.toLowerCase() === "content-type")?.value || "unknown";
   // chop off any charset or other extra data
-  return contentType.match(/^(.*)[,;]/)?.[0] || contentType;
+  return contentType.match(/^(.*)[,;]/)?.[1] || contentType;
 };
 
 export const partialRequestsToCompleteSummaries = (


### PR DESCRIPTION
Index 0 returns up to and including the semi or comma, the first capture
group is what we want.