### PR TITLE
Disable failing e2e tests

### DIFF
--- a/test/manifest.js
+++ b/test/manifest.js
@@ -44,6 +44,7 @@ module.exports = [
     // Not supported on chromium, needs source maps.
     // https://github.com/RecordReplay/chromium/issues/5
     targets: ["gecko"],
+    pending: true,
   },
   {
     // This test is pretty darn broken. The sources are different when recording
@@ -89,6 +90,7 @@ module.exports = [
     // Not supported on chromium, needs event listener support.
     // https://github.com/RecordReplay/chromium/issues/7
     targets: ["gecko"],
+    pending: true,
   },
   {
     example: "doc_async.html",
@@ -119,6 +121,7 @@ module.exports = [
     example: "doc_rr_basic.html",
     script: "console_eval.js",
     targets: ["gecko", "chromium"],
+    pending: true,
   },
   {
     example: "doc_async.html",
@@ -146,6 +149,7 @@ module.exports = [
     example: "cra/dist/index.html",
     script: "sourcemap_stacktrace.js",
     targets: ["gecko", "chromium"],
+    pending: true,
   },
   {
     example: "node/basic.js",
@@ -213,6 +217,7 @@ module.exports = [
     example: "doc_rr_objects.html",
     script: "object_preview-02.js",
     targets: ["gecko", "chromium"],
+    pending: true,
   },
   {
     example: "doc_rr_preview.html",
@@ -225,6 +230,7 @@ module.exports = [
     // Not supported on chromium, needs source maps.
     // https://github.com/RecordReplay/chromium/issues/5
     targets: ["gecko"],
+    pending: true,
   },
   {
     example: "node/objects.js",
@@ -263,6 +269,7 @@ module.exports = [
     example: "doc_inspector_sourcemapped.html",
     script: "inspector-05.js",
     targets: ["gecko"],
+    pending: true,
   },
   {
     example: "doc_inspector_shorthand.html",
@@ -273,6 +280,7 @@ module.exports = [
     example: "doc_inspector_shorthand.html",
     script: "inspector-07.js",
     targets: ["gecko"],
+    pending: true,
   },
   {
     example: "doc_inspector_basic.html",
@@ -293,6 +301,7 @@ module.exports = [
     example: "doc_rr_region_loading.html",
     script: "region_loading-01.js",
     targets: ["gecko", "chromium"],
+    pending: true,
   },
 
   //////////////////////////////////////////////////////////////////////////////
@@ -304,6 +313,7 @@ module.exports = [
     example: "doc_rr_basic.html",
     script: "settings.js",
     targets: ["gecko", "chromium"],
+    pending: true,
   },
   {
     example: "doc_rr_worker.html",
@@ -314,6 +324,7 @@ module.exports = [
     example: "cra/dist/index.html",
     script: "react_devtools.js",
     targets: ["gecko", "chromium"],
+    pending: true,
   },
   {
     example: "node/spawn.js",

--- a/test/vscodeTestLauncher.js
+++ b/test/vscodeTestLauncher.js
@@ -39,11 +39,12 @@ function loadTests() {
   const onlyTarget = process.env.TEST_ONLY_TARGET;
   const e2eTests = e2eManifest
     .filter(({ targets }) => !onlyTarget || targets.includes(onlyTarget))
-    .map(({ script }) => ({
+    .map(({ script, pending }) => ({
       type: "test",
       id: e2eTestPrefix + script,
       label: script,
       debuggable: false,
+      skipped: !!pending,
     }));
 
   const mockManifest = require("./mock/manifest");


### PR DESCRIPTION
At least some of these tests are currently failing because they need sourcemaps in the example recordings:
- playwright currently doesn't include sourcemaps in the example recordings: RecordReplay/ops#209
- at least some of the bundles and sourcemaps in the examples were manually edited in RecordReplay/devtools#4915 and are now broken - we need to recreate them with the necessary change (replacing `dump("RecReplaySendAsyncMessage Example__Finished")` with `console.log("ExampleFinished")`)