### PR TITLE
Add team logo

### DIFF
--- a/src/ui/components/Library/Viewer.tsx
+++ b/src/ui/components/Library/Viewer.tsx
@@ -51,7 +51,7 @@ export default function Viewer({
   searchString,
 }: {
   recordings: Recording[];
-  workspaceName: string;
+  workspaceName: string | React.ReactNode;
   searchString: string;
 }) {
   const filteredRecordings = searchString
@@ -72,7 +72,7 @@ function ViewerContent({
   workspaceName,
 }: {
   recordings: Recording[];
-  workspaceName: string;
+  workspaceName: string | React.ReactNode;
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -87,10 +87,8 @@ function ViewerContent({
 
   const HeaderLeft = (
     <ViewerHeaderLeft>
-      <>
-        <span>{workspaceName}</span>
-        <span>{recordings.length != 0 ? <>({recordings.length})</> : <></>}</span>
-      </>
+      <span>{workspaceName}</span>
+      <span>{recordings.length != 0 ? <>({recordings.length})</> : <></>}</span>
     </ViewerHeaderLeft>
   );
 

--- a/src/ui/components/Library/ViewerHeader.tsx
+++ b/src/ui/components/Library/ViewerHeader.tsx
@@ -13,5 +13,7 @@ export function ViewerHeaderLeft({
 }: {
   children: React.ReactChild | React.ReactChild[];
 }) {
-  return <div className="flex flex-row space-x-2 text-2xl font-semibold">{children}</div>;
+  return (
+    <div className="flex flex-row space-x-2 text-2xl font-semibold items-center">{children}</div>
+  );
 }

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -10,6 +10,7 @@ import { PendingTeamScreen } from "./PendingTeamScreen";
 import { MY_LIBRARY } from "../UploadScreen/Sharing";
 import { actions } from "ui/actions";
 import { BlankViewportWrapper } from "../shared/Viewport";
+import Base64Image from "../shared/Base64Image";
 
 function ViewerLoader() {
   return (
@@ -56,11 +57,17 @@ function NonPendingTeamLibrary({ currentWorkspaceId, searchString }: ViewerRoute
     return <ViewerLoader />;
   }
 
+  const workspace = workspaces.find(ws => ws.id === currentWorkspaceId)!;
+
   return (
     <Viewer
       {...{
         recordings,
-        workspaceName: workspaces.find(ws => ws.id === currentWorkspaceId)!.name,
+        workspaceName: workspace.logo ? (
+          <Base64Image src={workspace.logo} className="max-h-12" />
+        ) : (
+          workspace.name
+        ),
         searchString,
       }}
     />

--- a/src/ui/components/shared/Base64Image.tsx
+++ b/src/ui/components/shared/Base64Image.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default function Base64Image({ src, ...rest }: React.ImgHTMLAttributes<HTMLImageElement>) {
+  if (!src) return null;
+
+  return <img {...rest} src={`data:image/png;base64,${src}`} />;
+}

--- a/src/ui/components/shared/SettingsModal/SettingsBody.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBody.tsx
@@ -16,7 +16,7 @@ function SettingsBodyWrapper({ children }: { children: (React.ReactChild | null)
   return <main className="text-sm">{children}</main>;
 }
 
-export function SettingsHeader({ children }: { children: React.ReactChild }) {
+export function SettingsHeader({ children }: { children: React.ReactNode }) {
   return <h1 className="text-2xl">{children}</h1>;
 }
 

--- a/src/ui/components/shared/SettingsModal/SettingsModal.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsModal.tsx
@@ -28,7 +28,7 @@ export default function SettingsModal<
   settings: Settings<T, V, P>;
   values?: V;
   size?: "sm" | "lg";
-  title?: string | React.ReactNode;
+  title?: React.ReactNode;
 }) {
   const [selectedTab, setSelectedTab] = useState<T | undefined>(tab);
   const selectedSetting = settings.find(setting => setting.title === selectedTab)!;

--- a/src/ui/components/shared/SettingsModal/SettingsModal.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsModal.tsx
@@ -28,7 +28,7 @@ export default function SettingsModal<
   settings: Settings<T, V, P>;
   values?: V;
   size?: "sm" | "lg";
-  title?: string;
+  title?: string | React.ReactNode;
 }) {
   const [selectedTab, setSelectedTab] = useState<T | undefined>(tab);
   const selectedSetting = settings.find(setting => setting.title === selectedTab)!;

--- a/src/ui/components/shared/SettingsModal/SettingsNavigation.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsNavigation.tsx
@@ -22,7 +22,7 @@ interface SettingNavigationProps<
   settings: Settings<T, V, P>;
   selectedTab?: T;
   setSelectedTab: (title: T) => void;
-  title?: string;
+  title?: React.ReactNode;
   hiddenTabs?: T[];
 }
 

--- a/src/ui/components/shared/WorkspaceSettingsModal/GeneralSettings.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/GeneralSettings.tsx
@@ -27,7 +27,7 @@ const useImageUpload = (
   const [err, setErr] = useState<string>();
   const [img, setImg] = useState(image);
 
-  const handleUpload = (input: HTMLInputElement) => {
+  const onUpload = (input: HTMLInputElement) => {
     if (!input.files?.[0]) return;
 
     input.files[0].arrayBuffer().then(b => {
@@ -45,13 +45,13 @@ const useImageUpload = (
     });
   };
 
-  return [img, err, handleUpload];
+  return { img, err, onUpload };
 };
 
 const GeneralSettings = ({ workspaceId }: { workspaceId: string }) => {
   const { workspace } = hooks.useGetWorkspace(workspaceId);
   const updateWorkspaceSettings = hooks.useUpdateWorkspaceSettings();
-  const [img, err, handleUpload] = useImageUpload(workspace?.logo, 250, logo =>
+  const { img, err, onUpload } = useImageUpload(workspace?.logo, 250, logo =>
     updateWorkspaceSettings({
       variables: {
         workspaceId,
@@ -98,7 +98,7 @@ const GeneralSettings = ({ workspaceId }: { workspaceId: string }) => {
                 type="file"
                 className="invisible h-1 w-0"
                 accept="image/png"
-                onChange={e => handleUpload(e.currentTarget)}
+                onChange={e => onUpload(e.currentTarget)}
               />
               <span>Upload</span>
               <span className="text-sm material-icons ml-2">upload</span>

--- a/src/ui/components/shared/WorkspaceSettingsModal/GeneralSettings.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/GeneralSettings.tsx
@@ -51,7 +51,7 @@ const useImageUpload = (
 const GeneralSettings = ({ workspaceId }: { workspaceId: string }) => {
   const { workspace } = hooks.useGetWorkspace(workspaceId);
   const updateWorkspaceSettings = hooks.useUpdateWorkspaceSettings();
-  const { img, err, onUpload } = useImageUpload(workspace?.logo, 250, logo =>
+  const { img, err, onUpload } = useImageUpload(workspace?.logo, 50, logo =>
     updateWorkspaceSettings({
       variables: {
         workspaceId,

--- a/src/ui/components/shared/WorkspaceSettingsModal/GeneralSettings.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/GeneralSettings.tsx
@@ -19,9 +19,46 @@ const Row = ({ children }: { children: React.ReactNode }) => {
   return <div className="flex items-center">{children}</div>;
 };
 
+const useImageUpload = (
+  image: string | undefined,
+  maxSize: number,
+  callback: (img: string) => void
+) => {
+  const [err, setErr] = useState<string>();
+  const [img, setImg] = useState(image);
+
+  const handleUpload = (input: HTMLInputElement) => {
+    if (!input.files?.[0]) return;
+
+    input.files[0].arrayBuffer().then(b => {
+      if (maxSize && b.byteLength > maxSize * 1024) {
+        setErr(`Image must be less than ${maxSize} kilobytes`);
+        return;
+      }
+
+      const ua = new Uint8Array(b);
+      const str = ua.reduce((a, b) => a + String.fromCharCode(b), "");
+      const newImage = btoa(str);
+      setErr(undefined);
+      setImg(newImage);
+      callback(newImage);
+    });
+  };
+
+  return [img, err, handleUpload];
+};
+
 const GeneralSettings = ({ workspaceId }: { workspaceId: string }) => {
   const { workspace } = hooks.useGetWorkspace(workspaceId);
   const updateWorkspaceSettings = hooks.useUpdateWorkspaceSettings();
+  const [img, err, handleUpload] = useImageUpload(workspace?.logo, 250, logo =>
+    updateWorkspaceSettings({
+      variables: {
+        workspaceId,
+        logo,
+      },
+    })
+  );
   const [name, setName] = useDebounceState(
     workspace?.name,
     name =>
@@ -51,12 +88,25 @@ const GeneralSettings = ({ workspaceId }: { workspaceId: string }) => {
           />
         </Input>
       </Row>
-      {/* <Row>
-        <Label>Logo</Label>
+      <Row>
+        <Label className="self-start">Logo</Label>
         <Input>
-          <button className="border p-2 rounded-md">Upload</button>
+          <div className="flex flex-col items-start space-y-4">
+            {img ? <img className="block max-h-12" src={`data:image/png;base64,${img}`} /> : null}
+            <label className="cursor-pointer border rounded-md p-2 flex-inline items-center justify-center">
+              <input
+                type="file"
+                className="invisible h-1 w-0"
+                accept="image/png"
+                onChange={e => handleUpload(e.currentTarget)}
+              />
+              <span>Upload</span>
+              <span className="text-sm material-icons ml-2">upload</span>
+            </label>
+            {err ? <div className="text-red-500">{err}</div> : null}
+          </div>
         </Input>
-      </Row> */}
+      </Row>
     </div>
   );
 };

--- a/src/ui/components/shared/WorkspaceSettingsModal/GeneralSettings.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/GeneralSettings.tsx
@@ -51,14 +51,16 @@ const useImageUpload = (
 const GeneralSettings = ({ workspaceId }: { workspaceId: string }) => {
   const { workspace } = hooks.useGetWorkspace(workspaceId);
   const updateWorkspaceSettings = hooks.useUpdateWorkspaceSettings();
+  const updateWorkspaceLogo = hooks.useUpdateWorkspaceLogo();
   const { img, err, onUpload } = useImageUpload(workspace?.logo, 50, logo =>
-    updateWorkspaceSettings({
+    updateWorkspaceLogo({
       variables: {
         workspaceId,
         logo,
       },
     })
   );
+
   const [name, setName] = useDebounceState(
     workspace?.name,
     name =>

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -250,7 +250,13 @@ function WorkspaceSettingsModal({ workspaceId, view, ...rest }: PropsFromRedux) 
       panelProps={{ isAdmin, workspaceId, ...rest }}
       settings={settings}
       size="lg"
-      title={workspace.name || "Team Settings"}
+      title={
+        workspace.logo ? (
+          <img src={`data:image/png;base64,${workspace.logo}`} className="max-h-12" />
+        ) : (
+          workspace.name || "Team Settings"
+        )
+      }
     />
   );
 }

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -17,6 +17,7 @@ import { Button, DisabledButton, PrimaryButton } from "../Button";
 import { useConfirm } from "../Confirm";
 import GeneralSettings from "./GeneralSettings";
 import OrganizationSettings from "./OrganizationSettings";
+import Base64Image from "../Base64Image";
 
 export function WorkspaceMembers({
   members,
@@ -252,7 +253,7 @@ function WorkspaceSettingsModal({ workspaceId, view, ...rest }: PropsFromRedux) 
       size="lg"
       title={
         workspace.logo ? (
-          <img src={`data:image/png;base64,${workspace.logo}`} className="max-h-12" />
+          <Base64Image src={workspace.logo} className="max-h-12" />
         ) : (
           workspace.name || "Team Settings"
         )

--- a/src/ui/hooks/workspaces.ts
+++ b/src/ui/hooks/workspaces.ts
@@ -102,6 +102,29 @@ export function useGetWorkspace(workspaceId: string): { workspace?: Workspace; l
   };
 }
 
+export function useUpdateWorkspaceLogo() {
+  const [updateWorkspaceLogo] = useMutation<
+    any,
+    {
+      workspaceId: string;
+      logo: string | null;
+    }
+  >(
+    gql`
+      mutation UpdateWorkspaceLogo($workspaceId: ID!, $logo: String) {
+        updateWorkspaceLogo(input: { workspaceId: $workspaceId, logo: $logo }) {
+          success
+        }
+      }
+    `,
+    {
+      refetchQueries: ["GetNonPendingWorkspaces"],
+    }
+  );
+
+  return updateWorkspaceLogo;
+}
+
 export function useUpdateWorkspaceSettings() {
   const [updateWorkspaceSettings] = useMutation<
     any,
@@ -117,18 +140,11 @@ export function useUpdateWorkspaceSettings() {
       mutation UpdateWorkspaceSettings(
         $workspaceId: ID!
         $name: String
-        $logo: String
         $motd: String
         $features: JSONObject
       ) {
         updateWorkspaceSettings(
-          input: {
-            workspaceId: $workspaceId
-            name: $name
-            logo: $logo
-            motd: $motd
-            features: $features
-          }
+          input: { workspaceId: $workspaceId, name: $name, motd: $motd, features: $features }
         ) {
           success
         }

--- a/src/ui/hooks/workspaces.ts
+++ b/src/ui/hooks/workspaces.ts
@@ -108,6 +108,7 @@ export function useUpdateWorkspaceSettings() {
     {
       workspaceId: string;
       name?: string | null;
+      logo?: string | null;
       motd?: string | null;
       features?: Partial<WorkspaceSettings["features"]>;
     }
@@ -116,11 +117,18 @@ export function useUpdateWorkspaceSettings() {
       mutation UpdateWorkspaceSettings(
         $workspaceId: ID!
         $name: String
+        $logo: String
         $motd: String
         $features: JSONObject
       ) {
         updateWorkspaceSettings(
-          input: { workspaceId: $workspaceId, name: $name, motd: $motd, features: $features }
+          input: {
+            workspaceId: $workspaceId
+            name: $name
+            logo: $logo
+            motd: $motd
+            features: $features
+          }
         ) {
           success
         }
@@ -144,6 +152,7 @@ export function useGetNonPendingWorkspaces(): { workspaces: Workspace[]; loading
               node {
                 id
                 name
+                logo
                 invitationCode
                 domain
                 isDomainLimitedCode

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -136,6 +136,7 @@ export interface PendingWorkspaceInvitation extends Workspace {
 
 export interface Workspace {
   apiKeys?: ApiKey[];
+  logo?: string;
   domain: string;
   hasPaymentMethod: boolean;
   id: string;


### PR DESCRIPTION
Blocked by https://github.com/RecordReplay/backend/pull/3801, #4575 

## Issue
Teams should be able to upload a logo that is displayed in the workspace settings and in their library

## Resolution

* Adds logo upload to Profile settings pane
* Display logo in the settings and top of library (falling back to team name when unset)

![image](https://user-images.githubusercontent.com/788456/144333370-27694260-0f19-48d5-aed6-732a860907d5.png)
