### PR TITLE
Only render a panel if it is selected

### DIFF
--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -164,22 +164,10 @@ function SecondaryToolbox({
         </header>
       )}
       <Redacted className="secondary-toolbox-content text-xs">
-        {/* {selectedPanel === "network" && <NetworkMonitor />} */}
-        <div className={classNames("h-full", { hidden: selectedPanel !== "network" })}>
-          <NetworkMonitor />
-        </div>
-        {/* {selectedPanel === "console" ? <ConsolePanel /> : null} */}
-        <div className={classNames("h-full", { hidden: selectedPanel !== "console" })}>
-          <ConsolePanel />
-        </div>
-        {/* {selectedPanel === "inspector" ? <InspectorPanel /> : null} */}
-        <div className={classNames("h-full", { hidden: selectedPanel !== "inspector" })}>
-          <InspectorPanel />
-        </div>
-        {/* {selectedPanel === "react-components" ? <ReactDevtoolsPanel /> : null} */}
-        <div className={classNames("h-full", { hidden: selectedPanel !== "react-components" })}>
-          <ReactDevtoolsPanel />
-        </div>
+        {selectedPanel === "network" && <NetworkMonitor />}
+        {selectedPanel === "console" ? <ConsolePanel /> : null}
+        {selectedPanel === "inspector" ? <InspectorPanel /> : null}
+        {selectedPanel === "react-components" ? <ReactDevtoolsPanel /> : null}
       </Redacted>
     </div>
   );


### PR DESCRIPTION
There are two benefits:

1. performance, we found firefox devtools was much faster when we did not have all the panels running in the background
2. https://github.com/RecordReplay/devtools/issues/4578#issuecomment-983759761 - react devtools is stealing key presses