### PR TITLE
Elements panel breadcrumbs fixes (#5032)

### DIFF
--- a/src/devtools/client/themes/breadcrumbs.css
+++ b/src/devtools/client/themes/breadcrumbs.css
@@ -34,7 +34,6 @@
   list-style-image: none;
   margin: 0;
   padding: 0;
-  visibility: collapse;
 }
 
 .scrollbutton-up > .toolbarbutton-icon,


### PR DESCRIPTION
- fixes the scroll buttons in Chrome
- fixes the ellipsis that is used when a breadcrumb is shortened