### PR TITLE
Only show the first line of folded console errors

### DIFF
--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -145,6 +145,14 @@
   background-color: var(--console-error-background);
 }
 
+.webconsole-app .message.error .message-body {
+  max-height: 1rem;
+}
+
+.webconsole-app .message.error.open .message-body {
+  max-height: none;
+}
+
 .webconsole-app .message.warn {
   z-index: 2;
   color: var(--console-warning-color);


### PR DESCRIPTION
Fixes #4630.

If this is an issue for things other than errors we might have to expand it. I'm a little nervous about console styling because it's pretty intricate and I don't have a lot of experience with it, so I kept the targeting pretty specific.

### Before

![CleanShot 2021-12-10 at 15 06 41](https://user-images.githubusercontent.com/5903784/145652252-9dd23729-3c2f-4e3e-804d-1e769933126d.png)


### After

![CleanShot 2021-12-10 at 15 07 06](https://user-images.githubusercontent.com/5903784/145652276-1d4b64a4-56e0-4605-b5c0-b95eaaca88c0.png)

