### PR TITLE
Add Request Bodies to the Network Monitor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@auth0/auth0-react": "^1.2.0",
         "@headlessui/react": "^1.4.1",
         "@heroicons/react": "^1.0.1",
-        "@recordreplay/protocol": "^0.16.0",
+        "@recordreplay/protocol": "^0.17.0",
         "@sentry/react": "^6.8.0",
         "@sentry/tracing": "^6.8.0",
         "@stripe/react-stripe-js": "^1.4.1",
@@ -3901,9 +3901,9 @@
       }
     },
     "node_modules/@recordreplay/protocol": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.16.0.tgz",
-      "integrity": "sha512-rbskEt1OSntGtT8wP+LLSCLUSw2SQC5yFIsxev8gU1LVvm863HKKuAiL7RqxQlBcKQs9XfpnYihgclSMo1SEIg=="
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.17.0.tgz",
+      "integrity": "sha512-vTdu8dmwfZsvYMIYEwWj+eInVccJZ8T/cCkXSPu/TfFsvodNCnIi8jJMcK6keLC4IVfhCwVd03MMEFaZWWZarw=="
     },
     "node_modules/@recordreplay/recordings-cli": {
       "version": "0.4.1",
@@ -41574,9 +41574,9 @@
       }
     },
     "@recordreplay/protocol": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.16.0.tgz",
-      "integrity": "sha512-rbskEt1OSntGtT8wP+LLSCLUSw2SQC5yFIsxev8gU1LVvm863HKKuAiL7RqxQlBcKQs9XfpnYihgclSMo1SEIg=="
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.17.0.tgz",
+      "integrity": "sha512-vTdu8dmwfZsvYMIYEwWj+eInVccJZ8T/cCkXSPu/TfFsvodNCnIi8jJMcK6keLC4IVfhCwVd03MMEFaZWWZarw=="
     },
     "@recordreplay/recordings-cli": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@auth0/auth0-react": "^1.2.0",
     "@headlessui/react": "^1.4.1",
     "@heroicons/react": "^1.0.1",
-    "@recordreplay/protocol": "^0.16.0",
+    "@recordreplay/protocol": "^0.17.0",
     "@sentry/react": "^6.8.0",
     "@sentry/tracing": "^6.8.0",
     "@stripe/react-stripe-js": "^1.4.1",

--- a/src/devtools/client/webconsole/actions/network.ts
+++ b/src/devtools/client/webconsole/actions/network.ts
@@ -1,7 +1,7 @@
 import { RequestInfo, RequestEventInfo, responseBodyData } from "@recordreplay/protocol";
 import { ThreadFront } from "protocol/thread";
 import { UIStore } from "ui/actions";
-import { newNetworkRequests, newResponseBodyParts } from "ui/actions/network";
+import { newNetworkRequests, newResponseBodyParts, newRequestBodyParts } from "ui/actions/network";
 import { AppDispatch } from "ui/setup";
 
 let onResponseBodyPart: (responseBodyParts: responseBodyData) => void;
@@ -9,7 +9,8 @@ let onResponseBodyPart: (responseBodyParts: responseBodyData) => void;
 export const setupNetwork = (store: UIStore) => {
   ThreadFront.findNetworkRequests(
     async data => store.dispatch(onNetworkRequestsThunk(data)),
-    async data => store.dispatch(newResponseBodyParts(data))
+    async data => store.dispatch(newResponseBodyParts(data)),
+    async data => store.dispatch(newRequestBodyParts(data))
   );
 };
 

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -34,6 +34,7 @@ import {
   SearchSourceContentsMatch,
   FunctionMatch,
   responseBodyData,
+  requestBodyData,
 } from "@recordreplay/protocol";
 import { client, log } from "../socket";
 import { defer, assert, EventEmitter, ArrayMap } from "../utils";
