### PR TITLE
Add trackers to the network panel

### DIFF
--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -5,6 +5,7 @@ import { RequestSummary } from "./utils";
 import { HeaderGroups } from "./HeaderGroups";
 import { RequestRow } from "./RequestRow";
 import { Row, TableInstance } from "react-table";
+import { safeTrackEvent } from "ui/utils/mixpanel";
 
 const RequestTable = ({
   className,
@@ -26,6 +27,7 @@ const RequestTable = ({
   const { columns, getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = table;
 
   const onSeek = (request: RequestSummary) => {
+    safeTrackEvent("net_monitor.seek_to_request");
     seek(request.point.point, request.point.time, true);
     onRowSelect(request);
   };

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -19,6 +19,8 @@ import Table from "./Table";
 import { fetchFrames, fetchResponseBody, fetchRequestBody } from "ui/actions/network";
 import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import LoadingProgressBar from "../shared/LoadingProgressBar";
+import mixpanel from "mixpanel-browser";
+import { safeTrackEvent } from "ui/utils/mixpanel";
 
 export const NetworkMonitor = ({
   currentTime,
@@ -44,8 +46,10 @@ export const NetworkMonitor = ({
   const toggleType = (type: CanonicalRequestType) => {
     const newTypes = new Set(types);
     if (newTypes.has(type)) {
+      safeTrackEvent("net_monitor.delete_type", { type });
       newTypes.delete(type);
     } else {
+      safeTrackEvent("net_monitor.add_type", { type });
       newTypes.add(type);
     }
     setTypes(newTypes);
@@ -62,12 +66,15 @@ export const NetworkMonitor = ({
   }, [container.current]);
 
   if (loading) {
+    mixpanel.time_event("net_monitor.open_network_monitor");
     return (
       <div className="relative">
         <LoadingProgressBar />
       </div>
     );
   }
+
+  safeTrackEvent("net_monitor.open_network_monitor");
 
   return (
     <Table events={events} requests={requests} types={types}>
@@ -85,6 +92,7 @@ export const NetworkMonitor = ({
                 data={data}
                 currentTime={currentTime}
                 onRowSelect={row => {
+                  safeTrackEvent("net_monitor.select_request_row");
                   fetchFrames(row.point);
                   if (row.hasResponseBody) {
                     fetchResponseBody(row.id);

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -5,6 +5,14 @@ import { ViewMode } from "ui/state/layout";
 import { isReplayBrowser, skipTelemetry } from "./environment";
 import { prefs } from "./prefs";
 import { TelemetryUser, trackTiming } from "./telemetry";
+import { CanonicalRequestType } from "ui/components/NetworkMonitor/utils";
+
+type MixpanelEvent =
+  | ["net_monitor.add_type", { type: CanonicalRequestType }]
+  | ["net_monitor.delete_type", { type: CanonicalRequestType }]
+  | ["net_monitor.open_network_monitor"]
+  | ["net_monitor.seek_to_request"]
+  | ["net_monitor.select_request_row"];
 
 const QA_EMAIL_ADDRESSES = ["mock@user.io"];
 
@@ -55,6 +63,10 @@ const namespaceFromEventName = (event: string): string => {
   const namespace = event.slice(0, event.indexOf("."));
   return namespace.length ? namespace : NULL_NAMESPACE;
 };
+
+export function safeTrackEvent(...[event, properties]: [...MixpanelEvent]) {
+  trackMixpanelEvent(event, properties);
+}
 
 export async function trackMixpanelEvent(event: string, properties?: Dict) {
   if (prefs.logTelemetryEvent) {


### PR DESCRIPTION
Fix #5078.

This ought to help us have more visibility in the [network panel usage dashboard](https://mixpanel.com/project/2349904/view/2894968/app/dashboards#id=2775967&focused-bookmark-id=27783645)