### PR TITLE
Clean up breakpoint widget nags

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
@@ -2,39 +2,33 @@ import React, { useEffect, useState } from "react";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
+import { shouldShowNag } from "ui/utils/user";
 
 const TEXT = {
-  clickPrompt: "Edit your first print statement",
-  enterPrompt: "Add some local variables",
+  editPrompt: "Edit your first print statement",
+  savePrompt: "Add some local variables",
   success: "Check the console",
 };
 
 type Step = keyof typeof TEXT;
 
-function getStep(nags: Nag[], editing: boolean): Step | void {
-  if (!nags) {
-    return undefined;
-  }
-
-  if (!nags.includes(Nag.FIRST_BREAKPOINT_ADD)) {
-    return "clickPrompt";
-  }
-
-  if (editing && !nags.includes(Nag.FIRST_BREAKPOINT_EDIT)) {
-    return "enterPrompt";
-  }
-
-  if (!nags.includes(Nag.FIRST_BREAKPOINT_REMOVED)) {
-    return "success";
-  }
-
-  return undefined;
-}
-
 export default function FirstEditNag({ editing }: { editing: boolean }) {
+  const [step, setStep] = useState<Step | null>(null);
   const { nags } = hooks.useGetUserInfo();
 
-  const step = getStep(nags, editing);
+  useEffect(() => {
+    if (shouldShowNag(nags, Nag.FIRST_BREAKPOINT_EDIT)) {
+      setStep("editPrompt");
+    } else if (editing && shouldShowNag(nags, Nag.FIRST_BREAKPOINT_SAVE)) {
+      setStep("savePrompt");
+    }
+
+    // Show the user the success state if they've just finished saving the breakpoint.
+    if (step === "savePrompt" && !shouldShowNag(nags, Nag.FIRST_BREAKPOINT_SAVE)) {
+      setStep("success");
+    }
+  }, [nags, editing]);
+
   if (!step) {
     return null;
   }

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -19,7 +19,6 @@ import FirstEditNag from "./FirstEditNag";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
 import { prefs } from "ui/utils/prefs";
-import { shouldShowNag } from "ui/utils/user";
 
 function getPanelWidth({ editor }) {
   // The indent value is an adjustment for the distance from the gutter's left edge
@@ -54,12 +53,9 @@ function Panel({
 
   useEffect(() => {
     editor.editor.on("refresh", updateWidth);
-    dismissNag(Nag.FIRST_GUTTER_CLICK);
+    dismissNag(Nag.FIRST_BREAKPOINT_ADD);
 
     return () => {
-      if (nags?.includes(Nag.FIRST_BREAKPOINT_EDIT)) {
-        dismissNag(Nag.FIRST_BREAKPOINT_REMOVED);
-      }
       editor.editor.off("refresh", updateWidth);
     };
   }, []);
@@ -71,12 +67,12 @@ function Panel({
   });
 
   const toggleEditingOn = () => {
-    dismissNag(Nag.FIRST_BREAKPOINT_ADD);
+    dismissNag(Nag.FIRST_BREAKPOINT_EDIT);
     setEditing(true);
   };
 
   const toggleEditingOff = () => {
-    dismissNag(Nag.FIRST_BREAKPOINT_EDIT);
+    dismissNag(Nag.FIRST_BREAKPOINT_SAVE);
     setEditing(false);
   };
 

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -76,7 +76,7 @@ function LineNumberTooltip({
       );
   }, [analysisPoints]);
 
-  const showNag = shouldShowNag(nags, Nag.FIRST_GUTTER_CLICK);
+  const showNag = shouldShowNag(nags, Nag.FIRST_BREAKPOINT_ADD);
 
   if (!lineNumberNode) {
     return null;

--- a/src/ui/components/shared/Nags/Nags.tsx
+++ b/src/ui/components/shared/Nags/Nags.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import React from "react";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
+import { shouldShowNag } from "ui/utils/user";
 import MaterialIcon from "../MaterialIcon";
 
 // This is very arbitrary but we need it to keep the editor
@@ -20,7 +21,7 @@ function NagHat({
 }) {
   const { nags } = hooks.useGetUserInfo();
 
-  if (!nags || (nags && nags.includes(nagType))) {
+  if (!shouldShowNag(nags, nagType)) {
     return null;
   }
 
@@ -56,7 +57,7 @@ export function EditorNag() {
     <NagHat
       mainText="Ready to add your first print statement?"
       subText="Click on a line number in the gutter"
-      nagType={Nag.FIRST_GUTTER_CLICK}
+      nagType={Nag.FIRST_BREAKPOINT_ADD}
     />
   );
 }

--- a/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/OnboardingModal.tsx
@@ -49,7 +49,7 @@ function Navigation({
 
   const onSkipOrDone = () => {
     hideModal();
-    dismissNag(Nag.FIRST_REPLAY);
+    dismissNag(Nag.FIRST_REPLAY_2);
   };
 
   return (

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -43,14 +43,20 @@ export type UserInfo = {
 };
 
 export enum Nag {
-  FIRST_REPLAY = "first_replay",
   FIRST_REPLAY_2 = "first_replay_2",
   FIRST_BREAKPOINT_EDIT = "first_breakpoint_edit",
   FIRST_BREAKPOINT_ADD = "first_breakpoint_add",
-  FIRST_BREAKPOINT_REMOVED = "first_breakpoint_removed",
+  FIRST_BREAKPOINT_SAVE = "first_breakpoint_save",
   FIRST_CONSOLE_NAVIGATE = "first_console_navigate",
-  FIRST_GUTTER_CLICK = "first_gutter_click",
   DOWNLOAD_REPLAY = "download_replay",
+}
+
+// Keeping a list of unused nag types here so we don't accidentally
+// overwrite them as we come up with new ones.
+enum DeprecatedNag {
+  FIRST_REPLAY = "first_replay",
+  FIRST_BREAKPOINT_REMOVED = "first_breakpoint_removed",
+  FIRST_GUTTER_CLICK = "first_gutter_click",
 }
 
 export enum EmailSubscription {


### PR DESCRIPTION
Fix #4670.

Demo: https://app.replay.io/recording/2781dbdb-0981-4f9f-a118-ce108c638ddb

This will make sure that the same problem won't happen again. But it won't apply retroactively, i.e. Matt will still look as if he hasn't added a breakpoint in the admin panel. To fix that, we should run these three mutations on the database (https://gist.github.com/jaril/685823a170c804afdbc760137a75133b).