### PR TITLE
Also set `workspaceId` on events

### DIFF
--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -35,7 +35,7 @@ export function maybeSetMixpanelContext(userInfo: TelemetryUser & { workspaceId:
   if (!shouldDisableMixpanel || forceEnableMixpanel) {
     setMixpanelContext(userInfo);
     enableMixpanel();
-    trackMixpanelEvent("session_start");
+    trackMixpanelEvent("session_start", { workspaceId: userInfo.workspaceId });
     setupSessionEndListener();
   } else {
     disableMixpanel();
@@ -45,6 +45,7 @@ export function maybeSetMixpanelContext(userInfo: TelemetryUser & { workspaceId:
 export const maybeTrackTeamChange = (newWorkspaceId: string | null) => {
   if (!mixpanelDisabled) {
     mixpanel.people.set({ workspaceId: newWorkspaceId });
+    trackMixpanelEvent("team_change", { workspaceId: newWorkspaceId });
   }
 };
 


### PR DESCRIPTION
This needs to be set on at least one event as well as the user profile, so that we can write a `distinct count` query in MixPanel for tracking "Weekly Active Teams".