### PR TITLE
Add support for annual subscriptions

### DIFF
--- a/src/stories/WorkspaceSettingsModal/PricingPage.stories.tsx
+++ b/src/stories/WorkspaceSettingsModal/PricingPage.stories.tsx
@@ -17,6 +17,7 @@ export const Team = Template.bind({});
 Team.args = {
   subscription: {
     billingSchedule: "monthly",
+    discount: 0,
     createdAt: new Date().toISOString(),
     createdBy: { name: "test", id: "test", internal: false, picture: "" },
     displayName: "Team",
@@ -43,6 +44,7 @@ export const Organization = Template.bind({});
 Organization.args = {
   subscription: {
     billingSchedule: "monthly",
+    discount: 0,
     createdAt: new Date().toISOString(),
     createdBy: { name: "test", id: "test", internal: false, picture: "" },
     displayName: "Organization",
@@ -69,6 +71,7 @@ export const BetaTester = Template.bind({});
 BetaTester.args = {
   subscription: {
     billingSchedule: null,
+    discount: 0,
     createdAt: new Date().toISOString(),
     createdBy: { name: "test", id: "test", internal: false, picture: "" },
     displayName: "Beta Tester Appreciation",

--- a/src/ui/components/shared/WorkspaceSettingsModal/PlanDetails.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/PlanDetails.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import { SubscriptionWithPricing } from "ui/types";
 import { ExpirationRow } from "./ExpirationRow";
 import startCase from "lodash/startCase";
-import { cycleCharge } from "./utils";
+import {
+  cycleCharge,
+  cycleDiscount,
+  cycleSubtotal,
+  formatCurrency,
+  formatPercentage,
+} from "./utils";
 
 export function PlanDetails({ subscription }: { subscription: SubscriptionWithPricing }) {
   return (
@@ -20,11 +26,23 @@ export function PlanDetails({ subscription }: { subscription: SubscriptionWithPr
         <>
           <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between">
             <span>Cost per seat</span>
-            <span>${subscription.seatPrice}</span>
+            <span>{formatCurrency(subscription.seatPrice)}</span>
           </div>
-          <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between">
+          {subscription.discount ? (
+            <>
+              <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between font-bold">
+                <span>Subtotal</span>
+                <span>{cycleSubtotal(subscription)}</span>
+              </div>
+              <div className="ml-3 py-2 border-b border-color-gray-50 flex flex-row items-center justify-between">
+                <span>Discount ({formatPercentage(subscription.discount)})</span>
+                <span>{cycleDiscount(subscription)}</span>
+              </div>
+            </>
+          ) : null}
+          <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between font-bold">
             <span>{startCase(subscription.billingSchedule)} charge</span>
-            <span>${cycleCharge(subscription)}</span>
+            <span>{cycleCharge(subscription)}</span>
           </div>
         </>
       )}

--- a/src/ui/components/shared/WorkspaceSettingsModal/PlanDetails.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/PlanDetails.tsx
@@ -10,7 +10,7 @@ export function PlanDetails({ subscription }: { subscription: SubscriptionWithPr
       <ExpirationRow subscription={subscription} />
       <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between">
         <span>Renewal Schedule</span>
-        <span>Monthly</span>
+        <span>{startCase(subscription.billingSchedule || "monthly")}</span>
       </div>
       <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between">
         <span>Number of seats</span>

--- a/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
@@ -45,6 +45,7 @@ export const pricingDetailsForSubscription = (subscription: Subscription): PlanP
         billingSchedule: null,
         displayName: "Beta Tester Appreciation",
         seatPrice: 0,
+        discount: 0,
         trial: isTrial(subscription),
       };
     case "team-v1":
@@ -53,13 +54,15 @@ export const pricingDetailsForSubscription = (subscription: Subscription): PlanP
         billingSchedule: "monthly",
         displayName: "Team",
         seatPrice: 20,
+        discount: 0,
         trial: isTrial(subscription),
       };
     case "team-annual-v1":
       return {
         billingSchedule: "annual",
         displayName: "Team",
-        seatPrice: 220,
+        seatPrice: 20,
+        discount: 0.1,
         trial: isTrial(subscription),
       };
     case "org-v1":
@@ -67,13 +70,15 @@ export const pricingDetailsForSubscription = (subscription: Subscription): PlanP
         billingSchedule: "monthly",
         displayName: "Organization",
         seatPrice: 75,
+        discount: 0,
         trial: isTrial(subscription),
       };
     case "org-annual-v1":
       return {
         billingSchedule: "annual",
         displayName: "Organization",
-        seatPrice: 825,
+        seatPrice: 75,
+        discount: 0.1,
         trial: isTrial(subscription),
       };
     case "ent-v1":
@@ -81,6 +86,7 @@ export const pricingDetailsForSubscription = (subscription: Subscription): PlanP
         billingSchedule: "contract",
         displayName: "Enterprise Contract",
         seatPrice: 0,
+        discount: 0,
         trial: false,
       };
   }
@@ -90,10 +96,40 @@ export const getSubscriptionWithPricing = (subscription: Subscription): Subscrip
   return { ...subscription, ...pricingDetailsForSubscription(subscription) };
 };
 
-export const cycleCharge = (planPricing: SubscriptionWithPricing): number => {
+const monthsPerCycle = (planPricing: SubscriptionWithPricing): number => {
+  return planPricing.billingSchedule === "annual" ? 12 : 1;
+};
+
+const calcSubtotal = (planPricing: SubscriptionWithPricing): number => {
   if (!planPricing.billingSchedule) {
     return 0;
   }
 
-  return planPricing.seatPrice * planPricing.seatCount;
+  return planPricing.seatPrice * planPricing.seatCount * monthsPerCycle(planPricing);
 };
+
+export const cycleDiscount = (planPricing: SubscriptionWithPricing): string => {
+  if (!planPricing.billingSchedule) {
+    return formatCurrency(0);
+  }
+
+  return formatCurrency(-1 * calcSubtotal(planPricing) * planPricing.discount);
+};
+
+export const cycleSubtotal = (planPricing: SubscriptionWithPricing): string => {
+  return formatCurrency(calcSubtotal(planPricing));
+};
+
+export const cycleCharge = (planPricing: SubscriptionWithPricing): string => {
+  return formatCurrency(calcSubtotal(planPricing) * (1 - planPricing.discount));
+};
+
+export function formatCurrency(amount: number) {
+  const formatter = new Intl.NumberFormat("en-us", { style: "currency", currency: "USD" });
+  return formatter.format(amount);
+}
+
+export function formatPercentage(amount: number) {
+  const formatter = new Intl.NumberFormat("en-us", { style: "percent" });
+  return formatter.format(amount);
+}

--- a/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
@@ -55,11 +55,25 @@ export const pricingDetailsForSubscription = (subscription: Subscription): PlanP
         seatPrice: 20,
         trial: isTrial(subscription),
       };
+    case "team-annual-v1":
+      return {
+        billingSchedule: "annual",
+        displayName: "Team",
+        seatPrice: 220,
+        trial: isTrial(subscription),
+      };
     case "org-v1":
       return {
         billingSchedule: "monthly",
         displayName: "Organization",
         seatPrice: 75,
+        trial: isTrial(subscription),
+      };
+    case "org-annual-v1":
+      return {
+        billingSchedule: "annual",
+        displayName: "Organization",
+        seatPrice: 825,
         trial: isTrial(subscription),
       };
     case "ent-v1":
@@ -81,9 +95,5 @@ export const cycleCharge = (planPricing: SubscriptionWithPricing): number => {
     return 0;
   }
 
-  let monthsPerCycle = 1;
-  if (planPricing.billingSchedule === "annual") {
-    monthsPerCycle = 12;
-  }
-  return monthsPerCycle * planPricing.seatPrice * planPricing.seatCount;
+  return planPricing.seatPrice * planPricing.seatCount;
 };

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -97,6 +97,7 @@ export interface PlanPricing {
   displayName: string;
   seatPrice: number;
   trial: boolean;
+  discount: number;
 }
 
 export interface SubscriptionWithPricing extends Subscription, PlanPricing {}

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -62,7 +62,15 @@ export interface PaymentMethod {
   };
 }
 
-type PlanKey = "org-v1" | "team-v1" | "test-team-v1" | "beta-v1" | "test-beta-v1" | "ent-v1";
+type PlanKey =
+  | "org-v1"
+  | "team-v1"
+  | "test-team-v1"
+  | "beta-v1"
+  | "test-beta-v1"
+  | "ent-v1"
+  | "team-annual-v1"
+  | "org-annual-v1";
 
 export interface Subscription {
   id: string;

--- a/test/ui/components/shared/WorkspaceSettingsModal/utils.test.js
+++ b/test/ui/components/shared/WorkspaceSettingsModal/utils.test.js
@@ -8,6 +8,7 @@ describe("subscriptionWithPricing", () => {
     expect(getSubscriptionWithPricing({ plan: { key: "team-v1" } })).toEqual({
       plan: { key: "team-v1" },
       billingSchedule: "monthly",
+      discount: 0,
       displayName: "Team",
       seatPrice: 20,
       trial: false,
@@ -18,6 +19,7 @@ describe("subscriptionWithPricing", () => {
     expect(getSubscriptionWithPricing({ plan: { key: "org-v1" } })).toEqual({
       plan: { key: "org-v1" },
       billingSchedule: "monthly",
+      discount: 0,
       displayName: "Organization",
       seatPrice: 75,
       trial: false,
@@ -27,14 +29,26 @@ describe("subscriptionWithPricing", () => {
 
 describe("cycleCharge", () => {
   test("will return the seatCount * seatPrice when billing monthly", () => {
-    expect(cycleCharge({ seatCount: 5, seatPrice: 25, billingSchedule: "monthly" })).toEqual(
-      5 * 25
-    );
+    expect(
+      cycleCharge({ seatCount: 5, seatPrice: 25, billingSchedule: "monthly", discount: 0 })
+    ).toEqual("$125.00");
+  });
+
+  test("will return the seatCount * seatPrice when billing monthly", () => {
+    expect(
+      cycleCharge({ seatCount: 5, seatPrice: 25, billingSchedule: "monthly", discount: 0.1 })
+    ).toEqual("$112.50");
   });
 
   test("will return the seatCount * seatPrice * 12 when billing annually", () => {
-    expect(cycleCharge({ seatCount: 5, seatPrice: 25, billingSchedule: "annual" })).toEqual(
-      5 * 25 * 12
-    );
+    expect(
+      cycleCharge({ seatCount: 5, seatPrice: 25, billingSchedule: "annual", discount: 0 })
+    ).toEqual("$1,500.00");
+  });
+
+  test("will apply the discount for the seatCount * seatPrice * 12 when billing annually", () => {
+    expect(
+      cycleCharge({ seatCount: 5, seatPrice: 25, billingSchedule: "annual", discount: 0.1 })
+    ).toEqual("$1,350.00");
   });
 });


### PR DESCRIPTION
## Issue

We'd like to be able to support yearly subscriptions. At the moment, this is limited to subscriptions manually created but will likely eventually allow for self service selection between monthly and annual subscriptions.

## Resolution

This first iteration adds support for displaying the details of two new annual plans -- one for teams and one for orgs -- so that any teams manually configured for those plans will render correctly in the app.

![image](https://user-images.githubusercontent.com/788456/150434368-11c3293d-1367-48a3-8a66-4ecdf19e20c3.png)
