### PR TITLE
Allow team members to change the privacy of a recording that belongs to their team

### DIFF
--- a/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
+++ b/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { Dispatch, ReactNode, SetStateAction, useState } from "react";
 import PortalDropdown from "../PortalDropdown";
 import { Dropdown, DropdownItem, DropdownItemContent } from "ui/components/Library/LibraryDropdown";
 import { WorkspaceId } from "ui/state/app";
@@ -32,25 +32,38 @@ export function getPrivacySummaryAndIcon(recording: Recording) {
   return { icon: "group", summary: "Only people with access can view" };
 }
 
-export default function PrivacyDropdown({ recording }: { recording: Recording }) {
-  const [expanded, setExpanded] = useState(false);
-  const updateRecordingWorkspace = hooks.useUpdateRecordingWorkspace(false);
-  const { workspaces } = hooks.useGetNonPendingWorkspaces();
-  const workspaceId = recording.workspace?.id || null;
-  const isOwner = hooks.useIsOwner(recording.id || "00000000-0000-0000-0000-000000000000");
+function DropdownButton({ disabled, children }: { disabled?: boolean; children: ReactNode }) {
+  return (
+    <div className="flex flex-row space-x-1">
+      <span className="text-xs overflow-hidden overflow-ellipsis whitespace-pre">{children}</span>
+      {!disabled ? (
+        <div style={{ lineHeight: "0px" }}>
+          <MaterialIcon>expand_more</MaterialIcon>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function useGetPrivacyOptions(
+  recording: Recording,
+  setExpanded: Dispatch<SetStateAction<boolean>>
+) {
   const isPrivate = recording.private;
+  const workspaceId = recording.workspace?.id || null;
+  const { workspaces } = hooks.useGetNonPendingWorkspaces();
+  const isOwner = hooks.useIsOwner(recording.id || "00000000-0000-0000-0000-000000000000");
+
+  const userBelongsToTeam = workspaceId && workspaces.find(w => w.id === workspaceId);
+
   const toggleIsPrivate = hooks.useToggleIsPrivate(recording.id, isPrivate);
+  const updateRecordingWorkspace = hooks.useUpdateRecordingWorkspace(false);
+
+  const options: ReactNode[] = [];
 
   const setPublic = () => {
     trackEvent("share_modal.set_public");
     if (isPrivate) {
-      toggleIsPrivate();
-    }
-    setExpanded(false);
-  };
-  const setPrivate = () => {
-    trackEvent("share_modal.set_private");
-    if (!isPrivate) {
       toggleIsPrivate();
     }
     setExpanded(false);
@@ -64,31 +77,85 @@ export default function PrivacyDropdown({ recording }: { recording: Recording })
     setPrivate();
     setExpanded(false);
   };
+  const setPrivate = () => {
+    trackEvent("share_modal.set_private");
+    if (!isPrivate) {
+      toggleIsPrivate();
+    }
+    setExpanded(false);
+  };
 
+  if (!isPublicDisabled(workspaces, workspaceId)) {
+    options.push(
+      <DropdownItem onClick={setPublic}>
+        <DropdownItemContent icon="link" selected={!isPrivate}>
+          Anyone with the link
+        </DropdownItemContent>
+      </DropdownItem>
+    );
+  }
+
+  if (isOwner) {
+    // This gives the user who owns the recording the option to move the recording
+    // to their library, or any team they belong to.
+    options.push(
+      <DropdownItem onClick={() => handleMoveToTeam(null)}>
+        <DropdownItemContent icon="domain" selected={isPrivate && !workspaceId}>
+          Only people with access
+        </DropdownItemContent>
+      </DropdownItem>,
+      <div>
+        {workspaces.map(({ id, name }) => (
+          <DropdownItem onClick={() => handleMoveToTeam(id)} key={id}>
+            <DropdownItemContent icon="group" selected={isPrivate && id === workspaceId}>
+              <span className="overflow-hidden overflow-ellipsis whitespace-pre">
+                Members of {name}
+              </span>
+            </DropdownItemContent>
+          </DropdownItem>
+        ))}
+      </div>
+    );
+  } else if (userBelongsToTeam) {
+    // This gives a user who belongs to the replay's team an option to set it to private
+    // without moving the replay's team.
+    options.push(
+      <DropdownItem onClick={setPrivate}>
+        <DropdownItemContent icon="group" selected={isPrivate}>
+          <span className="overflow-hidden overflow-ellipsis whitespace-pre">
+            Members of {recording.workspace?.name || "this team"}
+          </span>
+        </DropdownItemContent>
+      </DropdownItem>
+    );
+  }
+
+  return options;
+}
+
+export default function PrivacyDropdown({ recording }: { recording: Recording }) {
+  const workspaceId = recording.workspace?.id || null;
+  const [expanded, setExpanded] = useState(false);
+  const privacyOptions = useGetPrivacyOptions(recording, setExpanded);
   const { summary } = getPrivacySummaryAndIcon(recording);
 
-  const button = (
-    <div className="flex flex-row space-x-1">
-      <span className="text-xs overflow-hidden overflow-ellipsis whitespace-pre">{summary}</span>
-      {isOwner ? (
-        <div style={{ lineHeight: "0px" }}>
-          <MaterialIcon>expand_more</MaterialIcon>
-        </div>
-      ) : null}
-    </div>
-  );
-
-  if (!isOwner) {
+  if (!privacyOptions.length) {
     return (
-      <button disabled className="cursor-default" title="Only the owner can modify these settings">
-        {button}
-      </button>
+      <div
+        title={
+          workspaceId
+            ? "Only team members can can modify these settings"
+            : "Only the owner can modify these settings"
+        }
+      >
+        <DropdownButton disabled>{summary}</DropdownButton>
+      </div>
     );
   }
 
   return (
     <PortalDropdown
-      buttonContent={button}
+      buttonContent={<DropdownButton>{summary}</DropdownButton>}
       buttonStyle={"overflow-hidden"}
       setExpanded={setExpanded}
       expanded={expanded}
@@ -96,29 +163,7 @@ export default function PrivacyDropdown({ recording }: { recording: Recording })
       position="bottom-right"
     >
       <Dropdown menuItemsClassName="z-50 overflow-auto max-h-48" widthClass="w-80">
-        {isPublicDisabled(workspaces, workspaceId) ? null : (
-          <DropdownItem onClick={setPublic}>
-            <DropdownItemContent icon="link" selected={!isPrivate}>
-              Anyone with the link
-            </DropdownItemContent>
-          </DropdownItem>
-        )}
-        <DropdownItem onClick={() => handleMoveToTeam(null)}>
-          <DropdownItemContent icon="domain" selected={isPrivate && !workspaceId}>
-            Only people with access
-          </DropdownItemContent>
-        </DropdownItem>
-        <div>
-          {workspaces.map(({ id, name }) => (
-            <DropdownItem onClick={() => handleMoveToTeam(id)} key={id}>
-              <DropdownItemContent icon="group" selected={isPrivate && id === workspaceId}>
-                <span className="overflow-hidden overflow-ellipsis whitespace-pre">
-                  Members of {name}
-                </span>
-              </DropdownItemContent>
-            </DropdownItem>
-          ))}
-        </div>
+        {privacyOptions}
       </Dropdown>
     </PortalDropdown>
   );


### PR DESCRIPTION
Fix #4762.

Demo: https://share.descript.com/view/HKbG6afjkbC

This gets a fair bit messy because of how any dropdown option can potentially affect either the public/private, or the replay's team, or both.

This makes it so that if you're the owner of a replay, you're allowed to a) make the replay public/private, and b) move the replay to your library or any of the teams you belong to. If you're a team member who belongs to the same team that the replay does, you're allowed to make the replay public/private.

**Case 1: Replay owner**
```
- Anyone with the link (Toggle public)
- People with access (Toggle private **and move to My Library**)
- Team 1 (Toggle private **and move to Team 1**)
- Team 2
- Team 3
```

**Case 2: Replay team member**
```
- Anyone with the link (Toggle public)
- People with access (Toggle private)
```

**Case 3: No edit permissions, e.g. public team replay for a team the user doesn't belong to, or public replay that doesn't belong to a team**
```
No options, since the dropdown is disabled.
```