### PR TITLE
Use google's favicon api for fetching favicons

### DIFF
--- a/src/ui/components/UploadScreen/Privacy.tsx
+++ b/src/ui/components/UploadScreen/Privacy.tsx
@@ -44,13 +44,13 @@ export function ToggleShowPrivacyButton({
 
 function FavIcon({ url }: { url: string }) {
   return (
-    <div className="h-5 w-5 relative">
-      <MaterialIcon className="leading-5 relative" iconSize="xl">
-        public
-      </MaterialIcon>
+    <div className="relative">
+      <div className="flex">
+        <MaterialIcon>public</MaterialIcon>
+      </div>
       <img
-        className="h-5 w-5 absolute top-0 left-0 bg-white"
-        src={`https://api.faviconkit.com/${url}`}
+        className="h-4 w-4 absolute top-0 left-0 bg-white"
+        src={`https://www.google.com/s2/favicons?domain=${url}`}
       />
     </div>
   );


### PR DESCRIPTION
We used to use https://faviconkit.com/ for displaying favicons in the privacy panel where we have a list of domains. That API's no longer maintained, so this switches us to using Google's favicon api instead in the meantime.