### PR TITLE
Fix UserAPIKeys and remove values prop from settings

### DIFF
--- a/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
@@ -43,7 +43,7 @@ class PrimaryPanes extends Component<PropsFromRedux> {
       onToggle: () => {
         this.props.toggleSourcesCollapse();
       },
-      collapsed: prefs.sourcesCollapsed,
+      collapsed: !!prefs.sourcesCollapsed,
       button: <QuickOpenButton />,
     };
   }

--- a/src/ui/components/shared/SettingsModal/SettingsBody.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBody.tsx
@@ -2,13 +2,8 @@ import React from "react";
 
 import { Setting } from "./types";
 
-interface SettingsBodyProps<
-  T extends string,
-  V extends Record<string, unknown>,
-  P extends Record<string, unknown>
-> {
-  selectedSetting: Setting<T, V, P>;
-  values?: V;
+interface SettingsBodyProps<T extends string, P extends Record<string, unknown>> {
+  selectedSetting: Setting<T, P>;
   panelProps: P;
 }
 
@@ -24,17 +19,16 @@ export function SettingsBodyHeader({ children }: { children: React.ReactChild })
   return <h2 className="text-lg">{children}</h2>;
 }
 
-export default function SettingsBody<
-  T extends string,
-  V extends Record<string, unknown>,
-  P extends Record<string, unknown>
->({ panelProps, selectedSetting, values }: SettingsBodyProps<T, V, P>) {
+export default function SettingsBody<T extends string, P extends Record<string, unknown>>({
+  panelProps,
+  selectedSetting,
+}: SettingsBodyProps<T, P>) {
   const { title } = selectedSetting;
 
   return (
     <SettingsBodyWrapper>
       {selectedSetting.noTitle ? null : <SettingsHeader>{title}</SettingsHeader>}
-      <selectedSetting.component settings={values} {...panelProps} />
+      <selectedSetting.component {...panelProps} />
     </SettingsBodyWrapper>
   );
 }

--- a/src/ui/components/shared/SettingsModal/SettingsModal.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsModal.tsx
@@ -7,17 +7,12 @@ import { Settings } from "./types";
 
 import classnames from "classnames";
 
-export default function SettingsModal<
-  T extends string,
-  V extends Record<string, unknown>,
-  P extends Record<string, unknown>
->({
+export default function SettingsModal<T extends string, P extends Record<string, unknown>>({
   tab,
   hiddenTabs,
   loading,
   panelProps,
   settings,
-  values,
   size = "sm",
   title,
 }: {
@@ -25,8 +20,7 @@ export default function SettingsModal<
   hiddenTabs?: T[];
   loading?: boolean;
   panelProps: P;
-  settings: Settings<T, V, P>;
-  values?: V;
+  settings: Settings<T, P>;
   size?: "sm" | "lg";
   title?: React.ReactNode;
 }) {
@@ -51,7 +45,7 @@ export default function SettingsModal<
     <div className={classnames("settings-modal", { "settings-modal-large": size === "lg" })}>
       <Modal>
         <SettingsNavigation {...{ hiddenTabs, settings, selectedTab, setSelectedTab, title }} />
-        <SettingsBody values={values} selectedSetting={selectedSetting} panelProps={panelProps} />
+        <SettingsBody selectedSetting={selectedSetting} panelProps={panelProps} />
       </Modal>
     </div>
   );

--- a/src/ui/components/shared/SettingsModal/SettingsNavigation.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsNavigation.tsx
@@ -4,33 +4,25 @@ import { Setting, Settings } from "./types";
 import MaterialIcon from "../MaterialIcon";
 import { SettingsHeader } from "./SettingsBody";
 
-interface SettingNavigationItemProps<
-  T extends string,
-  V extends Record<string, unknown>,
-  P extends Record<string, unknown>
-> {
-  setting: Setting<T, V, P>;
+interface SettingNavigationItemProps<T extends string, P extends Record<string, unknown>> {
+  setting: Setting<T, P>;
   selectedTab?: T;
   setSelectedTab: (title: T) => void;
 }
 
-interface SettingNavigationProps<
-  T extends string,
-  V extends Record<string, unknown>,
-  P extends Record<string, unknown>
-> {
-  settings: Settings<T, V, P>;
+interface SettingNavigationProps<T extends string, P extends Record<string, unknown>> {
+  settings: Settings<T, P>;
   selectedTab?: T;
   setSelectedTab: (title: T) => void;
   title?: React.ReactNode;
   hiddenTabs?: T[];
 }
 
-function SettingNavigationItem<
-  T extends string,
-  V extends Record<string, unknown>,
-  P extends Record<string, unknown>
->({ setting, selectedTab, setSelectedTab }: SettingNavigationItemProps<T, V, P>) {
+function SettingNavigationItem<T extends string, P extends Record<string, unknown>>({
+  setting,
+  selectedTab,
+  setSelectedTab,
+}: SettingNavigationItemProps<T, P>) {
   const { title, icon } = setting;
   const onClick = () => {
     setSelectedTab(title);
@@ -44,17 +36,13 @@ function SettingNavigationItem<
   );
 }
 
-export default function SettingNavigation<
-  T extends string,
-  V extends Record<string, unknown>,
-  P extends Record<string, unknown>
->({
+export default function SettingNavigation<T extends string, P extends Record<string, unknown>>({
   hiddenTabs,
   settings,
   selectedTab,
   setSelectedTab,
   title = "Settings",
-}: SettingNavigationProps<T, V, P>) {
+}: SettingNavigationProps<T, P>) {
   return (
     <nav style={{ maxWidth: 240 }}>
       <SettingsHeader>{title}</SettingsHeader>

--- a/src/ui/components/shared/SettingsModal/types.ts
+++ b/src/ui/components/shared/SettingsModal/types.ts
@@ -1,30 +1,21 @@
 import React from "react";
 import { UserSettings } from "ui/types";
 
-export type Settings<
-  T extends string,
-  V extends Record<string, unknown>,
-  P extends Record<string, unknown>
-> = Setting<T, V, P>[];
+export type Settings<T extends string, P extends Record<string, unknown>> = Setting<T, P>[];
 
 export type SettingType = "checkbox" | "dropdown";
 
-export interface SettingWithComponent<
-  T extends string,
-  V extends Record<string, unknown>,
-  P extends Record<string, unknown>
-> {
+export interface SettingWithComponent<T extends string, P extends Record<string, unknown>> {
   title: T;
-  component: React.ComponentType<{ settings?: V } & P>;
+  component: React.ComponentType<P>;
   icon?: string;
   noTitle?: boolean;
 }
 
-export type Setting<
-  T extends string,
-  V extends Record<string, unknown>,
-  P extends Record<string, unknown>
-> = SettingWithComponent<T, V, P>;
+export type Setting<T extends string, P extends Record<string, unknown>> = SettingWithComponent<
+  T,
+  P
+>;
 
 export interface SettingItem<V> {
   label: string;

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -98,13 +98,16 @@ function Legal() {
   );
 }
 
-function UserAPIKeys({ apiKeys }: { apiKeys: ApiKey[] }) {
+function UserAPIKeys() {
+  const { userSettings, loading } = hooks.useGetUserSettings();
   const { addUserApiKey, loading: addLoading, error: addError } = hooks.useAddUserApiKey();
   const { deleteUserApiKey } = hooks.useDeleteUserApiKey();
 
+  if (loading) return null;
+
   return (
     <APIKeys
-      apiKeys={apiKeys}
+      apiKeys={userSettings.apiKeys}
       description="API Keys allow you to upload recordings programmatically from your automated tests or from your continuous integration environment."
       loading={addLoading}
       error={addError}
@@ -119,13 +122,7 @@ function UserAPIKeys({ apiKeys }: { apiKeys: ApiKey[] }) {
   );
 }
 
-function ApiKeysWrapper({ settings }: { settings?: UserSettings }) {
-  if (!settings) return null;
-
-  return <UserAPIKeys apiKeys={settings.apiKeys} />;
-}
-
-const getSettings = (): Settings<SettingsTabTitle, CombinedUserSettings, {}> => [
+const getSettings = (): Settings<SettingsTabTitle, {}> => [
   {
     title: "Personal",
     icon: "person",
@@ -134,7 +131,7 @@ const getSettings = (): Settings<SettingsTabTitle, CombinedUserSettings, {}> => 
   {
     title: "API Keys",
     icon: "vpn_key",
-    component: ApiKeysWrapper,
+    component: UserAPIKeys,
   },
   {
     title: "Preferences",

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -115,7 +115,6 @@ export type SettingsTabTitle =
 
 const settings: Settings<
   SettingsTabTitle,
-  {},
   {
     settings?: any;
     isAdmin: boolean;


### PR DESCRIPTION
## Issue

API Keys pane in the user settings doesn't render anything

## Analysis

This was the only pane that was relying on the settings being passed down to it via the `values` prop. This prop was dropped in #4658.

## Resolution

* Fetch the settings in UserAPIKeys instead of relying on it being passed down
* Remove the `values` stuff from `SettingsModal` since it wasn't used by anything else

## Notes

I don't love all of these views fetching their own data. It makes it harder to test them in storybook without stubbing out the APIs. But, we've already done it in a bunch of places and the generalization of `SettingsModal` was adding more complexity than value so here we are :)