### PR TITLE
Removed jellyfish and reduced font size

### DIFF
--- a/src/ui/components/UploadScreen/Privacy.tsx
+++ b/src/ui/components/UploadScreen/Privacy.tsx
@@ -86,7 +86,7 @@ export function Privacy() {
   const { operations } = recording!;
 
   return (
-    <div className="flex w-full h-full rounded-xl shadow-xl text-lg relative p-8 bg-jellyfish overflow-hidden">
+    <div className="flex w-full h-full rounded-xl shadow-xl text-md relative p-8 bg-white overflow-hidden">
       <div className="flex flex-col space-y-7 overflow-hidden">
         <div className="flex flex-col space-y-1">
           <div className="text-2xl font-bold">Privacy</div>


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/9154902/143311377-005ee508-48ce-4e00-839c-b37fba03b634.png)

New:
![image](https://user-images.githubusercontent.com/9154902/143311305-cbdd90c8-a42d-413e-835a-f553a91689df.png)

Notes:

1. We shouldn't show broken images for favicons. Can we confirm that these aren't returning a 404 before showing them? We can do this in another ticket

2. This screen is heavy on tailwind, whereas we should have aligned more closely to our other modals.

