### PR TITLE
Add a console loading bar whenever there's a logpoint analysis in flight

### DIFF
--- a/src/devtools/client/debugger/src/client/commands.js
+++ b/src/devtools/client/debugger/src/client/commands.js
@@ -114,8 +114,9 @@ function hasBreakpoint(location) {
   return !!breakpoints[locationKey(location)];
 }
 
-function setBreakpoint(location, options) {
+async function setBreakpoint(location, options) {
   maybeClearLogpoint(location);
+  const oldLogGroupId = options.logGroupId;
   options = maybeGenerateLogGroupId(options);
   breakpoints[locationKey(location)] = { location, options };
 
@@ -133,7 +134,10 @@ function setBreakpoint(location, options) {
       promises.push(setLogpointByURL(logGroupId, sourceUrl, line, column, logValue, condition));
     }
   }
-  return Promise.all(promises);
+
+  await Promise.all(promises);
+
+  return { oldLogGroupId, logGroupId: options.logGroupId };
 }
 
 function removeBreakpoint(location) {

--- a/src/devtools/client/debugger/src/components/Outline/Outline.js
+++ b/src/devtools/client/debugger/src/components/Outline/Outline.js
@@ -122,7 +122,7 @@ export class Outline extends Component {
       return <div className="outline-pane-info">{placeholderMessage}</div>;
     }
 
-    if (!symbols || symbols.loading || true) {
+    if (!symbols || symbols.loading) {
       return (
         <div className="flex p-4 justify-center">
           <Spinner className="animate-spin h-4 w-4 text-gray-500" />

--- a/src/devtools/client/debugger/src/components/Outline/Outline.js
+++ b/src/devtools/client/debugger/src/components/Outline/Outline.js
@@ -122,7 +122,7 @@ export class Outline extends Component {
       return <div className="outline-pane-info">{placeholderMessage}</div>;
     }
 
-    if (!symbols || symbols.loading) {
+    if (!symbols || symbols.loading || true) {
       return (
         <div className="flex p-4 justify-center">
           <Spinner className="animate-spin h-4 w-4 text-gray-500" />

--- a/src/devtools/client/webconsole/actions/messages.js
+++ b/src/devtools/client/webconsole/actions/messages.js
@@ -34,7 +34,11 @@ export function setupMessages(store) {
     store.dispatch(onLogpointLoading(logGroupId, point, time, location));
   LogpointHandlers.onResult = (logGroupId, point, time, location, pause, values) =>
     store.dispatch(onLogpointResult(logGroupId, point, time, location, pause, values));
-  LogpointHandlers.clearLogpoint = logGroupId => store.dispatch(messagesClearLogpoint(logGroupId));
+  LogpointHandlers.clearLogpoint = logGroupId => {
+    store.dispatch(removeLogGroupId(logGroupId));
+    store.dispatch(messagesClearLogpoint(logGroupId));
+  };
+  LogpointHandlers.onError = logGroupId => store.dispatch(removeLogGroupId(logGroupId));
 
   ThreadFront.findConsoleMessages((_, msg) => store.dispatch(onConsoleMessage(msg)));
 }
@@ -139,6 +143,7 @@ function onLogpointLoading(logGroupId, point, time, { sourceId, line, column }) 
     };
 
     dispatch(dispatchMessageAdd(packet));
+    dispatch({ type: "ADD_LOG_GROUP_ID", logGroupId });
   };
 }
 
@@ -161,7 +166,12 @@ function onLogpointResult(logGroupId, point, time, { sourceId, line, column }, p
     };
 
     dispatch(dispatchMessageAdd(packet));
+    dispatch({ type: "REMOVE_LOG_GROUP_ID", logGroupId });
   };
+}
+
+function removeLogGroupId(logGroupId) {
+  return { type: "REMOVE_LOG_GROUP_ID", logGroupId };
 }
 
 function dispatchMessageAdd(packet) {

--- a/src/devtools/client/webconsole/actions/messages.js
+++ b/src/devtools/client/webconsole/actions/messages.js
@@ -170,7 +170,7 @@ function onLogpointResult(logGroupId, point, time, { sourceId, line, column }, p
   };
 }
 
-function removeLogGroupId(logGroupId) {
+export function removeLogGroupId(logGroupId) {
   return { type: "REMOVE_LOG_GROUP_ID", logGroupId };
 }
 

--- a/src/devtools/client/webconsole/components/Output/ConsoleLoadingBar.tsx
+++ b/src/devtools/client/webconsole/components/Output/ConsoleLoadingBar.tsx
@@ -1,0 +1,20 @@
+import React, { ReactNode } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import LoadingProgressBar from "ui/components/shared/LoadingProgressBar";
+import { UIState } from "ui/state";
+import { hasPendingLogGroupIds } from "../../selectors/messages";
+
+function ConsoleLoadingBar({ hasPendingLogGroupIds }: PropsFromRedux) {
+  if (!hasPendingLogGroupIds) {
+    return null;
+  }
+
+  return <LoadingProgressBar />;
+}
+
+const connector = connect((state: UIState) => ({
+  hasPendingLogGroupIds: hasPendingLogGroupIds(state),
+}));
+export type PropsFromRedux = ConnectedProps<typeof connector> & { children: ReactNode };
+
+export default connector(ConsoleLoadingBar);

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+const React = require("react");
 const { Component, createElement } = require("react");
 const dom = require("react-dom-factories");
 const { connect } = require("devtools/client/shared/redux/visibility-handler-connect");
@@ -11,6 +12,7 @@ const { isVisible } = require("ui/utils/dom");
 const ReactDOM = require("react-dom");
 const { selectors } = require("ui/reducers");
 const { isDemo } = require("ui/utils/environment");
+const ConsoleLoadingBar = require("./ConsoleLoadingBar").default;
 
 const PropTypes = require("prop-types");
 const {
@@ -170,6 +172,7 @@ class ConsoleOutput extends Component {
           this.outputNode = node;
         },
       },
+      <ConsoleLoadingBar />,
       messageNodes
     );
   }

--- a/src/devtools/client/webconsole/reducers/messages.js
+++ b/src/devtools/client/webconsole/reducers/messages.js
@@ -45,6 +45,8 @@ const MessageState = overrides =>
         hasExecutionPoints: false,
         // Id of the last messages that was added.
         lastMessageId: null,
+        // Set of logpointIds for analyses that have been kicked off but haven't resolved yet.
+        pendingLogGroupIds: new Set(),
       },
       overrides
     )
