### PR TITLE
Add back autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.14.8",
-        "@babel/generator": "^7.14.8",
+        "@babel/generator": "^7.16.8",
         "@babel/parser": "^7.14.8",
         "@babel/plugin-proposal-class-properties": "^7.14.5",
         "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
@@ -257,11 +257,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
+      "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
       "dependencies": {
-        "@babel/types": "^7.16.0",
+        "@babel/types": "^7.16.8",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -535,9 +535,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2121,11 +2121,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
+      "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -39010,11 +39010,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
+      "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
       "requires": {
-        "@babel/types": "^7.16.0",
+        "@babel/types": "^7.16.8",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -39216,9 +39216,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
@@ -40296,11 +40296,11 @@
       }
     },
     "@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
+      "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",
-    "@babel/generator": "^7.14.8",
+    "@babel/generator": "^7.16.8",
     "@babel/parser": "^7.14.8",
     "@babel/plugin-proposal-class-properties": "^7.14.5",
     "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",

--- a/src/devtools/client/debugger/src/reducers/pause.d.ts
+++ b/src/devtools/client/debugger/src/reducers/pause.d.ts
@@ -5,3 +5,4 @@ import { Source } from "./source";
 declare function getExecutionPoint(state: UIState): string | null;
 export function getAlternateSource(state: UIState): Source | null;
 export function getShouldLogExceptions(state: UIState): boolean;
+export function getFrameScope(state: UIState, frameId: string): any;

--- a/src/devtools/client/debugger/src/selectors/index.d.ts
+++ b/src/devtools/client/debugger/src/selectors/index.d.ts
@@ -27,3 +27,4 @@ export function hasFrames(state: UIState): boolean;
 export function getSelectedSourceWithContent(state: UIState): any;
 export function getSymbols(state: UIState, source: any): any;
 export function getCursorPosition(state: UIState): any;
+export function getSelectedFrame(state: UIState): any;

