### PR TITLE
Fix the network monitor's borders

### DIFF
--- a/src/devtools/client/shared/components/splitter/SplitBox.css
+++ b/src/devtools/client/shared/components/splitter/SplitBox.css
@@ -6,8 +6,6 @@
   display: flex;
   flex: 1;
   min-width: 0;
-  height: 100%;
-  width: 100%;
 }
 
 .split-box.vert {

--- a/src/devtools/client/shared/components/tabs/Tabs.css
+++ b/src/devtools/client/shared/components/tabs/Tabs.css
@@ -12,7 +12,7 @@
 }
 
 /* Hides the tab strip in the TabBar */
-div[hidetabs=true] .tabs .tabs-navigation {
+div[hidetabs="true"] .tabs .tabs-navigation {
   display: none;
 }
 
@@ -24,6 +24,14 @@ div[hidetabs=true] .tabs .tabs-navigation {
   position: relative;
   border-bottom: 1px solid var(--theme-splitter-color);
   background: var(--theme-tab-toolbar-background);
+}
+
+.requestDetails .tabs .tabs-navigation {
+  border-bottom: none;
+}
+
+.requestDetails .tabs .tabs-menu-item a {
+  border-bottom: none;
 }
 
 .tabs .tabs-menu {

--- a/src/devtools/packages/devtools-splitter/index.d.ts
+++ b/src/devtools/packages/devtools-splitter/index.d.ts
@@ -13,6 +13,7 @@ interface SplitBoxProps {
   endPanelCollapsed?: boolean;
   endPanelControl?: boolean;
   splitterSize?: number;
+  splitterClass?: string;
   vert?: boolean;
   style?: object;
   onResizeEnd?: Function;

--- a/src/devtools/packages/devtools-splitter/src/SplitBox.js
+++ b/src/devtools/packages/devtools-splitter/src/SplitBox.js
@@ -40,6 +40,8 @@ class SplitBox extends Component {
       endPanelControl: PropTypes.bool,
       // Size of the splitter handle bar.
       splitterSize: PropTypes.number,
+      // Class for the splitter handle bar.
+      splitterClass: PropTypes.string,
       // True if the splitter bar is vertical (default is vertical).
       vert: PropTypes.bool,
       // Optional style properties passed into the splitbox
@@ -208,6 +210,7 @@ class SplitBox extends Component {
       endPanel,
       endPanelControl,
       splitterSize,
+      splitterClass,
       endPanelCollapsed,
     } = this.props;
 
@@ -247,7 +250,7 @@ class SplitBox extends Component {
     const draggable =
       startPanelDiv && endPanelDiv
         ? Draggable({
-            className: "splitter",
+            className: `splitter ${splitterClass}`,
             style: splitterStyle,
             onStart: this.onStartMove,
             onStop: this.onStopMove,

--- a/src/ui/components/App.css
+++ b/src/ui/components/App.css
@@ -102,6 +102,10 @@
   width: 100%;
 }
 
+.no-scrollbar::-webkit-scrollbar {
+  width: 0px;
+}
+
 @import url("devtools/client/themes/variables.css");
 @import url("devtools/client/themes/webconsole.css");
 @import url("devtools/client/themes/components-frame.css");

--- a/src/ui/components/NetworkMonitor/HeaderGroups.tsx
+++ b/src/ui/components/NetworkMonitor/HeaderGroups.tsx
@@ -35,7 +35,7 @@ export function HeaderGroups({
       )}
       {headerGroups.map((headerGroup: HeaderGroup<RequestSummary>) => (
         <div
-          className="flex font-normal items-center divide-x bg-toolbarBackground"
+          className="flex font-normal items-center divide-x"
           {...headerGroup.getHeaderGroupProps()}
         >
           {headerGroup.headers.map(column => (

--- a/src/ui/components/NetworkMonitor/HttpBody.tsx
+++ b/src/ui/components/NetworkMonitor/HttpBody.tsx
@@ -34,11 +34,7 @@ const HttpBody = ({
   }, [content, contentType]);
 
   if (Number(contentLength) > FIVE_MEGABYTES) {
-    return (
-      <div className="bg-white w-full overflow-y-auto">
-        <div>This response is larger than 5MB, so it will only be partially displayed</div>
-      </div>
-    );
+    return <div>This response is larger than 5MB, so it will only be partially displayed</div>;
   }
 
   if (json) {

--- a/src/ui/components/NetworkMonitor/RequestDetails.module.css
+++ b/src/ui/components/NetworkMonitor/RequestDetails.module.css
@@ -1,10 +1,7 @@
 .requestDetails {
-  background: white;
   display: flex;
   flex-direction: column;
-  overflow-x: auto;
   font-size: 12px;
-  height: 100%;
 }
 
 .requestDetails .request {

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -43,8 +43,8 @@ function FormattedUrl({ url }: { url: string }) {
 const DetailTable = ({ className, details }: { className?: string; details: Detail[] }) => {
   return (
     <div className={classNames(className, "flex flex-col")}>
-      {details.map(h => (
-        <div className={classNames(styles.row, "hover:bg-gray-100 py-1")} key={h.name}>
+      {details.map((h, i) => (
+        <div className={classNames(styles.row, "hover:bg-gray-100 py-1")} key={`${h.name}-${i}`}>
           <span className="font-bold ">{h.name}:</span> {h.value}
         </div>
       ))}
@@ -231,13 +231,16 @@ const RequestDetails = ({
   }, [activeTab, activeTabs]);
 
   return (
-    <div className="h-full w-full overflow-hidden">
-      <div className={classNames("", styles.requestDetails)}>
-        <div className="flex justify-between bg-toolbarBackground items-center">
-          <PanelTabs tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
-          <CloseButton buttonClass="" handleClick={closePanel} tooltip={"Close tab"} />
-        </div>
-        <div className="overflow-auto">
+    <div className="bg-white border-l min-w-full overflow-scroll">
+      <div
+        className="flex border-b justify-between bg-toolbarBackground items-center sticky z-10 top-0"
+        style={{ height: 25 }}
+      >
+        <PanelTabs tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
+        <CloseButton buttonClass="mr-1" handleClick={closePanel} tooltip={"Close tab"} />
+      </div>
+      <div className={classNames("requestDetails", styles.requestDetails)}>
+        <div>
           {activeTab == "headers" && <HeadersPanel request={request} />}
           {activeTab == "cookies" && <Cookies request={request} />}
           {activeTab == "response" && (

--- a/src/ui/components/NetworkMonitor/RequestTable.module.css
+++ b/src/ui/components/NetworkMonitor/RequestTable.module.css
@@ -3,9 +3,11 @@ table.requests {
 }
 
 .row {
-  position: relative;
-  border: 2px solid transparent;
+  background: white;
+  border-top: 2px solid transparent;
+  border-bottom: 2px solid transparent;
   min-width: fit-content;
+  position: relative;
   width: 100%;
 }
 
@@ -25,6 +27,14 @@ table.requests {
 
 .row.current {
   border-top: 2px solid var(--secondary-accent);
+}
+
+.current.end {
+  background: var(--secondary-accent);
+  height: 2px;
+  width: 100%;
+  position: absolute;
+  bottom: 0;
 }
 
 .resizer {

--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -7,6 +7,7 @@ import { RequestRow } from "./RequestRow";
 import { Row, TableInstance } from "react-table";
 
 const RequestTable = ({
+  className,
   currentTime,
   data,
   onRowSelect,
@@ -14,6 +15,7 @@ const RequestTable = ({
   selectedRequest,
   table,
 }: {
+  className?: string;
   currentTime: number;
   data: RequestSummary[];
   onRowSelect: (request: RequestSummary) => void;
@@ -31,15 +33,17 @@ const RequestTable = ({
   let inPast = true;
 
   return (
-    <div className="bg-white w-full overflow-y-auto">
-      <div className={classNames(styles.request)} {...getTableProps()}>
-        <div
-          className="sticky z-10 top-0 bg-toolbarBackground border-b border-t w-full"
-          style={{ minWidth: "fit-content" }}
-        >
+    <div className={classNames("no-scrollbar bg-white min-w-full overflow-scroll", className)}>
+      {/* Relative here helps with when the timeline goes past the last request*/}
+      <div
+        style={{ minWidth: "fit-content" }}
+        className={classNames(styles.request, "relative")}
+        {...getTableProps()}
+      >
+        <div className="sticky z-10 top-0 bg-toolbarBackground border-b">
           <HeaderGroups columns={columns} headerGroups={headerGroups} />
         </div>
-        <div {...getTableBodyProps()}>
+        <div style={{ minWidth: "fit-content" }} {...getTableBodyProps()}>
           {rows.map((row: Row<RequestSummary>) => {
             let firstInFuture = false;
             if (inPast && row.original.point.time >= currentTime) {
@@ -62,12 +66,13 @@ const RequestTable = ({
               />
             );
           })}
+          <div
+            className={classNames({
+              [styles.current]: data.every(r => (r.point?.time || 0) < currentTime),
+              [styles.end]: data.every(r => (r.point?.time || 0) < currentTime),
+            })}
+          />
         </div>
-        <div
-          className={classNames(styles.row, {
-            [styles.current]: data.every(r => (r.point?.time || 0) <= currentTime),
-          })}
-        />
       </div>
     </div>
   );

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -54,61 +54,61 @@ export const NetworkMonitor = ({
   );
 
   useEffect(() => {
+    console.log({ current: container.current?.offsetWidth });
     if (container.current) {
       resizeObserver.current.observe(container.current);
     }
   }, [container.current]);
 
   return (
-    <div className="network-monitor overflow-hidden h-full" ref={container}>
-      <Table events={events} requests={requests} types={types}>
-        {({ table, data }: { table: any; data: RequestSummary[] }) => (
-          <>
-            <FilterBar types={types} toggleType={toggleType} table={table} />
-            <SplitBox
-              className="max-h-full"
-              initialSize="50%"
-              minSize={selectedRequest ? "20%" : "100%"}
-              maxSize={selectedRequest ? "80%" : "100%"}
-              endPanel={
-                selectedRequest ? (
-                  <RequestDetails
-                    closePanel={closePanel}
-                    cx={cx}
-                    request={selectedRequest}
-                    responseBody={responseBodies[selectedRequest.id]}
-                    requestBody={requestBodies[selectedRequest.id]}
-                    frames={frames[selectedRequest?.point.point]}
-                    selectFrame={selectFrame}
-                  />
-                ) : null
-              }
-              startPanel={
-                <RequestTable
-                  table={table}
-                  data={data}
-                  currentTime={currentTime}
-                  onRowSelect={row => {
-                    fetchFrames(row.point);
-                    if (row.hasResponseBody) {
-                      fetchResponseBody(row.id);
-                    }
-                    if (row.hasRequestBody) {
-                      fetchRequestBody(row.id);
-                    }
-                    setSelectedRequest(row);
-                  }}
-                  seek={seek}
-                  selectedRequest={selectedRequest}
+    <Table events={events} requests={requests} types={types}>
+      {({ table, data }: { table: any; data: RequestSummary[] }) => (
+        <div className="flex flex-col min-h-0 h-full" ref={container}>
+          <FilterBar types={types} toggleType={toggleType} table={table} />
+          <SplitBox
+            className="border-t min-h-0"
+            initialSize="350"
+            minSize={selectedRequest ? "20%" : "100%"}
+            maxSize={selectedRequest ? "80%" : "100%"}
+            startPanel={
+              <RequestTable
+                table={table}
+                data={data}
+                currentTime={currentTime}
+                onRowSelect={row => {
+                  fetchFrames(row.point);
+                  if (row.hasResponseBody) {
+                    fetchResponseBody(row.id);
+                  }
+                  if (row.hasRequestBody) {
+                    fetchRequestBody(row.id);
+                  }
+                  setSelectedRequest(row);
+                }}
+                seek={seek}
+                selectedRequest={selectedRequest}
+              />
+            }
+            endPanel={
+              selectedRequest && (
+                <RequestDetails
+                  closePanel={closePanel}
+                  cx={cx}
+                  request={selectedRequest}
+                  responseBody={responseBodies[selectedRequest.id]}
+                  requestBody={requestBodies[selectedRequest.id]}
+                  frames={frames[selectedRequest?.point.point]}
+                  selectFrame={selectFrame}
                 />
-              }
-              vert={vert}
-              splitterSize={4}
-            />
-          </>
-        )}
-      </Table>
-    </div>
+              )
+            }
+            splitterClass="-m-1 bg-clip-padding box-border border-4 z-10"
+            splitterSize={1}
+            vert={vert}
+          />
+        </div>
+      )}
+    </Table>
   );
 };
 

--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -80,7 +80,6 @@ overflows its container (https://drafts.csswg.org/css-flexbox-1/#min-size-auto) 
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  height: 100%;
 }
 
 .secondary-toolbox .toolbox-bottom-panels {
@@ -98,5 +97,5 @@ overflows its container (https://drafts.csswg.org/css-flexbox-1/#min-size-auto) 
 }
 
 .secondary-toolbox .splitter {
-  background: var(--chrome);
+  background-clip: padding-box;
 }


### PR DESCRIPTION
# Before
![CleanShot 2022-01-12 at 14 37 17](https://user-images.githubusercontent.com/5903784/149234306-e69ee636-f841-43bc-bc5e-0105991b87a1.png)
- Border runs across only the left half of the filter bar when the details are open
- Border only runs along the bottom of the request detail tabs but doesn't extend to the end of the bar
- Scrollbar is big and combines with the splitter to make a crazy wide seam in pretty restricted real-estate

# After
![CleanShot 2022-01-12 at 14 56 07](https://user-images.githubusercontent.com/5903784/149236161-0158a764-cacf-4de5-bbd6-fafd5e910d02.png)

- Borders are the same width and color and won't suddenly stop running across anything
- Scroll bar is *much* narrower
- "But Josh!" you will say "how am I supposed to grab that tiny 1px splitter!?" And to that I say:

```
  background-clip: padding-box;
```

And by that I mean that the splitter can be grabbed across an 8px area, but will only present as 1px wide because of a little magic in the combination of `background-clip: padding-box`, transparent borders, and negative margin.
