### PR TITLE
UI Tweaks to network monitor

### DIFF
--- a/src/ui/components/NetworkMonitor/FilterBar.tsx
+++ b/src/ui/components/NetworkMonitor/FilterBar.tsx
@@ -13,7 +13,7 @@ export default function FilterBar({
   types: Set<RequestType>;
 }) {
   return (
-    <div className="bg-white border-1 border-b border-bottom flex items-center px-1 py-1">
+    <div className="bg-white flex items-center px-1 py-1">
       <TypesDropdown toggleType={toggleType} types={types} />
 
       <MaterialIcon iconSize="lg">search</MaterialIcon>

--- a/src/ui/components/NetworkMonitor/HeaderGroups.tsx
+++ b/src/ui/components/NetworkMonitor/HeaderGroups.tsx
@@ -25,7 +25,6 @@ export function HeaderGroups({
         ev.preventDefault();
         setMenuLocation({ x: ev.pageX, y: ev.pageY });
       }}
-      className="border-b"
     >
       {menuLocation ? (
         <ContextMenu x={menuLocation.x} y={menuLocation.y} close={() => setMenuLocation(undefined)}>
@@ -35,7 +34,10 @@ export function HeaderGroups({
         ""
       )}
       {headerGroups.map((headerGroup: HeaderGroup<RequestSummary>) => (
-        <div className="flex font-normal items-center" {...headerGroup.getHeaderGroupProps()}>
+        <div
+          className="flex font-normal items-center divide-x bg-toolbarBackground"
+          {...headerGroup.getHeaderGroupProps()}
+        >
           {headerGroup.headers.map(column => (
             <div className={classNames("p-1", styles[column.id])} {...column.getHeaderProps()}>
               {column.render("Header")}

--- a/src/ui/components/NetworkMonitor/RequestTable.module.css
+++ b/src/ui/components/NetworkMonitor/RequestTable.module.css
@@ -26,18 +26,13 @@ table.requests {
 }
 
 .resizer {
-  display: inline-block;
+  cursor: ew-resize;
   height: 100%;
   position: absolute;
   top: 0;
-  right: 0;
-  transform: translateX(-50%);
+  right: -4px;
   width: 8px;
-}
-
-.resizer:hover,
-.resizer:active {
-  background: var(--primary-accent);
+  z-index: 50;
 }
 
 .seekBadge {

--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -33,10 +33,7 @@ const RequestTable = ({
   return (
     <div className="bg-white w-full overflow-y-auto">
       <div className={classNames(styles.request)} {...getTableProps()}>
-        <div
-          className="sticky z-10 top-0"
-          style={{ background: "var(--theme-tab-toolbar-background)" }}
-        >
+        <div className="sticky z-10 top-0 bg-toolbarBackground border-b border-t">
           <HeaderGroups columns={columns} headerGroups={headerGroups} />
         </div>
         <div {...getTableBodyProps()}>

--- a/src/ui/components/NetworkMonitor/Table.tsx
+++ b/src/ui/components/NetworkMonitor/Table.tsx
@@ -30,7 +30,6 @@ export default function Table({
         Header: "Status",
         // https://github.com/tannerlinsley/react-table/discussions/2664
         accessor: "status" as const,
-        className: "m-auto",
         width: 50,
         maxWidth: 100,
       },
@@ -41,7 +40,6 @@ export default function Table({
       {
         Header: "Method",
         accessor: "method" as const,
-        className: "m-auto",
         width: 50,
         maxWidth: 100,
       },
@@ -66,7 +64,7 @@ export default function Table({
 
   const defaultColumn = useMemo(
     () => ({
-      minWidth: 50,
+      minWidth: 60,
       width: 200,
       maxWidth: 1000,
     }),


### PR DESCRIPTION
- Use a single vertical line to denote network table header slider (with
  a cursor change)
- Make sure all columns are left-aligned
- Simplify our border setup on the Network Monitor Request Table

Fixes https://github.com/RecordReplay/devtools/issues/4974