### PR TITLE
Set the comments panel as the default if there is a comment

### DIFF
--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -10,6 +10,14 @@ import { UIState } from "ui/state";
 import LoadingTip from "./LoadingTip";
 import { BubbleViewportWrapper } from "./Viewport";
 
+export function StaticLoadingScreen() {
+  return (
+    <LoadingScreenTemplate>
+      <div className="w-56 h-1"></div>
+    </LoadingScreenTemplate>
+  );
+}
+
 export function LoadingScreenTemplate({
   children,
   showTips,

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -24,6 +24,9 @@ export const GET_RECORDING = gql`
       ownerNeedsInvite
       userRole
       operations
+      comments {
+        id
+      }
       owner {
         id
         name

--- a/src/ui/setup/helpers.ts
+++ b/src/ui/setup/helpers.ts
@@ -13,6 +13,7 @@ declare global {
     dumpPrefs: () => string;
     local: () => void;
     prod: () => void;
+    clearIndexedDB: () => void;
   }
 }
 
@@ -39,6 +40,10 @@ export function setupAppHelper(store: UIStore) {
       } else {
         window.location.href = "https://app.replay.io/";
       }
+    },
+    clearIndexedDB: async () => {
+      const databases = await indexedDB.databases();
+      databases.map(db => db.name && indexedDB.deleteDatabase(db.name));
     },
   };
 }

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -36,7 +36,6 @@ export async function bootstrapApp() {
   if (typeof window === "undefined") return store;
 
   setupTelemetry();
-
   setupDOMHelpers();
 
   window.store = store;

--- a/src/ui/utils/apolloClient.tsx
+++ b/src/ui/utils/apolloClient.tsx
@@ -17,7 +17,7 @@ import { RetryLink } from "@apollo/client/link/retry";
 import { isTest, isMock, waitForMockEnvironment } from "ui/utils/environment";
 import useToken from "ui/utils/useToken";
 import { PopupBlockedError } from "ui/components/shared/Error";
-import LoadingScreen from "ui/components/shared/LoadingScreen";
+import { StaticLoadingScreen } from "ui/components/shared/LoadingScreen";
 
 const clientWaiter = defer<ApolloClient<NormalizedCacheObject>>();
 
@@ -54,7 +54,7 @@ export function ApolloWrapper({ children }: { children: ReactNode }) {
   }
 
   if (!isTest() && loading) {
-    return <LoadingScreen />;
+    return <StaticLoadingScreen />;
   }
 
   if (error) {

--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -62,7 +62,7 @@ class TokenManager {
         domain={domain}
         clientId={clientId}
         audience={audience}
-        redirectUri={window.location.origin}
+        redirectUri={typeof window === "undefined" ? undefined : window.location.origin}
         onRedirectCallback={onRedirectCallback}
         cacheLocation="localstorage"
         prompt="select_account"


### PR DESCRIPTION
Fix #4687.

This is the second part for https://github.com/RecordReplay/devtools/pull/4904.

This changes how we render the app so that we have access to things provided by `AppUtilities` (e.g. apollo client). This means that by the time we can use queries as we bootstrap the store.

Behavior:
1) User's first time viewing replay A and there's no comment: Show Events/Replay Info
2) User's first time viewing replay A and there's a comment: Show Comments
3) User's n-th time viewing replay A: Show last panel they were on

https://user-images.githubusercontent.com/15959269/147260709-1f70c9c7-5b30-45c4-9bfd-cdf3fe0e2eb4.mov
