### PR TITLE
Fix making recordings public from my library

### DIFF
--- a/src/ui/components/Library/RecordingOptionsDropdown.tsx
+++ b/src/ui/components/Library/RecordingOptionsDropdown.tsx
@@ -13,6 +13,7 @@ import PortalDropdown from "../shared/PortalDropdown";
 import classNames from "classnames";
 import MoveRecordingMenu from "./MoveRecordingMenu";
 import { useConfirm } from "../shared/Confirm";
+import { isPublicDisabled } from "ui/utils/org";
 
 type RecordingOptionsDropdownProps = PropsFromRedux & {
   recording: Recording;
@@ -31,8 +32,6 @@ function RecordingOptionsDropdown({
   const updateIsPrivate = hooks.useUpdateIsPrivate();
   const recordingId = recording.id;
   const { confirmDestructive } = useConfirm();
-
-  const workspace = workspaces.find(w => w.id === currentWorkspaceId);
 
   const toggleIsPrivate = () => {
     setIsPrivate(!isPrivate);
@@ -83,11 +82,11 @@ function RecordingOptionsDropdown({
     >
       <Dropdown>
         <DropdownItem onClick={() => onDeleteRecording(recordingId)}>Delete</DropdownItem>
-        {workspace?.settings.features.recording.public ? (
+        {isPublicDisabled(workspaces, currentWorkspaceId || "My Library") ? null : (
           <DropdownItem onClick={toggleIsPrivate}>{`Make ${
             isPrivate ? "public" : "private"
           }`}</DropdownItem>
-        ) : null}
+        )}
         <DropdownItem onClick={handleShareClick}>Share</DropdownItem>
         {!loading ? (
           <MoveRecordingMenu workspaces={workspaces} onMoveRecording={updateRecording} />

--- a/src/ui/components/UploadScreen/Sharing.tsx
+++ b/src/ui/components/UploadScreen/Sharing.tsx
@@ -5,6 +5,7 @@ import { Workspace } from "ui/types";
 import { Toggle } from "../shared/Forms";
 import SettingsPreview from "./SettingsPreview";
 import classNames from "classnames";
+import { isPublicDisabled } from "ui/utils/org";
 
 export const MY_LIBRARY = "My Library";
 export const personalWorkspace = { id: MY_LIBRARY, name: MY_LIBRARY };
@@ -16,17 +17,6 @@ type SharingProps = {
   isPublic: boolean;
   setIsPublic: Dispatch<SetStateAction<boolean>>;
 };
-
-function isPublicDisabled(workspaces: Workspace[], selectedWorkspaceId: string) {
-  const workspace = workspaces.find(w => w.id === selectedWorkspaceId);
-  const publicDisabledMyLibrary = workspaces.some(
-    w => w.settings.features.recording.public === false
-  );
-  return (
-    (selectedWorkspaceId === "My Library" && publicDisabledMyLibrary) ||
-    workspace?.settings.features.recording.public === false
-  );
-}
 
 function EditableSettings({
   workspaces,

--- a/src/ui/utils/org.ts
+++ b/src/ui/utils/org.ts
@@ -18,3 +18,14 @@ export function getOrganizationSettings(workspaces: Workspace[]) {
   const org = workspaces.find(w => w.isOrganization);
   return org?.settings || getDefaultOrganizationSettings();
 }
+
+export function isPublicDisabled(workspaces: Workspace[], selectedWorkspaceId: string) {
+  const workspace = workspaces.find(w => w.id === selectedWorkspaceId);
+  const publicDisabledMyLibrary = workspaces.some(
+    w => w.settings.features.recording.public === false
+  );
+  return (
+    (selectedWorkspaceId === "My Library" && publicDisabledMyLibrary) ||
+    workspace?.settings.features.recording.public === false
+  );
+}


### PR DESCRIPTION
## Issue

The "Make Public" command is always missing from My Library

https://app.replay.io/recording/65c708c2-ba66-4ee1-b3d0-8a3d0fca9250#

## Resolution

Reuse the same `isPublicDisabled` logic from the sharing modal to only hide the menu item when the user is part of an org that has public recordings disabled

https://app.replay.io/recording/f2d06c64-a651-4ac3-bba1-d2f5efe66ee9#
https://app.replay.io/recording/ada93cc7-d4a9-4cd5-aa83-a36b839fa7b6 (forgot to demo with the flag off too)