### PR TITLE
Use custom auth0 hook everywhere

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -10,6 +10,7 @@ import { User } from "ui/types";
 import TipTapEditor from "./TipTapEditor";
 import { FocusContext } from "../CommentCard";
 import classNames from "classnames";
+import useAuth0 from "ui/utils/useAuth0";
 
 export function getCommentEditorDOMId(comment: Comment | Reply) {
   return `comment-editor-${comment.id}`;
@@ -27,6 +28,7 @@ function CommentEditor({
   editable,
   handleSubmit,
 }: CommentEditorProps) {
+  const { isAuthenticated } = useAuth0();
   const recordingId = hooks.useGetRecordingId();
   const { collaborators, recording, loading } = hooks.useGetOwnersAndCollaborators(recordingId!);
 
@@ -37,6 +39,8 @@ function CommentEditor({
         : undefined,
     [loading]
   );
+
+  if (!isAuthenticated) return null;
 
   return (
     <div className="comment-input-container" id={getCommentEditorDOMId(comment)}>

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -10,7 +10,6 @@ import { User } from "ui/types";
 import TipTapEditor from "./TipTapEditor";
 import { FocusContext } from "../CommentCard";
 import classNames from "classnames";
-import useAuth0 from "ui/utils/useAuth0";
 
 export function getCommentEditorDOMId(comment: Comment | Reply) {
   return `comment-editor-${comment.id}`;
@@ -28,7 +27,6 @@ function CommentEditor({
   editable,
   handleSubmit,
 }: CommentEditorProps) {
-  const { isAuthenticated } = useAuth0();
   const recordingId = hooks.useGetRecordingId();
   const { collaborators, recording, loading } = hooks.useGetOwnersAndCollaborators(recordingId!);
 
@@ -39,8 +37,6 @@ function CommentEditor({
         : undefined,
     [loading]
   );
-
-  if (!isAuthenticated) return null;
 
   return (
     <div className="comment-input-container" id={getCommentEditorDOMId(comment)}>

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
@@ -4,7 +4,7 @@ import hooks from "ui/hooks";
 import { actions } from "ui/actions";
 import { Comment, Reply } from "ui/state/comments";
 import CommentEditor from "./CommentEditor";
-import { useAuth0 } from "@auth0/auth0-react";
+import useAuth0 from "ui/utils/useAuth0";
 
 interface NewCommentEditorProps extends PropsFromRedux {
   comment: Comment | Reply;

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { EditorContent, Extension, Editor } from "@tiptap/react";
+import React, { useEffect, useState } from "react";
+import { useEditor, EditorContent, Extension } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { User } from "ui/types";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -52,8 +52,8 @@ const TipTapEditor = ({
     close();
   };
 
-  const editor = useMemo(() => {
-    return new Editor({
+  const editor = useEditor(
+    {
       extensions: [
         StarterKit,
         GitHubLink,
@@ -86,8 +86,9 @@ const TipTapEditor = ({
       content: tryToParse(content),
       editable,
       autofocus,
-    });
-  }, [onSubmit]);
+    },
+    [onSubmit]
+  );
 
   useEffect(() => {
     editor?.setEditable(editable);

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -52,43 +52,40 @@ const TipTapEditor = ({
     close();
   };
 
-  const editor = useEditor(
-    {
-      extensions: [
-        StarterKit,
-        GitHubLink,
-        ReplayLink,
-        // Mention.configure({ suggestion: suggestion(possibleMentions.map(u => u.name)) }),
-        Placeholder.configure({ placeholder }),
-        Extension.create({
-          name: "submitOnEnter",
-          addKeyboardShortcuts() {
-            return {
-              "Cmd-Enter": ({ editor }) => {
-                onSubmit(JSON.stringify(editor.getJSON()));
-                return true;
-              },
-              Enter: ({ editor }) => {
-                onSubmit(JSON.stringify(editor.getJSON()));
-                return true;
-              },
-              Escape: ({ editor }) => {
-                editor.commands.blur();
-                editor.commands.setContent(tryToParse(content));
-                handleCancel();
-                return true;
-              },
-            };
-          },
-        }),
-      ],
-      editorProps: { attributes: { class: "focus:outline-none" } },
-      content: tryToParse(content),
-      editable,
-      autofocus,
-    },
-    [onSubmit]
-  );
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      GitHubLink,
+      ReplayLink,
+      // Mention.configure({ suggestion: suggestion(possibleMentions.map(u => u.name)) }),
+      Placeholder.configure({ placeholder }),
+      Extension.create({
+        name: "submitOnEnter",
+        addKeyboardShortcuts() {
+          return {
+            "Cmd-Enter": ({ editor }) => {
+              onSubmit(JSON.stringify(editor.getJSON()));
+              return true;
+            },
+            Enter: ({ editor }) => {
+              onSubmit(JSON.stringify(editor.getJSON()));
+              return true;
+            },
+            Escape: ({ editor }) => {
+              editor.commands.blur();
+              editor.commands.setContent(tryToParse(content));
+              handleCancel();
+              return true;
+            },
+          };
+        },
+      }),
+    ],
+    editorProps: { attributes: { class: "focus:outline-none" } },
+    content: tryToParse(content),
+    editable,
+    autofocus,
+  });
 
   useEffect(() => {
     editor?.setEditable(editable);

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -6,6 +6,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import classNames from "classnames";
 import { GitHubLink } from "./githubLink";
 import { ReplayLink } from "./replayLink";
+import useAuth0 from "ui/utils/useAuth0";
 
 interface TipTapEditorProps {
   autofocus: boolean;
@@ -46,46 +47,51 @@ const TipTapEditor = ({
   placeholder,
   takeFocus,
 }: TipTapEditorProps) => {
+  const { isAuthenticated } = useAuth0();
+
   const onSubmit = (newContent: string) => {
     handleSubmit(newContent);
     blur();
     close();
   };
 
-  const editor = useEditor({
-    extensions: [
-      StarterKit,
-      GitHubLink,
-      ReplayLink,
-      // Mention.configure({ suggestion: suggestion(possibleMentions.map(u => u.name)) }),
-      Placeholder.configure({ placeholder }),
-      Extension.create({
-        name: "submitOnEnter",
-        addKeyboardShortcuts() {
-          return {
-            "Cmd-Enter": ({ editor }) => {
-              onSubmit(JSON.stringify(editor.getJSON()));
-              return true;
-            },
-            Enter: ({ editor }) => {
-              onSubmit(JSON.stringify(editor.getJSON()));
-              return true;
-            },
-            Escape: ({ editor }) => {
-              editor.commands.blur();
-              editor.commands.setContent(tryToParse(content));
-              handleCancel();
-              return true;
-            },
-          };
-        },
-      }),
-    ],
-    editorProps: { attributes: { class: "focus:outline-none" } },
-    content: tryToParse(content),
-    editable,
-    autofocus,
-  });
+  const editor = useEditor(
+    {
+      extensions: [
+        StarterKit,
+        GitHubLink,
+        ReplayLink,
+        // Mention.configure({ suggestion: suggestion(possibleMentions.map(u => u.name)) }),
+        Placeholder.configure({ placeholder }),
+        Extension.create({
+          name: "submitOnEnter",
+          addKeyboardShortcuts() {
+            return {
+              "Cmd-Enter": ({ editor }) => {
+                onSubmit(JSON.stringify(editor.getJSON()));
+                return true;
+              },
+              Enter: ({ editor }) => {
+                onSubmit(JSON.stringify(editor.getJSON()));
+                return true;
+              },
+              Escape: ({ editor }) => {
+                editor.commands.blur();
+                editor.commands.setContent(tryToParse(content));
+                handleCancel();
+                return true;
+              },
+            };
+          },
+        }),
+      ],
+      editorProps: { attributes: { class: "focus:outline-none" } },
+      content: tryToParse(content),
+      editable,
+      autofocus,
+    },
+    [isAuthenticated]
+  );
 
   useEffect(() => {
     editor?.setEditable(editable);

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { useEditor, EditorContent, Extension } from "@tiptap/react";
+import React, { useEffect, useMemo, useState } from "react";
+import { EditorContent, Extension, Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { User } from "ui/types";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -52,40 +52,42 @@ const TipTapEditor = ({
     close();
   };
 
-  const editor = useEditor({
-    extensions: [
-      StarterKit,
-      GitHubLink,
-      ReplayLink,
-      // Mention.configure({ suggestion: suggestion(possibleMentions.map(u => u.name)) }),
-      Placeholder.configure({ placeholder }),
-      Extension.create({
-        name: "submitOnEnter",
-        addKeyboardShortcuts() {
-          return {
-            "Cmd-Enter": ({ editor }) => {
-              onSubmit(JSON.stringify(editor.getJSON()));
-              return true;
-            },
-            Enter: ({ editor }) => {
-              onSubmit(JSON.stringify(editor.getJSON()));
-              return true;
-            },
-            Escape: ({ editor }) => {
-              editor.commands.blur();
-              editor.commands.setContent(tryToParse(content));
-              handleCancel();
-              return true;
-            },
-          };
-        },
-      }),
-    ],
-    editorProps: { attributes: { class: "focus:outline-none" } },
-    content: tryToParse(content),
-    editable,
-    autofocus,
-  });
+  const editor = useMemo(() => {
+    return new Editor({
+      extensions: [
+        StarterKit,
+        GitHubLink,
+        ReplayLink,
+        // Mention.configure({ suggestion: suggestion(possibleMentions.map(u => u.name)) }),
+        Placeholder.configure({ placeholder }),
+        Extension.create({
+          name: "submitOnEnter",
+          addKeyboardShortcuts() {
+            return {
+              "Cmd-Enter": ({ editor }) => {
+                onSubmit(JSON.stringify(editor.getJSON()));
+                return true;
+              },
+              Enter: ({ editor }) => {
+                onSubmit(JSON.stringify(editor.getJSON()));
+                return true;
+              },
+              Escape: ({ editor }) => {
+                editor.commands.blur();
+                editor.commands.setContent(tryToParse(content));
+                handleCancel();
+                return true;
+              },
+            };
+          },
+        }),
+      ],
+      editorProps: { attributes: { class: "focus:outline-none" } },
+      content: tryToParse(content),
+      editable,
+      autofocus,
+    });
+  }, [onSubmit]);
 
   useEffect(() => {
     editor?.setEditable(editable);

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
-import { useAuth0 } from "@auth0/auth0-react";
+import useAuth0 from "ui/utils/useAuth0";
 import LogRocket from "ui/utils/logrocket";
 import hooks from "ui/hooks";
 import * as actions from "ui/actions/app";

--- a/src/ui/components/Library/SidebarFooter.tsx
+++ b/src/ui/components/Library/SidebarFooter.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useAuth0 } from "@auth0/auth0-react";
+import useAuth0 from "ui/utils/useAuth0";
 import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
 import { AvatarImage } from "../Avatar";


### PR DESCRIPTION
## Issue

Fixes #4821 

## Resolution

There were a few places where we were using the stock `useAuth0` hook rather than our custom wrapper which means that some of our special handling for auth via API keys or the e2e test identity do not work.