### PR TITLE
Add telemetry to auth API routes

### DIFF
--- a/pages/api/browser/auth.ts
+++ b/pages/api/browser/auth.ts
@@ -1,5 +1,6 @@
 import cookie from "cookie";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { pingTelemetry } from "ui/utils/replay-telemetry";
 
 const getQueryValue = (query: string | string[]) => (Array.isArray(query) ? query[0] : query);
 const getAppUrl = (path: string) =>
@@ -46,7 +47,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const key = getQueryValue(req.query.key);
   if (!key) {
     res.statusCode = 400;
-    res.statusMessage = "Missing key parameter";
+    res.statusMessage = "Missing parameter";
     res.send("");
 
     return;
@@ -69,8 +70,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     );
     res.redirect(url);
   } catch (e: any) {
+    console.error(e);
+
+    pingTelemetry("devtools-api-browser-auth", { error: e.message });
+
     res.statusCode = 500;
-    res.statusMessage = e.message;
     res.send("");
   }
 };

--- a/pages/api/browser/callback.ts
+++ b/pages/api/browser/callback.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { pingTelemetry } from "ui/utils/replay-telemetry";
 
 interface Token {
   access_token: string;
@@ -101,8 +102,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     res.redirect("/browser/auth");
   } catch (e: any) {
+    console.error(e);
+
+    pingTelemetry("devtools-api-browser-callback", { error: e.message });
+
     res.statusCode = 500;
-    res.statusMessage = e.message;
     res.send("");
   }
 };

--- a/src/ui/utils/replay-telemetry.ts
+++ b/src/ui/utils/replay-telemetry.ts
@@ -1,0 +1,16 @@
+export async function pingTelemetry(event: string, tags: any = {}) {
+  try {
+    const response = await fetch("https://telemetry.replay.io/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ event, ...tags }),
+    });
+    if (!response.ok) {
+      console.error(`Sent telemetry event ${event} but got status code ${response.status}`);
+    }
+  } catch (e) {
+    console.error(`Couldn't send telemetry event ${event}`, e);
+  }
+}

--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -4,6 +4,7 @@ import { skipTelemetry } from "./environment";
 import { Recording, Workspace } from "ui/types";
 import { prefs } from "./prefs";
 import { initializeMixpanel, trackMixpanelEvent } from "./mixpanel";
+import { pingTelemetry } from "./replay-telemetry";
 
 const timings: Record<string, number> = {};
 
@@ -75,20 +76,7 @@ export async function sendTelemetryEvent(event: string, tags: any = {}) {
     return;
   }
 
-  try {
-    const response = await fetch("https://telemetry.replay.io/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ event, ...tags, user: telemetryUser }),
-    });
-    if (!response.ok) {
-      console.error(`Sent telemetry event ${event} but got status code ${response.status}`);
-    }
-  } catch (e) {
-    console.error(`Couldn't send telemetry event ${event}`, e);
-  }
+  pingTelemetry(event, { ...tags, user: telemetryUser });
 }
 
 export function trackTiming(event: string, properties: any = {}) {


### PR DESCRIPTION
## Issue

The auth API routes are failing but I can't see why.

## Resolution

* Add logging and telemetry to help track down the issue
* Refactor a simpler `pingTelemetry` out of the existing telemetry method so we don't try to import Sentry and all of its dependencies into the bundle for the API routes.