### PR TITLE
Aligning avatar to other icons

### DIFF
--- a/src/ui/components/Header/UserOptions.css
+++ b/src/ui/components/Header/UserOptions.css
@@ -84,8 +84,8 @@
 }
 
 .avatar img {
-  height: 24px;
-  width: 24px;
+  height: 20px;
+  width: 20px;
   border-radius: 50%;
 }
 


### PR DESCRIPTION
Our profile avatar was too large, which meant it was misaligned with our other icons.

Old:
![image](https://user-images.githubusercontent.com/9154902/148331695-616ea9c5-dff3-41fa-b137-1c2d7874375a.png)

New:
![image](https://user-images.githubusercontent.com/9154902/148331715-fd16d190-6cea-4bce-a330-29b933952fd4.png)
