### PR TITLE
Use graphql api for user data instead of auth0

### DIFF
--- a/src/ui/components/Library/SidebarFooter.tsx
+++ b/src/ui/components/Library/SidebarFooter.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import useAuth0 from "ui/utils/useAuth0";
 import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
 import { AvatarImage } from "../Avatar";
+import { useGetUserInfo } from "ui/hooks/users";
 
 function SidebarFooter({ setModal }: PropsFromRedux) {
-  const { user } = useAuth0();
-  const { name, picture } = user || { name: "", picture: "" };
+  const { name, picture } = useGetUserInfo();
 
   const handleSettingsClick = () => {
     setModal("settings");

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 
-import { updateEnableRepaint } from "protocol/enable-repaint";
+import { AvatarImage } from "ui/components/Avatar";
 import { handleIntercomLogout } from "ui/utils/intercom";
 import useAuth0 from "ui/utils/useAuth0";
 import hooks from "ui/hooks";
@@ -9,17 +9,16 @@ import * as actions from "ui/actions/app";
 import * as selectors from "ui/reducers/app";
 import { UIState } from "ui/state";
 import { SettingsTabTitle } from "ui/state/app";
-import { ApiKey, CombinedUserSettings, UserSettings } from "ui/types";
+import { useGetUserInfo } from "ui/hooks/users";
+import { getFeatureFlag } from "ui/utils/launchdarkly";
 
 import APIKeys from "../APIKeys";
+import ExternalLink from "../ExternalLink";
 import SettingsModal from "../SettingsModal";
 import { Settings } from "../SettingsModal/types";
 import { SettingsBodyHeader } from "../SettingsModal/SettingsBody";
 
-import { getFeatureFlag } from "ui/utils/launchdarkly";
-import { AvatarImage } from "ui/components/Avatar";
 import PreferencesSettings from "./PreferencesSettings";
-import ExternalLink from "../ExternalLink";
 import ExperimentalSettings from "./ExperimentalSettings";
 
 function Support() {
@@ -49,8 +48,8 @@ function Support() {
 }
 
 function Personal() {
-  const { logout, user } = useAuth0();
-  const { name, picture, email } = user || {};
+  const { logout } = useAuth0();
+  const { name, email, picture } = useGetUserInfo();
 
   return (
     <div className="space-y-12">

--- a/src/ui/graphql/users.ts
+++ b/src/ui/graphql/users.ts
@@ -12,6 +12,8 @@ export const GET_USER_INFO = gql`
   query GetUser {
     viewer {
       user {
+        name
+        picture
         id
       }
       motd

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -40,6 +40,8 @@ export function useUserIsAuthor() {
 export type UserInfo = {
   motd: string | null;
   acceptedTOSVersion: number | null;
+  name: string;
+  picture: string;
   email: string;
   id: string;
   internal: boolean;
@@ -86,6 +88,8 @@ export async function getUserInfo(): Promise<UserInfo | undefined> {
     return undefined;
   }
   return {
+    name: viewer.user.name,
+    picture: viewer.user.picture,
     motd: viewer.motd,
     acceptedTOSVersion: viewer.acceptedTOSVersion,
     email: viewer.email,
@@ -105,6 +109,8 @@ export function useGetUserInfo(): UserInfo & { loading: boolean } {
   }
 
   const id: string = data?.viewer?.user.id;
+  const picture: string = data?.viewer?.user.picture;
+  const name: string = data?.viewer?.user.name;
   const email: string = data?.viewer?.email;
   const internal: boolean = data?.viewer?.internal;
   const nags: Nag[] = data?.viewer?.nags;
@@ -117,6 +123,8 @@ export function useGetUserInfo(): UserInfo & { loading: boolean } {
     loading,
     id,
     email,
+    picture,
+    name,
     internal,
     nags,
     acceptedTOSVersion,


### PR DESCRIPTION
## Issue

We're currently pulling email, name, and picture from auth0 to display in the footer and in the user settings modal but this data isn't available for API key based auth or the upcoming Replay browser-injected auth.

## Resolution

* Add `name` and `picture` to the user info graphql query
* Use the user info query instead of auth0 for those data elements