### PR TITLE
Remove splitConsole references

### DIFF
--- a/src/devtools/client/debugger/assets/dictionary.txt
+++ b/src/devtools/client/debugger/assets/dictionary.txt
@@ -101,7 +101,6 @@ HighlightLine
 isMinified
 setInScopeLines
 updateScopeBindings
-getSplitConsole
 wasmparser
 getSymbols
 codefolding

--- a/src/devtools/client/debugger/test/mochitest/.eslintrc
+++ b/src/devtools/client/debugger/test/mochitest/.eslintrc
@@ -44,7 +44,6 @@
     "getContext": false,
     "getEditorLineGutter": false,
     "getCM": false,
-    "getDebuggerSplitConsole": false,
     "hasConsoleMessage": false,
     "findConsoleMessage": false,
     "promise": false,

--- a/src/devtools/client/locales/en-us/toolbox.properties
+++ b/src/devtools/client/locales/en-us/toolbox.properties
@@ -147,13 +147,6 @@ toolbox.meatballMenu.dock.left.label=Dock to Left
 toolbox.meatballMenu.dock.right.label=Dock to Right
 toolbox.meatballMenu.dock.separateWindow.label=Separate Window
 
-# LOCALIZATION NOTE (toolbox.meatballMenu.{splitconsole,hideconsole}.label):
-# These are the labels in the "..." menu in the toolbox for toggling the split
-# console window.
-# The keyboard shortcut will be shown to the side of the label.
-toolbox.meatballMenu.splitconsole.label=Show Split Console
-toolbox.meatballMenu.hideconsole.label=Hide Split Console
-
 # LOCALIZATION NOTE (toolbox.meatballMenu.noautohide.label): This is the label
 # in the "..." menu in the toolbox to force the popups/panels to stay visible on
 # blur.

--- a/src/devtools/client/locales/en-us/webconsole.properties
+++ b/src/devtools/client/locales/en-us/webconsole.properties
@@ -265,10 +265,6 @@ browserconsole.contentMessagesCheckbox.tooltip=Enable this to display messages f
 # Parameters: %S is the new URL.
 webconsole.navigated=Navigated to %S
 
-# LOCALIZATION NOTE (webconsole.closeSplitConsoleButton.tooltip): This is the tooltip for
-# the close button of the split console.
-webconsole.closeSplitConsoleButton.tooltip=Close Split Console (Esc)
-
 # LOCALIZATION NOTE (webconsole.closeSidebarButton.tooltip): This is the tooltip for
 # the close button of the sidebar.
 webconsole.closeSidebarButton.tooltip=Close Sidebar

--- a/src/devtools/client/webconsole/actions/toolbox.js
+++ b/src/devtools/client/webconsole/actions/toolbox.js
@@ -72,9 +72,3 @@ export function onViewSourceInDebugger(frame) {
     toolbox.viewSourceInDebugger(frame.url, frame.line, frame.column, frame.sourceId);
   };
 }
-
-export function closeSplitConsole() {
-  return ({ toolbox }) => {
-    toolbox.toggleSplitConsole(false);
-  };
-}

