### PR TITLE
Use the current time for new reply timestamp

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -200,7 +200,14 @@ function CommentCard({
           >
             <NewCommentEditor
               key={PENDING_COMMENT_ID}
-              comment={{ ...comment, content: "", parentId: comment.id, id: PENDING_COMMENT_ID }}
+              comment={{
+                ...comment,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                content: "",
+                parentId: comment.id,
+                id: PENDING_COMMENT_ID,
+              }}
               type={"new_reply"}
             />
           </FocusContext.Provider>


### PR DESCRIPTION
We were spreading in attributes for replies, which *mostly* makes sense,
but the dates should obviously be right now.

Fixes #4968 