### PR TITLE
Fixing the background on the editor

### DIFF
--- a/src/devtools/client/debugger/src/components/WelcomeBox.tsx
+++ b/src/devtools/client/debugger/src/components/WelcomeBox.tsx
@@ -95,7 +95,7 @@ function WelcomeBox({
         ))}
       </div>
       <div className="absolute z-0">
-        <img src="/images/bubble.svg" className=" " style={{ transform: "scale(2.4)" }} />
+        <img src="/images/bubble.svg" className="editor-bg" style={{ transform: "scale(2.4)" }} />
       </div>
     </div>
   );

--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -498,6 +498,16 @@ checkbox:-moz-focusring {
   right: 0;
 }
 
+/* Images */
+
+.editor-bg {
+  transform: scale(2.4);
+  position: relative;
+  max-width: none;
+  left: -340px;
+  top: 400px;
+}
+
 /* Text input */
 
 .devtools-textinput,


### PR DESCRIPTION
Right now the editor BG does an ugly thing when you resize it. This fixes it.

Prod:
![image](https://user-images.githubusercontent.com/9154902/148318719-1b411e5a-7a11-4db2-9dd1-a55e72d7b462.png)

Proposed:
![image](https://user-images.githubusercontent.com/9154902/148318756-2cae1d28-5204-4829-866f-f902bac9de97.png)

