### PR TITLE
Add more specific network monitor icons

### DIFF
--- a/src/ui/components/NetworkMonitor/TypesDropdown.tsx
+++ b/src/ui/components/NetworkMonitor/TypesDropdown.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import PortalDropdown from "ui/components/shared/PortalDropdown";
 import { Dropdown, DropdownItem, DropdownItemContent } from "ui/components/Library/LibraryDropdown";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
-import { RequestType, REQUEST_TYPES } from "./utils";
+import { RequestType, REQUEST_ICONS, REQUEST_TYPES } from "./utils";
 
 export default function TypesDropdown({
   types,
@@ -20,8 +20,7 @@ export default function TypesDropdown({
     </MaterialIcon>
   );
 
-  const TypeItem = ({ type, label }: { type: RequestType; label: string }) => {
-    const icon = "description";
+  const TypeItem = ({ icon, label, type }: { icon: string; label: string; type: RequestType }) => {
     return (
       <DropdownItem onClick={() => toggleType(type)}>
         <DropdownItemContent selected={types.has(type)} icon={icon}>
@@ -42,7 +41,11 @@ export default function TypesDropdown({
     >
       <Dropdown>
         {Object.entries(REQUEST_TYPES).map((pair: string[]) => (
-          <TypeItem type={pair[0] as RequestType} label={pair[1]} />
+          <TypeItem
+            icon={REQUEST_ICONS[pair[0]] || "description"}
+            type={pair[0] as RequestType}
+            label={pair[1]}
+          />
         ))}
       </Dropdown>
     </PortalDropdown>

--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -38,7 +38,21 @@ export const REQUEST_TYPES = {
   media: "Media",
   other: "Other",
   wasm: "WASM",
-  websocket: "WS",
+  websocket: "Websocket",
+};
+
+export const REQUEST_ICONS: Record<string, string> = {
+  xhr: "description",
+  javascript: "code",
+  css: "color_lens",
+  font: "text_fields",
+  html: "description",
+  img: "perm_media",
+  manifest: "description",
+  media: "perm_media",
+  other: "question_mark",
+  wasm: "handyman",
+  websocket: "autorenew",
 };
 
 export type RequestType = keyof typeof REQUEST_TYPES;


### PR DESCRIPTION
This is an easy improvement to our types filter.

![CleanShot 2021-12-07 at 10 54 22](https://user-images.githubusercontent.com/5903784/145089129-f1b4b508-f112-4b0b-9a0b-a6cc10538e42.png)

