### PR TITLE
Hide 'Move to' when no other workspaces

### DIFF
--- a/src/ui/components/Library/MoveRecordingMenu.tsx
+++ b/src/ui/components/Library/MoveRecordingMenu.tsx
@@ -19,7 +19,14 @@ function MoveRecordingMenu({
   workspaces,
 }: RecordingOptionsDropdownProps) {
   const { workspace, loading } = hooks.useGetWorkspace(currentWorkspaceId || "");
-  if (loading || (workspace && (!workspace?.subscription || subscriptionExpired(workspace))))
+
+  const availableWorkspaces = workspaces.filter(w => w.id !== currentWorkspaceId);
+
+  if (
+    availableWorkspaces.length === 0 ||
+    loading ||
+    (workspace && (!workspace?.subscription || subscriptionExpired(workspace)))
+  )
     return null;
 
   return (
@@ -30,13 +37,11 @@ function MoveRecordingMenu({
         {currentWorkspaceId !== null ? (
           <DropdownItem onClick={() => onMoveRecording(null)}>Your library</DropdownItem>
         ) : null}
-        {workspaces
-          .filter(w => w.id !== currentWorkspaceId)
-          .map(({ id, name }) => (
-            <DropdownItem onClick={() => onMoveRecording(id)} key={id}>
-              {name}
-            </DropdownItem>
-          ))}
+        {availableWorkspaces.map(({ id, name }) => (
+          <DropdownItem onClick={() => onMoveRecording(id)} key={id}>
+            {name}
+          </DropdownItem>
+        ))}
       </div>
     </>
   );


### PR DESCRIPTION
Small maintenance to hide "Move to" when there are no other workspaces available (noticed it along the way).

Before:

<img width="1047" alt="Screenshot 2021-12-20 at 11 35 12 AM" src="https://user-images.githubusercontent.com/1355455/146754022-bab1dc2c-4b6b-47e9-ade6-715d00723c4b.png">

After:

<img width="1056" alt="Screenshot 2021-12-20 at 11 35 24 AM" src="https://user-images.githubusercontent.com/1355455/146754005-9d56c2ba-8018-48b1-b62b-92e61ee92627.png">