### PR TITLE
Make the network monitor split more even

### DIFF
--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -77,8 +77,8 @@ export const NetworkMonitor = ({
           <SplitBox
             className="border-t min-h-0"
             initialSize="350"
-            minSize={selectedRequest ? "20%" : "100%"}
-            maxSize={selectedRequest ? "80%" : "100%"}
+            minSize={selectedRequest ? "30%" : "100%"}
+            maxSize={selectedRequest ? "70%" : "100%"}
             startPanel={
               <RequestTable
                 table={table}

--- a/src/ui/components/Viewer.tsx
+++ b/src/ui/components/Viewer.tsx
@@ -18,8 +18,8 @@ const Vertical = ({ showVideo }: ViewerProps) => {
       onResizeEnd={(num: number) => {
         prefs.secondaryPanelHeight = `${num}px`;
       }}
-      minSize={showVideo ? "20%" : "100%"}
-      maxSize={showVideo ? "80%" : "100%"}
+      minSize={showVideo ? "30%" : "100%"}
+      maxSize={showVideo ? "70%" : "100%"}
       vert={true}
       startPanel={<SecondaryToolbox />}
       endPanel={showVideo && <Video />}
@@ -37,8 +37,8 @@ const Horizontal = ({ showVideo }: ViewerProps) => {
       onResizeEnd={(num: number) => {
         prefs.secondaryPanelHeight = `${num}px`;
       }}
-      minSize={showVideo ? "100px" : "0"}
-      maxSize={showVideo ? "80%" : "0"}
+      minSize={showVideo ? "30%" : "0"}
+      maxSize={showVideo ? "70%" : "0"}
       vert={false}
       startPanel={showVideo && <Video />}
       endPanel={<SecondaryToolbox />}


### PR DESCRIPTION
When the secondary toolbox is at its smallest in the Viewer SplitBox and
the Request Details panel is at its smallest in the Network Monitor
SplitBox the Request Details panel is basically not visible at all. This
bumps the minimums from 20% to 30%. 30% is still too small for it to be
really usable, but it would be painful to have a larger minimum on big
displays, and this will at least cut out scenarios where it feels broken
because the RequestDetails just don't appear.

### Latest Version
![CleanShot 2022-01-18 at 09 33 30](https://user-images.githubusercontent.com/5903784/149988681-dc9f64ac-ca57-42fd-b62a-c7f31a1103c1.png)