### PR TITLE
Dont let the editor be hidden by the split panes

### DIFF
--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -241,7 +241,7 @@ class Debugger extends Component {
           endPanel={this.renderEndPane()}
           initialSize={prefs.sidePanelSize}
           maxSize={this.props.showEditor ? "80%" : "100%"}
-          minSize={this.props.showEditor ? "240px" : "100%"}
+          minSize={this.props.showEditor ? "200px" : "100%"}
           onControlledPanelResized={onResize}
           splitterSize={8}
           style={{ width: "100%", overflow: "hidden" }}

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/index.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/index.js
@@ -20,7 +20,6 @@ import {
   getFramesLoading,
 } from "../../selectors";
 
-import AccessibleImage from "../shared/AccessibleImage";
 import { prefs } from "../../utils/prefs";
 
 import LogpointsPane from "./LogpointsPane";
@@ -31,14 +30,6 @@ import CommandBar from "./CommandBar";
 import FrameTimeline from "./FrameTimeline";
 
 import Scopes from "./Scopes";
-
-function debugBtn(onClick, type, className, tooltip) {
-  return (
-    <button onClick={onClick} className={`${type} ${className}`} key={type} title={tooltip}>
-      <AccessibleImage className={type} title={tooltip} aria-label={tooltip} />
-    </button>
-  );
-}
 
 const mdnLink =
   "https://developer.mozilla.org/docs/Tools/Debugger/Using_the_Debugger_map_scopes_feature?utm_source=devtools&utm_medium=debugger-map-scopes";

--- a/src/ui/components/Views/NonDevView.tsx
+++ b/src/ui/components/Views/NonDevView.tsx
@@ -9,7 +9,6 @@ import SidePanel from "ui/components/SidePanel";
 import EventListeners from "devtools/client/debugger/src/components/SecondaryPanes/EventListeners";
 import Dropdown from "ui/components/shared/Dropdown";
 
-import { updateTimelineDimensions } from "../../actions/timeline";
 import { prefs } from "../../utils/prefs";
 import { selectors } from "../../reducers";
 import { UIState } from "ui/state";
@@ -33,7 +32,7 @@ export function EventsFilter() {
   );
 }
 
-function NonDevView({ updateTimelineDimensions, sidePanelCollapsed }: PropsFromRedux) {
+function NonDevView({ sidePanelCollapsed }: PropsFromRedux) {
   const viewer = (
     <div className="vertical-panels">
       <Video />
@@ -41,7 +40,6 @@ function NonDevView({ updateTimelineDimensions, sidePanelCollapsed }: PropsFromR
   );
 
   const handleMove = (size: number) => {
-    updateTimelineDimensions();
     prefs.sidePanelSize = `${size}px`;
   };
 
@@ -66,15 +64,10 @@ function NonDevView({ updateTimelineDimensions, sidePanelCollapsed }: PropsFromR
   );
 }
 
-const connector = connect(
-  (state: UIState) => ({
-    selectedPrimaryPanel: selectors.getSelectedPrimaryPanel(state),
-    sidePanelCollapsed: selectors.getPaneCollapse(state),
-  }),
-  {
-    updateTimelineDimensions,
-  }
-);
+const connector = connect((state: UIState) => ({
+  selectedPrimaryPanel: selectors.getSelectedPrimaryPanel(state),
+  sidePanelCollapsed: selectors.getPaneCollapse(state),
+}));
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 export default connector(NonDevView);

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -9,7 +9,7 @@ pref("devtools.selected-panel", "console");
 pref("devtools.user", "{}");
 pref("devtools.recording-id", "");
 pref("devtools.event-listeners-breakpoints", true);
-pref("devtools.toolbox-height", "50%");
+pref("devtools.toolbox-size", "50%");
 pref("devtools.view-mode", "non-dev");
 pref("devtools.dev-secondary-panel-height", "375px");
 pref("devtools.sidePanelSize", "240px");
@@ -46,7 +46,7 @@ export const prefs = new PrefsHelper("devtools", {
   user: ["Json", "user"],
   recordingId: ["Json", "recording-id"],
   eventListenersBreakpoints: ["Bool", "event-listeners-breakpoints"],
-  toolboxHeight: ["String", "toolbox-height"],
+  toolboxSize: ["String", "toolbox-size"],
   viewMode: ["String", "view-mode"],
   secondaryPanelHeight: ["String", "dev-secondary-panel-height"],
   maxHitsDisplayed: ["Int", "maxHitsDisplayed"],


### PR DESCRIPTION
Previously it was possible to slide the devview splitpane so far that it would hide the editor which was especially problematic on refresh.

* also removes some calls to updateTimelineDimensions which are no longer needed.
* also renames toolboxHeight to toolboxSize

There is still an issue resizes the sidebar when the editor is hidden
