### PR TITLE
Show requests with no responses 

### DIFF
--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -152,35 +152,39 @@ const HeadersPanel = ({ request }: { request: RequestSummary }) => {
       {requestHeadersExpanded && (
         <DetailTable className={styles.headerTable} details={requestHeaders} />
       )}
-      <h2
-        className={classNames("py-1 border-t cursor-pointer font-bold", styles.title)}
-        onClick={() => setResponseHeadersExpanded(!responseHeadersExpanded)}
-      >
-        <TriangleToggle open={responseHeadersExpanded} />
-        Response Headers
-      </h2>
-      {responseHeadersExpanded && (
-        <DetailTable className={styles.headerTable} details={responseHeaders} />
-      )}
-      {request.queryParams.length > 0 && (
-        <div>
+      {request.responseHeaders.length > 0 && (
+        <>
           <h2
             className={classNames("py-1 border-t cursor-pointer font-bold", styles.title)}
-            onClick={() => setQueryParametersExpanded(!queryParametersExpanded)}
+            onClick={() => setResponseHeadersExpanded(!responseHeadersExpanded)}
           >
-            <TriangleToggle open={queryParametersExpanded} />
-            Query Parameters
+            <TriangleToggle open={responseHeadersExpanded} />
+            Response Headers
           </h2>
-          {queryParametersExpanded && (
-            <DetailTable
-              className={classNames("py-1", styles.request)}
-              details={request.queryParams.map(x => ({
-                name: x[0],
-                value: x[1],
-              }))}
-            />
+          {responseHeadersExpanded && (
+            <DetailTable className={styles.headerTable} details={responseHeaders} />
           )}
-        </div>
+          {request.queryParams.length && (
+            <div>
+              <h2
+                className={classNames("py-1 border-t cursor-pointer font-bold", styles.title)}
+                onClick={() => setQueryParametersExpanded(!queryParametersExpanded)}
+              >
+                <TriangleToggle open={queryParametersExpanded} />
+                Query Parameters
+              </h2>
+              {queryParametersExpanded && (
+                <DetailTable
+                  className={classNames("py-1", styles.request)}
+                  details={request.queryParams.map(x => ({
+                    name: x[0],
+                    value: x[1],
+                  }))}
+                />
+              )}
+            </div>
+          )}
+        </>
       )}
     </>
   );
@@ -237,7 +241,7 @@ const RequestDetails = ({
         style={{ height: 25 }}
       >
         <PanelTabs tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
-        <CloseButton buttonClass="mr-1" handleClick={closePanel} tooltip={"Close tab"} />
+        <CloseButton buttonClass="mr-4" handleClick={closePanel} tooltip={"Close tab"} />
       </div>
       <div className={classNames("requestDetails", styles.requestDetails)}>
         <div>

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -54,7 +54,6 @@ export const NetworkMonitor = ({
   );
 
   useEffect(() => {
-    console.log({ current: container.current?.offsetWidth });
     if (container.current) {
       resizeObserver.current.observe(container.current);
     }


### PR DESCRIPTION
There are times when things go wrong for an HTTP request too early in
the process for a response event to get recorded. In that case we still
want to show the request (whereas right now we filter those out,
expecting them to eventually fully load with both a request and response
event).

Changes
---
- Show requests that have no responses
- When a request is to the root of a hostname, show the name as `/`, not
  an empty field
- Move the close button a little more left, in the Replay browser it
  sometimes gets hidden by the scrollbar

Fixes https://github.com/RecordReplay/customer-support/issues/12