### PR TITLE
Update the billing UI to be consistent across plan types

### DIFF
--- a/src/ui/components/shared/WorkspaceSettingsModal/Details.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/Details.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Subscription, SubscriptionWithPricing, Workspace } from "ui/types";
+import { SubscriptionWithPricing, Workspace } from "ui/types";
 import { Button } from "../Button";
 import { SettingsHeader } from "../SettingsModal/SettingsBody";
 import { BillingBanners } from "./BillingBanners";
-import { ExpirationRow } from "./ExpirationRow";
+import { PlanDetails } from "./PlanDetails";
 import { isSubscriptionCancelled, formatPaymentMethod, Views } from "./utils";
 import { inUnpaidFreeTrial, subscriptionEndsIn } from "ui/utils/workspace";
 
@@ -69,20 +69,10 @@ function SubscriptionDetails({
 }) {
   return (
     <section>
-      <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between">
-        <span>Current Plan</span>
-        <span>
-          {subscription.displayName}
-          {subscription.trial ? " (Trial)" : ""}
-        </span>
-      </div>
-      <ExpirationRow subscription={subscription} />
-      <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between">
-        <span>Number of seats</span>
-        <span>{subscription.seatCount}</span>
-      </div>
+      <PlanDetails subscription={subscription} />
       {isSubscriptionCancelled(subscription) ||
-      subscription.billingSchedule === "contract" ? null : (
+      subscription.billingSchedule === "contract" ||
+      subscription.plan.key === "beta-v1" ? null : (
         <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between">
           <span>Payment Method</span>
           <span className="flex flex-col items-end">
@@ -130,7 +120,7 @@ export function Details({
 
   return (
     <>
-      <SettingsHeader>Billing</SettingsHeader>
+      <SettingsHeader>{`${subscription.displayName} Plan`}</SettingsHeader>
       <BillingBanners subscription={subscription} confirmed={confirmed} />
       <SubscriptionDetails
         subscription={subscription}

--- a/src/ui/components/shared/WorkspaceSettingsModal/ExpirationRow.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/ExpirationRow.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Subscription } from "ui/types";
-import { getFeatureFlag } from "ui/utils/launchdarkly";
 import { formatDate } from "./formatDate";
 
 export function ExpirationRow({ subscription }: { subscription: Subscription }) {

--- a/src/ui/components/shared/WorkspaceSettingsModal/PlanDetails.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/PlanDetails.tsx
@@ -22,7 +22,7 @@ export function PlanDetails({ subscription }: { subscription: SubscriptionWithPr
         <span>Number of seats</span>
         <span>{subscription.seatCount}</span>
       </div>
-      {subscription.billingSchedule && (
+      {subscription.billingSchedule && subscription.billingSchedule !== "contract" && (
         <>
           <div className="py-2 border-b border-color-gray-50 flex flex-row items-center justify-between">
             <span>Cost per seat</span>

--- a/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
@@ -84,7 +84,7 @@ export const pricingDetailsForSubscription = (subscription: Subscription): PlanP
     case "ent-v1":
       return {
         billingSchedule: "contract",
-        displayName: "Enterprise Contract",
+        displayName: "Enterprise",
         seatPrice: 0,
         discount: 0,
         trial: false,


### PR DESCRIPTION
## Issue

The default billing view for a subscription doesn't have the expected info (e.g. totals, cost per seat).

![image](https://user-images.githubusercontent.com/788456/150586747-e5f87a10-755a-481a-8217-91413d4f763a.png)

## Resolution

* Reuse the `PlanDetails` component to show the same data for active sub as when you complete the add payment flow.
* Re-title the default view to include the plan type
* Remove the "Add Payment Method" link for Beta plans
* Hide the default seat cost for enterprise plans on a contract

![image](https://user-images.githubusercontent.com/788456/150587464-c284040f-e828-4afd-beef-99b6a37fc9cd.png)

## Screenshots from other configurations

![image](https://user-images.githubusercontent.com/788456/150587381-fa5915c3-505f-4a2e-b8c0-fcde98a29336.png)

![image](https://user-images.githubusercontent.com/788456/150587396-e4303ad9-b091-4431-a40d-6a8cdb58252a.png)

![image](https://user-images.githubusercontent.com/788456/150587411-809cde52-3c4e-4462-a0fe-74895f57f6f2.png)

![image](https://user-images.githubusercontent.com/788456/150587425-c7e81041-c9cf-45ec-b1fb-6cda83a05fb5.png)

![image](https://user-images.githubusercontent.com/788456/150587442-6df2f686-35ae-4ce5-9b26-8352ef7f6219.png)

![image](https://user-images.githubusercontent.com/788456/150587451-a33cf114-a6ce-4726-9915-58ea3632d1f9.png)
