### PR TITLE
Highlight selection of Node attributes

### DIFF
--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -57,6 +57,11 @@
   color: var(--theme-selection-color);
 }
 
+.attr-value::selection,
+.attr-name::selection {
+  background: var(--theme-highlight-bluegrey);
+}
+
 .devtools-monospace {
   font-family: var(--monospace-font-family);
   font-size: var(--theme-code-font-size);

--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -58,6 +58,7 @@
 }
 
 .attr-value::selection,
+.attr-value *::selection,
 .attr-name::selection {
   background: var(--theme-highlight-bluegrey);
 }

--- a/src/devtools/client/themes/markup.css
+++ b/src/devtools/client/themes/markup.css
@@ -460,3 +460,8 @@ ul.children + .tag-line::before {
 #markup-root ul {
   outline: none;
 }
+
+.attr-name,
+.attr-value {
+  user-select: all;
+}


### PR DESCRIPTION
ticket: #4755 

Attributes already were selectable, only their selection color was the same as the background of the entire Node element.

I've updated the background color of the selection and enforced the selection of the attribute's entire name/value, instead of just parts of it.