### PR TITLE
Fix recording URLs that target the root path with an id param

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,17 @@ module.exports = {
         destination: "/recording/:id",
         permanent: true,
       },
+      {
+        source: "/",
+        has: [
+          {
+            type: "query",
+            key: "id",
+          },
+        ],
+        destination: "/recording/:id",
+        permanent: true,
+      },
     ];
   },
 


### PR DESCRIPTION
## Issue

Our sharing email includes URLs to recordings in the format `https://app.replay.io/?id=XXX`. The support for the `id` mapping was removed by #5021 which broke this.

## Resolution

Add a URL redirect for this path.

## Notes

Also will be fixing up the email template to use the correct path.