### PR TITLE
Fix e2e tests that use the elements panel

### DIFF
--- a/public/test/scripts/highlighter.js
+++ b/public/test/scripts/highlighter.js
@@ -1,4 +1,7 @@
 Test.describe(`Test that the element highlighter works everywhere.`, async () => {
+  await Test.selectConsole();
+  await Test.warpToMessage("ExampleFinished");
+
   await Test.selectInspector();
   await Test.searchMarkup("iframediv");
   await Test.waitForSelectedMarkupNode(`div id="iframediv"`);

--- a/public/test/scripts/inspector-01.js
+++ b/public/test/scripts/inspector-01.js
@@ -1,5 +1,8 @@
 // Test basic inspector functionality: the inspector is able to
 Test.describe(`show contents when paused according to the child's current position.`, async () => {
+  await Test.selectConsole();
+  await Test.warpToMessage("ExampleFinished");
+
   await Test.selectInspector();
 
   let node;

--- a/public/test/scripts/inspector-03.js
+++ b/public/test/scripts/inspector-03.js
@@ -1,4 +1,7 @@
 Test.describe(`Test that styles for elements can be viewed.`, async () => {
+  await Test.selectConsole();
+  await Test.warpToMessage("ExampleFinished");
+
   await Test.selectInspector();
 
   let node;

--- a/public/test/scripts/inspector-04.js
+++ b/public/test/scripts/inspector-04.js
@@ -1,4 +1,7 @@
 Test.describe(`Test the rule view`, async () => {
+  await Test.selectConsole();
+  await Test.warpToMessage("ExampleFinished");
+
   await Test.selectInspector();
 
   Test.it(`Check rules for "maindiv" node`, async () => {

--- a/public/test/scripts/inspector-05.js
+++ b/public/test/scripts/inspector-05.js
@@ -1,4 +1,7 @@
 Test.describe(`Test showing rules in source mapped style sheets.`, async () => {
+  await Test.selectConsole();
+  await Test.warpToMessage("ExampleFinished");
+
   await Test.selectInspector();
 
   const node = await Test.findMarkupNode("maindiv");

--- a/public/test/scripts/inspector-06.js
+++ b/public/test/scripts/inspector-06.js
@@ -1,4 +1,7 @@
 Test.describe(`Test showing both longhand and shorthand properties in rules.`, async () => {
+  await Test.selectConsole();
+  await Test.warpToMessage("ExampleFinished");
+
   await Test.selectInspector();
 
   const node = await Test.findMarkupNode('<div id="first" class="parent">');

--- a/public/test/scripts/inspector-07.js
+++ b/public/test/scripts/inspector-07.js
@@ -1,4 +1,7 @@
 Test.describe(`Test showing both longhand and shorthand properties in rules.`, async () => {
+  await Test.selectConsole();
+  await Test.warpToMessage("ExampleFinished");
+
   await Test.selectInspector();
 
   let node = await Test.findMarkupNode('<div id="first" class="parent">');

--- a/public/test/scripts/stacking.js
+++ b/public/test/scripts/stacking.js
@@ -1,6 +1,9 @@
 Test.describe(
   `Test that the element highlighter selects the correct element when they overlap.`,
   async () => {
+    await Test.selectConsole();
+    await Test.warpToMessage("ExampleFinished");
+
     await Test.selectInspector();
 
     // elements are stacked in the order in which they appear in the DOM (from back to front)

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -779,7 +779,7 @@ async function checkHighlighterShape(svgPath) {
   const highlighterPath = await waitUntil(
     () => {
       const highlighterNode = document.getElementById("box-model-content");
-      return (highlighterPath = highlighterNode?.attributes["d"].textContent);
+      return highlighterNode?.attributes["d"].textContent;
     },
     { waitingFor: "highlighter to appear" }
   );


### PR DESCRIPTION
Fixes the failures caused by RecordReplay/gecko-dev#665 and a bug in the test harness.