### PR TITLE
Louder gutter tooltip

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -50,7 +50,7 @@ function LineNumberTooltip({
         if (lineNumber === lastHoveredLineNumber.current) {
           runAnalysisOnLine(lineNumber);
         }
-      }, 100);
+      }, 200);
     }
 
     updateHoveredLineNumber(lineNumber);

--- a/src/devtools/client/debugger/src/utils/editor/gutter-events.js
+++ b/src/devtools/client/debugger/src/utils/editor/gutter-events.js
@@ -16,16 +16,21 @@ function safeJsonParse(text) {
 }
 
 function getLineNumberNode(target) {
-  const wrapper = target.closest(".CodeMirror-gutter-wrapper");
+  const row =
+    target.closest(".CodeMirror-gutter-wrapper")?.parentElement ||
+    target.closest(".CodeMirror-line")?.parentElement;
+
+  if (!row) return null;
+
+  const wrapper = row.querySelector(".CodeMirror-gutter-wrapper");
+
   return wrapper.querySelector(".CodeMirror-linenumber");
 }
 
 function isValidTarget(target) {
-  const isGutterNode = target.closest(".CodeMirror-gutter-wrapper");
+  const lineNumberNode = getLineNumberNode(target);
 
-  if (!isGutterNode) {
-    return false;
-  }
+  if (!lineNumberNode) return false;
 
   const isNonBreakableLineNode = target.closest(".empty-line");
   const isTooltip = target.closest(".static-tooltip");
@@ -42,7 +47,7 @@ export function onGutterMouseOver(codeMirror) {
     }
 
     const lineNumberNode = getLineNumberNode(target);
-    const lineNumber = safeJsonParse(lineNumberNode.firstChild.textContent);
+    const lineNumber = safeJsonParse(lineNumberNode.textContent);
 
     target.addEventListener(
       "mouseleave",


### PR DESCRIPTION
This extends the behavior of showing the hits for a line number. Instead of having to hover on the gutter line number, you can now hover on the whole row in the editor.

https://user-images.githubusercontent.com/15959269/142805022-f8c5991f-2cf2-4d50-afc8-5b1efc989171.mov



