### PR TITLE
Add a `pending` flag to tests in the manifest

### DIFF
--- a/test/manifest.js
+++ b/test/manifest.js
@@ -49,12 +49,15 @@ module.exports = [
     example: "doc_navigate.html",
     script: "breakpoints-07.js",
     targets: ["gecko", "chromium"],
+    // This test is the most failing test in our suite. I am not sure why
+    pending: true,
   },
-  // {
-  //   example: "node/control_flow.js",
-  //   script: "node_control_flow.js",
-  //   targets: ["node"],
-  // },
+  {
+    example: "node/control_flow.js",
+    script: "node_control_flow.js",
+    targets: ["node"],
+    pending: true,
+  },
 
   //////////////////////////////////////////////////////////////////////////////
   // Stepping
@@ -201,11 +204,12 @@ module.exports = [
     script: "object_preview-01.js",
     targets: ["gecko", "chromium"],
   },
-  // {
-  //   example: "doc_rr_objects.html",
-  //   script: "object_preview-02.js",
-  //   targets: ["gecko", "chromium"],
-  // },
+  {
+    example: "doc_rr_objects.html",
+    script: "object_preview-02.js",
+    targets: ["gecko", "chromium"],
+    pending: true,
+  },
   {
     example: "doc_rr_preview.html",
     script: "object_preview-03.js",
@@ -240,12 +244,13 @@ module.exports = [
     script: "inspector-02.js",
     targets: ["gecko"],
   },
-  // {
-  //   This  test just times out, it doesn't even seem to run
-  //   example: "doc_inspector_styles.html",
-  //   script: "inspector-03.js",
-  //   targets: ["gecko"],
-  // },
+  {
+    // This  test just times out, it doesn't even seem to run
+    example: "doc_inspector_styles.html",
+    script: "inspector-03.js",
+    targets: ["gecko"],
+    pending: true,
+  },
   {
     example: "doc_inspector_styles.html",
     script: "inspector-04.js",
@@ -291,12 +296,13 @@ module.exports = [
   // Miscellaneous
   //////////////////////////////////////////////////////////////////////////////
 
-  // Disabled for now because this test requires authentication
-  // {
-  //   example: "doc_rr_basic.html",
-  //   script: "settings.js",
-  //   targets: ["gecko", "chromium"],
-  // },
+  // disabled for now because this test requires authentication
+  {
+    example: "doc_rr_basic.html",
+    script: "settings.js",
+    targets: ["gecko", "chromium"],
+    pending: true,
+  },
   {
     example: "doc_rr_worker.html",
     script: "worker-01.js",

--- a/test/mock/run.js
+++ b/test/mock/run.js
@@ -1,7 +1,6 @@
 const { spawnSync } = require("child_process");
 const manifest = require("./manifest");
 const { listAllRecordings, uploadRecording } = require("@recordreplay/recordings-cli");
-const { match } = require("assert");
 
 const devtools = `${__dirname}/../..`;
 let scriptsToRun = [];

--- a/test/run.js
+++ b/test/run.js
@@ -15,6 +15,7 @@ const {
   defer,
 } = require("./utils");
 const { listAllRecordings } = require("@recordreplay/recordings-cli");
+const { default: next } = require("next");
 
 // These don't work quite perfectly yet, there are still places where we are
 // hardcoding localhost:8080, in files like `header.js` and `runTest.js`.  When
@@ -139,7 +140,11 @@ async function runMatchingTests() {
       continue;
     }
 
-    const { example, script, targets } = Manifest[i];
+    const { pending, example, script, targets } = Manifest[i];
+    if (pending) {
+      console.log(`Pending test: ${script}`);
+      continue;
+    }
     if (!onlyTarget) {
       for (const target of targets) {
         await runTest(script, example, target);


### PR DESCRIPTION
This is just a way for us to skip tests that are problematic without having to comment them out. I've also marked `breakpoints-07` as pending, because of this:

![CleanShot 2021-12-10 at 16 38 48](https://user-images.githubusercontent.com/5903784/145657181-8cc72aca-f7db-4e36-9922-01cfd8f82cb3.png)

Those are our failures for the past week. I've fixed the top one in #4824 , and `breakpoints-07` is by far the next most common failing test, but it's totally unclear what's failing or why, it passes perfectly every time locally.