### PR TITLE
Fix the SplitBox css

### DIFF
--- a/src/devtools/client/shared/components/splitter/SplitBox.css
+++ b/src/devtools/client/shared/components/splitter/SplitBox.css
@@ -6,6 +6,8 @@
   display: flex;
   flex: 1;
   min-width: 0;
+  height: 100%;
+  width: 100%;
 }
 
 .split-box.vert {


### PR DESCRIPTION
@jcmorrow You removed these 2 lines in #5006, but this affects other panels (I noticed it in the elements panel). Adding them back I couldn't see any difference in the Network panel, but maybe I'm overlooking something...