### PR TITLE
Small visual updates

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.css
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.css
@@ -4,6 +4,7 @@
   animation: static-tooltip 200ms ease;
   opacity: 0;
   animation-fill-mode: forwards;
+  font-size: var(--theme-body-font-size);
   min-width: 42px; /* Reduces jitter between loading state (...) and non-loading state (3 hits) */
   pointer-events: none;
 }
@@ -28,7 +29,7 @@
 }
 
 .static-tooltip.hot .material-icons {
-  font-size: 16px;
+  font-size: var(--theme-body-font-size);
   color: white;
   margin-right: 4px;
 }

--- a/src/devtools/client/debugger/src/components/Editor/Tabs.css
+++ b/src/devtools/client/debugger/src/components/Editor/Tabs.css
@@ -44,7 +44,7 @@
   padding: 4px 10px;
   cursor: default;
   height: var(--editor-header-height);
-  font-size: 15px;
+  font-size: var(--theme-tab-font-size);
   background-color: transparent;
   vertical-align: bottom;
 }

--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -36,6 +36,18 @@
   font-family: Inter, sans-serif;
 }
 
+.theme-body-font-size {
+  font-size: var(--theme-body-font-size);
+}
+
+.theme-code-font-size {
+  font-size: var(--theme-code-font-size);
+}
+
+.theme-tab-font-size {
+  font-size: var(--theme-tab-font-size);
+}
+
 /**
   * Customize the dark theme's scrollbar colors to avoid excessive contrast.
   */

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -11,6 +11,7 @@
   --devtools-base-font-size: 12px;
   --theme-body-font-size: 12px;
   --theme-code-font-size: 11px;
+  --theme-tab-font-size: 15px;
   --theme-code-line-height: calc(15 / 11);
 
   /* Toolbar size (excluding borders) */

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -46,7 +46,7 @@ function PanelButtons({
   };
 
   return (
-    <div className="flex flex-row items-center overflow-hidden text-sm">
+    <div className="flex flex-row items-center overflow-hidden theme-tab-font-size">
       {showElements && !isNode && <NodePicker />}
       <button
         className={classnames("console-panel-button", {

--- a/src/ui/components/shared/Login/Login.tsx
+++ b/src/ui/components/shared/Login/Login.tsx
@@ -44,7 +44,7 @@ export default function Login() {
           )}
         </div>
         <PrimaryLgButton color="blue" onClick={onLogin} className="w-full justify-center">
-          {isTeamMemberInvite() ? "Sign in with Google" : "Login"}
+          {isTeamMemberInvite() ? "Sign in with Google" : "Log in"}
         </PrimaryLgButton>
       </OnboardingContentWrapper>
     </OnboardingModalContainer>

--- a/src/ui/components/shared/UserSettingsModal/PreferencesSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/PreferencesSettings.tsx
@@ -91,7 +91,7 @@ function PrivacyPreferences() {
             disabled={loading}
             onChange={ev => toggle(ev.currentTarget.checked)}
           />
-          <div>Disable LogRocket Session Replay</div>
+          <div>Disable LogRocket session replay</div>
         </label>
       </div>
     </div>


### PR DESCRIPTION
A series of small, uncontroversial changes:

1. Changed "Login" to "Log in" -- it's a verb, not a noun
2. Changed a string to sentence case to align to our styleguide
3. Standardised tab size with a CSS variable