### PR TITLE
Add Stack Trace to Network Monitor Request Detail

### DIFF
--- a/src/devtools/client/debugger/src/actions/index.d.ts
+++ b/src/devtools/client/debugger/src/actions/index.d.ts
@@ -1,8 +1,10 @@
+import { WiredFrame } from "protocol/thread/pause";
 import { UIAction, UIThunkAction } from "ui/actions";
 import { SourceLocation } from "ui/state/comments";
 
 declare const _default: {
   [name: string]: (...args: any[]) => UIAction | UIThunkAction;
+  selectFrame: (cx: any, frame: WiredFrame) => UIThunkAction;
   selectLocation: (cx: any, location: SourceLocation) => UIThunkAction;
   togglePaneCollapse: () => UIThunkAction;
 };

--- a/src/devtools/client/debugger/src/actions/pause/selectFrame.js
+++ b/src/devtools/client/debugger/src/actions/pause/selectFrame.js
@@ -14,7 +14,7 @@ import assert from "../../utils/assert";
  * @static
  */
 export function selectFrame(cx, frame) {
-  return async ({ dispatch, client, getState, sourceMaps }) => {
+  return async ({ dispatch, client }) => {
     assert(cx.thread == frame.thread, "Thread mismatch");
 
     // Frames that aren't on-stack do not support evalling and may not

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/Group.js
@@ -4,7 +4,6 @@
 
 //
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import classNames from "classnames";
 
 import { getLibraryFromUrl } from "../../../utils/pause/frames";
@@ -125,15 +124,13 @@ export default class Group extends Component {
   }
 
   renderDescription() {
-    const { l10n } = this.context;
     const { group } = this.props;
 
     const frame = group[0];
     const expanded = this.state.expanded;
-    const l10NEntry = this.state.expanded
-      ? "callStack.group.collapseTooltip"
-      : "callStack.group.expandTooltip";
-    const title = l10n.getFormatStr(l10NEntry, frame.library);
+    const title = this.state.expanded
+      ? `Collapse ${frame.library} frames`
+      : `Expand ${frame.library} frames`;
 
     return (
       <div
@@ -169,4 +166,3 @@ export default class Group extends Component {
 }
 
 Group.displayName = "Group";
-Group.contextTypes = { l10n: PropTypes.object };

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/index.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Frames/index.js
@@ -60,7 +60,6 @@ class Frames extends Component {
     const {
       cx,
       selectFrame,
-      selectLocation,
       selectedFrame,
       toggleBlackBox,
       frameworkGroupingOn,
@@ -86,7 +85,6 @@ class Frames extends Component {
               copyStackTrace={this.copyStackTrace}
               frameworkGroupingOn={frameworkGroupingOn}
               selectFrame={selectFrame}
-              selectLocation={selectLocation}
               selectedFrame={selectedFrame}
               toggleBlackBox={toggleBlackBox}
               key={String(frameOrGroup.id)}
@@ -103,7 +101,6 @@ class Frames extends Component {
               copyStackTrace={this.copyStackTrace}
               frameworkGroupingOn={frameworkGroupingOn}
               selectFrame={selectFrame}
-              selectLocation={selectLocation}
               selectedFrame={selectedFrame}
               toggleBlackBox={toggleBlackBox}
               key={frameOrGroup[0].id}
@@ -124,9 +121,7 @@ class Frames extends Component {
     if (!frames) {
       return (
         <div className="pane frames">
-          <div className="pane-info empty">
-            {L10N.getStr(framesLoading ? "callStack.loading" : "callStack.notPaused")}
-          </div>
+          <div className="pane-info empty">{framesLoading ? "Loading..." : "Not paused"}</div>
         </div>
       );
     }
@@ -150,7 +145,6 @@ const mapStateToProps = state => ({
 
 export default connect(mapStateToProps, {
   selectFrame: actions.selectFrame,
-  selectLocation: actions.selectLocation,
   toggleBlackBox: actions.toggleBlackBox,
   toggleFrameworkGrouping: actions.toggleFrameworkGrouping,
 })(Frames);

--- a/src/devtools/client/debugger/src/reducers/sources.d.ts
+++ b/src/devtools/client/debugger/src/reducers/sources.d.ts
@@ -24,3 +24,4 @@ export type Source = {
 
 export function getSelectedSourceWithContent(state: UIState): Source;
 export function getIsSourceMappedSource(state: UIState): boolean;
+export function getSources(state: UIState): Source[];

--- a/src/devtools/client/debugger/src/selectors/index.d.ts
+++ b/src/devtools/client/debugger/src/selectors/index.d.ts
@@ -1,5 +1,7 @@
 import { UIState } from "ui/state";
 import { Location } from "@recordreplay/protocol";
+import { UIThunkAction } from "ui/actions";
+import { WiredFrame } from "protocol/thread/pause";
 
 export interface UrlLocation extends Location {
   sourceUrl: string;

--- a/src/devtools/client/locales/en-us/debugger.properties
+++ b/src/devtools/client/locales/en-us/debugger.properties
@@ -328,10 +328,6 @@ breakpoints.removeBreakpointTooltip=Remove breakpoint
 # LOCALIZATION NOTE (callStack.header): Call Stack right sidebar pane header.
 callStack.header=Call stack
 
-# LOCALIZATION NOTE (callStack.notPaused): Call Stack right sidebar pane
-# message when not paused.
-callStack.notPaused=Not paused
-
 # LOCALIZATION NOTE (callStack.collapse): Call Stack right sidebar pane
 # message to hide some of the frames that are shown.
 callStack.collapse=Collapse rows

--- a/src/devtools/client/webconsole/actions/network.ts
+++ b/src/devtools/client/webconsole/actions/network.ts
@@ -1,7 +1,7 @@
 import { RequestInfo, RequestEventInfo } from "@recordreplay/protocol";
 import { ThreadFront } from "protocol/thread";
 import { UIStore } from "ui/actions";
-import { newNetworkRequestsAction, NEW_NETWORK_REQUESTS } from "ui/actions/network";
+import { newNetworkRequests } from "ui/actions/network";
 import { AppDispatch } from "ui/setup";
 
 export const setupNetwork = (store: UIStore) => {
@@ -11,4 +11,4 @@ export const setupNetwork = (store: UIStore) => {
 const onNetworkRequestsThunk =
   (data: { requests: RequestInfo[]; events: RequestEventInfo[] }) =>
   async ({ dispatch }: { dispatch: AppDispatch }) =>
-    dispatch(newNetworkRequestsAction(data));
+    dispatch(newNetworkRequests(data));

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { RequestSummary } from "./utils";
 import styles from "./RequestDetails.module.css";
 import classNames from "classnames";
@@ -6,6 +6,8 @@ import sortBy from "lodash/sortBy";
 import PanelTabs from "devtools/client/shared/components/PanelTabs";
 import ComingSoon from "./ComingSoon";
 import CloseButton from "devtools/client/debugger/src/components/shared/Button/CloseButton";
+import { Frames } from "../../../devtools/client/debugger/src/components/SecondaryPanes/Frames";
+import { WiredFrame } from "protocol/thread/pause";
 
 interface Detail {
   name: string;
@@ -59,6 +61,25 @@ const Cookies = ({ request }: { request: RequestSummary }) => {
           }
         )}
       />
+    </div>
+  );
+};
+
+const StackTrace = ({
+  cx,
+  frames,
+  selectFrame,
+}: {
+  cx: any;
+  frames: WiredFrame[];
+  selectFrame: (cx: any, frame: WiredFrame) => void;
+}) => {
+  return (
+    <div>
+      <h1 className="p-3 font-bold">Stack Trace</h1>
+      <div className="px-2">
+        <Frames cx={cx} framesLoading={true} frames={frames} selectFrame={selectFrame} />
+      </div>
     </div>
   );
 };
@@ -143,23 +164,39 @@ const HeadersPanel = ({ request }: { request: RequestSummary }) => {
   );
 };
 
+const DEFAULT_TAB = "headers";
+
 const RequestDetails = ({
   closePanel,
+  cx,
+  frames,
   request,
+  selectFrame,
 }: {
   closePanel: () => void;
+  cx: any;
+  frames: WiredFrame[];
   request: RequestSummary;
+  selectFrame: (cx: any, frame: WiredFrame) => void;
 }) => {
-  const [activeTab, setActiveTab] = useState("headers");
+  const [activeTab, setActiveTab] = useState(DEFAULT_TAB);
 
   const tabs = [
     { id: "headers", title: "Headers", visible: true },
     { id: "cookies", title: "Cookies", visible: Boolean(cookieHeader(request)) },
     { id: "response", title: "Response", visible: true },
     { id: "request", title: "Request", visible: true },
-    { id: "initiator", title: "Stack Trace", visible: true },
+    { id: "stackTrace", title: "Stack Trace", visible: Boolean(request.triggerPoint) },
     { id: "timings", title: "Timings", visible: true },
   ];
+
+  const activeTabs = tabs.filter(t => t.visible);
+
+  useEffect(() => {
+    if (!activeTabs.find(t => t.id === activeTab)) {
+      setActiveTab(DEFAULT_TAB);
+    }
+  }, [activeTab, activeTabs]);
 
   if (!request) {
     return null;
@@ -176,7 +213,9 @@ const RequestDetails = ({
         {activeTab == "cookies" && <Cookies request={request} />}
         {activeTab == "response" && <ComingSoon />}
         {activeTab == "request" && <ComingSoon />}
-        {activeTab == "initiator" && <ComingSoon />}
+        {activeTab == "stackTrace" && (
+          <StackTrace cx={cx} frames={frames} selectFrame={selectFrame} />
+        )}
         {activeTab == "timings" && <ComingSoon />}
       </div>
     </div>

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -1,15 +1,20 @@
-import { createSelector } from "reselect";
 import { RequestEventInfo, RequestInfo } from "@recordreplay/protocol";
 import { UIState } from "ui/state";
 import { NetworkAction } from "ui/actions/network";
+import { WiredFrame } from "protocol/thread/pause";
+import { createSelector } from "reselect";
+import { getSources } from "devtools/client/debugger/src/reducers/sources";
+import { formatCallStackFrames } from "devtools/client/debugger/src/selectors/getCallStackFrames";
 
 export type NetworkState = {
   events: RequestEventInfo[];
+  frames: Record<string, WiredFrame[]>;
   requests: RequestInfo[];
 };
 
 const initialState = (): NetworkState => ({
   events: [],
+  frames: {},
   requests: [],
 });
 
@@ -17,8 +22,17 @@ const update = (state: NetworkState = initialState(), action: NetworkAction): Ne
   switch (action.type) {
     case "NEW_NETWORK_REQUESTS":
       return {
+        ...state,
         events: [...action.payload.events, ...state.events],
         requests: [...action.payload.requests, ...state.requests],
+      };
+    case "SET_FRAMES":
+      return {
+        ...state,
+        frames: {
+          ...state.frames,
+          [action.payload.point]: action.payload.frames,
+        },
       };
     default:
       return state;
@@ -27,5 +41,12 @@ const update = (state: NetworkState = initialState(), action: NetworkAction): Ne
 
 export const getEvents = (state: UIState) => state.network.events;
 export const getRequests = (state: UIState) => state.network.requests;
+export const getFrames = (state: UIState) => state.network.frames;
+
+export const getFormattedFrames = createSelector(getFrames, getSources, (frames, sources) => {
+  return Object.keys(frames).reduce((acc: Record<string, WiredFrame[]>, frame) => {
+    return { ...acc, [frame]: formatCallStackFrames(frames[frame], sources) };
+  }, {});
+});
 
 export default update;


### PR DESCRIPTION
This adds a `Frames` component to the `Stack Trace` tab inside of the network monitor's request detail pane.

![CleanShot 2021-12-14 at 17 16 29](https://user-images.githubusercontent.com/5903784/146104858-4446bd5f-777e-4628-9eaa-4303210e2367.png)

It also makes a change so that if you are on a tab in the Network Request Detail panel and the active tabs change (because the active request changes), any invisible tabs will be "redirected" to the headers tab.

Replay: https://app.replay.io/recording/823241b9-54fd-4cc4-b315-3937694c0b0c

Fixes #4808 