### PR TITLE
Fix slug redirect loop

### DIFF
--- a/src/ui/utils/recording.ts
+++ b/src/ui/utils/recording.ts
@@ -9,7 +9,7 @@ export const showDurationWarning = (recording: Recording) => recording.duration 
 export function getRecordingURL(recording: Recording) {
   let id = recording.id;
   if (recording.title) {
-    id = slugify(recording.title).toLowerCase() + SLUG_SEPARATOR + recording.id;
+    id = slugify(recording.title, { strict: true }).toLowerCase() + SLUG_SEPARATOR + recording.id;
   }
 
   return `/recording/${id}`;


### PR DESCRIPTION
## Issue

Recordings with special characters in the title produce an infinite `history.replace` loop because the path returned by `router.asPath` is URL-encoded but the URL returned from `window.location.pathname` is not.

https://app.replay.io/recording/title-swapping-repeatedly--686c2dcf-5bd0-4d71-8689-bee99bc70dda

## Resolution

Enable the `strict` flag of `slugify` to strip special characters

https://www.npmjs.com/package/slugify/v/1.4.0