### PR TITLE
Pull tip index out of redux

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -93,9 +93,6 @@ export type SetRecordingWorkspaceAction = Action<"set_recording_workspace"> & {
 export type SetLoadedRegions = Action<"set_loaded_regions"> & {
   parameters: loadedRegions;
 };
-export type SetLoadingPageTipIndexAction = Action<"set_loading_page_tip_index"> & {
-  index: number;
-};
 
 export type SetMouseTargetsLoading = Action<"mouse_targets_loading"> & {
   loading: boolean;
@@ -127,8 +124,7 @@ export type AppActions =
   | SetRecordingTargetAction
   | SetRecordingWorkspaceAction
   | SetLoadedRegions
-  | SetAwaitingSourcemapsAction
-  | SetLoadingPageTipIndexAction;
+  | SetAwaitingSourcemapsAction;
 
 export function setupApp(store: UIStore) {
   if (!isTest()) {
@@ -361,10 +357,6 @@ export function loadMouseTargets(): UIThunkAction {
       dispatch(setIsNodePickerActive(true));
     }
   };
-}
-
-export function setLoadingPageTipIndex(index: number): SetLoadingPageTipIndexAction {
-  return { type: "set_loading_page_tip_index", index };
 }
 
 export function executeCommand(key: CommandKey): UIThunkAction {

--- a/src/ui/components/shared/LoadingTip.tsx
+++ b/src/ui/components/shared/LoadingTip.tsx
@@ -1,9 +1,5 @@
 import classNames from "classnames";
-import React, { useEffect, useRef } from "react";
-import { connect, ConnectedProps } from "react-redux";
-import { setLoadingPageTipIndex } from "ui/actions/app";
-import { selectors } from "ui/reducers";
-import { UIState } from "ui/state";
+import React, { useEffect, useRef, useState } from "react";
 
 const TIPS = [
   {
@@ -31,8 +27,9 @@ const TIPS = [
   },
 ];
 
-function LoadingTip({ loadingPageTipIndex, setLoadingPageTipIndex }: PropsFromRedux) {
-  const { title, description, icon } = TIPS[loadingPageTipIndex || 0];
+export default function LoadingTip() {
+  const [loadingPageTipIndex, setLoadingPageTipIndex] = useState(0);
+  const { title, description, icon } = TIPS[loadingPageTipIndex];
   const key = useRef<any>();
 
   const resetAutoNext = () => clearTimeout(key.current);
@@ -75,15 +72,3 @@ function LoadingTip({ loadingPageTipIndex, setLoadingPageTipIndex }: PropsFromRe
     </div>
   );
 }
-
-const connector = connect(
-  (state: UIState) => ({
-    loadingPageTipIndex: selectors.getLoadingPageTipIndex(state),
-  }),
-  {
-    setLoadingPageTipIndex,
-  }
-);
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export default connector(LoadingTip);

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -39,7 +39,6 @@ export const initialAppState: AppState = {
   recordingTarget: null,
   recordingWorkspace: null,
   loadedRegions: null,
-  loadingPageTipIndex: 0,
   mouseTargetsLoading: false,
 };
 
@@ -204,10 +203,6 @@ export default function update(
       return { ...state, recordingWorkspace: action.workspace };
     }
 
-    case "set_loading_page_tip_index": {
-      return { ...state, loadingPageTipIndex: action.index };
-    }
-
     default: {
       return state;
     }
@@ -314,5 +309,4 @@ export const isFinishedLoadingRegions = (state: UIState) => {
   return isSameTimeStampedPointRange(loading, loaded);
 };
 export const getIsTrimming = (state: UIState) => getModal(state) === "trimming";
-export const getLoadingPageTipIndex = (state: UIState) => state.app.loadingPageTipIndex;
 export const areMouseTargetsLoading = (state: UIState) => state.app.mouseTargetsLoading;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -85,7 +85,6 @@ export interface AppState {
   loadedRegions: loadedRegions | null;
   loading: number;
   loadingFinished: boolean;
-  loadingPageTipIndex: number;
   modal: ModalType | null;
   modalOptions: ModalOptionsType;
   recordingDuration: number;


### PR DESCRIPTION
Saw a comment about not showing tips in one of the loading states because the store was initialized yet. There doesn't seem to be a compelling reason to use the store for this state data since it's localized to a given instance of the tips so this removes that requirement so tips can be shown on that loading screen as well. Seems like a good simplification and decoupling but open to discuss!

I didn't enable the tips on that block yet but we can tack that on to this PR if it is desired.

https://github.com/RecordReplay/devtools/blob/0bab84257e3e20fb7452fbc558f722e3aeb4edf6/pages/_app.tsx#L157-L161