### PR TITLE
Enforce org features for user

### DIFF
--- a/src/ui/components/Library/Sidebar.tsx
+++ b/src/ui/components/Library/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useGetUserInfo } from "ui/hooks/users";
 import { Workspace } from "ui/types";
 import Invitations from "./Invitations";
 import NewTeamButton from "./NewTeamButton";
@@ -6,6 +7,7 @@ import SidebarFooter from "./SidebarFooter";
 import TeamButton from "./TeamButton";
 
 export default function Sidebar({ nonPendingWorkspaces }: { nonPendingWorkspaces: Workspace[] }) {
+  const { features } = useGetUserInfo();
   const userLibrary = { id: null, name: "Your Library", members: [] };
 
   // This corresponds with tailwind colors: thumb is gray-500 and track is gray-800
@@ -20,7 +22,9 @@ export default function Sidebar({ nonPendingWorkspaces }: { nonPendingWorkspaces
         className="library-sidebar flex flex-col flex-grow text-sm overflow-auto"
         style={scrollbarStyle}
       >
-        <TeamButton key={userLibrary.id} id={userLibrary.id} text={userLibrary.name} />
+        {features.library ? (
+          <TeamButton key={userLibrary.id} id={userLibrary.id} text={userLibrary.name} />
+        ) : null}
         <Invitations />
         {nonPendingWorkspaces.map(w => (
           <TeamButton key={w.id} id={w.id} text={w.name} workspace={w} />

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Viewer from "./Viewer";
 
 import { connect, ConnectedProps } from "react-redux";
@@ -8,6 +8,8 @@ import hooks from "ui/hooks";
 import Spinner from "../shared/Spinner";
 import { PendingTeamScreen } from "./PendingTeamScreen";
 import { MY_LIBRARY } from "../UploadScreen/Sharing";
+import BlankScreen from "../shared/BlankScreen";
+import { actions } from "ui/actions";
 
 function ViewerLoader() {
   return (
@@ -70,17 +72,43 @@ type ViewerRouterProps = PropsFromRedux & {
 };
 
 function ViewerRouter(props: ViewerRouterProps) {
+  const { workspaces, loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
+  const { features, loading } = hooks.useGetUserInfo();
   const { currentWorkspaceId } = props;
 
-  if (currentWorkspaceId === null) {
+  if (loading) return <BlankScreen />;
+
+  useEffect(() => {
+    if (currentWorkspaceId === null && !features.library && !nonPendingLoading) {
+      if (!workspaces.length) {
+        // This shouldn't be reachable because the library can only be disabled
+        // by a workspace setting which means the user must be in a workspace
+        props.setUnexpectedError({
+          message: "Unexpected error",
+          content: "Unable to find an active team",
+        });
+
+        return;
+      }
+
+      props.setWorkspaceId(workspaces[0].id);
+    }
+  });
+
+  if (currentWorkspaceId === null && features.library) {
     return <MyLibrary {...props} />;
-  } else {
+  } else if (currentWorkspaceId) {
     return <TeamLibrary {...props} />;
   }
+
+  return null;
 }
 
-const connector = connect((state: UIState) => ({
-  currentWorkspaceId: selectors.getWorkspaceId(state),
-}));
+const connector = connect(
+  (state: UIState) => ({
+    currentWorkspaceId: selectors.getWorkspaceId(state),
+  }),
+  { setWorkspaceId: actions.setWorkspaceId, setUnexpectedError: actions.setUnexpectedError }
+);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(ViewerRouter);

--- a/src/ui/components/UploadScreen/TeamSelect.tsx
+++ b/src/ui/components/UploadScreen/TeamSelect.tsx
@@ -17,6 +17,11 @@ const TeamSelectButton = ({ selectedWorkspaceName }: { selectedWorkspaceName: st
   );
 };
 
+interface DisplayedWorkspace {
+  id: string;
+  name: string;
+}
+
 export default function TeamSelect({
   workspaces,
   selectedWorkspaceId,
@@ -28,13 +33,13 @@ export default function TeamSelect({
 }) {
   const userInfo = useGetUserInfo();
   const [expanded, setExpanded] = useState(false);
-  const displayedWorkspaces: { id: string; name: string }[] = [...workspaces].sort();
+  let displayedWorkspaces: DisplayedWorkspace[] = [...workspaces].sort();
 
   if (userInfo.features.library) {
-    displayedWorkspaces.unshift(personalWorkspace);
+    displayedWorkspaces = [personalWorkspace, ...displayedWorkspaces];
   }
 
-  const handleSelect = (workspace: Workspace | typeof personalWorkspace) => {
+  const handleSelect = (workspace: DisplayedWorkspace) => {
     handleWorkspaceSelect(workspace.id);
     setExpanded(false);
   };

--- a/src/ui/components/UploadScreen/TeamSelect.tsx
+++ b/src/ui/components/UploadScreen/TeamSelect.tsx
@@ -4,6 +4,7 @@ import { Dropdown, DropdownItem } from "../Library/LibraryDropdown";
 import PortalDropdown from "../shared/PortalDropdown";
 import { SelectorIcon } from "@heroicons/react/solid";
 import { personalWorkspace } from "./Sharing";
+import { useGetUserInfo } from "ui/hooks/users";
 
 const TeamSelectButton = ({ selectedWorkspaceName }: { selectedWorkspaceName: string }) => {
   return (
@@ -25,15 +26,22 @@ export default function TeamSelect({
   selectedWorkspaceId: string;
   handleWorkspaceSelect: (id: string) => void;
 }) {
+  const userInfo = useGetUserInfo();
   const [expanded, setExpanded] = useState(false);
-  const displayedWorkspaces = [personalWorkspace, ...workspaces].sort();
+  const displayedWorkspaces: { id: string; name: string }[] = [...workspaces].sort();
+
+  if (userInfo.features.library) {
+    displayedWorkspaces.unshift(personalWorkspace);
+  }
 
   const handleSelect = (workspace: Workspace | typeof personalWorkspace) => {
     handleWorkspaceSelect(workspace.id);
     setExpanded(false);
   };
 
-  const selectedWorkspaceName = displayedWorkspaces.find(w => w.id === selectedWorkspaceId)!.name;
+  const selectedWorkspace =
+    displayedWorkspaces.find(w => w.id === selectedWorkspaceId) || displayedWorkspaces[0];
+  const selectedWorkspaceName = selectedWorkspace.name;
   const button = <TeamSelectButton selectedWorkspaceName={selectedWorkspaceName} />;
 
   return (

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -227,7 +227,7 @@ export function UserSettingsModal(props: PropsFromRedux) {
   };
 
   const hiddenTabs = getFeatureFlag("new-user-invitations", true) ? undefined : ["Invitations"];
-  if (!orgFeatures.apiKey && hiddenTabs) {
+  if (!orgFeatures.library && hiddenTabs) {
     hiddenTabs.push("API Keys");
   }
 

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -198,6 +198,7 @@ const getSettings = (internal: boolean): Settings<SettingsTabTitle, CombinedUser
 
 export function UserSettingsModal(props: PropsFromRedux) {
   const { userSettings, loading } = hooks.useGetUserSettings();
+  const { features: orgFeatures, loading: orgFeaturesLoading } = hooks.useGetUserInfo();
   const { internal, loading: userInfoLoading } = hooks.useGetUserInfo();
   const view = props.view === "preferences" ? "Preferences" : props.defaultSettingsTab;
 
@@ -226,13 +227,16 @@ export function UserSettingsModal(props: PropsFromRedux) {
   };
 
   const hiddenTabs = getFeatureFlag("new-user-invitations", true) ? undefined : ["Invitations"];
+  if (!orgFeatures.apiKey && hiddenTabs) {
+    hiddenTabs.push("API Keys");
+  }
 
   const settings = getSettings(internal);
   return (
     <SettingsModal
       hiddenTabs={hiddenTabs}
       tab={view}
-      loading={loading || userInfoLoading}
+      loading={loading || userInfoLoading || orgFeaturesLoading}
       onChange={onChange}
       panelProps={{}}
       settings={settings}

--- a/src/ui/graphql/users.ts
+++ b/src/ui/graphql/users.ts
@@ -15,7 +15,6 @@ export const GET_USER_INFO = gql`
         id
       }
       features {
-        apiKey
         library
       }
       acceptedTOSVersion

--- a/src/ui/graphql/users.ts
+++ b/src/ui/graphql/users.ts
@@ -14,6 +14,10 @@ export const GET_USER_INFO = gql`
       user {
         id
       }
+      features {
+        apiKey
+        library
+      }
       acceptedTOSVersion
       email
       internal

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -39,7 +39,7 @@ export type UserInfo = {
   id: string;
   internal: boolean;
   nags: Nag[];
-  unsubscribedEmailTypes: string[];
+  unsubscribedEmailTypes: EmailSubscription[];
   features: { library: boolean };
 };
 

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -40,6 +40,7 @@ export type UserInfo = {
   internal: boolean;
   nags: Nag[];
   unsubscribedEmailTypes: string[];
+  features: { apiKey: boolean; library: boolean };
 };
 
 export enum Nag {
@@ -85,10 +86,11 @@ export async function getUserInfo(): Promise<UserInfo | undefined> {
     internal: viewer.internal,
     nags: viewer.nags,
     unsubscribedEmailTypes: viewer.unsubscribedEmailTypes,
+    features: viewer.features || {},
   };
 }
 
-export function useGetUserInfo() {
+export function useGetUserInfo(): UserInfo & { loading: boolean } {
   const { data, loading, error } = useQuery(GET_USER_INFO);
 
   if (error) {
@@ -96,13 +98,12 @@ export function useGetUserInfo() {
   }
 
   const id: string = data?.viewer?.user.id;
-  const name: string = data?.viewer?.user.name;
-  const picture: string = data?.viewer?.user.picture;
   const email: string = data?.viewer?.email;
   const internal: boolean = data?.viewer?.internal;
   const nags: Nag[] = data?.viewer?.nags;
   const unsubscribedEmailTypes: EmailSubscription[] = data?.viewer?.unsubscribedEmailTypes;
   const acceptedTOSVersion = data?.viewer?.acceptedTOSVersion;
+  const features = data?.viewer?.features || {};
 
   return {
     loading,
@@ -110,10 +111,9 @@ export function useGetUserInfo() {
     email,
     internal,
     nags,
-    name,
-    picture,
     acceptedTOSVersion,
     unsubscribedEmailTypes,
+    features,
   };
 }
 

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -40,7 +40,7 @@ export type UserInfo = {
   internal: boolean;
   nags: Nag[];
   unsubscribedEmailTypes: string[];
-  features: { apiKey: boolean; library: boolean };
+  features: { library: boolean };
 };
 
 export enum Nag {

--- a/src/ui/utils/useAuth0.ts
+++ b/src/ui/utils/useAuth0.ts
@@ -24,7 +24,7 @@ export type AuthContext = Auth0ContextInterface | typeof TEST_AUTH;
  */
 export default function useAuth0() {
   const auth = useOrigAuth0();
-  const { loading, name, email, picture } = useGetUserInfo();
+  const { loading, email } = useGetUserInfo();
   const { token, apiKey } = useToken();
 
   if (apiKey && token) {
@@ -35,9 +35,7 @@ export default function useAuth0() {
         ? undefined
         : {
             sub: "api-key",
-            name,
             email,
-            picture,
           },
       loginWithRedirect: () => {},
       logout: () => {},


### PR DESCRIPTION
Issue: https://github.com/RecordReplay/ops/issues/327
Blocked by https://github.com/RecordReplay/backend/pull/3707

## Issue

Orgs can prevent their users from viewing their personal library.

## Resolution

* Adds `features` to user info graphql query
* Disables the library when `user.library` is false
* Disables personal API keys when `user.library` is false
