### PR TITLE
Outline: small fixes from the prior refactor

### DIFF
--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Outline.js
@@ -87,9 +87,10 @@ const OutlineClassFunctions = React.memo(function OutlineClassFunctions({
   }, [isFocused]);
 
   const item = classFunc || classInfo;
+  const className = item.klass && item.name == "anonymous" ? item.klass : item.name;
 
   return (
-    <li className="outline-list__class" key={item.name}>
+    <li className="outline-list__class" key={className}>
       <h2
         className={classnames("", { focused: isFocused })}
         onClick={() => onSelect(item)}
@@ -99,7 +100,7 @@ const OutlineClassFunctions = React.memo(function OutlineClassFunctions({
           <OutlineFunction func={classFunc} isFocused={false} outlineList={outlineList} />
         ) : (
           <div>
-            <span className="keyword">class</span> {item.name}
+            <span className="keyword">class</span> {className}
           </div>
         )}
       </h2>
@@ -208,20 +209,21 @@ export class Outline extends Component {
     }
 
     const { focusedItem } = this.state;
-    const classFunc = functions.find(func => func.name === klass);
-    const classFunctions = functions.filter(func => func.klass === klass);
-    const classInfo = symbols.classes.find(c => c.name === klass);
+    const classFunc = symbols.functions.find(func => func.name === klass);
+    const classInfo = symbols.functions.find(c => c.klass === klass);
 
     const item = classFunc || classInfo;
     const isFocused = focusedItem === item;
+
     return (
       <OutlineClassFunctions
         classFunc={classFunc}
         classInfo={classInfo}
         isFocused={isFocused}
         outlineList={outlineList}
+        onSelect={this.selectItem}
       >
-        {classFunctions.map(func => this.renderFunction(func))}
+        {functions.map(func => this.renderFunction(func))}
       </OutlineClassFunctions>
     );
   }

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -233,9 +233,11 @@ export function setExpectedError(error: ExpectedError): UIThunkAction {
 export function setTrialExpired(expired = true): SetTrialExpiredAction {
   return { type: "set_trial_expired", expired };
 }
+
 export function clearTrialExpired(): UIThunkAction {
   return ({ dispatch }) => dispatch(setTrialExpired(false));
 }
+
 export function setUnexpectedError(error: UnexpectedError, skipTelemetry = false): UIThunkAction {
   return ({ getState, dispatch }) => {
     const state = getState();


### PR DESCRIPTION
- passing in onSelect
- fix class info by using symbols.functions
- find a better class name

Here's a [replay](http://localhost:8080/recording/73b0fd77-f448-490d-84a2-79e29ecc3790?point=26610521403300987730770443127227166&time=10454.416827728723&hasFrames=true) of the bug
Here's a [replay](https://app.replay.io/recording/b611c874-5451-4816-9b1d-1a980458a6b6?point=30180225494250797307198085055644405&time=27414.506505097066&hasFrames=true#) of the fix