### PR TITLE
Don't show the red events timeline when there are no events

### DIFF
--- a/src/ui/components/Events/Events.tsx
+++ b/src/ui/components/Events/Events.tsx
@@ -47,7 +47,7 @@ function Events({ currentTime, events, executionPoint, seek }: PropsFromRedux) {
           </div>
         );
       })}
-      <CurrentTimeLine isActive={currentEventIndex === events.length} />
+      <CurrentTimeLine isActive={currentEventIndex === events.length && !!events.length} />
     </div>
   );
 }


### PR DESCRIPTION
Fix #4239.