### PR TITLE
Add react hooks rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,11 @@
     "browser": true,
     "es6": true
   },
-  "extends": ["plugin:react/recommended", "plugin:prettier/recommended"],
+  "extends": [
+    "plugin:react/recommended", 
+    "plugin:react-hooks/recommended",
+    "plugin:prettier/recommended"
+  ],
   "globals": {
     "Atomics": "readonly",
     "SharedArrayBuffer": "readonly"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2728,7 +2728,7 @@
       "version": "1.10.6",
       "resolved": "https://registry.npmjs.org/@recordreplay/playwright/-/playwright-1.10.6.tgz",
       "integrity": "sha512-OMdl8jDV9UCL0EiMKA+huVC98ykBJB7efarfqNk3tRbSh8C1buN3zJRMd8AolyFjIBn7475BhUFJtaQyITeXYg==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "commander": "^6.1.0",
         "debug": "^4.1.1",
@@ -2749,19 +2749,19 @@
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
           "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-          "dev": true
+          "optional": true
         },
         "mime": {
           "version": "2.5.2",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
           "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
-          "dev": true
+          "optional": true
         },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
           "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -2770,7 +2770,7 @@
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
           "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -16411,7 +16411,6 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
       "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -18248,7 +18247,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
+      "optional": true
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -20477,7 +20476,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -21058,9 +21056,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.2.tgz",
-      "integrity": "sha512-ykUeqkGyUGgwTtk78C0o8UG2fzwmgJ0qxBGPp2WqRKsTwcLuVf01kTDRAtOsd4u6whX2XOC8749n2vPydP82fg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true
     },
     "eslint-scope": {
@@ -21475,7 +21473,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
@@ -21487,7 +21485,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
           "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -21631,7 +21629,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -25503,7 +25501,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
       "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==",
-      "dev": true
+      "optional": true
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -27895,7 +27893,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
+      "optional": true
     },
     "picocolors": {
       "version": "1.0.0",
@@ -27993,7 +27991,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-      "dev": true
+      "optional": true
     },
     "pnp-webpack-plugin": {
       "version": "1.6.4",
@@ -28518,8 +28516,7 @@
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -28580,7 +28577,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
@@ -28712,7 +28709,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "optional": true
     },
     "prr": {
       "version": "1.0.1",
@@ -28749,7 +28746,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -29976,8 +29972,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "dev": true
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "reusify": {
       "version": "1.0.4",
@@ -34321,7 +34316,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",
-    "eslint-plugin-react-hooks": "^4.1.2",
+    "eslint-plugin-react-hooks": "^4.3.0",
     "framer-motion": "^3.10.0",
     "fs-extra": "^10.0.0",
     "html-webpack-plugin": "^5.5.0",


### PR DESCRIPTION
Adding the official react hooks linter. Will first need to fix these warnings though

```
./pages/callback.tsx
26:6  Warning: React Hook useEffect has missing dependencies: 'auth0', 'connection', and 'router'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps

./pages/profile/[...view].tsx
19:6  Warning: React Hook useEffect has missing dependencies: 'isAuthenticated', 'replace', and 'setModal'. Either include them or remove the dependency array. If 'setModal' changes too often, find the parent component that defines it and wrap that definition in useCallback.  react-hooks/exhaustive-deps

./pages/recording/[id].tsx
25:6  Warning: React Hook useEffect has a missing dependency: 'getAccessibleRecording'. Either include it or remove the dependency array. If 'getAccessibleRecording' changes too often, find the parent component that defines it and wrap that definition in useCallback.  react-hooks/exhaustive-deps

./pages/settings.tsx
10:6  Warning: React Hook useEffect has a missing dependency: 'replace'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps

./pages/team/[...id].tsx
27:6  Warning: React Hook useEffect has missing dependencies: 'replace', 'setWorkspaceId', and 'updateDefaultWorkspace'. Either include them or remove the dependency array. If 'setWorkspaceId' changes too often, find the parent component that defines it and wrap that definition in useCallback.  react-hooks/exhaustive-deps
33:6  Warning: React Hook useEffect has a missing dependency: 'setModal'. Either include it or remove the dependency array. If 'setModal' changes too often, find the parent component that defines it and wrap that definition in useCallback.  react-hooks/exhaustive-deps
```