### PR TITLE
Small usability improvements to the net monitor

### DIFF
--- a/src/ui/components/NetworkMonitor/RequestDetails.module.css
+++ b/src/ui/components/NetworkMonitor/RequestDetails.module.css
@@ -32,4 +32,5 @@ h2.title {
 .row {
   padding-left: 1rem;
   word-break: break-all;
+  cursor: default;
 }

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -11,15 +11,37 @@ import { WiredFrame } from "protocol/thread/pause";
 
 interface Detail {
   name: string;
-  value: string;
+  value: string | React.ReactChild;
+}
+
+function FormattedUrl({ url }: { url: string }) {
+  const parsedUrl = new URL(url);
+  const params = [...parsedUrl.searchParams.entries()];
+  return (
+    <span className="text-gray-600">
+      <span className="">{parsedUrl.origin}</span>
+      <span className="">{parsedUrl.pathname}</span>
+      {params.length > 0 ? (
+        <>
+          {params.map(([key, value], index) => (
+            <span key={key}>
+              <span className="">{index == 0 ? "?" : "&"}</span>
+              <span className="text-primaryAccent">{key}</span>
+              <span>={value}</span>
+            </span>
+          ))}
+        </>
+      ) : null}
+    </span>
+  );
 }
 
 const DetailTable = ({ className, details }: { className?: string; details: Detail[] }) => {
   return (
     <div className={classNames(className, "flex flex-col")}>
       {details.map(h => (
-        <div className={classNames(styles.row)} key={h.name}>
-          <span className="font-bold text-gray-500">{h.name}:</span> {h.value}
+        <div className={classNames(styles.row, "hover:bg-gray-100 py-1")} key={h.name}>
+          <span className="font-bold ">{h.name}:</span> {h.value}
         </div>
       ))}
     </div>
@@ -111,7 +133,7 @@ const HeadersPanel = ({ request }: { request: RequestSummary }) => {
         <DetailTable
           className={styles.request}
           details={[
-            { name: "URL", value: request.url },
+            { name: "URL", value: <FormattedUrl url={request.url} /> },
             { name: "Request Method", value: request.method },
             { name: "Status Code", value: String(request.status) },
             { name: "Type", value: request.documentType },

--- a/src/ui/components/NetworkMonitor/Table.tsx
+++ b/src/ui/components/NetworkMonitor/Table.tsx
@@ -27,16 +27,16 @@ export default function Table({
   const columns = useMemo(
     () => [
       {
-        Header: "Name",
-        accessor: "name" as const,
-      },
-      {
         Header: "Status",
         // https://github.com/tannerlinsley/react-table/discussions/2664
         accessor: "status" as const,
         className: "m-auto",
         width: 50,
         maxWidth: 100,
+      },
+      {
+        Header: "Name",
+        accessor: "name" as const,
       },
       {
         Header: "Method",

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -24,7 +24,7 @@ export const NetworkMonitor = ({
   selectFrame,
 }: PropsFromRedux) => {
   const [selectedRequest, setSelectedRequest] = useState<RequestSummary>();
-  const [types, setTypes] = useState<Set<RequestType>>(new Set(["xhr"]));
+  const [types, setTypes] = useState<Set<RequestType>>(new Set(["xhr", "javascript", "html"]));
   const [vert, setVert] = useState<boolean>(false);
 
   const container = useRef<HTMLDivElement>(null);

--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -30,9 +30,9 @@ export type RequestSummary = {
 export const REQUEST_TYPES = {
   xhr: "Fetch/XHR",
   javascript: "Javascript",
+  html: "HTML",
   css: "CSS",
   font: "Font",
-  html: "HTML",
   img: "Image",
   manifest: "Manifest",
   media: "Media",


### PR DESCRIPTION
* query params are formatted like firefox
* details row hovered
* cursor default
* status is on the left so that the name isnt overlayed by the fast forward button
* js and html request types are now selected by default 