### PR TITLE
Do not cache SSR for uninitialized recordings

### DIFF
--- a/pages/recording/[id].tsx
+++ b/pages/recording/[id].tsx
@@ -118,11 +118,16 @@ const ConnectedRecordingPage = connector(RecordingPage);
 export const getStaticProps: GetStaticProps = async function ({ params }) {
   const id = Array.isArray(params?.id) ? params?.id[0] : params?.id;
   const metadata = id ? await getRecordingMetadata(id) : null;
+
+  const initialized = metadata?.initialized;
+  const canRenderMetadata = initialized && !metadata.private;
+
   return {
     props: {
-      metadata: metadata,
+      metadata: canRenderMetadata ? metadata : null,
     },
-    revalidate: !metadata?.initialized ? 1 : 360,
+    // revalidate immediately if the recording exists and hasn't been initialized
+    revalidate: !initialized ? 1 : 360,
   };
 };
 

--- a/pages/recording/[id].tsx
+++ b/pages/recording/[id].tsx
@@ -117,11 +117,12 @@ const ConnectedRecordingPage = connector(RecordingPage);
 
 export const getStaticProps: GetStaticProps = async function ({ params }) {
   const id = Array.isArray(params?.id) ? params?.id[0] : params?.id;
+  const metadata = id ? await getRecordingMetadata(id) : null;
   return {
     props: {
-      metadata: id ? await getRecordingMetadata(id) : null,
+      metadata: metadata,
     },
-    revalidate: 360,
+    revalidate: !metadata?.initialized ? 1 : 360,
   };
 };
 

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -781,5 +781,6 @@ export async function getRecordingMetadata(id: string) {
     url: json.data.recording.url,
     duration: json.data.recording.duration,
     owner: json.data.recording.owner?.name || null,
+    initialized: json.data.recording.isInitialized,
   };
 }

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -126,6 +126,16 @@ export interface Recording {
   operations: OperationsData;
 }
 
+export interface RecordingMetadata {
+  id: string;
+  url: string;
+  title: string;
+  duration: number;
+  private: boolean;
+  ownerName: string;
+  isInitialized: boolean;
+}
+
 export interface OperationsData {
   scriptDomains: string[];
   cookies?: string[];


### PR DESCRIPTION
## Issue

The server-side rendering of new, uninitialized recordings doesn't include the social metadata because the recording is private by default so the first render of the page for the upload screen caches a rendering for 60 minutes that doesn't include the metadata.

## Resolution

Set the refresh time to be "as soon as possible" (1) if the recording is not initialized.

## Notes

This isn't quite ready yet because if the recording hasn't been initialized yet, it can't be public so the graphql query can't find it.