### PR TITLE
Add a context menu to show or hide network monitor table columns

### DIFF
--- a/src/ui/components/NetworkMonitor/ColumnsDropdown.tsx
+++ b/src/ui/components/NetworkMonitor/ColumnsDropdown.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import { Dropdown, DropdownItem, DropdownItemContent } from "ui/components/Library/LibraryDropdown";
+import { Column } from "react-table";
+
+export default function ColumnsDropdown({ columns }: { columns: Column[] }) {
+  const ColumnItem = ({ column }: { column: Column }) => {
+    const attrs = (column as any).getToggleHiddenProps();
+    return (
+      <DropdownItem onClick={() => attrs.onChange({ target: { checked: !attrs.checked } })}>
+        <DropdownItemContent selected={attrs.checked} icon={attrs.checked ? "check" : ""}>
+          <span className="capitalize">{String(column.id)}</span>
+        </DropdownItemContent>
+      </DropdownItem>
+    );
+  };
+
+  return (
+    <Dropdown>
+      {columns.map(column => (
+        <ColumnItem key={column.id} column={column} />
+      ))}
+    </Dropdown>
+  );
+}

--- a/src/ui/components/NetworkMonitor/HeaderGroups.tsx
+++ b/src/ui/components/NetworkMonitor/HeaderGroups.tsx
@@ -1,12 +1,39 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "./RequestTable.module.css";
 import classNames from "classnames";
-import { HeaderGroup } from "react-table";
+import { Column, HeaderGroup } from "react-table";
 import { RequestSummary } from "./utils";
+import { ContextMenu } from "../ContextMenu";
+import ColumnsDropdown from "./ColumnsDropdown";
 
-export function HeaderGroups({ headerGroups }: { headerGroups: HeaderGroup<RequestSummary>[] }) {
+interface MenuLocation {
+  x: number;
+  y: number;
+}
+
+export function HeaderGroups({
+  columns,
+  headerGroups,
+}: {
+  columns: Column[];
+  headerGroups: HeaderGroup<RequestSummary>[];
+}) {
+  const [menuLocation, setMenuLocation] = useState<MenuLocation>();
   return (
-    <div className="border-b">
+    <div
+      onContextMenu={ev => {
+        ev.preventDefault();
+        setMenuLocation({ x: ev.pageX, y: ev.pageY });
+      }}
+      className="border-b"
+    >
+      {menuLocation ? (
+        <ContextMenu x={menuLocation.x} y={menuLocation.y} close={() => setMenuLocation(undefined)}>
+          <ColumnsDropdown columns={columns} />
+        </ContextMenu>
+      ) : (
+        ""
+      )}
       {headerGroups.map((headerGroup: HeaderGroup<RequestSummary>) => (
         <div className="flex font-normal items-center" {...headerGroup.getHeaderGroupProps()}>
           {headerGroup.headers.map(column => (

--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -21,7 +21,7 @@ const RequestTable = ({
   selectedRequest?: RequestSummary;
   table: TableInstance<RequestSummary>;
 }) => {
-  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = table;
+  const { columns, getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = table;
 
   const onSeek = (request: RequestSummary) => {
     seek(request.point.point, request.point.time, true);
@@ -37,7 +37,7 @@ const RequestTable = ({
           className="sticky z-10 top-0"
           style={{ background: "var(--theme-tab-toolbar-background)" }}
         >
-          <HeaderGroups headerGroups={headerGroups} />
+          <HeaderGroups columns={columns} headerGroups={headerGroups} />
         </div>
         <div {...getTableBodyProps()}>
           {rows.map((row: Row<RequestSummary>) => {

--- a/src/ui/reducers/layout.ts
+++ b/src/ui/reducers/layout.ts
@@ -23,4 +23,4 @@ export default function update(state = initialLayoutState(), action: LayoutActio
   }
 }
 
-export const getShowCommandPalette = (state: UIState) => state.layout.showCommandPalette;
+export const getShowCommandPalette = (state: UIState) => state.layout?.showCommandPalette;


### PR DESCRIPTION
This was mostly a straight-forward change. I had to shoe-horn the actual toggles a *little bit* because React Table really expects you to be spreading the results of `column.getToggleHiddenProps()` into the `props` of a checkbox input, and instead we are using dropdown menu items, but it shouldn't be *too* hard to read/maintain.

https://user-images.githubusercontent.com/5903784/145482628-93e51bf6-4a59-4de4-b27f-27c04ef27c86.mp4

Fixes #4807 