### PR TITLE
Standardising default states

### DIFF
--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -94,7 +94,7 @@ export function SourceOutline({
   if (!selectedSource || !symbols) {
     return (
       <div className="p-3 space-y-3 text-gray-500 text-xs whitespace-normal bg-gray-50 rounded-lg mx-2 mt-2 mb-4 text-center">
-        {`Select a source to see available functions.`}
+        {`Select a source to see available functions`}
       </div>
     );
   }

--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -93,9 +93,8 @@ export function SourceOutline({
 
   if (!selectedSource || !symbols) {
     return (
-      <div className="onboarding-text p-3 space-y-3 text-gray-500 text-base whitespace-normal">
-        <MaterialIcon className="large-icon">info</MaterialIcon>
-        <p>{`Select a source to see available function.`}</p>
+      <div className="p-3 space-y-3 text-gray-500 text-xs whitespace-normal bg-gray-50 rounded-lg mx-2 mt-2 mb-4 text-center">
+        {`Select a source to see available functions.`}
       </div>
     );
   }


### PR DESCRIPTION
Here's how our default outline state looks:
![image](https://user-images.githubusercontent.com/9154902/147893976-0f5bd12e-be3c-4eef-9961-9501dec8f664.png)

This is inconsistent with our other default states:
![image](https://user-images.githubusercontent.com/9154902/147893995-8d575ee2-7b04-4201-9e1e-26458e4e5252.png)

So I made it consistent by making it look like this:
![image](https://user-images.githubusercontent.com/9154902/147894035-d6ddb494-6658-411d-bedf-a4051a6eaa4a.png)