### PR TITLE
Text nodes can contain an empty string (#4754)

### DIFF
--- a/src/devtools/client/inspector/markup/components/TextNode.tsx
+++ b/src/devtools/client/inspector/markup/components/TextNode.tsx
@@ -12,7 +12,7 @@ interface TextNodeProps {
 class TextNode extends PureComponent<TextNodeProps> {
   render() {
     const { type, value } = this.props;
-    assert(value);
+    assert(typeof value === "string");
     const isComment = type === COMMENT_NODE;
     const isWhiteSpace = !/[^\s]/.exec(value);
 


### PR DESCRIPTION
Together with RecordReplay/gecko-dev#618 fixes #4754