### PR TITLE
Figure out how to display more content types

### DIFF
--- a/src/ui/components/NetworkMonitor/BodyDownload.tsx
+++ b/src/ui/components/NetworkMonitor/BodyDownload.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useMemo } from "react";
+import { RawBody } from "./content";
+
+const BodyDownload = ({ raw, filename }: { raw: RawBody; filename: string }) => {
+  const dataURL = useMemo(
+    () => URL.createObjectURL(new Blob(raw.content, { type: raw.contentType })),
+    [raw]
+  );
+
+  useEffect(() => {
+    return () => URL.revokeObjectURL(dataURL);
+  }, [dataURL]);
+
+  return (
+    <a href={dataURL} download={filename} target="_blank" rel="noreferrer noopener">
+      <div className="mt-4 text-white inline-block p-2 rounded-lg bg-primaryAccent">
+        Download Body
+      </div>
+    </a>
+  );
+};
+
+export default BodyDownload;

--- a/src/ui/components/NetworkMonitor/RequestBody.tsx
+++ b/src/ui/components/NetworkMonitor/RequestBody.tsx
@@ -1,7 +1,6 @@
 import { RequestBodyData } from "@recordreplay/protocol";
 import React, { useState } from "react";
 import HttpBody from "./HttpBody";
-import { TriangleToggle } from "./RequestDetails";
 import { contentType, findHeader, RequestSummary } from "./utils";
 
 const RequestBody = ({
@@ -11,30 +10,20 @@ const RequestBody = ({
   request: RequestSummary | undefined;
   requestBodyParts: RequestBodyData[] | undefined;
 }) => {
-  const [expanded, setExpanded] = useState(true);
-
   if (!request || !requestBodyParts) {
     return null;
   }
 
   return (
     <>
-      <div
-        className="flex items-center py-1 cursor-pointer font-bold"
-        onClick={() => setExpanded(!expanded)}
-      >
-        <TriangleToggle open={expanded} />
-        Request body:
+      <div className="flex items-center pl-4 py-2 font-bold">Request body:</div>
+      <div className="pl-6">
+        <HttpBody
+          bodyParts={requestBodyParts}
+          contentType={findHeader(request.responseHeaders, "content-type") || "unknown"}
+          filename={request.name}
+        />
       </div>
-      {expanded && (
-        <div className="pl-6">
-          <HttpBody
-            bodyParts={requestBodyParts}
-            contentLength={findHeader(request.requestHeaders, "content-length")}
-            contentType={contentType(request.requestHeaders)}
-          />
-        </div>
-      )}
     </>
   );
 };

--- a/src/ui/components/NetworkMonitor/ResponseBody.tsx
+++ b/src/ui/components/NetworkMonitor/ResponseBody.tsx
@@ -1,7 +1,6 @@
 import { ResponseBodyData } from "@recordreplay/protocol";
-import React, { useState } from "react";
+import React from "react";
 import HttpBody from "./HttpBody";
-import { TriangleToggle } from "./RequestDetails";
 import { contentType, findHeader, RequestSummary } from "./utils";
 
 const ResponseBody = ({
@@ -11,30 +10,19 @@ const ResponseBody = ({
   request?: RequestSummary;
   responseBodyParts: ResponseBodyData[] | undefined;
 }) => {
-  const [expanded, setExpanded] = useState(true);
-
   if (!request || !responseBodyParts) {
     return null;
   }
-
   return (
     <>
-      <div
-        className="flex items-center py-1 cursor-pointer font-bold"
-        onClick={() => setExpanded(!expanded)}
-      >
-        <TriangleToggle open={expanded} />
-        Response body:
+      <div className="flex justify-between items-center px-4 py-2 font-bold">Response body:</div>
+      <div className="pl-6">
+        <HttpBody
+          bodyParts={responseBodyParts}
+          contentType={findHeader(request.responseHeaders, "content-type") || "unknown"}
+          filename={request.name}
+        />
       </div>
-      {expanded && (
-        <div className="pl-6">
-          <HttpBody
-            bodyParts={responseBodyParts}
-            contentLength={findHeader(request.responseHeaders, "content-length")}
-            contentType={contentType(request.responseHeaders)}
-          />
-        </div>
-      )}
     </>
   );
 };

--- a/src/ui/components/NetworkMonitor/content.ts
+++ b/src/ui/components/NetworkMonitor/content.ts
@@ -1,0 +1,117 @@
+import { BodyData } from "@recordreplay/protocol";
+
+// These are the types that we know how to display The functions in this file
+// have two jobs:
+// 1. Map the entire world of content types (see
+// http://www.iana.org/assignments/media-types/media-types.xhtml) onto the small
+// number of things that we know how to display
+// 2. When neccessary, change the form that we are holding that content in so
+// that we will be able to display it
+
+export enum Displayable {
+  JSON,
+  Text,
+  Raw,
+}
+
+export type JSONBody = {
+  // What to display it as when shown in the UI
+  as: Displayable.JSON;
+  // The content as it is currently held
+  content: object;
+  // The content-type header that the server sent with this request
+  contentType: string;
+};
+
+export type RawBody = {
+  as: Displayable.Raw;
+  content: ArrayBuffer[];
+  contentType: string;
+};
+
+export type TextBody = {
+  as: Displayable.Text;
+  content: string;
+  contentType: string;
+};
+
+// Here we will probably eventually add stuff like Image.
+export type DisplayableBody = JSONBody | RawBody | TextBody;
+
+const TEXTISH_CONTENT_TYPES = [
+  "application/javascript",
+  "application/json",
+  "application/xhtml+xml",
+  "application/xml",
+  "image/svg+xml",
+];
+
+export const shouldTryAndTurnIntoText = (contentType: string): boolean => {
+  const withoutCharset = contentType.split(";")[0];
+  if (withoutCharset.startsWith("text")) {
+    return true;
+  }
+  if (TEXTISH_CONTENT_TYPES.includes(withoutCharset)) {
+    return true;
+  }
+  return false;
+};
+
+export const Base64ToArrayBuffer = (base64: string): ArrayBuffer => {
+  var binaryString = atob(base64);
+  var len = binaryString.length;
+  var bytes = new Uint8Array(len);
+  for (var i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes.buffer;
+};
+
+export const BodyPartsToArrayBuffer = (bodyParts: BodyData[], contentType: string): RawBody => {
+  return {
+    as: Displayable.Raw,
+    content: bodyParts.map(p => p.value).map(Base64ToArrayBuffer),
+    contentType,
+  };
+};
+
+let utf8decoder = new TextDecoder();
+export const RawToUTF8 = (input: DisplayableBody): DisplayableBody => {
+  if (input.as === Displayable.Raw && shouldTryAndTurnIntoText(input.contentType)) {
+    return {
+      ...input,
+      as: Displayable.Text,
+      content: utf8decoder.decode(...input.content),
+    };
+  } else {
+    return input;
+  }
+};
+
+export const StringToObjectMaybe = (input: DisplayableBody): DisplayableBody => {
+  if (input.as === Displayable.Text) {
+    try {
+      return {
+        ...input,
+        as: Displayable.JSON,
+        content: JSON.parse(input.content),
+      };
+    } catch (e) {
+      return input;
+    }
+  } else {
+    return input;
+  }
+};
+
+export const URLEncodedToPlaintext = (input: DisplayableBody): DisplayableBody => {
+  if (input.contentType === "application/x-www-form-urlencoded" && input.as === Displayable.Text) {
+    return {
+      ...input,
+      as: Displayable.Text,
+      content: decodeURI(input.content),
+    };
+  } else {
+    return input;
+  }
+};


### PR DESCRIPTION
This is a little bit over-engineered probably for the current small set of things we display, but it felt like the kind of problem that could get hard to reason about or change pretty quickly. Right now all of these translation functions are applied in a fixed order, but theoretically in the future we could compose them differently for particular content types (and have something like a default stack otherwise). The idea is that each of the functions in `content.ts` takes a `DisplayableBody`, which can be:

- an HTTP body that is currently either a string, an ArrayBuffer, or a JSON object
- a flag saying which of those it is
- the original content-type header that came with it

Based off of that information, each function either returns the object untouched, or modifies the current representation (and accordingly, the flag). It seems to work pretty well right now! One situation that I'm not sure how to address is the `socket.io` requests in http://localhost:8080/recording/9ff6c903-d606-4bf2-b39d-3eb37e3eff7a. They seem to have a few nonsense bytes at the very beginning (hex `08 08 ef bf bd`), but otherwise are just normal JSON. I can't tell from googling what those bytes are supposed to be? Chrome displays the JSON preview correctly, so obviously this is a known possibility, but short of trying every substring in `JSON.parse` I'm not sure how to detect which bits are good and which are not? I guess we could filter out values outside of a particular unicode range and try and to parse the results?

---

Also, add the ability to download responses.

Fixes https://github.com/RecordReplay/devtools/issues/5012
Fixes https://github.com/RecordReplay/devtools/issues/5011