### PR TITLE
Remove call to syncBreakpoints

### DIFF
--- a/src/devtools/client/debugger/src/client/index.js
+++ b/src/devtools/client/debugger/src/client/index.js
@@ -18,16 +18,6 @@ import * as selectors from "../selectors";
 import { updatePrefs } from "../utils/bootstrap";
 import { initialBreakpointsState } from "../reducers/breakpoints";
 
-async function syncBreakpoints() {
-  const breakpoints = await asyncStore.pendingBreakpoints;
-  const breakpointValues = Object.values(breakpoints);
-  breakpointValues.forEach(({ disabled, options, location }) => {
-    if (!disabled) {
-      clientCommands.setBreakpoint(location, options);
-    }
-  });
-}
-
 export async function loadInitialState() {
   const pendingBreakpoints = await asyncStore.pendingBreakpoints;
   const tabs = { tabs: await asyncStore.tabs };
@@ -57,8 +47,6 @@ async function setupDebugger() {
     })
   );
   store.dispatch({ type: "SOURCES_LOADED" });
-
-  syncBreakpoints();
 }
 
 export function bootstrap(_store) {


### PR DESCRIPTION
https://github.com/RecordReplay/devtools/commit/0c32dcf95ca4209294f8f7d636086f02134c1c2d triggered some surprising behavior where syncBreakpoints started trying to sync breakpoints stored in indexdb