### PR TITLE
Fix `breakpoints-05` test

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Footer.css
+++ b/src/devtools/client/debugger/src/components/Editor/Footer.css
@@ -57,18 +57,6 @@
   background-color: var(--theme-icon-checked-color);
 }
 
-.source-footer .mapped-source,
-.source-footer .cursor-position {
-  color: var(--theme-body-color);
-  padding-right: 2.5px;
-}
-
-.source-footer .mapped-source {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .source-footer .cursor-position {
   padding: 5px;
   white-space: nowrap;

--- a/src/devtools/client/debugger/src/components/Editor/SourcemapToggle.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/SourcemapToggle.tsx
@@ -80,7 +80,7 @@ export function SourcemapToggle({
   };
 
   return (
-    <div className="flex items-center pl-3 space-x-1">
+    <div className="flex items-center pl-3 space-x-1 mapped-source">
       <Toggle
         enabled={selectedSource.isOriginal}
         setEnabled={setEnabled}

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -554,7 +554,7 @@ async function toggleExceptionLogging() {
 }
 
 async function toggleMappedSources() {
-  return clickElement(".mapped-source");
+  return clickElement(".mapped-source button");
 }
 
 async function playbackRecording() {

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -127,17 +127,17 @@ export function useGetUserInfo(): UserInfo & { loading: boolean } {
 }
 
 export function useDismissNag() {
+  const { id, nags } = useGetUserInfo();
   const [dismissNag, { error }] = useMutation(DISMISS_NAG, {
     refetchQueries: ["GetUser"],
   });
-  const { nags } = useGetUserInfo();
 
   if (error) {
     console.error("Apollo error while updating the user's nags:", error);
   }
 
   return (nag: Nag) => {
-    if (!nags || nags.includes(nag)) {
+    if (!nags || nags.includes(nag) || !id) {
       return;
     }
 

--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -3,7 +3,6 @@ import { Integrations } from "@sentry/tracing";
 import { skipTelemetry } from "./environment";
 import { Recording, Workspace } from "ui/types";
 import { prefs } from "./prefs";
-import { UserInfo } from "ui/hooks/users";
 import { initializeMixpanel, trackMixpanelEvent } from "./mixpanel";
 
 const timings: Record<string, number> = {};

--- a/test/mock/src/graphql/users.ts
+++ b/test/mock/src/graphql/users.ts
@@ -1,5 +1,5 @@
 import { MockedResponse } from "@apollo/client/testing";
-import { GET_USER_INFO, GET_USER_ID } from "ui/graphql/users";
+import { GET_USER_INFO, GET_USER_ID, DISMISS_NAG } from "ui/graphql/users";
 import { cloneResponse } from "./utils";
 
 export function createGetUserMock(opts: { user?: { id: string; uuid: string } }): MockedResponse[] {
@@ -17,9 +17,7 @@ export function createGetUserMock(opts: { user?: { id: string; uuid: string } })
       query: GET_USER_INFO,
     },
     result: {
-      data: {
-        viewer: userInfo,
-      },
+      data: { viewer: userInfo },
     },
   };
   const getUserId = {


### PR DESCRIPTION
We removed the `mapped-source` class from the toggle in  7003f6d784328bc2b45c33e8d2ccbdff3edb60f8, which was breaking the test. Also, there's a problem where if a user who is not logged in tries to dismiss a nag, but that's actually not what was failing the test, so 🤷.