### PR TITLE
Hide the splitter if the pane is not split

### DIFF
--- a/src/devtools/packages/devtools-splitter/src/SplitBox.js
+++ b/src/devtools/packages/devtools-splitter/src/SplitBox.js
@@ -162,13 +162,8 @@ class SplitBox extends Component {
   // Rendering
   preparePanelStyles() {
     const vert = this.state.vert;
-    const {
-      minSize,
-      maxSize,
-      startPanelCollapsed,
-      endPanelControl,
-      endPanelCollapsed,
-    } = this.props;
+    const { minSize, maxSize, startPanelCollapsed, endPanelControl, endPanelCollapsed } =
+      this.props;
     let leftPanelStyle, rightPanelStyle;
 
     // Set proper size for panels depending on the current state.
@@ -232,12 +227,8 @@ class SplitBox extends Component {
       flex: `0 0 ${splitterSize}px`,
     };
 
-    return dom.div(
-      {
-        className: classNames.join(" "),
-        style: style,
-      },
-      !startPanelCollapsed
+    const startPanelDiv =
+      startPanel && !startPanelCollapsed
         ? dom.div(
             {
               className: endPanelControl ? "uncontrolled" : "controlled",
@@ -245,23 +236,33 @@ class SplitBox extends Component {
             },
             startPanel
           )
-        : null,
-      Draggable({
-        className: "splitter",
-        style: splitterStyle,
-        onStart: this.onStartMove,
-        onStop: this.onStopMove,
-        onMove: this.onMove,
-      }),
-      !endPanelCollapsed
+        : null;
+    const endPanelDiv =
+      endPanel && !endPanelCollapsed
         ? dom.div(
-            {
-              className: endPanelControl ? "controlled" : "uncontrolled",
-              style: rightPanelStyle,
-            },
+            { className: endPanelControl ? "controlled" : "uncontrolled", style: rightPanelStyle },
             endPanel
           )
-        : null
+        : null;
+    const draggable =
+      startPanelDiv && endPanelDiv
+        ? Draggable({
+            className: "splitter",
+            style: splitterStyle,
+            onStart: this.onStartMove,
+            onStop: this.onStopMove,
+            onMove: this.onMove,
+          })
+        : null;
+
+    return dom.div(
+      {
+        className: classNames.join(" "),
+        style: style,
+      },
+      startPanelDiv,
+      draggable,
+      endPanelDiv
     );
   }
 }


### PR DESCRIPTION
The draggable splitter is only useful if both panels are non-null and open.

Fixes https://github.com/RecordReplay/devtools/issues/4936