### PR TITLE
Add more full text search mixpanel trackers

### DIFF
--- a/src/devtools/client/debugger/src/components/FullTextSearch/index.js
+++ b/src/devtools/client/debugger/src/components/FullTextSearch/index.js
@@ -59,6 +59,7 @@ export class FullTextSearch extends Component {
     const { sourcesById } = this.props;
 
     if (e.key === "ArrowDown") {
+      trackEvent("project_search.go_to_first_result");
       this.searchRef.current.querySelector(".file-result:first-child").focus();
       e.preventDefault();
       return;

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -5,6 +5,7 @@ import { connect, ConnectedProps } from "react-redux";
 import { UIState } from "ui/state";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
+import { trackEvent } from "ui/utils/telemetry";
 
 function setupShortcuts() {
   return usesWindow(win => {
@@ -21,6 +22,7 @@ function KeyboardShortcuts({ viewMode, setSelectedPrimaryPanel, setViewMode }: P
       setViewMode("dev");
     }
 
+    trackEvent("key_shortcut.full_text_search");
     setSelectedPrimaryPanel("search");
   };
 


### PR DESCRIPTION
This adds to more trackers so we have the following related trackers to the full text search:
- When the user opens full text search with a shortcut (`key_shortcut.full_text_search`)
- When the user opens full text search by clicking in the sidebar (`toolbox.primary.search_select`)
- When the user opens a result in the editor (`project_search.select`)
- When the user presses down from the input box to move onto the first search result(`project_search.go_to_first_result`)