### PR TITLE
Fix the splitter styling in the elements panel

### DIFF
--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -200,7 +200,7 @@ class InspectorApp extends Component<PropsFromRedux> {
             minSize="20%"
             maxSize="80%"
             onMove={this.onSplitboxResize}
-            splitterSize={2}
+            splitterSize={4}
             endPanelControl={true}
             startPanel={markupView}
             endPanel={

--- a/src/devtools/client/themes/inspector.css
+++ b/src/devtools/client/themes/inspector.css
@@ -43,6 +43,10 @@ window {
   width: 100%;
 }
 
+#inspector-splitter-box .splitter {
+  background-color: var(--chrome);
+}
+
 /* Minimum dimensions for the Inspector splitter areas. */
 #inspector-splitter-box .uncontrolled,
 #inspector-splitter-box .controlled {


### PR DESCRIPTION
Before:
![Screenshot from 2022-01-20 14-46-18](https://user-images.githubusercontent.com/16060807/150350576-bf2f28fd-518e-47a3-bf34-86f81bd4caa8.png)

After:
![Screenshot from 2022-01-20 14-46-01](https://user-images.githubusercontent.com/16060807/150350598-5127cebd-2cf4-4b6e-8043-38bf65d2c697.png)

