### PR TITLE
Distinguish between hovered row and button

### DIFF
--- a/src/ui/components/NetworkMonitor/RequestRow.tsx
+++ b/src/ui/components/NetworkMonitor/RequestRow.tsx
@@ -34,7 +34,7 @@ export const RequestRow = ({
       <div {...row.getRowProps()}>
         {row.original.triggerPoint && row.original.triggerPoint.time !== currentTime && (
           <div
-            className={classNames(styles.seekBadge)}
+            className={classNames(styles.seekBadge, "shadow-md")}
             onClick={() => {
               if (!row.original.triggerPoint) {
                 return;

--- a/src/ui/components/NetworkMonitor/RequestTable.module.css
+++ b/src/ui/components/NetworkMonitor/RequestTable.module.css
@@ -16,8 +16,8 @@ table.requests {
 }
 
 .row.selected {
-  background: var(--primary-accent);
-  border-color: var(--primary-accent);
+  background: var(--primary-accent-hover);
+  border-color: var(--primary-accent-hover);
   color: white;
 }
 
@@ -47,6 +47,7 @@ table.requests {
   padding-left: 6px;
   padding-right: 6px;
   position: absolute;
+  left: -2px;
   z-index: 1;
 }
 


### PR DESCRIPTION
We were sort of losing the distinction between the hovered network monitor row when it was selected and the fast-forward/rewind button that appears over top of it. Adding a slight color distinction and a box shadow helps a lot.

Fixes #4873