### PR TITLE
Move search toolbar next to sources

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -18,7 +18,6 @@ function Toolbar({
   setSelectedPrimaryPanel,
   togglePaneCollapse,
   panelCollapsed,
-  progressPercentage,
   viewMode,
   isPaused,
 }: PropsFromRedux) {
@@ -90,6 +89,21 @@ function Toolbar({
               />
             </div>
             <div
+              className={classnames("toolbar-panel-button search", {
+                active: selectedPrimaryPanel == "search",
+              })}
+            >
+              <IconWithTooltip
+                icon={
+                  <MaterialIcon className="motion_photos_paused toolbar-panel-icon" iconSize="2xl">
+                    search
+                  </MaterialIcon>
+                }
+                content={"Search"}
+                handleClick={() => onClick("search")}
+              />
+            </div>
+            <div
               className={classnames("toolbar-panel-button debug", {
                 active: selectedPrimaryPanel == "debug",
                 paused: isPaused,
@@ -103,21 +117,6 @@ function Toolbar({
                 }
                 content={"Pause Information"}
                 handleClick={() => onClick("debug")}
-              />
-            </div>
-            <div
-              className={classnames("toolbar-panel-button search", {
-                active: selectedPrimaryPanel == "search",
-              })}
-            >
-              <IconWithTooltip
-                icon={
-                  <MaterialIcon className="motion_photos_paused toolbar-panel-icon" iconSize="2xl">
-                    search
-                  </MaterialIcon>
-                }
-                content={"Search"}
-                handleClick={() => onClick("search")}
               />
             </div>
           </>

--- a/src/ui/components/Toolbox.css
+++ b/src/ui/components/Toolbox.css
@@ -39,6 +39,9 @@
 }
 
 /* Toolbar Styles */
+.toolbar-panel-button:first-child {
+  margin-top: 0;
+}
 
 .toolbar-panel-button {
   float: left;
@@ -49,6 +52,7 @@
   border-radius: 4px;
   cursor: pointer;
   transition-duration: 200ms;
+  margin-top: 4px;
 }
 
 .toolbar-panel-button:hover {


### PR DESCRIPTION
1. search is more similar to sources
2. pause is only useful when paused at a location with pause data

<img width="656" alt="Screen Shot 2021-11-20 at 9 51 45 AM" src="https://user-images.githubusercontent.com/254562/142736305-1b25f51a-3084-4b12-8da7-14348ed5b3da.png">
