### PR TITLE
Fix API key auth

### DIFF
--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -76,7 +76,7 @@ class TokenManager {
         <Auth0Context.Consumer>
           {auth0Client => {
             this.auth0Client = auth0Client;
-            if (!this.auth0Client || this.auth0Client.isLoading) {
+            if (!apiKey && (!this.auth0Client || this.auth0Client.isLoading)) {
               return;
             }
 


### PR DESCRIPTION
## Issue

Loading private replays via the API key auth used by automated tests was failing because the web socket auth is triggered by the token manager event listener callback but that logic wasn't ran soon enough because the token setup was guarded by a check for auth0 readiness.

## Resolution

Skip the auth0 readiness check when an API key is provided since we don't need to use that logic in this case.