### PR TITLE
Use new env variable for app url

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,6 @@ NEXT_PUBLIC_API_URL=https://api.replay.io/v1/graphql
 # Configures the dispatcher websocket endpoint
 NEXT_PUBLIC_DISPATCH_URL=wss://dispatch.replay.io
 # Configures the host in local environments. Will be populated by Vercel in deployments
-NEXT_PUBLIC_VERCEL_URL=http://localhost:8080
+NEXT_PUBLIC_APP_URL=http://localhost:8080
 # API Key to execute privileged requests to the backend
 FRONTEND_API_SECRET=

--- a/pages/api/browser/auth.ts
+++ b/pages/api/browser/auth.ts
@@ -2,6 +2,8 @@ import cookie from "cookie";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const getQueryValue = (query: string | string[]) => (Array.isArray(query) ? query[0] : query);
+const getAppUrl = (path: string) =>
+  `${process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_VERCEL_URL}${path}`;
 
 async function initAuthRequest(key: string) {
   const api = process.env.NEXT_PUBLIC_API_URL;
@@ -52,7 +54,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
   try {
     const clientId = "4FvFnJJW4XlnUyrXQF8zOLw6vNAH1MAo";
-    const redirectUri = `${process.env.NEXT_PUBLIC_VERCEL_URL}/api/browser/callback`;
+    const redirectUri = getAppUrl("/api/browser/callback");
     const { id, challenge, serverKey } = await initAuthRequest(key);
     const url = `https://webreplay.us.auth0.com/authorize?response_type=code&code_challenge_method=S256&code_challenge=${challenge}&client_id=${clientId}&redirect_uri=${redirectUri}&scope=openid profile offline_access&state=${id}&audience=https://api.replay.io`;
 

--- a/pages/api/browser/callback.ts
+++ b/pages/api/browser/callback.ts
@@ -1,4 +1,3 @@
-import cookie from "cookie";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 interface Token {
@@ -10,6 +9,8 @@ interface Token {
 }
 
 const getQueryValue = (query: string | string[]) => (Array.isArray(query) ? query[0] : query);
+const getAppUrl = (path: string) =>
+  `${process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_VERCEL_URL}${path}`;
 
 async function fulfillAuthRequest(id: string, token: string) {
   const api = process.env.NEXT_PUBLIC_API_URL;
@@ -63,7 +64,7 @@ async function fetchToken(code: string, verifier: string): Promise<Token> {
       scope: "openid profile offline_access",
       code_verifier: verifier,
       code,
-      redirect_uri: `${process.env.NEXT_PUBLIC_VERCEL_URL}/api/browser/callback`,
+      redirect_uri: getAppUrl("/api/browser/callback"),
     }),
   });
 


### PR DESCRIPTION
## Issue

The auth redirect is failing because `NEXT_PUBLIC_VERCEL_URL` is resolving to the `vercel.app` URL in prod rather than app.replay.io

## Resolution

Add a new environment variable (already configured in vercel) to point to our app domain so it can be used in prod.

## Notes

The preview branches should continue to use `NEXT_PUBLIC_VERCEL_URL` so the new env variable is only defined for prod.