### PR TITLE
Update the UI to show if the entire recording has been unloaded

### DIFF
--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -160,7 +160,6 @@
 }
 
 .timeline .unloaded-regions {
-  width: 0%;
   height: 3px;
   border-radius: 4px;
   height: 3px;

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -290,6 +290,12 @@ class Timeline extends Component<PropsFromRedux> {
       return null;
     }
 
+    // An empty loadedRegions array after we've finished loading regions means that
+    // the whole recording has been unloaded.
+    if (loadedRegions.length === 0) {
+      return <div className="unloaded-regions w-full" />;
+    }
+
     const { begin, end } = loadedRegions[0];
     const { endTime } = zoomRegion;
     const loadedRegionStart = getVisiblePosition({ time: begin.time, zoom: zoomRegion }) * 100;

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -299,13 +299,14 @@ export const isFinishedLoadingRegions = (state: UIState) => {
   const loadedRegions = getLoadedRegions(state)?.loaded;
   const loadingRegions = getLoadedRegions(state)?.loading;
 
-  if (
-    !loadingRegions ||
-    !loadedRegions ||
-    loadingRegions.length === 0 ||
-    loadedRegions.length === 0
-  ) {
+  if (!loadingRegions || !loadedRegions) {
     return false;
+  }
+
+  // If the empty loaded/loading region arrays, that means that the entire
+  // recording has been unloaded. We consider that as having finished loading.
+  if (loadingRegions.length === 0 && loadedRegions.length === 0) {
+    return true;
   }
 
   const loading = loadingRegions[0];


### PR DESCRIPTION
Fix #4715.

![image](https://user-images.githubusercontent.com/15959269/150005999-2e63964a-d944-44ba-837a-558614c72b8f.png)
