### PR TITLE
Keep the sidebar icon tooltip from overlapping with the editor

### DIFF
--- a/src/ui/components/shared/IconWithTooltip.css
+++ b/src/ui/components/shared/IconWithTooltip.css
@@ -23,18 +23,8 @@
   margin: var(--icon-margin);
 }
 
-.icon-with-tooltip .icon-tooltip {
-  width: max-content;
-  background: var(--theme-popup-color);
-  color: var(--theme-popup-background);
-  border-radius: 4px;
-  padding: 4px 8px;
-  line-height: 16px;
-  position: absolute;
-  display: inline-block;
-  margin-left: 8px;
+.icon-tooltip {
   animation: tooltip-pop-up 200ms ease;
-  z-index: var(--z-index-1--icon-tooltip);
 }
 
 @keyframes tooltip-pop-up {

--- a/src/ui/components/shared/IconWithTooltip.tsx
+++ b/src/ui/components/shared/IconWithTooltip.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from "react";
+import ReactDOM from "react-dom";
 
 interface IconWithTooltipProps {
   icon: React.ReactNode;
@@ -10,6 +11,7 @@ interface IconWithTooltipProps {
 // of the viewport. The tooltip appears to the immediate right of the provided icon.
 export default function IconWithTooltip({ icon, content, handleClick }: IconWithTooltipProps) {
   const timeoutKey = useRef<any>(null);
+  const [targetNode, setTargetNode] = useState<HTMLElement | null>(null);
   const [hovered, setHovered] = useState(false);
 
   const handleMouseEnter = () => {
@@ -22,10 +24,27 @@ export default function IconWithTooltip({ icon, content, handleClick }: IconWith
 
   return (
     <div className="icon-with-tooltip text-sm">
-      <button onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} onClick={handleClick}>
+      <button
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onClick={handleClick}
+        ref={node => setTargetNode(node)}
+      >
         {icon}
       </button>
-      {hovered ? <div className="icon-tooltip">{content}</div> : null}
+      {targetNode && hovered ? <IconTooltip targetNode={targetNode}>{content}</IconTooltip> : null}
     </div>
+  );
+}
+
+function IconTooltip({ targetNode, children }: { targetNode: HTMLElement; children: string }) {
+  const { top, left } = targetNode.getBoundingClientRect();
+  let style = { top: `${top}px`, left: `${left}px` };
+
+  return ReactDOM.createPortal(
+    <div className="icon-tooltip absolute z-10 ml-10 mt-1" style={style}>
+      <div className="text-sm py-1 px-2 bg-gray-700 text-white rounded-md">{children}</div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
Fix #4801.


https://user-images.githubusercontent.com/15959269/149982160-6d61ad46-9b65-48ea-9037-3e33ae666c78.mov