--- a/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
@@ -3,32 +3,29 @@ import classNames from "classnames";
 
 function Match({
   label,
-  selectedIndex,
-  index,
+  isSelected,
   onClick,
 }: {
   label: string;
-  selectedIndex: number;
-  index: number;
-  onClick: (index: number) => void;
+  isSelected: boolean;
+  onClick: (match: string) => void;
 }) {
-  const buttonNode = useRef<HTMLButtonElement | null>(null);
-  const selected = selectedIndex === index;
+  const buttonNode = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (selected && buttonNode.current) {
+    if (isSelected && buttonNode.current) {
       buttonNode.current.scrollIntoView({ block: "nearest", inline: "end" });
     }
-  }, [selected]);
+  }, [isSelected]);
 
   return (
     <button
       className={classNames(
         "text-left px-1 cursor-default",
-        selected ? "bg-blue-700 text-white" : "hover:bg-blue-100"
+        isSelected ? "bg-blue-700 text-white" : "hover:bg-blue-100"
       )}
       ref={buttonNode}
-      onClick={() => onClick(index)}
+      onClick={() => onClick(label)}
     >
       {label}
     </button>
@@ -44,7 +41,7 @@ export default function Autocomplete({
   leftOffset: number;
   matches: string[];
   selectedIndex: number;
-  onMatchClick: (index: number) => void;
+  onMatchClick: (match: string) => void;
 }) {
   return (
     <div
@@ -59,13 +56,7 @@ export default function Autocomplete({
       }}
     >
       {matches.map((match, i) => (
-        <Match
-          label={match}
-          selectedIndex={selectedIndex}
-          index={i}
-          key={i}
-          onClick={onMatchClick}
-        />
+        <Match label={match} isSelected={i === selectedIndex} key={i} onClick={onMatchClick} />
       ))}
     </div>
   );

--- a/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
@@ -1,0 +1,116 @@
+import classNames from "classnames";
+import { getFrameScope } from "devtools/client/debugger/src/reducers/pause";
+import { getSelectedFrame } from "devtools/client/debugger/src/selectors";
+import React, { useEffect, useRef } from "react";
+import { useSelector } from "react-redux";
+import { UIState } from "ui/state";
+import {
+  getBinding,
+  getBindingNames,
+  getGlobalVariables,
+  getPropertiesForObject,
+  shouldVariableAutocomplete,
+} from "../../utils/autocomplete";
+
+function useGetAutocompleteMatches(input: string) {
+  const selectedFrame = useSelector(getSelectedFrame);
+  // Is the selected frame id always 0:0? -jvv
+  const scopes = useSelector((state: UIState) => getFrameScope(state, "0:0"));
+
+  if (!scopes?.scope) {
+    return [];
+  }
+
+  const bindingNames = getBindingNames(scopes);
+
+  if (shouldVariableAutocomplete(input)) {
+    const variableNames = [...bindingNames, ...getGlobalVariables(scopes.scope)];
+    return variableNames.filter(name => name.toLowerCase().includes(input.toLowerCase()));
+  } else {
+    const expressions = input.split(".");
+    const lastExpression = expressions[expressions.length - 1];
+    const parentExpression = expressions.slice(0, expressions.length - 1).join(".");
+
+    const binding = getBinding(parentExpression, scopes);
+
+    if (!binding) {
+      return [];
+    }
+
+    const object = binding.value._object;
+
+    if (!object) {
+      return [];
+    }
+
+    const properties = getPropertiesForObject(object);
+
+    return properties.filter(p => p.toLowerCase().includes(lastExpression.toLowerCase()));
+  }
+}
+
+function Match({
+  label,
+  selectedIndex,
+  index,
+}: {
+  label: string;
+  selectedIndex: number;
+  index: number;
+}) {
+  const buttonNode = useRef<HTMLButtonElement | null>(null);
+  const selected = selectedIndex === index;
+
+  useEffect(() => {
+    if (selected && buttonNode.current) {
+      buttonNode.current.scrollIntoView({ block: "nearest" });
+    }
+  }, [selected]);
+
+  return (
+    <button
+      className={classNames(
+        "text-left px-1",
+        selected ? "bg-blue-700 text-white" : "hover:bg-blue-100"
+      )}
+      ref={buttonNode}
+    >
+      {label}
+    </button>
+  );
+}
+
+export default function Autocomplete({
+  input,
+  selectedIndex,
+}: {
+  input: string;
+  selectedIndex: number;
+}) {
+  const matches = useGetAutocompleteMatches(input);
+
+  if (!matches.length) {
+    return null;
+  }
+
+  return (
+    <div
+      className="flex flex-col border py-1 absolute left-7 bottom-8 font-mono overflow-auto"
+      style={{ minWidth: "240px", maxHeight: "240px", fontSize: "11px" }}
+    >
+      {matches.map((match, i) => (
+        <Match label={match} selectedIndex={selectedIndex} index={i} key={i} />
+      ))}
+    </div>
+  );
+}
+
+// V1
+// it should handle chained objects
+// it should handle computed property syntax
+// it should know what block it's in and suggest stuff for that block based on cursor position
+// it should replace the correct expression with the selected autocompleted expression
+// pressing escape should close autocomplete
+
+// V2
+// Todo: the dropdown should have a variable X position based on the cursor position

--- a/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
@@ -44,18 +44,14 @@ export default function Autocomplete({
   selectedIndex: number;
   onMatchClick: (index: number) => void;
 }) {
-  if (!matches.length) {
-    return null;
-  }
-
   return (
     <div
       className="flex flex-col bg-white border py-1 absolute left-7 -mb-1 shadow-sm font-mono overflow-auto"
       style={{
         minWidth: "240px",
         maxHeight: "160px",
-        fontSize: "11px",
-        bottom: "calc(var(--editor-footer-height))",
+        fontSize: "var(--theme-code-font-size)",
+        bottom: "var(--editor-footer-height)",
       }}
     >
       {matches.map((match, i) => (

--- a/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
@@ -13,8 +13,8 @@ function Match({
   const buttonNode = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (isSelected && buttonNode.current) {
-      buttonNode.current.scrollIntoView({ block: "nearest", inline: "end" });
+    if (isSelected) {
+      buttonNode.current?.scrollIntoView({ block: "nearest", inline: "end" });
     }
   }, [isSelected]);
 
@@ -47,12 +47,12 @@ export default function Autocomplete({
     <div
       className="flex flex-col bg-white border py-1 absolute left-7 -mb-1 shadow-sm font-mono overflow-x-hidden overflow-y-auto"
       style={{
+        bottom: "var(--editor-footer-height)",
+        fontSize: "var(--theme-code-font-size)",
+        marginLeft: `${leftOffset}px`,
+        maxHeight: "160px",
         maxWidth: "200px",
         minWidth: "160px",
-        maxHeight: "160px",
-        fontSize: "var(--theme-code-font-size)",
-        bottom: "var(--editor-footer-height)",
-        marginLeft: `${leftOffset}px`,
       }}
     >
       {matches.map((match, i) => (

--- a/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
@@ -48,9 +48,10 @@ export default function Autocomplete({
 }) {
   return (
     <div
-      className="flex flex-col bg-white border py-1 absolute left-7 -mb-1 shadow-sm font-mono overflow-auto"
+      className="flex flex-col bg-white border py-1 absolute left-7 -mb-1 shadow-sm font-mono overflow-x-hidden overflow-y-auto"
       style={{
-        minWidth: "240px",
+        maxWidth: "200px",
+        minWidth: "160px",
         maxHeight: "160px",
         fontSize: "var(--theme-code-font-size)",
         bottom: "var(--editor-footer-height)",

--- a/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
@@ -45,8 +45,13 @@ export default function Autocomplete({
 
   return (
     <div
-      className="flex flex-col border py-1 absolute left-7 bottom-8 font-mono overflow-auto"
-      style={{ minWidth: "240px", maxHeight: "160px", fontSize: "11px" }}
+      className="flex flex-col bg-white border py-1 absolute left-7 -mb-1 shadow-sm font-mono overflow-auto"
+      style={{
+        minWidth: "240px",
+        maxHeight: "160px",
+        fontSize: "11px",
+        bottom: "calc(var(--editor-footer-height))",
+      }}
     >
       {matches.map((match, i) => (
         <Match label={match} selectedIndex={selectedIndex} index={i} key={i} />
@@ -54,13 +59,3 @@ export default function Autocomplete({
     </div>
   );
 }
-
-// V1
-// it should handle chained objects
-// it should handle computed property syntax
-// it should know what block it's in and suggest stuff for that block based on cursor position
-// it should replace the correct expression with the selected autocompleted expression
-// pressing escape/left/right should close autocomplete
-
-// V2
-// Todo: the dropdown should have a variable X position based on the cursor position

--- a/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
@@ -5,10 +5,12 @@ function Match({
   label,
   selectedIndex,
   index,
+  onClick,
 }: {
   label: string;
   selectedIndex: number;
   index: number;
+  onClick: (index: number) => void;
 }) {
   const buttonNode = useRef<HTMLButtonElement | null>(null);
   const selected = selectedIndex === index;
@@ -26,6 +28,7 @@ function Match({
         selected ? "bg-blue-700 text-white" : "hover:bg-blue-100"
       )}
       ref={buttonNode}
+      onClick={() => onClick(index)}
     >
       {label}
     </button>
@@ -35,9 +38,11 @@ function Match({
 export default function Autocomplete({
   matches,
   selectedIndex,
+  onMatchClick,
 }: {
   matches: string[];
   selectedIndex: number;
+  onMatchClick: (index: number) => void;
 }) {
   if (!matches.length) {
     return null;
@@ -54,7 +59,13 @@ export default function Autocomplete({
       }}
     >
       {matches.map((match, i) => (
-        <Match label={match} selectedIndex={selectedIndex} index={i} key={i} />
+        <Match
+          label={match}
+          selectedIndex={selectedIndex}
+          index={i}
+          key={i}
+          onClick={onMatchClick}
+        />
       ))}
     </div>
   );

--- a/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
@@ -1,53 +1,5 @@
-import classNames from "classnames";
-import { getFrameScope } from "devtools/client/debugger/src/reducers/pause";
-import { getSelectedFrame } from "devtools/client/debugger/src/selectors";
 import React, { useEffect, useRef } from "react";
-import { useSelector } from "react-redux";
-import { UIState } from "ui/state";
-import {
-  getBinding,
-  getBindingNames,
-  getGlobalVariables,
-  getPropertiesForObject,
-  shouldVariableAutocomplete,
-} from "../../utils/autocomplete";
-
-function useGetAutocompleteMatches(input: string) {
-  const selectedFrame = useSelector(getSelectedFrame);
-  // Is the selected frame id always 0:0? -jvv
-  const scopes = useSelector((state: UIState) => getFrameScope(state, "0:0"));
-
-  if (!scopes?.scope) {
-    return [];
-  }
-
-  const bindingNames = getBindingNames(scopes);
-
-  if (shouldVariableAutocomplete(input)) {
-    const variableNames = [...bindingNames, ...getGlobalVariables(scopes.scope)];
-    return variableNames.filter(name => name.toLowerCase().includes(input.toLowerCase()));
-  } else {
-    const expressions = input.split(".");
-    const lastExpression = expressions[expressions.length - 1];
-    const parentExpression = expressions.slice(0, expressions.length - 1).join(".");
-
-    const binding = getBinding(parentExpression, scopes);
-
-    if (!binding) {
-      return [];
-    }
-
-    const object = binding.value._object;
-
-    if (!object) {
-      return [];
-    }
-
-    const properties = getPropertiesForObject(object);
-
-    return properties.filter(p => p.toLowerCase().includes(lastExpression.toLowerCase()));
-  }
-}
+import classNames from "classnames";
 
 function Match({
   label,
@@ -70,7 +22,7 @@ function Match({
   return (
     <button
       className={classNames(
-        "text-left px-1",
+        "text-left px-1 cursor-default",
         selected ? "bg-blue-700 text-white" : "hover:bg-blue-100"
       )}
       ref={buttonNode}
@@ -81,14 +33,12 @@ function Match({
 }
 
 export default function Autocomplete({
-  input,
+  matches,
   selectedIndex,
 }: {
-  input: string;
+  matches: string[];
   selectedIndex: number;
 }) {
-  const matches = useGetAutocompleteMatches(input);
-
   if (!matches.length) {
     return null;
   }
@@ -96,7 +46,7 @@ export default function Autocomplete({
   return (
     <div
       className="flex flex-col border py-1 absolute left-7 bottom-8 font-mono overflow-auto"
-      style={{ minWidth: "240px", maxHeight: "240px", fontSize: "11px" }}
+      style={{ minWidth: "240px", maxHeight: "160px", fontSize: "11px" }}
     >
       {matches.map((match, i) => (
         <Match label={match} selectedIndex={selectedIndex} index={i} key={i} />
@@ -110,7 +60,7 @@ export default function Autocomplete({
 // it should handle computed property syntax
 // it should know what block it's in and suggest stuff for that block based on cursor position
 // it should replace the correct expression with the selected autocompleted expression
-// pressing escape should close autocomplete
+// pressing escape/left/right should close autocomplete
 
 // V2
 // Todo: the dropdown should have a variable X position based on the cursor position

--- a/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/Autocomplete.tsx
@@ -17,7 +17,7 @@ function Match({
 
   useEffect(() => {
     if (selected && buttonNode.current) {
-      buttonNode.current.scrollIntoView({ block: "nearest" });
+      buttonNode.current.scrollIntoView({ block: "nearest", inline: "end" });
     }
   }, [selected]);
 
@@ -36,10 +36,12 @@ function Match({
 }
 
 export default function Autocomplete({
+  leftOffset,
   matches,
   selectedIndex,
   onMatchClick,
 }: {
+  leftOffset: number;
   matches: string[];
   selectedIndex: number;
   onMatchClick: (index: number) => void;
@@ -52,6 +54,7 @@ export default function Autocomplete({
         maxHeight: "160px",
         fontSize: "var(--theme-code-font-size)",
         bottom: "var(--editor-footer-height)",
+        marginLeft: `${leftOffset}px`,
       }}
     >
       {matches.map((match, i) => (

--- a/src/devtools/client/webconsole/components/Input/JSTerm.js
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.js
@@ -16,7 +16,7 @@ import { getCommandHistory } from "../../selectors/messages";
 import Autocomplete from "./Autocomplete";
 import clamp from "lodash/clamp";
 import {
-  appendAutocompleteMatch,
+  insertAutocompleteMatch,
   getAutocompleteMatches,
   getCursorIndex,
   getLastToken,
@@ -163,8 +163,7 @@ class JSTerm extends React.Component {
   selectAutocompleteMatch(match) {
     const { value } = this.state;
 
-    const newValue = appendAutocompleteMatch(value, match);
-
+    const newValue = insertAutocompleteMatch(value, match);
     this.setValue(newValue);
   }
 

--- a/src/devtools/client/webconsole/components/Input/JSTerm.js
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.js
@@ -87,6 +87,7 @@ class JSTerm extends React.Component {
 
     this.editor.codeMirror.on("change", this.onChange);
     this.editor.codeMirror.on("keydown", this.onKeyDown);
+    this.editor.codeMirror.on("beforeSelectionChange", this.onBeforeSelectionChange);
 
     const recordingId = getRecordingId();
     const recording = await getRecording(recordingId);
@@ -241,7 +242,7 @@ class JSTerm extends React.Component {
 
   onKeyDown = (_, event) => {
     if (["Enter", "Tab", "Escape", "ArrowRight", "ArrowLeft"].includes(event.key)) {
-      this.setState({ hideAutocomplete: true, autocompleteIndex: 0 });
+      this.setState({ hideAutocomplete: true });
     } else {
       this.setState({ hideAutocomplete: false, autocompleteIndex: 0 });
     }
@@ -250,6 +251,14 @@ class JSTerm extends React.Component {
   onChange = cm => {
     const value = cm.getValue();
     this.setState({ value });
+  };
+
+  onBeforeSelectionChange = (_, obj) => {
+    const cursorMoved = ["*mouse", "+move"].includes(obj.origin);
+
+    if (cursorMoved) {
+      this.setState({ hideAutocomplete: true });
+    }
   };
 
   getMatches() {

--- a/src/devtools/client/webconsole/components/Input/JSTerm.js
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.js
@@ -19,7 +19,6 @@ import {
   insertAutocompleteMatch,
   getAutocompleteMatches,
   getCursorIndex,
-  getLastToken,
 } from "../../utils/autocomplete";
 
 async function createEditor({ onArrowPress, onEnter, onTab }) {
@@ -101,17 +100,16 @@ class JSTerm extends React.Component {
   }
 
   showAutocomplete() {
-    const { value } = this.state;
-    const lastToken = getLastToken(value);
+    const { value, hideAutocomplete } = this.state;
     const matches = this.getMatches();
     const matchCount = matches.length;
 
-    // Bail if the only suggest autocomplete option is already in the input.
-    if (matchCount === 1 && matches[0] === lastToken) {
+    // Bail if the only suggested autocomplete option has already been applied to the input.
+    if (matchCount === 1 && insertAutocompleteMatch(value, matches[0]) === value) {
       return false;
     }
 
-    return !this.state.hideAutocomplete && matchCount;
+    return !hideAutocomplete && matchCount;
   }
 
   focus() {

--- a/src/devtools/client/webconsole/components/Input/JSTerm.js
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.js
@@ -18,6 +18,7 @@ import clamp from "lodash/clamp";
 import {
   appendAutocompleteMatch,
   getAutocompleteMatches,
+  getCursorIndex,
   getLastToken,
 } from "../../utils/autocomplete";
 
@@ -72,6 +73,7 @@ class JSTerm extends React.Component {
       historyIndex: 0,
       autocompleteIndex: 0,
       hideAutocomplete: false,
+      charWidth: 0,
       value: "",
     };
   }
@@ -92,7 +94,10 @@ class JSTerm extends React.Component {
     const recordingId = getRecordingId();
     const recording = await getRecording(recordingId);
 
-    this.setState({ canEval: recording.userRole !== "team-user" });
+    this.setState({
+      canEval: recording.userRole !== "team-user",
+      charWidth: this.editor.editor.display.cachedCharWidth,
+    });
   }
 
   showAutocomplete() {
@@ -255,7 +260,6 @@ class JSTerm extends React.Component {
 
   onBeforeSelectionChange = (_, obj) => {
     const cursorMoved = ["*mouse", "+move"].includes(obj.origin);
-
     if (cursorMoved) {
       this.setState({ hideAutocomplete: true });
     }
@@ -273,7 +277,7 @@ class JSTerm extends React.Component {
   }
 
   render() {
-    const { autocompleteIndex } = this.state;
+    const { autocompleteIndex, value, charWidth } = this.state;
     const matches = this.getMatches();
 
     return (
@@ -289,6 +293,7 @@ class JSTerm extends React.Component {
         />
         {this.showAutocomplete() ? (
           <Autocomplete
+            leftOffset={charWidth * getCursorIndex(value)}
             matches={matches}
             selectedIndex={autocompleteIndex}
             onMatchClick={this.onMatchClick}

--- a/src/devtools/client/webconsole/components/Input/JSTerm.js
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.js
@@ -154,9 +154,7 @@ class JSTerm extends React.Component {
     }
   };
 
-  onMatchClick = index => {
-    const match = this.getMatches()[index];
-
+  onMatchClick = match => {
     this.selectAutocompleteMatch(match);
   };
 
@@ -268,11 +266,11 @@ class JSTerm extends React.Component {
     const { frameScope } = this.props;
     const { value } = this.state;
 
-    if (!value) {
+    if (!value || !frameScope) {
       return [];
     }
 
-    return getAutocompleteMatches(value, frameScope);
+    return getAutocompleteMatches(value, frameScope.scope);
   }
 
   render() {
@@ -294,6 +292,7 @@ class JSTerm extends React.Component {
           <Autocomplete
             leftOffset={charWidth * getCursorIndex(value)}
             matches={matches}
+            value={value}
             selectedIndex={autocompleteIndex}
             onMatchClick={this.onMatchClick}
           />

--- a/src/devtools/client/webconsole/components/Input/JSTerm.js
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.js
@@ -132,21 +132,31 @@ class JSTerm extends React.Component {
     if (!this.showAutocomplete()) {
       this.execute();
     } else {
-      this.selectAutocompleteMatch();
+      const { autocompleteIndex } = this.state;
+      const match = this.getMatches()[autocompleteIndex];
+
+      this.selectAutocompleteMatch(match);
     }
   };
 
   onTab = () => {
+    const { autocompleteIndex } = this.state;
+    const match = this.getMatches()[autocompleteIndex];
+
     if (this.showAutocomplete()) {
-      this.selectAutocompleteMatch();
+      this.selectAutocompleteMatch(match);
     }
   };
 
-  selectAutocompleteMatch() {
-    const { autocompleteIndex } = this.state;
+  onMatchClick = index => {
+    const match = this.getMatches()[index];
+
+    this.selectAutocompleteMatch(match);
+  };
+
+  selectAutocompleteMatch(match) {
     const { value } = this.state;
 
-    const match = this.getMatches()[autocompleteIndex];
     const newValue = appendAutocompleteMatch(value, match);
 
     this.setValue(newValue);
@@ -269,7 +279,11 @@ class JSTerm extends React.Component {
           }}
         />
         {this.showAutocomplete() ? (
-          <Autocomplete matches={matches} selectedIndex={autocompleteIndex} />
+          <Autocomplete
+            matches={matches}
+            selectedIndex={autocompleteIndex}
+            onMatchClick={this.onMatchClick}
+          />
         ) : null}
       </div>
     );

--- a/src/devtools/client/webconsole/utils/autocomplete.test.js
+++ b/src/devtools/client/webconsole/utils/autocomplete.test.js
@@ -1,0 +1,39 @@
+import { getAutocompleteMatches } from "./autocomplete";
+
+const MOCK_SCOPE = {
+  bindings: [
+    {
+      name: "foo",
+      value: {
+        _object: {
+          className: "Object",
+          preview: { properties: [{ name: "bar" }, { name: "baz" }] },
+        },
+      },
+    },
+  ],
+  parent: {},
+};
+
+describe("autocomplete", () => {
+  test("should match a declared variable in the local scope", () => {
+    const input = "foo";
+    expect(getAutocompleteMatches(input, MOCK_SCOPE)).toEqual(["foo"]);
+  });
+  test("should show the parent expression's properties when using dot notation", () => {
+    expect(getAutocompleteMatches("foo.", MOCK_SCOPE)).toEqual(["bar", "baz"]);
+    expect(getAutocompleteMatches("foo.b", MOCK_SCOPE)).toEqual(["bar", "baz"]);
+    expect(getAutocompleteMatches("foo.bar", MOCK_SCOPE)).toEqual(["bar"]);
+  });
+  test("should show the parent expression's properties when using bracket notation", () => {
+    expect(getAutocompleteMatches(`foo["`, MOCK_SCOPE)).toEqual(["bar", "baz"]);
+    expect(getAutocompleteMatches(`foo["b`, MOCK_SCOPE)).toEqual(["bar", "baz"]);
+    expect(getAutocompleteMatches(`foo["bar`, MOCK_SCOPE)).toEqual(["bar"]);
+  });
+  test("should start autocompleting a bracket notation expression even before a quotation mark is added", () => {
+    expect(getAutocompleteMatches("foo[", MOCK_SCOPE)).toEqual(["bar", "baz"]);
+  });
+  test("should handle bracket notation expressions that start with a single quotation mark", () => {
+    expect(getAutocompleteMatches("foo['", MOCK_SCOPE)).toEqual(["bar", "baz"]);
+  });
+});

--- a/src/devtools/client/webconsole/utils/autocomplete.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete.ts
@@ -239,3 +239,5 @@ export function appendAutocompleteMatch(value: string, match: string) {
     return match;
   }
 }
+
+// used cachedCharWidth to find how out by many px we should move the window to the left

--- a/src/devtools/client/webconsole/utils/autocomplete.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete.ts
@@ -1,0 +1,109 @@
+type ObjectPreviewProperty = {
+  value: ValueFront;
+  writable: boolean;
+  configurable: boolean;
+  enumerable: boolean;
+  name: string;
+  get?: any;
+  set?: any;
+};
+type ObjectPreview = {
+  containerEntries: any[];
+  getterValues: any[];
+  properties: ObjectPreviewProperty[];
+  prototypeId: any;
+  prototypeValue: ValueFront;
+};
+type ObjectFront = {
+  className: string;
+  objectId: string;
+  preview?: ObjectPreview;
+};
+type ValueFront = {
+  _pause: any;
+  _hasPrimitive: false;
+  _primitive?: boolean;
+  _isBigInt: boolean;
+  _isSymbol: boolean;
+  _object: ObjectFront;
+  _uninitialized: boolean;
+  _unavailable: boolean;
+  _elements: null;
+  _isMapEntry: null;
+};
+type Binding = {
+  name: string;
+  value: ValueFront;
+};
+type Scope = {
+  bindings: Binding[];
+  actor: string;
+  parent: Scope;
+  functionName?: string;
+  object?: ValueFront;
+  scopeKind: string;
+  type: "block" | string;
+};
+type Scopes = {
+  scope: Scope;
+  pending: boolean;
+  originalScopesUnavailable: boolean;
+};
+
+export function getBindingNames(scopes: Scopes): string[] {
+  if (!scopes?.scope) {
+    return [];
+  }
+
+  return scopes.scope.bindings.map(b => b.name);
+}
+
+export function getPropertiesForObject(object: ObjectFront): string[] {
+  const preview = object.preview;
+  const properties = [];
+
+  // The object preview may be undefined until the user expands the object
+  // in the scopes panel. This applies primarily to prototype objects.
+  if (preview) {
+    const objectProperties = preview.properties.map(b => b.name);
+    properties.unshift(...objectProperties);
+  } else {
+    if (["Object", "Array"].includes(object.className)) {
+      const prototypeProperties = Object.getOwnPropertyNames(Object.prototype);
+      properties.unshift(...prototypeProperties);
+    }
+
+    if (object.className === "Array") {
+      const prototypeProperties = Object.getOwnPropertyNames(Array.prototype);
+      properties.unshift(...prototypeProperties);
+    }
+  }
+
+  const prototype = preview?.prototypeValue;
+
+  // Recursively gather the properties through the prototype chain.
+  if (prototype) {
+    const prototypeProperties = getPropertiesForObject(prototype._object);
+    properties.unshift(...prototypeProperties);
+  }
+
+  return properties;
+}
+export function getGlobalVariables(scopes: Scope) {
+  const variableNames = [];
+  const globalObject = scopes.parent.object;
+
+  if (globalObject) {
+    const properties = getPropertiesForObject(globalObject._object);
+    variableNames.push(...properties);
+  }
+
+  return variableNames;
+}
+
+export function shouldVariableAutocomplete(input: string) {
+  return !input.includes(".");
+}
+export function getBinding(name: string, scopes: Scopes) {
+  return scopes.scope.bindings.find(b => b.name === name);
+}

--- a/src/devtools/client/webconsole/utils/autocomplete.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete.ts
@@ -225,6 +225,15 @@ export function getAutocompleteMatches(input: string, frameScope: FrameScope) {
   return [];
 }
 
+export function getCursorIndex(value: string) {
+  if (shouldPropertyAutocomplete(value)) {
+    // +1 to account for the `.` or `[`
+    return getParentExpression(value).length + 1;
+  } else {
+    return 0;
+  }
+}
+
 export function appendAutocompleteMatch(value: string, match: string) {
   const parentExpression = getParentExpression(value);
 


### PR DESCRIPTION
Fix #5003.

### V1 requirements:
- [x] it should autocomplete variable names
- [x] it should autocomplete property names for scope objects
- [x] it should include a scope object's prototype's properties in the autocomplete options
- [x] it should handle both bracket and dot property syntax
- [x] it should support autocomplete for the top frame
- [x] it should hide the autocomplete options when the user moves the cursor left/right, or presses escape
- [x] it should hide the autocomplete options when the user moves the cursor left/right using the mouse
- [x] it should not show autocomplete if the current token is also the only autocomplete match available
- [x] modifying the console terminal input should show autocomplete, if there are corresponding matches
- [x] it should use fuzzy matching to find autocomplete matches
- [x] it should have clickable autocomplete options
- [x] it should be offset from the left such that it lines up with the current token being autocompleted

### Follow up: 
Moved to https://github.com/RecordReplay/devtools/issues/5080