### PR TITLE
Use the correct recordingID for creating console comments

### DIFF
--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -22,6 +22,7 @@ const PropTypes = require("prop-types");
 const SmartTrace = require("devtools/client/shared/components/SmartTrace");
 const { trackEvent } = require("ui/utils/telemetry");
 const { dismissNag, Nag } = require("ui/hooks/users");
+import { getRecordingId } from "ui/utils/recording";
 
 class Message extends Component {
   static get propTypes() {
@@ -194,7 +195,7 @@ class Message extends Component {
           true,
           frame,
           { ...this.props.auth0.user, id: userId },
-          this.props.router.query.id
+          getRecordingId(this.props.router.query.id)
         )
       );
     };

--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -241,7 +241,6 @@ const connector = connect(
   (state: UIState) => ({
     currentTime: selectors.getCurrentTime(state),
     executionPoint: getExecutionPoint(state),
-    hoveredComment: selectors.getHoveredComment(state),
     pendingComment: selectors.getPendingComment(state),
   }),
   {

--- a/src/ui/hooks/comments/useAddComment.tsx
+++ b/src/ui/hooks/comments/useAddComment.tsx
@@ -25,7 +25,6 @@ export default function useAddComment() {
   }
 
   return (comment: Comment) => {
-    const temporaryId = new Date().toISOString();
     trackEvent("comments.create");
 
     addComment({
@@ -39,7 +38,7 @@ export default function useAddComment() {
         addComment: {
           success: true,
           comment: {
-            id: temporaryId,
+            id: comment["id"],
             __typename: "Comment",
           },
           __typename: "AddComment",
@@ -79,9 +78,7 @@ export default function useAddComment() {
           recording: {
             ...data.recording,
             comments: [
-              ...data.recording.comments.filter(
-                (c: Remark) => c.id !== temporaryId && c.id !== commentId
-              ),
+              ...data.recording.comments.filter((c: Remark) => c.id !== commentId),
               newComment,
             ],
           },

--- a/src/ui/utils/recording.ts
+++ b/src/ui/utils/recording.ts
@@ -6,7 +6,7 @@ import { extractIdAndSlug, SLUG_SEPARATOR } from "./helpers";
 const WARNING_MS = 60 * 2 * 1000;
 export const showDurationWarning = (recording: Recording) => recording.duration > WARNING_MS;
 
-export function getRecordingURL(recording: Recording) {
+export function getRecordingURL(recording: Recording): string {
   let id = recording.id;
   if (recording.title) {
     id = slugify(recording.title, { strict: true }).toLowerCase() + SLUG_SEPARATOR + recording.id;
@@ -15,7 +15,7 @@ export function getRecordingURL(recording: Recording) {
   return `/recording/${id}`;
 }
 
-export function getRecordingId() {
+export function getRecordingId(): string | undefined {
   return usesWindow(win => {
     if (!win) return undefined;
 


### PR DESCRIPTION
After #5021 `router.query.id` now returns a slug as well as a recordingID. I've tried grepping through the code to see if this will bite us anywhere else but I didn't find anything.

This also fixes this bug:

https://user-images.githubusercontent.com/5903784/150882189-c85a62f0-a1b9-4aec-9ab0-718e1dd6f36b.mp4

Fixes #5094 