### PR TITLE
Add a canonical request type

### DIFF
--- a/src/stories/NetworkMonitor/RequestDetail.stories.tsx
+++ b/src/stories/NetworkMonitor/RequestDetail.stories.tsx
@@ -3,6 +3,7 @@ import React, { ComponentProps } from "react";
 import { Story, Meta } from "@storybook/react";
 
 import RequestDetails from "ui/components/NetworkMonitor/RequestDetails";
+import { CanonicalRequestType } from "ui/components/NetworkMonitor/utils";
 
 export default {
   title: "Network Monitor/Request Details",
@@ -78,6 +79,7 @@ Basic.args = {
     status: 200,
     start: 984,
     time: 166,
+    type: CanonicalRequestType.FETCH_XHR,
     url: "https://assets.website-files.com/613b96978e0f483f60fbb8c0/613b96978e0f48b736fbb935_SpaceGrotesk-Bold.woff2",
   },
 };

--- a/src/stories/NetworkMonitor/utils.ts
+++ b/src/stories/NetworkMonitor/utils.ts
@@ -1,5 +1,5 @@
 import { RequestInfo, RequestEventInfo } from "@recordreplay/protocol";
-import { RequestSummary } from "ui/components/NetworkMonitor/utils";
+import { CanonicalRequestType, RequestSummary } from "ui/components/NetworkMonitor/utils";
 
 export const eventsFor = (
   id: string,
@@ -95,6 +95,7 @@ export const requestSummary = (
     start: 0,
     status,
     time: 1600,
+    type: CanonicalRequestType.FETCH_XHR,
     url,
   };
 };

--- a/src/ui/components/NetworkMonitor/FilterBar.tsx
+++ b/src/ui/components/NetworkMonitor/FilterBar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import MaterialIcon from "../shared/MaterialIcon";
 import TypesDropdown from "./TypesDropdown";
