### PR TITLE
Make sure that class names are being displayed in the outline view

### DIFF
--- a/src/devtools/client/debugger/src/components/Outline/ClassFunctionsList.js
+++ b/src/devtools/client/debugger/src/components/Outline/ClassFunctionsList.js
@@ -17,8 +17,8 @@ export function ClassFunctionsList({
     return null;
   }
 
-  const classFunc = symbols.functions.find(func => func.name === klass);
-  const classInfo = symbols.functions.find(c => c.klass === klass);
+  const classFunc = functions.find(func => func.name === klass);
+  const classInfo = symbols.classes.find(c => c.name === klass);
   let classFunctions = functions.filter(
     func => filterOutlineItem(func.name, filter) && !!func.klass
   );


### PR DESCRIPTION
Fix #4701.

Demo: https://share.descript.com/view/aUpx4OKb8DP
Replay: https://app.replay.io/recording/a733cc6f-96ac-428c-ba39-d39fe77ef899