### PR TITLE
Allow responses that are text-like enough to be copied

### DIFF
--- a/src/ui/components/NetworkMonitor/BodyDownload.tsx
+++ b/src/ui/components/NetworkMonitor/BodyDownload.tsx
@@ -1,7 +1,10 @@
-import { useEffect, useMemo } from "react";
+import classNames from "classnames";
+import { useEffect, useMemo, useState } from "react";
+import MaterialIcon from "../shared/MaterialIcon";
 import { RawBody } from "./content";
 
 const BodyDownload = ({ raw, filename }: { raw: RawBody; filename: string }) => {
+  const [downloaded, setDownloaded] = useState(false);
   const dataURL = useMemo(
     () => URL.createObjectURL(new Blob(raw.content, { type: raw.contentType })),
     [raw]
@@ -12,10 +15,22 @@ const BodyDownload = ({ raw, filename }: { raw: RawBody; filename: string }) => 
   }, [dataURL]);
 
   return (
-    <a href={dataURL} download={filename} target="_blank" rel="noreferrer noopener">
-      <div className="mt-4 text-white inline-block p-2 rounded-lg bg-primaryAccent">
-        Download Body
-      </div>
+    <a
+      className="block flex items-center ml-1"
+      href={dataURL}
+      download={filename}
+      target="_blank"
+      rel="noreferrer noopener"
+      onClick={() => {
+        setDownloaded(true);
+        setTimeout(() => {
+          setDownloaded(false);
+        }, 2000);
+      }}
+    >
+      <MaterialIcon iconSize="lg" className={classNames({ "text-primaryAccent": downloaded })}>
+        file_download
+      </MaterialIcon>
     </a>
   );
 };

--- a/src/ui/components/NetworkMonitor/HttpBody.module.css
+++ b/src/ui/components/NetworkMonitor/HttpBody.module.css
@@ -1,0 +1,8 @@
+.copy-container .copy-icon {
+  display: none;
+}
+
+.copy-container:hover .copy-icon {
+  display: inline-block;
+  cursor: pointer;
+}

--- a/src/ui/components/NetworkMonitor/HttpBody.tsx
+++ b/src/ui/components/NetworkMonitor/HttpBody.tsx
@@ -1,14 +1,50 @@
+import styles from "./HttpBody.module.css";
 import { BodyData } from "@recordreplay/protocol";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import ReactJson from "react-json-view";
+import MaterialIcon from "../shared/MaterialIcon";
 import BodyDownload from "./BodyDownload";
 import {
   BodyPartsToArrayBuffer,
   Displayable,
+  RawBody,
   RawToUTF8,
   StringToObjectMaybe,
+  TextBody,
   URLEncodedToPlaintext,
 } from "./content";
+import classNames from "classnames";
+
+const TextBodyComponent = ({ raw, text }: { raw: RawBody; text: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <div
+      className={classNames(styles["copy-container"], "relative pr-6")}
+      style={{ width: "fit-content" }}
+    >
+      <pre className="whitespace-pre-wrap">
+        {text}
+        <div
+          className="absolute z-10 top-0 right-1"
+          onClick={() => {
+            const asString = RawToUTF8(raw) as TextBody;
+            const blob = new Blob([asString.content], { type: "text/plain" });
+            navigator.clipboard.write([new ClipboardItem({ "text/plain": blob })]);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+          }}
+        >
+          <MaterialIcon
+            className={classNames(styles["copy-icon"], { "text-primaryAccent": copied })}
+          >
+            content_copy
+          </MaterialIcon>
+        </div>
+      </pre>
+    </div>
+  );
+};
 
 const HttpBody = ({
   bodyParts,
@@ -31,15 +67,22 @@ const HttpBody = ({
     return <ReactJson src={displayable.content} shouldCollapse={() => true} />;
   }
   if (displayable.as === Displayable.Text) {
-    return <pre className="max-w-full overflow-scroll">{displayable.content}</pre>;
+    return (
+      <>
+        <TextBodyComponent raw={raw} text={displayable.content} />
+      </>
+    );
   }
   if (displayable.as === Displayable.Raw) {
     return (
       <>
-        <p>
-          This content-type ({contentType}) cannot be displayed, but you can download the response.
-        </p>
-        <BodyDownload raw={raw} filename={filename} />
+        <div className="flex items-center">
+          <p>
+            This content-type ({contentType}) cannot be displayed, but you can download the
+            response.
+          </p>
+          <BodyDownload raw={raw} filename={filename} />
+        </div>
       </>
     );
   }

--- a/src/ui/components/NetworkMonitor/content.ts
+++ b/src/ui/components/NetworkMonitor/content.ts
@@ -41,6 +41,7 @@ export type DisplayableBody = JSONBody | RawBody | TextBody;
 const TEXTISH_CONTENT_TYPES = [
   "application/javascript",
   "application/json",
+  "application/octet-stream",
   "application/xhtml+xml",
   "application/xml",
   "image/svg+xml",


### PR DESCRIPTION
Responses that register as JSON can already be copied from the JSON viewer, but this adds copying for text responses (or content-types that we're registered as text-like *enough* to be rendered as text, e.g. `socket.io` sends things in `application/octet-stream`, but it's *mostly* legible plaintext UTF-8, with a couple of preceding control characters).

This also moves the `download response` button to a similar style.

https://user-images.githubusercontent.com/5903784/149573669-06b06cc6-4b7d-4adb-af14-b0ce3f952529.mp4

