### PR TITLE
Removed colour as per #4980

### DIFF
--- a/src/ui/components/Toolbox.css
+++ b/src/ui/components/Toolbox.css
@@ -74,10 +74,6 @@
   color: #bcbcbc;
 }
 
-.toolbar-panel-button.debug.paused .toolbar-panel-icon {
-  color: var(--secondary-accent);
-}
-
 .toolbar-panel-button.active .toolbar-panel-icon,
 .toolbar-panel-button.active.debug.paused .toolbar-panel-icon {
   color: var(--primary-accent);


### PR DESCRIPTION
[Original discussion in Discord](https://discord.com/channels/779097926135054346/930228335865385020/930228338222571571) 

[Github ticket](https://github.com/RecordReplay/devtools/issues/4980)

[Jaril's original PR](https://github.com/RecordReplay/devtools/pull/4989)

This addresses one aspect of the design that we didn't get to -- the icon itself should have a notification badge, but not change colour. Notification badges are well understood, but having a tri-colour nav is confusing. Fixed!