### PR TITLE
Add special behavior for the default sidepanel open when a replay is opened

### DIFF
--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -24,6 +24,9 @@ export const GET_RECORDING = gql`
       ownerNeedsInvite
       userRole
       operations
+      comments {
+        id
+      }
       owner {
         id
         name


### PR DESCRIPTION
Fix #4687.

Putting this on hold, it's trickier than I first thought it would be.