--- a/src/devtools/client/webconsole/components/FilterBar/FilterBar.js
+++ b/src/devtools/client/webconsole/components/FilterBar/FilterBar.js
@@ -252,7 +252,6 @@ function mapStateToProps(state) {
 }
 
 export default connect(mapStateToProps, {
-  closeSplitConsole: actions.closeSplitConsole,
   filterBarDisplayModeSet: actions.filterBarDisplayModeSet,
   messagesClearEvaluations: actions.messagesClearEvaluations,
   filterTextSet: actions.filterTextSet,

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -47,7 +47,6 @@ export type SetLoadingFinishedAction = Action<"set_loading_finished"> & { finish
 export type IndexingAction = Action<"indexing"> & { indexing: number };
 export type SetSessionIdAction = Action<"set_session_id"> & { sessionId: SessionId };
 export type UpdateThemeAction = Action<"update_theme"> & { theme: string };
-export type SetSplitConsoleAction = Action<"set_split_console"> & { splitConsole: boolean };
 export type SetSelectedPanelAction = Action<"set_selected_panel"> & { panel: PanelName };
 export type SetSelectedPrimaryPanelAction = Action<"set_selected_primary_panel"> & {
   panel: PrimaryPanelName;
@@ -114,7 +113,6 @@ export type AppActions =
   | IndexingAction
   | SetSessionIdAction
   | UpdateThemeAction
-  | SetSplitConsoleAction
   | SetSelectedPanelAction
   | SetSelectedPrimaryPanelAction
   | SetInitializedPanelsAction
@@ -256,10 +254,6 @@ function setIndexing(indexing: number): IndexingAction {
 
 export function updateTheme(theme: string): UpdateThemeAction {
   return { type: "update_theme", theme };
-}
-
-export function setSplitConsole(open: boolean): SetSplitConsoleAction {
-  return { type: "set_split_console", splitConsole: open };
 }
 
 export function setSelectedPanel(panel: PanelName): SetSelectedPanelAction {

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -16,7 +16,6 @@ const syncInitialAppState: AppState = {
   unexpectedError: null,
   trialExpired: false,
   theme: "theme-light",
-  splitConsoleOpen: prefs.splitConsole as boolean,
   selectedPanel: prefs.selectedPanel as PanelName,
   selectedPrimaryPanel: "comments",
   initializedPanels: [],
@@ -132,10 +131,6 @@ export default function update(
 
     case "set_initialized_panels": {
       return { ...state, initializedPanels: [...state.initializedPanels, action.panel] };
-    }
-
-    case "set_split_console": {
-      return { ...state, splitConsoleOpen: action.splitConsole };
     }
 
     case "loading": {
@@ -266,7 +261,6 @@ export default function update(
 }
 
 export const getTheme = (state: UIState) => state.app.theme;
-export const isSplitConsoleOpen = (state: UIState) => state.app.splitConsoleOpen;
 export const getSelectedPanel = (state: UIState) => state.app.selectedPanel;
 export const isInspectorSelected = (state: UIState) =>
   getViewMode(state) === "dev" && getSelectedPanel(state) == "inspector";

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -7,7 +7,6 @@ import {
   getShowEditor,
   getShowVideoPanel,
   getViewMode,
-  isSplitConsoleOpen,
 } from "ui/reducers/app";
 import { getRecordingId } from "ui/utils/environment";
 import { ViewMode } from "ui/state/app";
@@ -46,7 +45,6 @@ export function updatePrefs(state: UIState, oldState: UIState) {
   }
 
   updatePref("viewMode", getViewMode);
-  updatePref("splitConsole", isSplitConsoleOpen);
   updatePref("selectedPanel", getSelectedPanel);
   updateAsyncPref("eventListenerBreakpoints", (state: UIState) => state.eventListenerBreakpoints);
   updateAsyncPref("commandHistory", (state: UIState) => state.messages?.commandHistory);

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -98,7 +98,6 @@ export interface AppState {
   sessionId: SessionId | null;
   showEditor: boolean;
   showVideoPanel: boolean;
-  splitConsoleOpen: boolean;
   theme: string;
   trialExpired: boolean;
   unexpectedError: UnexpectedError | null;

--- a/src/ui/utils/devtools-toolbox.ts
+++ b/src/ui/utils/devtools-toolbox.ts
@@ -117,10 +117,6 @@ export class DevToolsToolbox {
     return panel;
   }
 
-  toggleSplitConsole(open: boolean) {
-    store.dispatch(actions.setSplitConsole(open));
-  }
-
   async viewSourceInDebugger(
     url: string | undefined,
     line: number | undefined,

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -42,7 +42,6 @@ pref("devtools.features.widgetHover", false);
 pref("devtools.features.commentAttachments", false);
 
 export const prefs = new PrefsHelper("devtools", {
-  splitConsole: ["Bool", "split-console"],
   selectedPanel: ["String", "selected-panel"],
   user: ["Json", "user"],
   recordingId: ["Json", "recording-id"],


### PR DESCRIPTION
This removes a bunch of splitConsole related stuff that we used to care about while devtools was part of the browser, but is irrelevant now.