### PR TITLE
Fix command palette v1 bugs

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -28,7 +28,7 @@ import { Workspace } from "ui/types";
 import { client, sendMessage } from "protocol/socket";
 import groupBy from "lodash/groupBy";
 import { compareBigInt } from "ui/utils/helpers";
-import { isTest } from "ui/utils/environment";
+import { getRecordingId, isTest } from "ui/utils/environment";
 import tokenManager from "ui/utils/tokenManager";
 import { asyncStore } from "ui/utils/prefs";
 import {
@@ -369,6 +369,8 @@ export function setLoadingPageTipIndex(index: number): SetLoadingPageTipIndexAct
 
 export function executeCommand(key: CommandKey): UIThunkAction {
   return ({ dispatch }) => {
+    const recordingId = getRecordingId();
+
     if (key === "open_viewer") {
       dispatch(setViewMode("non-dev"));
     } else if (key === "open_devtools") {
@@ -385,10 +387,11 @@ export function executeCommand(key: CommandKey): UIThunkAction {
     } else if (key === "open_console") {
       dispatch(setViewMode("dev"));
       dispatch(setSelectedPanel("console"));
+      window.jsterm.focus();
     } else if (key === "show_privacy") {
       dispatch(setModal("privacy"));
     } else if (key === "show_sharing") {
-      dispatch(setModal("sharing"));
+      dispatch(setModal("sharing", { recordingId }));
     }
 
     dispatch(hideCommandPalette());

--- a/src/ui/components/CommandPalette/CommandButton.tsx
+++ b/src/ui/components/CommandPalette/CommandButton.tsx
@@ -1,5 +1,5 @@
 import { formatKeyShortcut } from "devtools/client/debugger/src/utils/text";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
 import { Command } from "./CommandPalette";
@@ -7,6 +7,7 @@ import { Command } from "./CommandPalette";
 type CommandButtonProps = PropsFromRedux & { command: Command; active: boolean };
 
 function CommandButton({ command, executeCommand, active }: CommandButtonProps) {
+  const buttonNode = useRef<HTMLButtonElement | null>(null);
   const { label, shortcut, key } = command;
   const onClick = () => {
     executeCommand(key);
@@ -14,11 +15,18 @@ function CommandButton({ command, executeCommand, active }: CommandButtonProps) 
 
   const bgColors = active ? "bg-primaryAccent text-white" : "hover:bg-gray-200";
 
+  useEffect(() => {
+    if (active && buttonNode.current) {
+      buttonNode.current.scrollIntoView({ block: "nearest" });
+    }
+  }, [active]);
+
   return (
     <button
       key={label}
       onClick={onClick}
       className={`${bgColors} px-4 py-1 flex  justify-between transition`}
+      ref={buttonNode}
     >
       <div>{label}</div>
       {shortcut ? (

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -11,6 +11,7 @@ declare global {
   var __IS_RECORD_REPLAY_RUNTIME__: boolean;
   interface Window {
     mockEnvironment?: MockEnvironment;
+    jsterm: any;
   }
 }
 


### PR DESCRIPTION
Fix #4819.

This PR does the following:
- Focuses the console terminal for the `Open Console` action.
- Fixes the `Show Sharing Options` action so it actually opens properly.
- Scrolls the currently active command into view when moving through with up/down.