### PR TITLE
Don't update the graphics when the mouse leaves the timeline

### DIFF
--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -82,7 +82,7 @@ class Timeline extends Component<PropsFromRedux> {
     if (!isHovered) {
       window.clearInterval(this.hoverInterval);
       this.hoverInterval = undefined;
-      setTimelineToTime(null);
+      setTimelineToTime(null, false);
     }
   };
 


### PR DESCRIPTION
The graphics was updated unnecessarily when the mouse leaves the timeline. With repainting enabled, this meant that the repainted screenshot was replaced by the recorded screenshot.