### PR TITLE
Simplify filter drawer labels

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/EventListeners.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/EventListeners.js
@@ -16,6 +16,7 @@ import { features, prefs } from "ui/utils/prefs";
 import { trackEvent } from "ui/utils/telemetry";
 import Spinner from "ui/components/shared/Spinner";
 import Checkbox from "ui/components/shared/Forms/Checkbox";
+import { CountPill } from "devtools/client/webconsole/components/FilterBar/FilterSettings";
 
 class EventListeners extends Component {
   state = {
@@ -260,11 +261,7 @@ class EventListeners extends Component {
             <span className="event-listener-category">{category.name}</span>
           </label>
         </div>
-        {!expanded ? (
-          <div className="event-listener-count font-mono text-gray-500 flex-shrink-0 bg-gray-200 py-0.5 px-2 rounded-md">
-            {count}
-          </div>
-        ) : null}
+        {!expanded ? <CountPill>{count}</CountPill> : null}
       </div>
     );
   }
@@ -316,9 +313,7 @@ class EventListeners extends Component {
               {searchText ? this.renderCategory(category) : null}
               {event.name}
             </span>
-            <span className="event-listener-count font-mono text-gray-500 flex-shrink-0 bg-gray-200 py-0.5 px-2 rounded-md">
-              {points.length}
-            </span>
+            <CountPill>{points.length}</CountPill>
           </label>
         </div>
       </li>

--- a/src/devtools/client/webconsole/components/FilterBar/ConsoleSettings.js
+++ b/src/devtools/client/webconsole/components/FilterBar/ConsoleSettings.js
@@ -18,9 +18,11 @@ const { FILTERS } = require("devtools/client/webconsole/constants");
 export const ToggleRow = ({ children, selected, onClick, id }) => {
   return (
     <label className="flex py-1 items-center select-none" htmlFor={id}>
-      <div className="flex flex-row space-x-2 items-center">
+      <div className="flex flex-row flex-grow space-x-2 items-center">
         <Checkbox id={id} checked={selected} className="m-0" onChange={onClick} />
-        <span className="whitespace-pre overflow-hidden overflow-ellipsis">{children}</span>
+        <span className="whitespace-pre overflow-hidden overflow-ellipsis flex-grow">
+          {children}
+        </span>
       </div>
     </label>
   );

--- a/src/devtools/client/webconsole/components/FilterBar/ConsoleSettings.js
+++ b/src/devtools/client/webconsole/components/FilterBar/ConsoleSettings.js
@@ -17,7 +17,7 @@ const { FILTERS } = require("devtools/client/webconsole/constants");
 
 export const ToggleRow = ({ children, selected, onClick, id }) => {
   return (
-    <label className="flex py-1 items-center select-none" htmlFor={id}>
+    <label className="flex py-0.5 items-center select-none" htmlFor={id}>
       <div className="flex flex-row flex-grow space-x-2 items-center">
         <Checkbox id={id} checked={selected} className="m-0" onChange={onClick} />
         <span className="whitespace-pre overflow-hidden overflow-ellipsis flex-grow">

--- a/src/devtools/client/webconsole/components/FilterBar/FilterSettings.js
+++ b/src/devtools/client/webconsole/components/FilterBar/FilterSettings.js
@@ -14,6 +14,14 @@ const { trackEvent } = require("ui/utils/telemetry");
 const { FILTERS } = require("devtools/client/webconsole/constants");
 const { ToggleRow } = require("./ConsoleSettings");
 
+export function CountPill({ children }) {
+  return (
+    <span className="font-mono text-red-500 flex-shrink-0 bg-gray-200 py-0.5 px-2 rounded-md">
+      {children}
+    </span>
+  );
+}
+
 function FilterToggle({ children, count, onClick, selected, id }) {
   return (
     <ToggleRow onClick={onClick} selected={selected} id={id}>
@@ -21,11 +29,7 @@ function FilterToggle({ children, count, onClick, selected, id }) {
         <span className="whitespace-pre overflow-hidden overflow-ellipsis flex-grow py-0.5">
           {children}
         </span>
-        {count ? (
-          <span className="event-listener-count font-mono text-gray-500 flex-shrink-0 bg-gray-200 py-0.5 px-2 rounded-md">
-            {count}
-          </span>
-        ) : null}
+        {count ? <CountPill>{count}</CountPill> : null}
       </div>
     </ToggleRow>
   );
@@ -38,7 +42,7 @@ function FilterSettings({
   filterToggle,
   logExceptions,
 }) {
-  function getLabel(filterKey) {
+  function getCount(filterKey) {
     return filteredMessagesCount[filterKey];
   }
 
@@ -55,7 +59,7 @@ function FilterSettings({
         Exceptions
       </FilterToggle>
       <FilterToggle
-        count={getLabel(FILTERS.ERROR)}
+        count={getCount(FILTERS.ERROR)}
         onClick={() => {
           trackEvent("console.settings.toggle_error");
           filterToggle(FILTERS.ERROR);
@@ -66,7 +70,7 @@ function FilterSettings({
         Errors
       </FilterToggle>
       <FilterToggle
-        count={getLabel(FILTERS.WARN)}
+        count={getCount(FILTERS.WARN)}
         onClick={() => {
           trackEvent("console.settings.toggle_warn");
           filterToggle(FILTERS.WARN);
@@ -77,7 +81,7 @@ function FilterSettings({
         Warnings
       </FilterToggle>
       <FilterToggle
-        count={getLabel(FILTERS.LOG)}
+        count={getCount(FILTERS.LOG)}
         onClick={() => {
           trackEvent("console.settings.toggle_logs");
           filterToggle(FILTERS.LOG);

--- a/src/devtools/client/webconsole/components/FilterBar/FilterSettings.js
+++ b/src/devtools/client/webconsole/components/FilterBar/FilterSettings.js
@@ -14,6 +14,23 @@ const { trackEvent } = require("ui/utils/telemetry");
 const { FILTERS } = require("devtools/client/webconsole/constants");
 const { ToggleRow } = require("./ConsoleSettings");
 
+function FilterToggle({ children, count, onClick, selected, id }) {
+  return (
+    <ToggleRow onClick={onClick} selected={selected} id={id}>
+      <div className="flex justify-between justify items-center">
+        <span className="whitespace-pre overflow-hidden overflow-ellipsis flex-grow py-0.5">
+          {children}
+        </span>
+        {count ? (
+          <span className="event-listener-count font-mono text-gray-500 flex-shrink-0 bg-gray-200 py-0.5 px-2 rounded-md">
+            {count}
+          </span>
+        ) : null}
+      </div>
+    </ToggleRow>
+  );
+}
+
 function FilterSettings({
   filters,
   filteredMessagesCount,
@@ -21,18 +38,13 @@ function FilterSettings({
   filterToggle,
   logExceptions,
 }) {
-  function getLabel(baseLabel, filterKey) {
-    const count = filteredMessagesCount[filterKey];
-    if (count === 0) {
-      return baseLabel;
-    }
-    return `${baseLabel} (${count})`;
+  function getLabel(filterKey) {
+    return filteredMessagesCount[filterKey];
   }
 
   return (
     <div className="flex flex-col">
-      {/* Show Error */}
-      <ToggleRow
+      <FilterToggle
         onClick={() => {
           trackEvent("console.settings.toggle_log_exceptions");
           logExceptions(!shouldLogExceptions);
@@ -40,11 +52,10 @@ function FilterSettings({
         selected={shouldLogExceptions}
         id="show-exceptions"
       >
-        Show Exceptions
-      </ToggleRow>
-
-      {/* Error */}
-      <ToggleRow
+        Exceptions
+      </FilterToggle>
+      <FilterToggle
+        count={getLabel(FILTERS.ERROR)}
         onClick={() => {
           trackEvent("console.settings.toggle_error");
           filterToggle(FILTERS.ERROR);
@@ -52,11 +63,10 @@ function FilterSettings({
         selected={filters[FILTERS.ERROR]}
         id="show-errors"
       >
-        {getLabel("Show Errors", FILTERS.ERROR)}
-      </ToggleRow>
-
-      {/* Warning */}
-      <ToggleRow
+        Errors
+      </FilterToggle>
+      <FilterToggle
+        count={getLabel(FILTERS.WARN)}
         onClick={() => {
           trackEvent("console.settings.toggle_warn");
           filterToggle(FILTERS.WARN);
@@ -64,11 +74,10 @@ function FilterSettings({
         selected={filters[FILTERS.WARN]}
         id="show-warnings"
       >
-        {getLabel("Show Warnings", FILTERS.WARN)}
-      </ToggleRow>
-
-      {/* Logs */}
-      <ToggleRow
+        Warnings
+      </FilterToggle>
+      <FilterToggle
+        count={getLabel(FILTERS.LOG)}
         onClick={() => {
           trackEvent("console.settings.toggle_logs");
           filterToggle(FILTERS.LOG);
@@ -76,8 +85,8 @@ function FilterSettings({
         selected={filters[FILTERS.LOG]}
         id="show-logs"
       >
-        {getLabel("Show Logs", FILTERS.LOG)}
-      </ToggleRow>
+        Logs
+      </FilterToggle>
     </div>
   );
 }


### PR DESCRIPTION
Follow-up items from talking with @jonbell-lot23 .

- Keep the count visual consistent by making it into a pill aligned to the right side.
- Remove "show" from filters, e.g. "Show exceptions" -> "Exceptions".

![image](https://user-images.githubusercontent.com/15959269/148090064-67fa637e-a3cd-4bb3-980a-3fae8ab44564.png)
