### PR TITLE
Add keys to network monitor iterators

### DIFF
--- a/src/devtools/client/shared/components/PanelTabs.tsx
+++ b/src/devtools/client/shared/components/PanelTabs.tsx
@@ -46,7 +46,7 @@ export default function PanelTabs({
         <nav className="tabs-navigation">
           <ul className="tabs-menu" role="tablist">
             {tabs.map((tab: Tab) => (
-              <PanelTab setActiveTab={setActiveTab} tab={tab} activeTab={activeTab} />
+              <PanelTab key={tab.id} setActiveTab={setActiveTab} tab={tab} activeTab={activeTab} />
             ))}
           </ul>
         </nav>

--- a/src/ui/components/NetworkMonitor/RequestRow.tsx
+++ b/src/ui/components/NetworkMonitor/RequestRow.tsx
@@ -10,7 +10,6 @@ export const RequestRow = ({
   isInPast,
   onClick,
   onSeek,
-  prepareRow,
   row,
 }: {
   currentTime: number;
@@ -18,10 +17,9 @@ export const RequestRow = ({
   isInPast: boolean;
   onClick: (row: RequestSummary) => void;
   onSeek: (row: RequestSummary) => void;
-  prepareRow: (row: Row<RequestSummary>) => void;
   row: Row<RequestSummary>;
 }) => {
-  let currentRow = false;
+  // let currentRow = false;
   // Did we just pass the row boundary that contains the current time?
   // If so, let's render this row as the "current" row and all rows
   // after it as future rows.
@@ -32,7 +30,6 @@ export const RequestRow = ({
   //   renderingRequestsInThePast = false;
   //   currentRow = true;
   // }
-  prepareRow(row);
   return (
     <div
       className={classNames(styles.row, {

--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -5,8 +5,6 @@ import { RequestSummary } from "./utils";
 import { HeaderGroups } from "./HeaderGroups";
 import { RequestRow } from "./RequestRow";
 import { Row, TableInstance } from "react-table";
-import { fi } from "date-fns/locale";
-import { first } from "lodash";
 
 const RequestTable = ({
   currentTime,
@@ -48,15 +46,17 @@ const RequestTable = ({
               firstInFuture = true;
             }
 
+            prepareRow(row);
+
             return (
               <RequestRow
-                row={row}
-                onClick={onRowSelect}
                 currentTime={currentTime}
-                onSeek={onSeek}
-                prepareRow={prepareRow}
                 isFirstInFuture={firstInFuture}
                 isInPast={inPast}
+                key={row.getRowProps().key}
+                onClick={onRowSelect}
+                onSeek={onSeek}
+                row={row}
               />
             );
           })}

--- a/src/ui/components/NetworkMonitor/TypesDropdown.tsx
+++ b/src/ui/components/NetworkMonitor/TypesDropdown.tsx
@@ -42,6 +42,7 @@ export default function TypesDropdown({
       <Dropdown>
         {Object.entries(REQUEST_TYPES).map((pair: string[]) => (
           <TypeItem
+            key={pair[0]}
             icon={REQUEST_ICONS[pair[0]] || "description"}
             type={pair[0] as RequestType}
             label={pair[1]}


### PR DESCRIPTION
We were missing some `key` props causing warnings in the console.