### PR TITLE
Show if the markup panel has focus (#4908)

### DIFF
--- a/src/devtools/client/themes/markup.css
+++ b/src/devtools/client/themes/markup.css
@@ -442,6 +442,11 @@ ul.children + .tag-line::before {
 
   overflow: auto;
   height: 100%;
+  border: 1px solid transparent;
+}
+
+#markup-box:focus-within {
+  border-color: var(--blue-50);
 }
 
 #markup-loading {


### PR DESCRIPTION
When the markup panel has focus (and therefore the cursor keys navigate in the markup and not in the timeline), we draw a blue border around it - the same border that we use to highlight text inputs having focus.