### PR TITLE
Preview tooltips

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Preview.css
+++ b/src/devtools/client/debugger/src/components/Editor/Preview.css
@@ -82,32 +82,3 @@
   height: 4px;
   padding-top: 4px;
 }
-
-.add-to-expression-bar {
-  border: 1px solid var(--theme-splitter-color);
-  border-top: none;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-size: 14px;
-  line-height: 30px;
-  background: var(--theme-toolbar-background);
-  color: var(--theme-text-color-inactive);
-  padding: 0 4px;
-}
-
-.add-to-expression-bar .prompt {
-  width: 1em;
-}
-
-.add-to-expression-bar .expression-to-save-label {
-  width: calc(100% - 4em);
-}
-
-.add-to-expression-bar .expression-to-save-button {
-  font-size: 14px;
-  color: var(--theme-comment);
-}

--- a/src/devtools/client/debugger/src/components/Editor/Preview/Popup.css
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/Popup.css
@@ -86,14 +86,15 @@
 .tooltip {
   position: fixed;
   z-index: 100;
+  font-size: 12px;
 }
 
 .tooltip .preview-popup {
-  background: var(--theme-toolbar-background);
+  background: var(--toolbox-background);
   max-width: inherit;
   min-height: 80px;
   border: 1px solid var(--theme-splitter-color);
-  box-shadow: 1px 2px 4px 1px var(--theme-toolbar-background-alt);
+  border-radius: 4px;
   padding: 5px;
   height: auto;
   min-height: inherit;
@@ -108,33 +109,4 @@
 .tooltip .gap {
   height: 4px;
   padding-top: 0px;
-}
-
-.add-to-expression-bar {
-  border: 1px solid var(--theme-splitter-color);
-  border-top: none;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-size: 14px;
-  line-height: 30px;
-  background: var(--theme-toolbar-background);
-  color: var(--theme-text-color-inactive);
-  padding: 0 4px;
-}
-
-.add-to-expression-bar .prompt {
-  width: 1em;
-}
-
-.add-to-expression-bar .expression-to-save-label {
-  width: calc(100% - 4em);
-}
-
-.add-to-expression-bar .expression-to-save-button {
-  font-size: 14px;
-  color: var(--theme-comment);
 }

--- a/src/devtools/client/debugger/src/components/Editor/Preview/Popup.js
+++ b/src/devtools/client/debugger/src/components/Editor/Preview/Popup.js
@@ -5,9 +5,12 @@
 //
 
 import React, { Component } from "react";
-import { connect } from "../../../utils/connect";
-
+import { connect } from "devtools/client/debugger/src/utils/connect";
 import Reps from "devtools/packages/devtools-reps";
+import actions from "devtools/client/debugger/src/actions";
+import { getThreadContext } from "devtools/client/debugger/src/selectors";
+import Popover from "../../shared/Popover";
+import PreviewFunction from "../../shared/PreviewFunction";
 
 const {
   REPS: { Rep },
@@ -22,20 +25,7 @@ const {
   node: { nodeIsPrimitive, nodeIsFunction, nodeIsObject },
 } = utils;
 
-import actions from "../../../actions";
-import { getThreadContext } from "../../../selectors";
-import Popover from "../../shared/Popover";
-import PreviewFunction from "../../shared/PreviewFunction";
-
 export class Popup extends Component {
-  marker;
-  pos;
-  popover;
-
-  constructor(props) {
-    super(props);
-  }
-
   calculateMaxHeight = () => {
     const { editorRef } = this.props;
     if (!editorRef) {

--- a/src/devtools/client/debugger/src/components/shared/Popover.css
+++ b/src/devtools/client/debugger/src/components/shared/Popover.css
@@ -26,7 +26,3 @@
 .popover:not(.orientation-right) .preview-popup {
   margin-left: var(--left-offset);
 }
-
-.popover .add-to-expression-bar {
-  margin-left: var(--left-offset);
-}

--- a/src/devtools/client/debugger/src/components/shared/Popover.js
+++ b/src/devtools/client/debugger/src/components/shared/Popover.js
@@ -4,6 +4,8 @@
 
 //
 import React, { Component } from "react";
+import ReactDOM from "react-dom";
+
 import classNames from "classnames";
 import BracketArrow from "./BracketArrow";
 import SmartGap from "./SmartGap";
@@ -258,7 +260,7 @@ class Popover extends Component {
     return (
       <div
         className={classNames("tooltip", `orientation-${orientation}`)}
-        style={{ top, left }}
+        style={{ top, left, zIndex: 20 }}
         ref={c => (this.$tooltip = c)}
       >
         {this.getChildren()}
@@ -269,11 +271,10 @@ class Popover extends Component {
   render() {
     const { type } = this.props;
 
-    if (type === "tooltip") {
-      return this.renderTooltip();
-    }
-
-    return this.renderPopover();
+    return ReactDOM.createPortal(
+      type === "tooltip" ? this.renderTooltip() : this.renderPopover(),
+      document.body
+    );
   }
 }
 


### PR DESCRIPTION
Fixes a small issue where the preview tooltip is clipped by the line number tooltip because the line number tooltip is rendered in the document body

<img width="227" alt="Screen Shot 2021-12-27 at 8 40 42 AM" src="https://user-images.githubusercontent.com/254562/147503559-e8cc4fe6-ed9f-4f98-ab18-bedbbeb43f01.png">
