### PR TITLE
Log loaded regions to console

### DIFF
--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -267,7 +267,8 @@ class _ThreadFront {
     const sessionId = await this.waitForSession();
 
     client.Session.addLoadedRegionsListener((parameters: loadedRegions) => {
-      // console.log("LoadedRegions", parameters);
+      // Log loaded regions to help with diagnostics.
+      console.log("LoadedRegions", parameters);
       listenerCallback(parameters);
     });
 


### PR DESCRIPTION
Uncomment the log message to show loaded regions in the console.  This is helpful for diagnosing problems while loading (e.g. https://github.com/RecordReplay/devtools/issues/4715) as the UI doesn't provide all this information.