### PR TITLE
Spruce up the elements panel toolbar

### DIFF
--- a/src/devtools/client/inspector/markup/components/MarkupApp.tsx
+++ b/src/devtools/client/inspector/markup/components/MarkupApp.tsx
@@ -39,8 +39,11 @@ function MarkupApp(props: PropsFromRedux & { inspector: Inspector }) {
             />
           </div>
           <div id="inspector-searchlabel-container" hidden={true}>
-            <div className="devtools-separator"></div>
-            <span id="inspector-searchlabel"></span>
+            <div
+              className="devtools-separator"
+              style={{ height: "calc(var(--theme-toolbar-height) - 8px" }}
+            ></div>
+            <span id="inspector-searchlabel" className="whitespace-nowrap"></span>
           </div>
           <div className="devtools-separator" hidden={true}></div>
           <button

--- a/src/devtools/client/shared/components/tabs/Tabs.css
+++ b/src/devtools/client/shared/components/tabs/Tabs.css
@@ -19,8 +19,7 @@ div[hidetabs="true"] .tabs .tabs-navigation {
 .tabs .tabs-navigation {
   box-sizing: border-box;
   display: flex;
-  /* Reserve 1px for the border */
-  height: calc(var(--theme-toolbar-height) + 1px);
+  height: 27px;
   position: relative;
   border-bottom: 1px solid var(--theme-splitter-color);
   background: var(--theme-tab-toolbar-background);

--- a/src/devtools/client/themes/inspector.css
+++ b/src/devtools/client/themes/inspector.css
@@ -80,7 +80,7 @@ window {
 }
 
 #inspector-searchlabel {
-  padding: 0 3px;
+  padding: 0 5px;
 }
 
 /* Add element toolbar button */

--- a/src/devtools/client/themes/toolbars.css
+++ b/src/devtools/client/themes/toolbars.css
@@ -29,13 +29,10 @@
 
 .devtools-input-toolbar {
   display: flex;
+  align-items: center;
   /* @TODO: Remove the !important in bug 1535956 */
   background-color: var(--theme-body-background) !important;
   color: inherit;
-}
-
-.devtools-input-toolbar > .devtools-searchbox:first-child {
-  margin-inline-start: -3px; /* This needs to match .devtools-toolbar's padding */
 }
 
 /* Expected space around a separator:
@@ -122,7 +119,13 @@
 }
 
 .devtools-sidebar-tabs tabs > tab {
-  border-image: linear-gradient(transparent 15%, var(--theme-splitter-color) 15%, var(--theme-splitter-color) 85%, transparent 85%) 1 1;
+  border-image: linear-gradient(
+      transparent 15%,
+      var(--theme-splitter-color) 15%,
+      var(--theme-splitter-color) 85%,
+      transparent 85%
+    )
+    1 1;
 }
 
 .devtools-sidebar-tabs tabs > tab[selected],


### PR DESCRIPTION
- Vertically center search bar items
- Make sure that the left side of the search box isn't cut off (I think at some point we removed the accompanying padding but not the negative margin)
- Make the toolbars the same height across the two panels
- Add a little more horizontal space around the results count
- Make the search box flex-grow so the results are on the right
- Remove the blue border on the input when focused

### Before
![CleanShot 2022-01-18 at 10 29 58](https://user-images.githubusercontent.com/5903784/149997289-9fd3d9b2-1b1c-4ffe-ace2-c28b8e5c6e89.png)


### After

![CleanShot 2022-01-18 at 14 53 13](https://user-images.githubusercontent.com/5903784/150031684-220a4b0f-78ff-4dc5-81fa-363f26ec2414.png)

