### PR TITLE
Set `workspaceId` in Mixpanel call

### DIFF
--- a/src/ui/components/Library/TeamButton.tsx
+++ b/src/ui/components/Library/TeamButton.tsx
@@ -8,6 +8,7 @@ import SidebarButton from "./SidebarButton";
 import classNames from "classnames";
 import { Workspace } from "ui/types";
 import { inUnpaidFreeTrial, subscriptionExpired } from "ui/utils/workspace";
+import { maybeTrackTeamChange } from "ui/utils/mixpanel";
 
 function TeamButton({
   text,
@@ -30,6 +31,8 @@ function TeamButton({
   const handleTeamClick = (e: React.MouseEvent) => {
     e.preventDefault();
     setWorkspaceId(id);
+
+    maybeTrackTeamChange(id);
 
     // We only set the new team as the default team if this is a non-pending team.
     // Otherwise, it would be possible to set pending teams as a default team.

--- a/src/ui/hooks/workspaces.ts
+++ b/src/ui/hooks/workspaces.ts
@@ -15,7 +15,6 @@ import {
   PendingWorkspaceInvitation,
   Subscription,
   Workspace,
-  WorkspaceSettings,
   WorkspaceUserRole,
 } from "ui/types";
 

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -60,13 +60,15 @@ export async function bootstrapApp() {
 
     const userInfo = await getUserInfo();
     if (userInfo) {
-      setTelemetryContext(userInfo);
-      maybeSetMixpanelContext(userInfo);
-
-      if (!getWorkspaceId(store.getState())) {
+      let workspaceId = getWorkspaceId(store.getState());
+      if (!workspaceId) {
         const userSettings = await getUserSettings();
         store.dispatch(setWorkspaceId(userSettings.defaultWorkspaceId));
+        workspaceId = userSettings.defaultWorkspaceId;
       }
+
+      setTelemetryContext(userInfo);
+      maybeSetMixpanelContext({ ...userInfo, workspaceId });
     }
 
     initLaunchDarkly();

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -23,7 +23,7 @@ export function initializeMixpanel() {
   mixpanel.register({ recordingId: getRecordingId() });
 }
 
-export function maybeSetMixpanelContext(userInfo: TelemetryUser) {
+export function maybeSetMixpanelContext(userInfo: TelemetryUser & { workspaceId: string | null }) {
   const { email, internal } = userInfo;
   const isQAUser = email && QA_EMAIL_ADDRESSES.includes(email);
   const isInternal = internal;
@@ -41,6 +41,12 @@ export function maybeSetMixpanelContext(userInfo: TelemetryUser) {
     disableMixpanel();
   }
 }
+
+export const maybeTrackTeamChange = (newWorkspaceId: string | null) => {
+  if (!mixpanelDisabled) {
+    mixpanel.people.set({ workspaceId: newWorkspaceId });
+  }
+};
 
 export async function trackMixpanelEvent(event: string, properties?: Dict) {
   if (prefs.logTelemetryEvent) {
@@ -63,7 +69,11 @@ export async function trackEventOnce(event: string, properties?: Dict) {
   trackMixpanelEvent(event, properties);
 }
 
-export function setMixpanelContext({ id, email }: TelemetryUser) {
+export function setMixpanelContext({
+  id,
+  email,
+  workspaceId,
+}: TelemetryUser & { workspaceId: string | null }) {
   mixpanel.register({ isReplayBrowser: isReplayBrowser() });
 
   if (id) {
@@ -72,6 +82,10 @@ export function setMixpanelContext({ id, email }: TelemetryUser) {
 
   if (email) {
     mixpanel.people.set({ $email: email });
+  }
+
+  if (workspaceId) {
+    mixpanel.people.set({ workspaceId });
   }
 
   if (prefs.logTelemetryEvent) {


### PR DESCRIPTION
This will set the `workspaceId` for all events that get sent to MixPanel, and we can use that to determine which teams (or workspaces) have been active in a given time period.

Fixes #4822 