### PR TITLE
Show the loading tips when a user opens a new tab in the replay browser

### DIFF
--- a/pages/browser/new-tab.tsx
+++ b/pages/browser/new-tab.tsx
@@ -1,18 +1,18 @@
 import React from "react";
+import { LoadingScreenTemplate, StaticLoadingScreen } from "ui/components/shared/LoadingScreen";
 import { useGetUserInfo } from "ui/hooks/users";
 
 export default function NewTab() {
   const { motd } = useGetUserInfo();
 
   return (
-    <div className="w-full h-full flex justify-center items-center">
+    <LoadingScreenTemplate showTips>
       <div className="text-center space-y-8" style={{ width: 420 }}>
         {motd ? <h2 className="text-2xl text-gray-600">{motd}</h2> : null}
-        <img src="/images/logo.svg" className="inline-block h-24 w-24" />
         <h1 className="text-2xl text-gray-600">
           Please navigate to the page you want to record, then press the blue record button.
         </h1>
       </div>
-    </div>
+    </LoadingScreenTemplate>
   );
 }


### PR DESCRIPTION
Fix #4726.

![image](https://user-images.githubusercontent.com/15959269/148238304-b255020f-330d-497b-83fa-6f12c5565b86.png)
