### PR TITLE
Accordion: dont render component when collapsed

### DIFF
--- a/src/ui/components/Accordion.tsx
+++ b/src/ui/components/Accordion.tsx
@@ -51,7 +51,7 @@ const Accordion = ({ items }: { items: AccordionItem[] }) => {
               </h2>
             </div>
             <div className={classNames(styles.content, { [styles.open]: !collapsed })}>
-              {component}
+              {!collapsed && component}
             </div>
           </div>
         );


### PR DESCRIPTION
This will prevent us from rendering the accordion content when collapsed. This is important because the outline component can be expensive