### PR TITLE
Fix updating the slug when the recording title changes

### DIFF
--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -730,7 +730,10 @@ export function useUpdateRecordingTitle() {
           }
         }
       }
-    `
+    `,
+    {
+      refetchQueries: ["GetRecording"],
+    }
   );
 
   return updateRecordingTitle;


### PR DESCRIPTION
## Issue

Changing the recordings title does not immediately update the slug in the URL although returning to the library and then back to the recording does fix it.

## Resolution

* Refetch the `GetRecording` query when the title changes
* Refactor the slug generation into a new hook that uses `useGetRecording` to ensure the refresh.

## Notes

While there is a local `recording` object in the component, we're getting it via a redux action which isn't refreshed when the title changes. We could also refactor that code to refresh itself (any maybe that's the better solution) but I don't think the result is much different.