### PR TITLE
Fix accordion css

### DIFF
--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
@@ -83,61 +83,6 @@
   align-items: center;
 }
 
-.source-outline-tabs {
-  font-size: 12px;
-  width: 100%;
-  background: var(--theme-body-background);
-  display: flex;
-  user-select: none;
-  box-sizing: border-box;
-  height: var(--editor-header-height);
-  margin: 0;
-  padding: 0;
-  border-bottom: 1px solid var(--theme-splitter-color);
-}
-
-.source-outline-tabs .tab {
-  align-items: center;
-  background-color: var(--theme-toolbar-background);
-  color: var(--theme-toolbar-color);
-  cursor: default;
-  display: inline-flex;
-  flex: 1;
-  justify-content: center;
-  overflow: hidden;
-  padding: 4px 8px;
-  position: relative;
-}
-
-.source-outline-tabs .tab::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 2px;
-  background-color: var(--tab-line-color, transparent);
-  transition: transform 250ms var(--animation-curve), opacity 250ms var(--animation-curve);
-  opacity: 0;
-  transform: scaleX(0);
-}
-
-.source-outline-tabs .tab.active {
-  --tab-line-color: var(--tab-line-selected-color);
-  color: var(--theme-toolbar-selected-color);
-  border-bottom-color: transparent;
-}
-
-.source-outline-tabs .tab:not(.active):hover {
-  --tab-line-color: var(--tab-line-hover-color);
-  background-color: var(--theme-toolbar-hover);
-}
-
-.source-outline-panel {
-  flex: 1;
-  overflow: auto;
-}
-
 .sources-pane {
   border-radius: 8px 8px 0 0;
 }

--- a/src/ui/components/Accordion.module.css
+++ b/src/ui/components/Accordion.module.css
@@ -12,9 +12,10 @@
 }
 
 .accordionItemContainer.open {
-  flex: 0 1 auto;
+  flex: 1 1;
   min-height: 20%;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .accordionItemContainer {
@@ -22,7 +23,7 @@
 }
 
 .accordionItemContainer:not(.open) {
-  flex-shrink: 0;
+  flex: 0 1 min-content;
 }
 
 .accordionItemContainer .header {
@@ -43,4 +44,5 @@
 
 .content.open {
   height: 100%;
+  overflow-y: auto;
 }


### PR DESCRIPTION
The sources / outline split-pane will now share the vertical space evenly. This is important so that if they're both expanded one pane is not too big or too small