### PR TITLE
Hide whitespace nodes in the markup panel

### DIFF
--- a/src/devtools/client/inspector/markup/actions/markup.ts
+++ b/src/devtools/client/inspector/markup/actions/markup.ts
@@ -13,7 +13,8 @@ import {
 } from "../selectors/markup";
 import { UIState } from "ui/state";
 import Highlighter from "highlighter/highlighter";
-const { DOCUMENT_TYPE_NODE } = require("devtools/shared/dom-node-constants");
+const { DOCUMENT_TYPE_NODE, TEXT_NODE } = require("devtools/shared/dom-node-constants");
+const { features } = require("devtools/client/inspector/prefs");
 
 export type ResetAction = Action<"RESET">;
 export type NewRootAction = Action<"NEW_ROOT"> & { rootNode: NodeInfo };
@@ -90,6 +91,11 @@ export function newRoot(): UIThunkAction {
  */
 export function addChildren(parentFront: NodeFront, childFronts: NodeFront[]): UIThunkAction {
   return async ({ dispatch }) => {
+    if (!features.showWhitespaceNodes) {
+      childFronts = childFronts.filter(
+        node => node.nodeType !== TEXT_NODE || /[^\s]/.exec(node.getNodeValue()!)
+      );
+    }
     dispatch({
       type: "ADD_CHILDREN",
       parentNodeId: parentFront.objectId(),

--- a/src/devtools/client/inspector/markup/components/Node.tsx
+++ b/src/devtools/client/inspector/markup/components/Node.tsx
@@ -7,7 +7,6 @@ const {
   TEXT_NODE,
 } = require("devtools/shared/dom-node-constants");
 import { assert } from "protocol/utils";
-const { features } = require("devtools/client/inspector/prefs");
 import {
   getNode,
   getRootNodeId,
@@ -168,11 +167,6 @@ class _Node extends PureComponent<NodeProps & PropsFromRedux> {
 
   render() {
     const { node, rootNodeId, isSelectedNode, isScrollIntoViewNode } = this.props;
-
-    const isWhitespaceTextNode = node.type === TEXT_NODE && !/[^\s]/.exec(node.value!);
-    if (isWhitespaceTextNode && !features.showWhitespaceNodes) {
-      return null;
-    }
 
     // Whether or not the node can be expanded - True if node has children and child is
     // not an inline text node.

--- a/src/devtools/client/inspector/prefs.js
+++ b/src/devtools/client/inspector/prefs.js
@@ -23,7 +23,7 @@ pref("devtools.defaultColorUnit", "authored");
 pref("devtools.inspector.show_pseudo_elements", false);
 
 // features
-pref("devtools.inspector.features.show-whitespace-nodes", true);
+pref("devtools.inspector.features.show-whitespace-nodes", false);
 
 export const prefs = new PrefsHelper("devtools.inspector", {
   is3PaneModeEnabled: ["Bool", "is-three-pane-mode-enabled"],


### PR DESCRIPTION
Firefox and Chrome devtools don't show whitespace text nodes by default (since they're rarely useful), so I think we shouldn't either.
This PR hides them and also makes sure that keyboard navigation in the markup panel doesn't select a hidden node.