### PR TITLE
Validate auth without the redirect

### DIFF
--- a/pages/callback.tsx
+++ b/pages/callback.tsx
@@ -11,15 +11,18 @@ export default function Connection() {
   const connection = Array.isArray(q.connection) ? q.connection[0] : q.connection;
 
   useEffect(() => {
+    const home = window.location.origin + "/";
     if (!connection || auth0.isAuthenticated) {
-      router.replace("/");
+      router.replace(home);
       return;
     }
 
-    // FIXME [ryanjduffy]: This results in an additional auth roundtrip with the
-    // id provider but works around auth0 no handling idp-initiated
-    // authentication.
-    auth0.loginWithRedirect({ connection });
+    auth0.getAccessTokenSilently({ connection, redirect_uri: home }).catch(e =>
+      auth0.loginWithRedirect({
+        connection,
+        redirectUri: home,
+      })
+    );
   }, []);
 
   return <LoadingScreen />;

--- a/src/ui/utils/useAuth0.ts
+++ b/src/ui/utils/useAuth0.ts
@@ -15,6 +15,7 @@ const TEST_AUTH = {
   },
   loginWithRedirect: () => {},
   logout: () => {},
+  getAccessTokenSilently: () => Promise.resolve(),
 };
 
 export type AuthContext = Auth0ContextInterface | typeof TEST_AUTH;
@@ -41,6 +42,7 @@ export default function useAuth0() {
           },
       loginWithRedirect: () => {},
       logout: () => {},
+      getAccessTokenSilently: () => Promise.resolve(),
     };
   }
 


### PR DESCRIPTION
## Issue

Using `loginWithRedirect` seems to force another login for SAML users

## Resolution

Use `getAccessTokenSilently` instead