### PR TITLE
Add configuration options to test runner

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -18,7 +18,9 @@ runs:
     - run: node ${{ github.action_path }}/../../../test/run.js
       shell: bash
       env:
-        RECORD_REPLAY_NODE: replay-node/macOS-replay-node
         RECORD_REPLAY_DRIVER: replay-driver/macOS-recordreplay.so
+        RECORD_REPLAY_NODE: replay-node/macOS-replay-node
         RECORD_REPLAY_PATH: firefox/Nightly.app/Contents/MacOS/firefox
+        RECORD_REPLAY_VERBOSE: 1
         SHOULD_RECORD_EXAMPLES: true
+        DEBUG: pw:browser*

--- a/test/src/getExample.js
+++ b/test/src/getExample.js
@@ -11,7 +11,7 @@ async function record(state, browserName, example) {
   console.log(`Recording Example:`, example, browserName);
 
   const browser = await playwright[browserName].launch({
-    executablePath: state.executablePath,
+    executablePath: state.browserPath,
     headless: state.headless,
   });
 

--- a/test/src/recordNode.js
+++ b/test/src/recordNode.js
@@ -24,8 +24,8 @@ async function recordNode(state, scriptPath) {
     console.log(`Skipping test: RECORD_REPLAY_NODE not set`);
     return;
   }
-  if (!process.env.RECORD_REPLAY_DRIVER) {
-    console.log(`Skipping test: RECORD_REPLAY_DRIVER not set`);
+  if (!state.driverPath) {
+    console.log(`Skipping test: RECORD_REPLAY_DRIVER not set and no --driverPath flag was passed`);
     return;
   }
 
@@ -34,9 +34,10 @@ async function recordNode(state, scriptPath) {
   spawnSync(process.env.RECORD_REPLAY_NODE, [scriptPath], {
     env: {
       ...process.env,
-      RECORD_REPLAY_RECORDING_ID_FILE: recordingIdFile,
-      RECORD_REPLAY_DISPATCH: state.dispatchServer,
       RECORD_REPLAY_API_KEY: state.replayApiKey,
+      RECORD_REPLAY_DISPATCH: state.dispatchServer,
+      RECORD_REPLAY_DRIVER: state.driverPath,
+      RECORD_REPLAY_RECORDING_ID_FILE: recordingIdFile,
     },
     stdio: "inherit",
   });

--- a/test/src/runTest.js
+++ b/test/src/runTest.js
@@ -11,8 +11,8 @@ async function recordBrowser(state, test, testPath, browserName) {
 
   let success, why;
   const browser = await playwright[browserName].launch({
+    executablePath: state.browserPath,
     headless: state.headless,
-    executablePath: state.executablePath,
   });
 
   const context = await browser.newContext();

--- a/test/src/state.js
+++ b/test/src/state.js
@@ -19,7 +19,8 @@ const defaultState = {
   headless: false,
   shouldRecordExamples: !!process.env.SHOULD_RECORD_EXAMPLES,
 
-  executablePath: process.env.RECORD_REPLAY_PATH,
+  browserPath: process.env.RECORD_REPLAY_PATH,
+  driverPath: process.env.RECORD_REPLAY_DRIVER,
   onlyTarget: process.env.onlyTarget,
   skippedTests: process.env.SKIPPED_TESTS,
   testTimeout: 240,
@@ -40,6 +41,8 @@ const usage = `
     --count N: Run tests N times
     --pattern PAT: Only run tests matching PAT
     --record-examples: Record the example and save the recordings locally for testing
+    --browserPath: Path to the local version of the replay browser to use
+    --driverPath: Path to the local version of the linker to use for recording examples
     --timeout N: Use a timeout of N seconds for tests (default 240).
     --target TARGET: Only run tests using given TARGET
     --server ADDRESS: Set server to connect to (default wss://dispatch.replay.io).
@@ -50,6 +53,12 @@ function processArgs(state, argv) {
     switch (arg) {
       case "--count":
         state.count = +argv[++i];
+        break;
+      case "--driverPath":
+        state.driverPath = argv[++i];
+        break;
+      case "--browserPath":
+        state.browserPath = argv[++i];
         break;
       case "--pattern":
         state.patterns.push(argv[++i]);
@@ -86,10 +95,25 @@ function processEnvironmentVariables(state) {
   }
 }
 
+function validateState(state) {
+  if (state.browserPath && !fs.existsSync(state.browserPath)) {
+    throw new Error(
+      `supplied browserPath (or $RECORD_REPLAY_PATH): ${state.browserPath} does not exist`
+    );
+  }
+  if (state.driverPath && !fs.existsSync(state.driverPath)) {
+    throw new Error(
+      `supplied driverPath (or $RECORD_REPLAY_DRIVER): ${state.driverPath} does not exist`
+    );
+  }
+}
+
 function bootstrap(argv) {
   let state = { ...defaultState };
   processArgs(state, argv);
   processEnvironmentVariables(state);
+  validateState(state);
+  console.log(state);
   return state;
 }
 


### PR DESCRIPTION
This adds explicit configuration options for `driverPath` (the linker to use when recording) and `browserPath` (the Replay Browser executable to use). Passing things by environment variables still totally works, but explicitly configuring this stuff makes doing things like overriding `replay-node` but only in certain cases (which is how we run the backend test suite) a *lot* easier.