### PR TITLE
Make sure we only fire events when hovering in the editor

### DIFF
--- a/src/devtools/client/debugger/src/utils/editor/gutter-events.js
+++ b/src/devtools/client/debugger/src/utils/editor/gutter-events.js
@@ -20,22 +20,18 @@ function getLineNumberNode(target) {
     target.closest(".CodeMirror-gutter-wrapper")?.parentElement ||
     target.closest(".CodeMirror-line")?.parentElement;
 
-  if (!row) return null;
-
-  const wrapper = row.querySelector(".CodeMirror-gutter-wrapper");
-
-  return wrapper.querySelector(".CodeMirror-linenumber");
+  return row.querySelector(".CodeMirror-linenumber");
 }
 
 function isValidTarget(target) {
-  const lineNumberNode = getLineNumberNode(target);
-
-  if (!lineNumberNode) return false;
-
+  const isRow =
+    target.closest(".CodeMirror-gutter-wrapper")?.parentElement ||
+    target.closest(".CodeMirror-line")?.parentElement;
+  const isWidget = target.closest(".CodeMirror-linewidget");
   const isNonBreakableLineNode = target.closest(".empty-line");
   const isTooltip = target.closest(".static-tooltip");
 
-  return !isNonBreakableLineNode && !isTooltip;
+  return isRow && !isWidget && !isNonBreakableLineNode && !isTooltip;
 }
 
 export function onGutterMouseOver(codeMirror) {


### PR DESCRIPTION
Demo: https://app.replay.io/recording/a306fc77-4ba4-4cae-be6d-3054af78c3b6

`gutter-events` could still use a refactor but this fixes #4637