### PR TITLE
Add space to billing page paragraph

### DIFF
--- a/src/ui/components/shared/WorkspaceSettingsModal/PricingPage.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/PricingPage.tsx
@@ -16,7 +16,7 @@ export function PricingPage({
       <p className="mb-4">
         With a Replay {subscription.displayName} Plan, you can expand your debugging superpowers
         with powerful collaboration features that make it easy to work together to fix bugs and
-        understand your software better.
+        understand your software better.{" "}
         <ExternalLink href="https://www.replay.io/pricing" className="text-primaryAccent underline">
           Learn More
         </ExternalLink>


### PR DESCRIPTION
This is a tiny change, I just noticed it on the billing page and thought this was a bad place for our copy to look unprofessional 😅 

Before
<img width="512" alt="CleanShot 2021-12-17 at 13 07 36@2x" src="https://user-images.githubusercontent.com/5903784/146595543-80fa0fd8-5790-44c3-b93b-bd32977df50e.png">


After
<img width="529" alt="CleanShot 2021-12-17 at 13 07 15@2x" src="https://user-images.githubusercontent.com/5903784/146595503-fd482af1-2a7a-43b9-ac0a-ad7971dd08bb.png">

