### PR TITLE
Stop ESLint warnings

### DIFF
--- a/pages/callback.tsx
+++ b/pages/callback.tsx
@@ -23,7 +23,7 @@ export default function Connection() {
         redirectUri: home,
       })
     );
-  }, []);
+  }, [auth0, connection, router]);
 
   return <LoadingScreen />;
 }

--- a/pages/profile/[...view].tsx
+++ b/pages/profile/[...view].tsx
@@ -16,7 +16,7 @@ function ProfilePage({ setModal }: PropsFromRedux) {
       setModal("settings", { view: "preferences" });
       replace("/");
     }
-  }, [modal]);
+  }, [isAuthenticated, modal, setModal, replace]);
 
   return <Account />;
 }

--- a/pages/recording/[id].tsx
+++ b/pages/recording/[id].tsx
@@ -84,7 +84,7 @@ function RecordingPage({
       setRecording(await getAccessibleRecording(recordingId));
     }
     getRecording();
-  }, [recordingId, store]);
+  }, [recordingId, store, getAccessibleRecording]);
 
   if (!recording || typeof window === "undefined") {
     return (

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -7,7 +7,7 @@ export default function SettingsRedirectPage() {
   useEffect(() => {
     // This is the existing route that should be deprecated
     replace("/profile/settings");
-  }, []);
+  }, [replace]);
 
   return null;
 }

--- a/pages/team/[...id].tsx
+++ b/pages/team/[...id].tsx
@@ -24,13 +24,13 @@ function TeamPage({ setWorkspaceId, setModal }: PropsFromRedux) {
 
       replace("/");
     }
-  }, [isAuthenticated, workspaceId]);
+  }, [isAuthenticated, workspaceId, replace, setWorkspaceId, updateDefaultWorkspace]);
 
   useEffect(() => {
     if (isAuthenticated && workspaceId && modal === "settings") {
       setModal("workspace-settings", view ? { view } : null);
     }
-  }, [isAuthenticated, workspaceId, modal, view]);
+  }, [isAuthenticated, workspaceId, modal, view, setModal]);
 
   return <Account />;
 }


### PR DESCRIPTION
Fixes #4965 by taking the ESLint warning literally. I am pretty sure this is fine, although it's a little dumb because we really don't expect these functions to change. The problem here usually starts when calling one of these functions inside of the effect causes the prop to change, causing another call and on and on into an infinite loop.

@abstractalgo Any thoughts on the *correct* thing to do here (probably using redux hooks I'm guessing 😄 )