### PR TITLE
Split out the namespace of MixPanel events

### DIFF
--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -50,13 +50,19 @@ export const maybeTrackTeamChange = (newWorkspaceId: string | null) => {
   }
 };
 
+const NULL_NAMESPACE = "no_namespace";
+const namespaceFromEventName = (event: string): string => {
+  const namespace = event.slice(0, event.indexOf("."));
+  return namespace.length ? namespace : NULL_NAMESPACE;
+};
+
 export async function trackMixpanelEvent(event: string, properties?: Dict) {
   if (prefs.logTelemetryEvent) {
     console.log("🔴", event, properties);
   }
 
   if (!mixpanelDisabled) {
-    mixpanel.track(event, properties);
+    mixpanel.track(event, { ...properties, namespace: namespaceFromEventName(event) });
   }
 }
 


### PR DESCRIPTION
It's actually really hard to pull this information out in a useful way
via MixPanel reporting when it is literally part of the event name, but
by also adding it to the event as a discrete field it should be easier
to do things like break down a particular report by namespace.