### PR TITLE
Only show material icons after they have loaded fixes #4835

### DIFF
--- a/public/fonts/material_icons/material_icons.css
+++ b/public/fonts/material_icons/material_icons.css
@@ -17,6 +17,11 @@
     url(/fonts/material_icons/MaterialIconsOutlined-Regular.otf) format("opentype");
 }
 
+.material-icon-loaded .material-icons,
+.material-icon-loaded .material-icons-outlined {
+  opacity: 1;
+}
+
 .material-icons,
 .material-icons-outlined {
   font-weight: normal;
@@ -29,6 +34,8 @@
   word-wrap: normal;
   white-space: nowrap;
   direction: ltr;
+  opacity: 0;
+  width: 1rem;
 
   /* Support for all WebKit browsers. */
   -webkit-font-smoothing: antialiased;

--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -1,5 +1,5 @@
 import classnames from "classnames";
-import React from "react";
+import React, { useEffect } from "react";
 
 const SIZE_STYLES = {
   xs: "text-xs",
@@ -18,6 +18,22 @@ type MaterialIconProps = React.HTMLProps<HTMLDivElement> & {
   iconSize?: keyof typeof SIZE_STYLES;
 };
 
+let isChecking = false;
+function useMaterialIconCheck() {
+  useEffect(() => {
+    if (isChecking) {
+      return;
+    }
+    isChecking = true;
+    let id = setInterval(() => {
+      if (typeof document === "object" && (document as any).fonts.check("12px Material Icons")) {
+        document.body.classList.add("material-icon-loaded");
+        clearInterval(id);
+      }
+    }, 100);
+  }, []);
+}
+
 export default function MaterialIcon({
   children,
   className,
@@ -26,6 +42,8 @@ export default function MaterialIcon({
   iconSize = "base",
   ...rest
 }: MaterialIconProps) {
+  useMaterialIconCheck();
+
   return (
     <div
       {...rest}


### PR DESCRIPTION
We used to use a font-face loader, but when the font would load via the cache it would fail. This gets around it by checking until the font is loaded