@@ -836,16 +837,25 @@ class _ThreadFront {
 
   async findNetworkRequests(
     onRequestsReceived: (data: { requests: RequestInfo[]; events: RequestEventInfo[] }) => void,
-    onResponseBodyData: (parameters: responseBodyData) => void
+    onResponseBodyData: (body: responseBodyData) => void,
+    onRequestBodyData: (body: requestBodyData) => void
   ) {
     const sessionId = await this.waitForSession();
     client.Network.addRequestsListener(onRequestsReceived);
     client.Network.addResponseBodyDataListener(onResponseBodyData);
+    client.Network.addRequestBodyDataListener(onRequestBodyData);
     client.Network.findRequests({}, sessionId);
   }
 
   fetchResponseBody(requestId: string) {
     return client.Network.getResponseBody(
+      { id: requestId, range: { end: 5e9 } },
+      ThreadFront.sessionId!
+    );
+  }
+
+  fetchRequestBody(requestId: string) {
+    return client.Network.getRequestBody(
       { id: requestId, range: { end: 5e9 } },
       ThreadFront.sessionId!
     );

--- a/src/stories/NetworkMonitor/RequestDetail.stories.tsx
+++ b/src/stories/NetworkMonitor/RequestDetail.stories.tsx
@@ -3,7 +3,6 @@ import React, { ComponentProps } from "react";
 import { Story, Meta } from "@storybook/react";
 
 import RequestDetails from "ui/components/NetworkMonitor/RequestDetails";
-import { requestProps } from "./utils";
 
 export default {
   title: "Network Monitor/Request Details",
@@ -24,6 +23,7 @@ Basic.args = {
     domain: "assets.website-files.com",
     end: 984,
     hasResponseBody: true,
+    hasRequestBody: true,
     id: "1",
     requestHeaders: [
       { name: "Host", value: "assets.website-files.com" },

--- a/src/stories/NetworkMonitor/utils.ts
+++ b/src/stories/NetworkMonitor/utils.ts
@@ -83,6 +83,7 @@ export const requestSummary = (
     documentType: "html",
     end: 1600,
     hasResponseBody: true,
+    hasRequestBody: true,
     id,
     method,
     name: "replay.io",

--- a/src/ui/actions/network.ts
+++ b/src/ui/actions/network.ts
@@ -4,6 +4,7 @@ import {
   TimeStampedPoint,
   responseBodyData,
   RequestId,
+  requestBodyData,
 } from "@recordreplay/protocol";
 import { ThreadFront } from "protocol/thread";
 import { AppDispatch } from "ui/setup";
@@ -21,18 +22,34 @@ type NewResponseBodyPartsAction = {
   payload: { responseBodyParts: responseBodyData };
 };
 
+type NewRequestBodyPartsAction = {
+  type: "NEW_REQUEST_BODY_PARTS";
+  payload: { requestBodyParts: requestBodyData };
+};
+
 type SetFramesAction = {
   type: "SET_FRAMES";
   payload: { frames: any[]; point: string };
 };
 
-export type NetworkAction = NewNetworkRequestsAction | SetFramesAction | NewResponseBodyPartsAction;
+export type NetworkAction =
+  | NewNetworkRequestsAction
+  | SetFramesAction
+  | NewResponseBodyPartsAction
+  | NewRequestBodyPartsAction;
 
 export const newResponseBodyParts = (
   responseBodyParts: responseBodyData
 ): NewResponseBodyPartsAction => ({
   type: "NEW_RESPONSE_BODY_PARTS",
   payload: { responseBodyParts },
+});
+
+export const newRequestBodyParts = (
+  requestBodyParts: requestBodyData
+): NewRequestBodyPartsAction => ({
+  type: "NEW_REQUEST_BODY_PARTS",
+  payload: { requestBodyParts },
 });
 
 export const newNetworkRequests = ({
@@ -48,6 +65,10 @@ export const newNetworkRequests = ({
 
 export function fetchResponseBody(requestId: RequestId) {
   ThreadFront.fetchResponseBody(requestId);
+}
+
+export function fetchRequestBody(requestId: RequestId) {
+  ThreadFront.fetchRequestBody(requestId);
 }
 
 export function fetchFrames(tsPoint: TimeStampedPoint) {

--- a/src/ui/components/NetworkMonitor/RequestBody.tsx
+++ b/src/ui/components/NetworkMonitor/RequestBody.tsx
@@ -1,0 +1,42 @@
+import { RequestBodyData } from "@recordreplay/protocol";
+import React, { useState } from "react";
+import HttpBody from "./HttpBody";
+import { TriangleToggle } from "./RequestDetails";
+import { contentType, findHeader, RequestSummary } from "./utils";
+
+const RequestBody = ({
+  request,
+  requestBodyParts,
+}: {
+  request: RequestSummary | undefined;
+  requestBodyParts: RequestBodyData[] | undefined;
+}) => {
+  const [expanded, setExpanded] = useState(true);
+
+  if (!request || !requestBodyParts) {
+    return null;
+  }
+
+  return (
+    <>
+      <div
+        className="flex items-center py-1 cursor-pointer font-bold"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <TriangleToggle open={expanded} />
+        Request body:
+      </div>
+      {expanded && (
+        <div className="pl-6">
+          <HttpBody
+            bodyParts={requestBodyParts}
+            contentLength={findHeader(request.requestHeaders, "content-length")}
+            contentType={contentType(request.requestHeaders)}
+          />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default RequestBody;

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -2,7 +2,13 @@ import SplitBox from "devtools/packages/devtools-splitter";
 import React, { useEffect, useRef, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
-import { getEvents, getFormattedFrames, getRequests, getResponseBodies } from "ui/reducers/network";
+import {
+  getEvents,
+  getFormattedFrames,
+  getRequests,
+  getResponseBodies,
+  getRequestBodies,
+} from "ui/reducers/network";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { UIState } from "ui/state";
 import RequestDetails from "./RequestDetails";
@@ -10,7 +16,7 @@ import RequestTable from "./RequestTable";
 import { RequestSummary, RequestType } from "./utils";
 import FilterBar from "./FilterBar";
 import Table from "./Table";
-import { fetchFrames, fetchResponseBody } from "ui/actions/network";
+import { fetchFrames, fetchResponseBody, fetchRequestBody } from "ui/actions/network";
 import { getThreadContext } from "devtools/client/debugger/src/selectors";
 
 export const NetworkMonitor = ({
@@ -19,6 +25,7 @@ export const NetworkMonitor = ({
   events,
   fetchFrames,
   frames,
+  requestBodies,
   requests,
   responseBodies,
   seek,
@@ -69,12 +76,11 @@ export const NetworkMonitor = ({
                     cx={cx}
                     request={selectedRequest}
                     responseBody={responseBodies[selectedRequest.id]}
+                    requestBody={requestBodies[selectedRequest.id]}
                     frames={frames[selectedRequest?.point.point]}
                     selectFrame={selectFrame}
                   />
-                ) : (
-                  <div />
-                )
+                ) : null
               }
               startPanel={
                 <RequestTable
@@ -85,6 +91,9 @@ export const NetworkMonitor = ({
                     fetchFrames(row.point);
                     if (row.hasResponseBody) {
                       fetchResponseBody(row.id);
+                    }
+                    if (row.hasRequestBody) {
+                      fetchRequestBody(row.id);
                     }
                     setSelectedRequest(row);
                   }}
@@ -108,6 +117,7 @@ const connector = connect(
     cx: getThreadContext(state),
     events: getEvents(state),
     frames: getFormattedFrames(state),
+    requestBodies: getRequestBodies(state),
     requests: getRequests(state),
     responseBodies: getResponseBodies(state),
   }),

--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -4,8 +4,9 @@ import {
   RequestInfo,
   RequestOpenEvent,
   RequestResponseEvent,
-  RequestResponseBody,
   TimeStampedPoint,
+  RequestBodyEvent,
+  RequestResponseBodyEvent,
 } from "@recordreplay/protocol";
 import keyBy from "lodash/keyBy";
 import { compareNumericStrings } from "protocol/utils";
@@ -17,6 +18,7 @@ export type RequestSummary = {
   documentType: string;
   end: number;
   hasResponseBody: boolean;
+  hasRequestBody: boolean;
   id: string;
   method: string;
   name: string;
@@ -45,8 +47,8 @@ export const REQUEST_TYPES = {
   websocket: "Websocket",
 };
 
-export const findHeader = (headers: Header[], key: string): string | undefined =>
-  headers.find(h => h.name.toLowerCase() === key)?.value;
+export const findHeader = (headers: Header[] | undefined, key: string): string | undefined =>
+  headers?.find(h => h.name.toLowerCase() === key)?.value;
 
 export const REQUEST_ICONS: Record<string, string> = {
   xhr: "description",
@@ -66,7 +68,8 @@ export type RequestType = keyof typeof REQUEST_TYPES;
 
 export type RequestEventMap = {
   request: { time: number; event: RequestOpenEvent };
-  "response-body": { time: number; event: RequestResponseBody };
+  "response-body": { time: number; event: RequestResponseBodyEvent };
+  "request-body": { time: number; event: RequestBodyEvent };
   response: { time: number; event: RequestResponseEvent };
 };
 
@@ -122,6 +125,7 @@ export const partialRequestsToCompleteSummaries = (
         domain: host(request.event.requestUrl),
         end: response.time,
         hasResponseBody: Boolean(r.events["response-body"]),
+        hasRequestBody: Boolean(r.events["request-body"]),
         id: r.id,
         method: request.event.requestMethod,
         name: name(request.event.requestUrl),

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -50,11 +50,8 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     key: "enableCommentAttachments",
   },
   {
-    // I'm going to change this to include requests once they are in.
-    // description: "Allow JSON response and request bodies to be inspected",
-    // label: "Http Request & Response Bodies",
-    label: "Http Response Bodies",
-    description: "Allow JSON response bodies to be inspected",
+    label: "Http Request & Response Bodies",
+    description: "Allow JSON response and request bodies to be inspected",
     key: "enableHttpBodies",
   },
 ];


### PR DESCRIPTION
This is super similar to https://github.com/RecordReplay/devtools/pull/4964, and doesn't really do anything new.

# Changes

- Update `protocol` to get the ability to fetch request bodies
- Track whether requests that are in the store have bodies or not
- Replace `Coming soon!` with an `HttpBody` component when the user has enabled that feature and the request has a body
