### PR TITLE
Fix comment flash when adding from console

### DIFF
--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -190,7 +190,7 @@ class Message extends Component {
         actions.createComment(
           executionPointTime,
           executionPoint,
-          undefined,
+          null,
           true,
           frame,
           { ...this.props.auth0.user, id: userId },


### PR DESCRIPTION
This is, I think, the last place where we were passing `undefined` when Apollo expected `null`. I spent some time after fixing this trying to figure out (to no avail) why the first long-poll for comments also sometimes triggers a quick re-render after comment submission. I dug into the React profiler, saw that the re-render and it's definitely triggered by some hooks changing. My guess is that the hook that is long-polling sees the length of comments change (even though we have the optimistic update already) and triggers an unnecessary refresh. I'm not sure how to stop it from doing that. Anyways, this fixes the worst flash.