### PR TITLE
Fix #5046

### DIFF
--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -303,10 +303,10 @@ export const isFinishedLoadingRegions = (state: UIState) => {
     return false;
   }
 
-  // If the empty loaded/loading region arrays, that means that the entire
-  // recording has been unloaded. We consider that as having finished loading.
-  if (loadingRegions.length === 0 && loadedRegions.length === 0) {
-    return true;
+  if (loadedRegions.length === 0) {
+    // If the empty loaded/loading region arrays, that means that the entire
+    // recording has been unloaded. We consider that as having finished loading.
+    return loadingRegions.length === 0;
   }
 
   const loading = loadingRegions[0];


### PR DESCRIPTION
This fixes the unexpected error when loading a recording.
Note that the assumption expressed in the comment (that empty loading/loaded arrays mean that all regions were _unloaded_) is wrong: we usually get a loaded regions event with both arrays empty in the beginning, as can be seen in this screenshot:
![Screenshot from 2022-01-19 16-43-06](https://user-images.githubusercontent.com/16060807/150164853-218af606-75f4-4031-8736-fff2d74f9d02.png)

