### PR TITLE
Add support for enterprise contracts in team billing page

### DIFF
--- a/src/ui/components/shared/WorkspaceSettingsModal/Details.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/Details.tsx
@@ -81,7 +81,8 @@ function SubscriptionDetails({
         <span>Number of seats</span>
         <span>{subscription.seatCount}</span>
       </div>
-      {isSubscriptionCancelled(subscription) ? null : (
+      {isSubscriptionCancelled(subscription) ||
+      subscription.billingSchedule === "contract" ? null : (
         <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between">
           <span>Payment Method</span>
           <span className="flex flex-col items-end">

--- a/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
@@ -62,6 +62,13 @@ export const pricingDetailsForSubscription = (subscription: Subscription): PlanP
         seatPrice: 75,
         trial: isTrial(subscription),
       };
+    case "ent-v1":
+      return {
+        billingSchedule: "contract",
+        displayName: "Enterprise Contract",
+        seatPrice: 0,
+        trial: false,
+      };
   }
 };
 

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -61,7 +61,7 @@ export interface PaymentMethod {
   };
 }
 
-type PlanKey = "org-v1" | "team-v1" | "test-team-v1" | "beta-v1" | "test-beta-v1";
+type PlanKey = "org-v1" | "team-v1" | "test-team-v1" | "beta-v1" | "test-beta-v1" | "ent-v1";
 
 export interface Subscription {
   id: string;
@@ -81,7 +81,7 @@ export interface Subscription {
   paymentMethods: PaymentMethod[];
 }
 
-export type BillingSchedule = "annual" | "monthly";
+export type BillingSchedule = "annual" | "monthly" | "contract";
 
 export interface PlanPricing {
   billingSchedule: BillingSchedule | null;


### PR DESCRIPTION
## Issue

We have an enterprise contract but need to do a touch of clean up in the team settings UI so we can display something

## Resolution

* Adds a new metadata entry for `ent-v1` plans
* Hides the "add payment method" link for `contract` plans since the payment will be managed outside of stripe.

## Media

https://app.replay.io/recording/ce9bc0e7-89d2-4ced-980e-79c52d248df2#

![image](https://user-images.githubusercontent.com/788456/148829772-0a4b79de-6baa-4597-b9dc-275679636ee0.png)