### PR TITLE
Update @recordreplay/protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@auth0/auth0-react": "^1.2.0",
         "@headlessui/react": "^1.4.1",
         "@heroicons/react": "^1.0.1",
-        "@recordreplay/protocol": "^0.15.4",
+        "@recordreplay/protocol": "^0.15.5",
         "@sentry/react": "^6.8.0",
         "@sentry/tracing": "^6.8.0",
         "@stripe/react-stripe-js": "^1.4.1",
@@ -4046,9 +4046,9 @@
       }
     },
     "node_modules/@recordreplay/protocol": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.15.4.tgz",
-      "integrity": "sha512-93HZF2ryjopqs0Tbntnydj/DygYVGLC9D4PvScmoEp61jOL8tLfNb+DfOOO7hsNSH6hS9N4Mg/oeZXdSjkhtRw=="
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.15.5.tgz",
+      "integrity": "sha512-gOdILGxSqqVqBGxpDO2jcClA/n0tjcAXKzi/Q7DHh9y5fugdob4sAIetcHW0UPplfCgc69MDi9tHk2MBjQi6iA=="
     },
     "node_modules/@recordreplay/recordings-cli": {
       "version": "0.4.1",
@@ -47927,9 +47927,9 @@
       }
     },
     "@recordreplay/protocol": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.15.4.tgz",
-      "integrity": "sha512-93HZF2ryjopqs0Tbntnydj/DygYVGLC9D4PvScmoEp61jOL8tLfNb+DfOOO7hsNSH6hS9N4Mg/oeZXdSjkhtRw=="
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.15.5.tgz",
+      "integrity": "sha512-gOdILGxSqqVqBGxpDO2jcClA/n0tjcAXKzi/Q7DHh9y5fugdob4sAIetcHW0UPplfCgc69MDi9tHk2MBjQi6iA=="
     },
     "@recordreplay/recordings-cli": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@auth0/auth0-react": "^1.2.0",
     "@headlessui/react": "^1.4.1",
     "@heroicons/react": "^1.0.1",
-    "@recordreplay/protocol": "^0.15.4",
+    "@recordreplay/protocol": "^0.15.5",
     "@sentry/react": "^6.8.0",
     "@sentry/tracing": "^6.8.0",
     "@stripe/react-stripe-js": "^1.4.1",

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -227,7 +227,6 @@ class _ThreadFront {
     this.ensureCurrentPause();
 
     if (this.testName) {
-      client.Internal.labelTestSession({ sessionId });
       await gToolbox.selectTool("debugger");
       window.Test = require("test/harness");
       const script = document.createElement("script");


### PR DESCRIPTION
This also removes `labelTestSession` since that's been [removed from the protocol](https://github.com/RecordReplay/backend/commit/a2d68898edd7dad959f2a98dfebc45cdc5eebafd) since.