### PR TITLE
Defensively check local nags

### DIFF
--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -75,7 +75,7 @@ export async function isLocalNagDismissed(nag: LocalNag) {
   const replaySessions = await getReplaySessions();
   const replaySession = replaySessions[recordingId];
 
-  return replaySession.localNags.includes(nag);
+  return replaySession?.localNags.includes(nag);
 }
 
 // This allows us to insert a local nag on a per session (replay) basis.


### PR DESCRIPTION
I can't tell if this is happening in prod, but it happened in this E2E
test: https://app.replay.io/recording/9febd9f5-11b4-477a-8af8-24250b22c259?point=29855706938421465504100931554249690&time=61856&hasFrames=false