### PR TITLE
Add a command palette that should show up on Cmd/Ctrl+K

### DIFF
--- a/src/devtools/client/debugger/src/components/FullTextSearch/FullTextFilter.js
+++ b/src/devtools/client/debugger/src/components/FullTextSearch/FullTextFilter.js
@@ -12,8 +12,6 @@ export function FullTextFilter({ results, onKeyDown }) {
       return;
     }
 
-    e.stopPropagation();
-
     if (e.key === "ArrowUp") {
       e.preventDefault();
       const newIndex = (historyIndex + 1) % history.length;

--- a/src/devtools/client/debugger/src/utils/text.d.ts
+++ b/src/devtools/client/debugger/src/utils/text.d.ts
@@ -1,0 +1,1 @@
+export function formatKeyShortcut(shortcut: string): string;

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -35,6 +35,9 @@ import { isTest } from "ui/utils/environment";
 import tokenManager from "ui/utils/tokenManager";
 import { asyncStore } from "ui/utils/prefs";
 import { dismissLocalNag, isLocalNagDismissed, LocalNag } from "ui/setup/prefs";
+import { CommandKey } from "ui/components/CommandPalette";
+import { hideCommandPalette } from "./layout";
+import { prefs } from "devtools/client/debugger/src/utils/prefs";
 
 export type SetRecordingDurationAction = Action<"set_recording_duration"> & { duration: number };
 export type LoadingAction = Action<"loading"> & { loading: number };
@@ -403,4 +406,32 @@ export function loadReplayPrefs(recordingId: RecordingId): UIThunkAction {
 
 export function setLoadingPageTipIndex(index: number): SetLoadingPageTipIndexAction {
   return { type: "set_loading_page_tip_index", index };
+}
+
+export function executeCommand(key: CommandKey): UIThunkAction {
+  return ({ dispatch }) => {
+    if (key === "open_viewer") {
+      dispatch(setViewMode("non-dev"));
+    } else if (key === "open_devtools") {
+      dispatch(setViewMode("dev"));
+    } else if (key === "open_full_text_search") {
+      dispatch(setViewMode("dev"));
+      dispatch(setSelectedPrimaryPanel("search"));
+    } else if (key === "open_sources" || key === "open_outline") {
+      dispatch(setViewMode("dev"));
+      dispatch(setSelectedPrimaryPanel("explorer"));
+    } else if (key === "open_print_statements") {
+      dispatch(setViewMode("dev"));
+      dispatch(setSelectedPrimaryPanel("debug"));
+    } else if (key === "open_console") {
+      dispatch(setViewMode("dev"));
+      dispatch(setSelectedPanel("console"));
+    } else if (key === "show_privacy") {
+      dispatch(setModal("privacy"));
+    } else if (key === "show_sharing") {
+      dispatch(setModal("sharing"));
+    }
+
+    dispatch(hideCommandPalette());
+  };
 }

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -35,9 +35,9 @@ import { isTest } from "ui/utils/environment";
 import tokenManager from "ui/utils/tokenManager";
 import { asyncStore } from "ui/utils/prefs";
 import { dismissLocalNag, isLocalNagDismissed, LocalNag } from "ui/setup/prefs";
-import { CommandKey } from "ui/components/CommandPalette";
 import { hideCommandPalette } from "./layout";
 import { prefs } from "devtools/client/debugger/src/utils/prefs";
+import { CommandKey } from "ui/components/CommandPalette/CommandPalette";
 
 export type SetRecordingDurationAction = Action<"set_recording_duration"> & { duration: number };
 export type LoadingAction = Action<"loading"> & { loading: number };

--- a/src/ui/actions/index.ts
+++ b/src/ui/actions/index.ts
@@ -4,6 +4,7 @@ import * as appActions from "./app";
 import * as timelineActions from "./timeline";
 import * as sessionActions from "./session";
 import * as commentsActions from "./comments";
+import * as layoutActions from "./layout";
 import * as reactDevToolsActions from "./reactDevTools";
 import { ThunkAction, ThunkExtraArgs } from "ui/utils/thunk";
 import { UIState } from "ui/state";
@@ -19,6 +20,7 @@ import { EventTooltipAction } from "devtools/client/inspector/markup/actions/eve
 import UserProperties from "devtools/client/inspector/rules/models/user-properties";
 import consoleActions from "devtools/client/webconsole/actions";
 import { NetworkAction } from "./network";
+import { LayoutAction } from "./layout";
 
 type DebuggerAction = Action<"RESUME" | "CLEAR_FRAME_POSITIONS">;
 
@@ -27,6 +29,7 @@ export type UIAction =
   | CommentsAction
   | DebuggerAction
   | EventTooltipAction
+  | LayoutAction
   | MarkupAction
   | NetworkAction
   | ReactDevToolsAction
@@ -41,11 +44,12 @@ export type UIStore = Store<UIState, UIAction> & {
 
 export const actions = {
   ...appActions,
-  ...timelineActions,
   ...commentsActions,
-  ...reactDevToolsActions,
-  ...eventListeners,
-  ...debuggerActions,
   ...consoleActions,
+  ...debuggerActions,
+  ...eventListeners,
+  ...layoutActions,
+  ...reactDevToolsActions,
   ...sessionActions,
+  ...timelineActions,
 };

--- a/src/ui/actions/layout.ts
+++ b/src/ui/actions/layout.ts
@@ -10,7 +10,7 @@ export function setShowCommandPalette(value: boolean): SetShowCommandPalette {
   return { type: "set_show_command_palette", value };
 }
 export function hideCommandPalette(): SetShowCommandPalette {
-  return { type: "set_show_command_palette", value: false };
+  return setShowCommandPalette(false);
 }
 export function toggleCommandPalette(): UIThunkAction {
   return ({ dispatch, getState }) => {

--- a/src/ui/actions/layout.ts
+++ b/src/ui/actions/layout.ts
@@ -1,0 +1,9 @@
+import { Action } from "redux";
+
+type SetShowCommandPalette = Action<"set_show_command_palette"> & { value: boolean };
+
+export type LayoutAction = SetShowCommandPalette;
+
+export function setShowCommandPalette(value: boolean): SetShowCommandPalette {
+  return { type: "set_show_command_palette", value };
+}

--- a/src/ui/actions/layout.ts
+++ b/src/ui/actions/layout.ts
@@ -1,4 +1,6 @@
 import { Action } from "redux";
+import { getShowCommandPalette } from "ui/reducers/layout";
+import { UIThunkAction } from ".";
 
 type SetShowCommandPalette = Action<"set_show_command_palette"> & { value: boolean };
 
@@ -6,4 +8,13 @@ export type LayoutAction = SetShowCommandPalette;
 
 export function setShowCommandPalette(value: boolean): SetShowCommandPalette {
   return { type: "set_show_command_palette", value };
+}
+export function hideCommandPalette(): SetShowCommandPalette {
+  return { type: "set_show_command_palette", value: false };
+}
+export function toggleCommandPalette(): UIThunkAction {
+  return ({ dispatch, getState }) => {
+    const showCommandPalette = getShowCommandPalette(getState());
+    dispatch(setShowCommandPalette(!showCommandPalette));
+  };
 }

--- a/src/ui/components/CommandPalette/CommandButton.tsx
+++ b/src/ui/components/CommandPalette/CommandButton.tsx
@@ -2,7 +2,7 @@ import { formatKeyShortcut } from "devtools/client/debugger/src/utils/text";
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
-import { Command } from ".";
+import { Command } from "./CommandPalette";
 
 type CommandButtonProps = PropsFromRedux & { command: Command };
 
@@ -19,7 +19,7 @@ function CommandButton({ command, executeCommand }: CommandButtonProps) {
       className="px-4 py-1 flex hover:bg-gray-200 justify-between transition"
     >
       <div>{label}</div>
-      <div className="text-gray-400">{formatKeyShortcut(shortcut)}</div>
+      {shortcut ? <div className="text-gray-400">{formatKeyShortcut(shortcut)}</div> : null}
     </button>
   );
 }

--- a/src/ui/components/CommandPalette/CommandButton.tsx
+++ b/src/ui/components/CommandPalette/CommandButton.tsx
@@ -1,0 +1,31 @@
+import { formatKeyShortcut } from "devtools/client/debugger/src/utils/text";
+import React from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { actions } from "ui/actions";
+import { Command } from ".";
+
+type CommandButtonProps = PropsFromRedux & { command: Command };
+
+function CommandButton({ command, executeCommand }: CommandButtonProps) {
+  const { label, shortcut, key } = command;
+  const onClick = () => {
+    executeCommand(key);
+  };
+
+  return (
+    <button
+      key={label}
+      onClick={onClick}
+      className="px-4 py-1 flex hover:bg-gray-200 justify-between transition"
+    >
+      <div>{label}</div>
+      <div className="text-gray-400">{formatKeyShortcut(shortcut)}</div>
+    </button>
+  );
+}
+
+const connector = connect(null, {
+  executeCommand: actions.executeCommand,
+});
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(CommandButton);

--- a/src/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/ui/components/CommandPalette/CommandPalette.tsx
@@ -6,7 +6,7 @@ import Modal from "../shared/NewModal";
 import CommandButton from "./CommandButton";
 const { filter } = require("fuzzaldrin-plus");
 
-export type Command = { key: CommandKey; label: string; shortcut: string };
+export type Command = { key: CommandKey; label: string; shortcut?: string };
 export type CommandKey =
   | "open_viewer"
   | "open_devtools"
@@ -19,22 +19,15 @@ export type CommandKey =
   | "show_sharing";
 
 const COMMANDS: Command[] = [
-  { key: "open_viewer", label: "Open Viewer", shortcut: "CMd+V" },
-  { key: "open_devtools", label: "Open DevTools", shortcut: "" },
-  { key: "open_full_text_search", label: "Open Full Text Search", shortcut: "" },
-  { key: "open_sources", label: "Open Sources", shortcut: "" },
-  { key: "open_outline", label: "Open Outline", shortcut: "" },
-  { key: "open_print_statements", label: "Open Print Statements", shortcut: "" },
-  { key: "open_console", label: "Open Console", shortcut: "" },
-  { key: "show_privacy", label: "Show Privacy Information", shortcut: "" },
-  { key: "show_sharing", label: "Show Sharing Options", shortcut: "" },
-
-  // Things that should probably done in a separate pass.
-  // { label: "Open React DevTools", shortcut: "" },
-  // { label: "Open Elements", shortcut: "" },
-  // { label: "Open Event Breakpoints", shortcut: "" },
-  // { label: "Show shortcuts", shortcut: "" },
-  // { label: "Add a comment", shortcut: "" },
+  { key: "open_viewer", label: "Open Viewer" },
+  { key: "open_devtools", label: "Open DevTools" },
+  { key: "open_full_text_search", label: "Open Full Text Search", shortcut: "CmdOrCtrl+Shift+F" },
+  { key: "open_sources", label: "Open Sources" },
+  { key: "open_outline", label: "Open Outline" },
+  { key: "open_print_statements", label: "Open Print Statements" },
+  { key: "open_console", label: "Open Console" },
+  { key: "show_privacy", label: "Show Privacy Information" },
+  { key: "show_sharing", label: "Show Sharing Options" },
 ];
 
 function CommandPalette({ hideCommandPalette }: PropsFromRedux) {
@@ -44,7 +37,6 @@ function CommandPalette({ hideCommandPalette }: PropsFromRedux) {
     setSearchString(e.target.value);
   };
   const onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    console.log({ e });
     if (e.key === "Escape") {
       hideCommandPalette();
     }

--- a/src/ui/components/CommandPalette/index.ts
+++ b/src/ui/components/CommandPalette/index.ts
@@ -1,0 +1,3 @@
+import CommandPalette from "./CommandPalette";
+
+export default CommandPalette;

--- a/src/ui/components/CommandPalette/index.tsx
+++ b/src/ui/components/CommandPalette/index.tsx
@@ -1,0 +1,84 @@
+import React, { ChangeEvent, useState } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { actions } from "ui/actions";
+import { TextInput } from "../shared/Forms";
+import Modal from "../shared/NewModal";
+import CommandButton from "./CommandButton";
+const { filter } = require("fuzzaldrin-plus");
+
+export type Command = { key: CommandKey; label: string; shortcut: string };
+export type CommandKey =
+  | "open_viewer"
+  | "open_devtools"
+  | "open_full_text_search"
+  | "open_sources"
+  | "open_outline"
+  | "open_print_statements"
+  | "open_console"
+  | "show_privacy"
+  | "show_sharing";
+
+const COMMANDS: Command[] = [
+  { key: "open_viewer", label: "Open Viewer", shortcut: "CMd+V" },
+  { key: "open_devtools", label: "Open DevTools", shortcut: "" },
+  { key: "open_full_text_search", label: "Open Full Text Search", shortcut: "" },
+  { key: "open_sources", label: "Open Sources", shortcut: "" },
+  { key: "open_outline", label: "Open Outline", shortcut: "" },
+  { key: "open_print_statements", label: "Open Print Statements", shortcut: "" },
+  { key: "open_console", label: "Open Console", shortcut: "" },
+  { key: "show_privacy", label: "Show Privacy Information", shortcut: "" },
+  { key: "show_sharing", label: "Show Sharing Options", shortcut: "" },
+
+  // Things that should probably done in a separate pass.
+  // { label: "Open React DevTools", shortcut: "" },
+  // { label: "Open Elements", shortcut: "" },
+  // { label: "Open Event Breakpoints", shortcut: "" },
+  // { label: "Show shortcuts", shortcut: "" },
+  // { label: "Add a comment", shortcut: "" },
+];
+
+function CommandPalette({ hideCommandPalette }: PropsFromRedux) {
+  const [searchString, setSearchString] = useState("");
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSearchString(e.target.value);
+  };
+  const onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    console.log({ e });
+    if (e.key === "Escape") {
+      hideCommandPalette();
+    }
+  };
+
+  const shownCommands = searchString ? filter(COMMANDS, searchString, { key: "label" }) : COMMANDS;
+
+  return (
+    <Modal
+      blurMask={false}
+      options={{ maskTransparency: "translucent" }}
+      onMaskClick={() => hideCommandPalette()}
+    >
+      <div className="w-96 h-64 flex flex-col overflow-hidden rounded-md bg-gray-100 shadow-xl ">
+        <div className="p-2 border-b border-gray-300" onKeyPress={onKeyPress}>
+          <TextInput
+            value={searchString}
+            onChange={onChange}
+            autoFocus
+            placeholder="What would you like to do?"
+          />
+        </div>
+        <div className="flex-grow text-sm flex flex-col overflow-auto">
+          {shownCommands.map((command: Command) => (
+            <CommandButton command={command} key={command.label} />
+          ))}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+const connector = connect(null, {
+  hideCommandPalette: actions.hideCommandPalette,
+});
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(CommandPalette);

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -12,6 +12,7 @@ import WaitForReduxSlice from "./WaitForReduxSlice";
 import { endUploadWaitTracking, trackEventOnce } from "ui/utils/mixpanel";
 import KeyboardShortcuts from "./KeyboardShortcuts";
 import { useUserIsAuthor } from "ui/hooks/users";
+import CommandPalette from "./CommandPalette";
 
 const DevView = React.lazy(() => import("./Views/DevView"));
 
@@ -19,11 +20,12 @@ type _DevToolsProps = PropsFromRedux & DevToolsProps;
 
 function _DevTools({
   clearTrialExpired,
-  loadingFinished,
-  viewMode,
   createSession,
-  uploadComplete,
+  loadingFinished,
   sessionId,
+  showCommandPalette,
+  uploadComplete,
+  viewMode,
 }: _DevToolsProps) {
   const recordingId = useGetRecordingId();
   const { userIsAuthor, loading } = useUserIsAuthor();
@@ -54,6 +56,7 @@ function _DevTools({
     <>
       <Header />
       {viewMode == "dev" ? <DevView /> : <NonDevView />}
+      {showCommandPalette ? <CommandPalette /> : null}
       <KeyboardShortcuts />
     </>
   );
@@ -64,6 +67,7 @@ const connector = connect(
     loadingFinished: selectors.getLoadingFinished(state),
     viewMode: selectors.getViewMode(state),
     sessionId: selectors.getSessionId(state),
+    showCommandPalette: selectors.getShowCommandPalette(state),
   }),
   {
     createSession,

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import KeyShortcuts from "devtools/client/shared/key-shortcuts";
 import { usesWindow } from "ssr";
 import { connect, ConnectedProps } from "react-redux";
@@ -17,18 +17,24 @@ function setupShortcuts() {
 const globalShortcuts = setupShortcuts();
 
 function KeyboardShortcuts({
-  viewMode,
   setSelectedPrimaryPanel,
-  togglePaneCollapse,
   setViewMode,
+  toggleCommandPalette,
+  togglePaneCollapse,
+  viewMode,
 }: PropsFromRedux) {
+  const addShortcut = (key: string, callback: (e: KeyboardEvent) => void) => {
+    globalShortcuts!.on(key, callback);
+  };
+  const removeShortcut = (key: string, callback: (e: KeyboardEvent) => void) => {
+    globalShortcuts!.off(key, callback);
+  };
+
   const openFullTextSearch = (e: KeyboardEvent) => {
     e.preventDefault();
-
     if (viewMode !== "dev") {
       setViewMode("dev");
     }
-
     trackEvent("key_shortcut.full_text_search");
     setSelectedPrimaryPanel("search");
   };
@@ -36,18 +42,24 @@ function KeyboardShortcuts({
     trackEvent("key_shortcut.toggle_left_sidebar");
     togglePaneCollapse();
   };
+  const togglePalette = () => {
+    trackEvent("key_shortcut.show_command_palette");
+    toggleCommandPalette();
+  };
 
   // The shortcuts have to be reassigned every time the dependencies change,
   // otherwise we end up with a stale prop.
   useEffect(() => {
     if (!globalShortcuts) return;
 
-    globalShortcuts.on("CmdOrCtrl+Shift+F", openFullTextSearch);
-    globalShortcuts.on("CmdOrCtrl+B", toggleLeftSidebar);
+    addShortcut("CmdOrCtrl+Shift+F", openFullTextSearch);
+    addShortcut("CmdOrCtrl+B", toggleLeftSidebar);
+    addShortcut("CmdOrCtrl+K", togglePalette);
 
     return () => {
-      globalShortcuts.off("CmdOrCtrl+Shift+F", openFullTextSearch);
-      globalShortcuts.off("CmdOrCtrl+B", toggleLeftSidebar);
+      removeShortcut("CmdOrCtrl+Shift+F", openFullTextSearch);
+      removeShortcut("CmdOrCtrl+B", toggleLeftSidebar);
+      removeShortcut("CmdOrCtrl+K", togglePalette);
     };
   }, [viewMode]);
 
@@ -63,6 +75,7 @@ const connector = connect(
     setSelectedPrimaryPanel: actions.setSelectedPrimaryPanel,
     setViewMode: actions.setViewMode,
     togglePaneCollapse: actions.togglePaneCollapse,
+    toggleCommandPalette: actions.toggleCommandPalette,
   }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -38,11 +38,14 @@ function KeyboardShortcuts({
     trackEvent("key_shortcut.full_text_search");
     setSelectedPrimaryPanel("search");
   };
-  const toggleLeftSidebar = () => {
+  const toggleLeftSidebar = (e: KeyboardEvent) => {
+    e.preventDefault();
+
     trackEvent("key_shortcut.toggle_left_sidebar");
     togglePaneCollapse();
   };
-  const togglePalette = () => {
+  const togglePalette = (e: KeyboardEvent) => {
+    e.preventDefault();
     trackEvent("key_shortcut.show_command_palette");
     toggleCommandPalette();
   };

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -24,10 +24,12 @@ function KeyboardShortcuts({
   viewMode,
 }: PropsFromRedux) {
   const addShortcut = (key: string, callback: (e: KeyboardEvent) => void) => {
-    globalShortcuts!.on(key, callback);
+    if (!globalShortcuts) return;
+    globalShortcuts.on(key, callback);
   };
   const removeShortcut = (key: string, callback: (e: KeyboardEvent) => void) => {
-    globalShortcuts!.off(key, callback);
+    if (!globalShortcuts) return;
+    globalShortcuts.off(key, callback);
   };
 
   const openFullTextSearch = (e: KeyboardEvent) => {
@@ -53,8 +55,6 @@ function KeyboardShortcuts({
   // The shortcuts have to be reassigned every time the dependencies change,
   // otherwise we end up with a stale prop.
   useEffect(() => {
-    if (!globalShortcuts) return;
-
     addShortcut("CmdOrCtrl+Shift+F", openFullTextSearch);
     addShortcut("CmdOrCtrl+B", toggleLeftSidebar);
     addShortcut("CmdOrCtrl+K", togglePalette);

--- a/src/ui/reducers/index.ts
+++ b/src/ui/reducers/index.ts
@@ -2,6 +2,7 @@ import app, * as appSelectors from "./app";
 import timeline, * as timelineSelectors from "./timeline";
 import comments, * as commentsSelectors from "./comments";
 import network, * as networkSelectors from "./network";
+import layout, * as layoutSelectors from "./layout";
 import contextMenus from "./contextMenus";
 import reactDevTools, * as reactDevToolsSelectors from "./reactDevTools";
 import * as eventListenerBreakpointsSelectors from "devtools/client/debugger/src/reducers/event-listeners";
@@ -18,6 +19,7 @@ export const reducers = {
   contextMenus,
   network,
   reactDevTools,
+  layout,
   ...debuggerReducers,
   ...consoleReducers.reducers,
   ...inspectorReducers,
@@ -29,6 +31,7 @@ export const selectors = {
   ...consoleSelectors,
   ...debuggerSelectors,
   ...eventListenerBreakpointsSelectors,
+  ...layoutSelectors,
   ...networkSelectors,
   ...reactDevToolsSelectors,
   ...timelineSelectors,

--- a/src/ui/reducers/layout.ts
+++ b/src/ui/reducers/layout.ts
@@ -10,13 +10,6 @@ function initialLayoutState(): LayoutState {
 
 export default function update(state = initialLayoutState(), action: LayoutAction): LayoutState {
   switch (action.type) {
-    // case "set_view_mode": {
-    //   return {
-    //     ...state,
-    //     showCommandPalette: false,
-    //   };
-    // }
-
     case "set_show_command_palette": {
       return {
         ...state,

--- a/src/ui/reducers/layout.ts
+++ b/src/ui/reducers/layout.ts
@@ -1,0 +1,26 @@
+import { UIState } from "ui/state";
+import { LayoutState } from "ui/state/layout";
+import { LayoutAction } from "ui/actions/layout";
+
+function initialLayoutState(): LayoutState {
+  return {
+    showCommandPalette: false,
+  };
+}
+
+export default function update(state = initialLayoutState(), action: LayoutAction): LayoutState {
+  switch (action.type) {
+    case "set_show_command_palette": {
+      return {
+        ...state,
+        showCommandPalette: action.value,
+      };
+    }
+
+    default: {
+      return state;
+    }
+  }
+}
+
+export const getShowCommandPalette = (state: UIState) => state.layout.showCommandPalette;

--- a/src/ui/reducers/layout.ts
+++ b/src/ui/reducers/layout.ts
@@ -10,6 +10,13 @@ function initialLayoutState(): LayoutState {
 
 export default function update(state = initialLayoutState(), action: LayoutAction): LayoutState {
   switch (action.type) {
+    // case "set_view_mode": {
+    //   return {
+    //     ...state,
+    //     showCommandPalette: false,
+    //   };
+    // }
+
     case "set_show_command_palette": {
       return {
         ...state,

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -106,10 +106,10 @@ export default async (store: Store) => {
     app,
     comments,
     contextMenus,
+    layout,
     network,
     reactDevTools,
     timeline,
-    layout,
     ...debuggerReducers,
     ...consoleReducers.reducers,
   };

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -13,6 +13,7 @@ import timeline from "ui/reducers/timeline";
 import comments from "ui/reducers/comments";
 import contextMenus from "ui/reducers/contextMenus";
 import reactDevTools from "ui/reducers/reactDevTools";
+import layout from "ui/reducers/layout";
 import { selectors } from "ui/reducers";
 import { actions, UIStore } from "ui/actions";
 const { setupApp, setupTimeline, setupReactDevTools, createSession } = actions;
@@ -103,11 +104,12 @@ export default async (store: Store) => {
 
   const reducers = {
     app,
-    timeline,
     comments,
     contextMenus,
     network,
     reactDevTools,
+    timeline,
+    layout,
     ...debuggerReducers,
     ...consoleReducers.reducers,
   };

--- a/src/ui/state/index.ts
+++ b/src/ui/state/index.ts
@@ -12,6 +12,7 @@ import { RulesState } from "devtools/client/inspector/rules/state/rules";
 import { ComputedState } from "devtools/client/inspector/computed/state";
 import { MessageState } from "devtools/client/webconsole/reducers/messages";
 import { NetworkState } from "ui/reducers/network";
+import { LayoutState } from "./layout";
 
 export interface UIState {
   app: AppState;
@@ -22,6 +23,7 @@ export interface UIState {
   eventListenerBreakpoints: any;
   eventTooltip: EventTooltipState;
   inspector: InspectorState;
+  layout: LayoutState;
   markup: MarkupState;
   messages: MessageState;
   network: NetworkState;

--- a/src/ui/state/layout.ts
+++ b/src/ui/state/layout.ts
@@ -1,0 +1,3 @@
+export type LayoutState = {
+  showCommandPalette: boolean;
+};


### PR DESCRIPTION
Fix #4617.

Remaining things to finish here before merging V1:
- [x] Add keyboard shortcuts for each of the commands **(edit: skipped for now since we need to come up with proper ones)**
- [x] Let the user trigger a keyboard shortcut while focused on an input, e.g. full text search input prevents keyboard shortcuts 
- [x] Do a design pass with Jon