### PR TITLE
Differentiating between minutes and months

### DIFF
--- a/src/ui/utils/comments.ts
+++ b/src/ui/utils/comments.ts
@@ -19,7 +19,7 @@ export function formatRelativeTime(date: Date) {
     return `${years}y`;
   }
   if (months > 0) {
-    return `${months}m`;
+    return `${months}mo`;
   }
   if (weeks > 0) {
     return `${weeks}w`;


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/9154902/147894314-f557d64f-ae2d-4754-85e5-33dac4dd4ec2.png)

New:
![image](https://user-images.githubusercontent.com/9154902/147894306-0691e83d-f819-45e2-960c-7fc1ebfbaa88.png)

Right now old comments (7 months) appear to be very new (7 minutes) so this fixes that