-import { RequestType } from "./utils";
+import { CanonicalRequestType } from "./utils";
 
 export default function FilterBar({
   table,
@@ -9,8 +9,8 @@ export default function FilterBar({
   types,
 }: {
   table: any;
-  toggleType: (type: RequestType) => void;
-  types: Set<RequestType>;
+  toggleType: (type: CanonicalRequestType) => void;
+  types: Set<CanonicalRequestType>;
 }) {
   return (
     <div className="bg-white flex items-center px-1 py-1">

--- a/src/ui/components/NetworkMonitor/HttpBody.tsx
+++ b/src/ui/components/NetworkMonitor/HttpBody.tsx
@@ -1,7 +1,7 @@
 import { BodyData, RequestBodyData, ResponseBodyData } from "@recordreplay/protocol";
 import { useMemo } from "react";
 import ReactJson from "react-json-view";
-import { base64ToArrayBuffer, ContentType } from "./utils";
+import { base64ToArrayBuffer } from "./utils";
 
 const FIVE_MEGABYTES = 5e6;
 
@@ -14,7 +14,7 @@ const HttpBody = ({
 }: {
   bodyParts: BodyData[];
   contentLength?: string;
-  contentType: ContentType;
+  contentType: "json" | "text" | "other";
 }) => {
   const content = useMemo(
     () =>

--- a/src/ui/components/NetworkMonitor/Table.tsx
+++ b/src/ui/components/NetworkMonitor/Table.tsx
@@ -7,7 +7,7 @@ import {
   useTable,
   TableInstance,
 } from "react-table";
-import { partialRequestsToCompleteSummaries, RequestSummary, RequestType } from "./utils";
+import { CanonicalRequestType, partialRequestsToCompleteSummaries, RequestSummary } from "./utils";
 
 export default function Table({
   children,
@@ -22,7 +22,7 @@ export default function Table({
   }) => JSX.Element;
   events: RequestEventInfo[];
   requests: RequestInfo[];
-  types: Set<RequestType>;
+  types: Set<CanonicalRequestType>;
 }) {
   const columns = useMemo(
     () => [

--- a/src/ui/components/NetworkMonitor/TypesDropdown.tsx
+++ b/src/ui/components/NetworkMonitor/TypesDropdown.tsx
@@ -3,14 +3,14 @@ import React, { useState } from "react";
 import PortalDropdown from "ui/components/shared/PortalDropdown";
 import { Dropdown, DropdownItem, DropdownItemContent } from "ui/components/Library/LibraryDropdown";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
-import { RequestType, REQUEST_ICONS, REQUEST_TYPES } from "./utils";
+import { CanonicalRequestType, RequestTypeOptions } from "./utils";
 
 export default function TypesDropdown({
   types,
   toggleType,
 }: {
-  types: Set<RequestType>;
-  toggleType: (type: RequestType) => void;
+  types: Set<CanonicalRequestType>;
+  toggleType: (type: CanonicalRequestType) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -20,7 +20,15 @@ export default function TypesDropdown({
     </MaterialIcon>
   );
 
-  const TypeItem = ({ icon, label, type }: { icon: string; label: string; type: RequestType }) => {
+  const TypeItem = ({
+    icon,
+    label,
+    type,
+  }: {
+    icon: string;
+    type: CanonicalRequestType;
+    label: string;
+  }) => {
     return (
       <DropdownItem onClick={() => toggleType(type)}>
         <DropdownItemContent selected={types.has(type)} icon={icon}>
@@ -40,12 +48,12 @@ export default function TypesDropdown({
       position="bottom-right"
     >
       <Dropdown>
-        {Object.entries(REQUEST_TYPES).map((pair: string[]) => (
+        {RequestTypeOptions.map(canonicalType => (
           <TypeItem
-            key={pair[0]}
-            icon={REQUEST_ICONS[pair[0]] || "description"}
-            type={pair[0] as RequestType}
-            label={pair[1]}
+            key={canonicalType.type}
+            label={canonicalType.label}
+            icon={canonicalType.icon}
+            type={canonicalType.type}
           />
         ))}
       </Dropdown>

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -13,7 +13,7 @@ import { getCurrentTime } from "ui/reducers/timeline";
 import { UIState } from "ui/state";
 import RequestDetails from "./RequestDetails";
 import RequestTable from "./RequestTable";
-import { RequestSummary, RequestType } from "./utils";
+import { CanonicalRequestType, RequestSummary } from "./utils";
 import FilterBar from "./FilterBar";
 import Table from "./Table";
 import { fetchFrames, fetchResponseBody, fetchRequestBody } from "ui/actions/network";
@@ -32,20 +32,21 @@ export const NetworkMonitor = ({
   selectFrame,
 }: PropsFromRedux) => {
   const [selectedRequest, setSelectedRequest] = useState<RequestSummary>();
-  const [types, setTypes] = useState<Set<RequestType>>(new Set(["xhr", "javascript", "html"]));
+  const [types, setTypes] = useState<Set<CanonicalRequestType>>(new Set([]));
   const [vert, setVert] = useState<boolean>(false);
 
   const container = useRef<HTMLDivElement>(null);
 
   const closePanel = () => setSelectedRequest(undefined);
 
-  const toggleType = (type: RequestType) => {
-    if (types.has(type)) {
-      types.delete(type);
+  const toggleType = (type: CanonicalRequestType) => {
+    const newTypes = new Set(types);
+    if (newTypes.has(type)) {
+      newTypes.delete(type);
     } else {
-      types.add(type);
+      newTypes.add(type);
     }
-    setTypes(new Set(types));
+    setTypes(newTypes);
   };
 
   let resizeObserver = useRef(

--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -11,7 +11,19 @@ import {
 import keyBy from "lodash/keyBy";
 import { compareNumericStrings } from "protocol/utils";
 
-export type ContentType = "json" | "text" | "other";
+export enum CanonicalRequestType {
+  CSS,
+  FETCH_XHR,
+  FONT,
+  HTML,
+  IMAGE,
+  JAVASCRIPT,
+  MANIFEST,
+  MEDIA,
+  OTHER,
+  WASM,
+  WEBSOCKET,
+}
 
 export type RequestSummary = {
   domain: string;
@@ -30,41 +42,55 @@ export type RequestSummary = {
   start: number;
   status: number;
   time: number;
+  type: CanonicalRequestType;
   url: string;
 };
 
-export const REQUEST_TYPES = {
-  xhr: "Fetch/XHR",
-  javascript: "Javascript",
-  html: "HTML",
-  css: "CSS",
-  font: "Font",
-  img: "Image",
-  manifest: "Manifest",
-  media: "Media",
-  other: "Other",
-  wasm: "WASM",
-  websocket: "Websocket",
+export const RequestTypeOptions: { type: CanonicalRequestType; icon: string; label: string }[] = [
+  { type: CanonicalRequestType.CSS, icon: "color_lens", label: "CSS" },
+  { type: CanonicalRequestType.FETCH_XHR, icon: "description", label: "Fetch/XHR" },
+  { type: CanonicalRequestType.FONT, icon: "text_fields", label: "Font" },
+  { type: CanonicalRequestType.HTML, icon: "description", label: "HTML" },
+  { type: CanonicalRequestType.IMAGE, icon: "perm_media", label: "Image" },
+  { type: CanonicalRequestType.JAVASCRIPT, icon: "code", label: "Javascript" },
+  { type: CanonicalRequestType.MANIFEST, icon: "description", label: "Manifest" },
+  { type: CanonicalRequestType.MEDIA, icon: "perm_media", label: "Media" },
+  { type: CanonicalRequestType.OTHER, icon: "question_mark", label: "Other" },
+  { type: CanonicalRequestType.WASM, icon: "handyman", label: "WASM" },
+  { type: CanonicalRequestType.WEBSOCKET, icon: "autorenew", label: "Websocket" },
+];
+
+// From https://github.com/RecordReplay/gecko-dev/blob/webreplay-release/devtools/server/actors/replay/network-helpers.jsm#L14
+export const REQUEST_TYPES: Record<string, CanonicalRequestType> = {
+  subdocument: CanonicalRequestType.HTML,
+  objectSubdoc: CanonicalRequestType.HTML,
+
+  fetch: CanonicalRequestType.FETCH_XHR,
+  xhr: CanonicalRequestType.FETCH_XHR,
+
+  beacon: CanonicalRequestType.OTHER,
+  csp: CanonicalRequestType.OTHER,
+  dtd: CanonicalRequestType.OTHER,
+  invalid: CanonicalRequestType.OTHER,
+  object: CanonicalRequestType.OTHER,
+  other: CanonicalRequestType.OTHER,
+  ping: CanonicalRequestType.OTHER,
+  xslt: CanonicalRequestType.OTHER,
+
+  img: CanonicalRequestType.IMAGE,
+  imageset: CanonicalRequestType.IMAGE,
+
+  font: CanonicalRequestType.FONT,
+  webManifest: CanonicalRequestType.MANIFEST,
+  media: CanonicalRequestType.MEDIA,
+  script: CanonicalRequestType.JAVASCRIPT,
+  stylesheet: CanonicalRequestType.CSS,
+  wasm: CanonicalRequestType.WASM,
+  websocket: CanonicalRequestType.WEBSOCKET,
 };
 
 export const findHeader = (headers: Header[] | undefined, key: string): string | undefined =>
   headers?.find(h => h.name.toLowerCase() === key)?.value;
-
-export const REQUEST_ICONS: Record<string, string> = {
-  xhr: "description",
-  javascript: "code",
-  css: "color_lens",
-  font: "text_fields",
-  html: "description",
-  img: "perm_media",
-  manifest: "description",
-  media: "perm_media",
-  other: "question_mark",
-  wasm: "handyman",
-  websocket: "autorenew",
-};
-
-export type RequestType = keyof typeof REQUEST_TYPES;
 
 export type RequestEventMap = {
   request: { time: number; event: RequestOpenEvent };
@@ -106,7 +132,7 @@ const getDocumentType = (headers: Header[]): string => {
 export const partialRequestsToCompleteSummaries = (
   requests: RequestInfo[],
   events: RequestEventInfo[],
-  types: Set<RequestType>
+  types: Set<CanonicalRequestType>
 ): RequestSummary[] => {
   const eventsMap = eventsByRequestId(events);
   const summaries = requests
@@ -119,7 +145,6 @@ export const partialRequestsToCompleteSummaries = (
       const request = r.events.request;
       const response = r.events.response;
       const documentType = getDocumentType(response.event.responseHeaders);
-      const type: RequestType = (documentType?.split("/")?.[1] || documentType) as RequestType;
       return {
         documentType,
         domain: host(request.event.requestUrl),
@@ -140,33 +165,14 @@ export const partialRequestsToCompleteSummaries = (
         status: response.event.responseStatus,
         time: response.time - request.time,
         triggerPoint: r.triggerPoint,
-        type,
+        type: REQUEST_TYPES[request.event.requestCause || ""] || CanonicalRequestType.OTHER,
         url: request.event.requestUrl,
       };
     })
-    .filter(row => {
-      if (types.size === 0) {
-        return true;
-      }
-
-      if (types.has(row.type)) {
-        return true;
-      }
-      if (types.has("xhr") && row.type.match(/json/)) {
-        return true;
-      }
-
-      if (types.has("font") && row.type.match(/(woff|ttf)/)) {
-        return true;
-      }
-
-      if (types.has("img") && row.type.match(/(svg|jpeg|png|gif)/)) {
-        return true;
-      }
-      return false;
-    });
+    .filter(row => types.size === 0 || types.has(row.type));
 
   summaries.sort((a, b) => compareNumericStrings(a.point.point, b.point.point));
+
   return summaries;
 };
 
@@ -180,12 +186,15 @@ export function base64ToArrayBuffer(base64: string) {
   return bytes.buffer;
 }
 
-export const contentType = (headers: Header[]): ContentType => {
+export const contentType = (headers: Header[]): "json" | "text" | "other" => {
   const contentType = getDocumentType(headers);
   if (contentType?.startsWith("application/json")) {
     return "json";
   }
   if (contentType?.startsWith("text/")) {
+    return "text";
+  }
+  if (contentType?.startsWith("application/x-www-form-urlencoded")) {
     return "text";
   }
   return "other";


### PR DESCRIPTION
I hope this makes sense. When we get requests, they can have a variety of types. But when we present filtering options to the user, we usually want to show rougher groupings. I have added a new type called `CanonicalRequestType`, which reflects what group we lump that kind of request into. We use those values to let the user filter requests. I think this simplifies the problem a little bit, because all of the logic goes into one place, rather than having to do one-off checks (like we were doing for `Fetch/XHR`) for categories that contain multiple smaller types.