@@ -64,6 +66,7 @@ function cloneState(state) {
     pausedExecutionPointTime: state.pausedExecutionPointTime,
     hasExecutionPoints: state.hasExecutionPoints,
     lastMessageId: state.lastMessageId,
+    pendingLogGroupIds: new Set(state.pendingLogGroupIds),
   };
 }
 
@@ -171,6 +174,23 @@ function messages(state = MessageState(), action) {
         }
       });
       return newState;
+
+    case "REMOVE_LOG_GROUP_ID": {
+      const newPendingLogGroupIds = new Set(state.pendingLogGroupIds);
+      newPendingLogGroupIds.delete(action.logGroupId);
+
+      return {
+        ...state,
+        pendingLogGroupIds: newPendingLogGroupIds,
+      };
+    }
+
+    case "ADD_LOG_GROUP_ID": {
+      return {
+        ...state,
+        pendingLogGroupIds: new Set([...state.pendingLogGroupIds, action.logGroupId]),
+      };
+    }
 
     case constants.MESSAGES_CLEAR:
       return MessageState({});

--- a/src/devtools/client/webconsole/selectors/messages.d.ts
+++ b/src/devtools/client/webconsole/selectors/messages.d.ts
@@ -1,0 +1,3 @@
+import { UIState } from "ui/state";
+
+export function hasPendingLogGroupIds(state: UIState): boolean;

--- a/src/devtools/client/webconsole/selectors/messages.js
+++ b/src/devtools/client/webconsole/selectors/messages.js
@@ -113,3 +113,7 @@ export const getClosestMessage = createSelector(
 export function getMessage(state, id) {
   return getAllMessagesById(state).get(id);
 }
+
+export function hasPendingLogGroupIds(state) {
+  return !!state.messages.pendingLogGroupIds.size;
+}

--- a/src/protocol/logpoint.ts
+++ b/src/protocol/logpoint.ts
@@ -35,6 +35,7 @@ export const LogpointHandlers: {
     location: Location
   ) => void;
   clearLogpoint?: (logGroupId: string) => void;
+  onError?: (logGroupId: string) => void;
 } = {};
 
 let store: UIStore;
@@ -286,6 +287,7 @@ async function setMultiSourceLogpoint(
   try {
     await analysisManager.runAnalysis(params, handler);
   } catch {
+    LogpointHandlers.onError!(logGroupId);
     saveAnalysisError(locations, condition);
     return;
   }


### PR DESCRIPTION
Fix #4365.

Replay: https://app.replay.io/recording/cc9f03b4-fc7b-4da7-8e2c-0da29191777d

Details:
- This skips doing anything for primitive logpoints, because we consider those to return immediately.
- Currently only works for adding logpoints, we should consider event breakpoints separately as a follow up.
- There's no short circuiting mechanism for a logpoint analysis, so if a user removes the breakpoint while the analysis is running, this continues showing the progress bar. Should probably be handled before shipping. _(edit: fixed)_

https://user-images.githubusercontent.com/15959269/144466062-81ffe713-6954-460f-854c-3a98e48d7b42.mov


