### PR TITLE
Fix the layout of the search/filter boxes in the elements panel

### DIFF
--- a/src/devtools/client/inspector/computed/components/ComputedToolbar.tsx
+++ b/src/devtools/client/inspector/computed/components/ComputedToolbar.tsx
@@ -21,7 +21,7 @@ function ComputedToolbar(props: PropsFromRedux) {
 
   return (
     <div id="computed-toolbar" className="devtools-toolbar devtools-input-toolbar">
-      <div className="devtools-searchbox">
+      <div id="computed-search" className="devtools-searchbox">
         <input
           id="computed-searchbox"
           className="devtools-filterinput"

--- a/src/devtools/client/inspector/rules/components/SearchBox.tsx
+++ b/src/devtools/client/inspector/rules/components/SearchBox.tsx
@@ -7,7 +7,7 @@ type SearchBoxProps = {
 
 export const SearchBox: FC<SearchBoxProps> = ({ query, onQueryChange }) => {
   return (
-    <div className="devtools-searchbox">
+    <div id="ruleview-search" className="devtools-searchbox">
       <input
         id="ruleview-searchbox"
         type="text"

--- a/src/devtools/client/themes/inspector.css
+++ b/src/devtools/client/themes/inspector.css
@@ -208,3 +208,19 @@ iframe {
 #inspector-breadcrumbs-toolbar {
   height: calc(var(--theme-toolbar-height) + 1px);
 }
+
+#inspector-search,
+#ruleview-search,
+#computed-search {
+  flex-grow: 1;
+}
+
+#inspector-searchbox,
+#ruleview-searchbox,
+#computed-searchbox {
+  width: 100%;
+}
+
+#inspector-searchlabel {
+  white-space: nowrap;
+}


### PR DESCRIPTION
Before:
![Screenshot from 2022-01-17 16-29-33](https://user-images.githubusercontent.com/16060807/149798071-ef86515f-1c13-4b5f-92c2-76ffe1ef5bc6.png)
![Screenshot from 2022-01-17 16-29-52](https://user-images.githubusercontent.com/16060807/149798084-4a12d742-1b99-470c-a001-ea09a0c0eb3f.png)

After:
![Screenshot from 2022-01-17 16-33-33](https://user-images.githubusercontent.com/16060807/149798383-dec667a3-ddf1-442a-80de-7140151e8a5a.png)
![Screenshot from 2022-01-17 16-31-07](https://user-images.githubusercontent.com/16060807/149798106-16728b8f-07e1-457f-9f61-e9b70bc18a79.png)

