### PR TITLE
Standardize `why` field of test events

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -342,7 +342,7 @@ async function runTestViewer(path, local, timeout, env) {
       }
     }
 
-    sendTelemetryEvent("E2EFinished", { success: 0, local, why });
+    sendTelemetryEvent("E2EFinished", { success: 0, local, why: why.replace(/ts=[\d]+/, ""))
 
     failures.push(`Failed test: ${local} ${why}`);
     console.log(`[${elapsedTime()}] Test failed: ${why}`);


### PR DESCRIPTION
If we include the timestamp query parameter then each JS failure reason
looks like a different reason (because it's a slightly different string)
when in fact those failures are the same and should be grouped together.

### Before

`JavaScript error: http://localhost:8080/_next/static/chunks/pages/_app.js?ts=1639702137866 line 8003 > eval, line 225: Error: waitUntil() timed out waiting for inspector to initialize`

### After

`JavaScript error: http://localhost:8080/_next/static/chunks/pages/_app.js? line 8003 > eval, line 225: Error: waitUntil() timed out waiting for inspector to initialize`