### PR TITLE
Make analytics calls type-safe

### DIFF
--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -257,7 +257,7 @@ async function waitForPaused(url) {
   const { getSelectedScope, getFrames } = dbgSelectors;
   // Make sure that the debug primary panel is selected so that the test can
   // interact with the pause navigation and info.
-  store.dispatch({ type: "set_selected_primary_panel", panel: "debug" });
+  store.dispatch({ type: "set_selected_primary_panel", panel: "debugger" });
   await waitUntil(() => isPaused() && !!getSelectedScope(), { waitingFor: "execution to pause" });
   await waitUntil(() => getFrames(), { waitingFor: "frames to populate" });
   await waitForLoadedScopes();

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -22,6 +22,7 @@ import {
   EventKind,
   ReplayEvent,
   ReplayNavigationEvent,
+  SecondaryPanelName,
 } from "ui/state/app";
 import { Workspace } from "ui/types";
 import { client, sendMessage } from "protocol/socket";
@@ -43,7 +44,7 @@ export type SetLoadingFinishedAction = Action<"set_loading_finished"> & { finish
 export type IndexingAction = Action<"indexing"> & { indexing: number };
 export type SetSessionIdAction = Action<"set_session_id"> & { sessionId: SessionId };
 export type UpdateThemeAction = Action<"update_theme"> & { theme: string };
-export type SetSelectedPanelAction = Action<"set_selected_panel"> & { panel: PanelName };
+export type SetSelectedPanelAction = Action<"set_selected_panel"> & { panel: SecondaryPanelName };
 export type SetInitializedPanelsAction = Action<"set_initialized_panels"> & { panel: PanelName };
 export type SetUploadingAction = Action<"set_uploading"> & { uploading: UploadInfo | null };
 export type SetAwaitingSourcemapsAction = Action<"set_awaiting_sourcemaps"> & {
@@ -243,7 +244,7 @@ export function updateTheme(theme: string): UpdateThemeAction {
   return { type: "update_theme", theme };
 }
 
-export function setSelectedPanel(panel: PanelName): SetSelectedPanelAction {
+export function setSelectedPanel(panel: SecondaryPanelName): SetSelectedPanelAction {
   return { type: "set_selected_panel", panel };
 }
 
@@ -387,7 +388,7 @@ export function executeCommand(key: CommandKey): UIThunkAction {
       dispatch(setSelectedPanel("network"));
     } else if (key === "open_print_statements") {
       dispatch(setViewMode("dev"));
-      dispatch(setSelectedPrimaryPanel("debug"));
+      dispatch(setSelectedPrimaryPanel("debugger"));
     } else if (key === "open_react_devtools") {
       dispatch(setViewMode("dev"));
       dispatch(setSelectedPanel("react-components"));

--- a/src/ui/actions/layout.ts
+++ b/src/ui/actions/layout.ts
@@ -2,7 +2,8 @@ import { RecordingId } from "@recordreplay/protocol";
 import { Action } from "redux";
 import { getShowCommandPalette } from "ui/reducers/layout";
 import { dismissLocalNag, isLocalNagDismissed, LocalNag } from "ui/setup/prefs";
-import { PrimaryPanelName, ViewMode } from "ui/state/layout";
+import { ViewMode } from "ui/state/layout";
+import { PrimaryPanelName } from "ui/state/app";
 import { asyncStore } from "ui/utils/prefs";
 import { trackEvent } from "ui/utils/telemetry";
 import { UIThunkAction } from ".";
@@ -48,7 +49,7 @@ export function setViewMode(viewMode: ViewMode): UIThunkAction {
     }
 
     dispatch({ type: "set_view_mode", viewMode });
-    trackEvent(viewMode == "dev" ? "visit devtools" : "visit viewer");
+    trackEvent(viewMode == "dev" ? "layout.devtools" : "layout.viewer");
   };
 }
 export function setShowVideoPanel(showVideoPanel: boolean): SetShowVideoPanelAction {

--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -5,7 +5,7 @@ import { RequestSummary } from "./utils";
 import { HeaderGroups } from "./HeaderGroups";
 import { RequestRow } from "./RequestRow";
 import { Row, TableInstance } from "react-table";
-import { safeTrackEvent } from "ui/utils/mixpanel";
+import { trackEvent } from "ui/utils/telemetry";
 
 const RequestTable = ({
   className,
@@ -27,7 +27,7 @@ const RequestTable = ({
   const { columns, getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = table;
 
   const onSeek = (request: RequestSummary) => {
-    safeTrackEvent("net_monitor.seek_to_request");
+    trackEvent("net_monitor.seek_to_request");
     seek(request.point.point, request.point.time, true);
     onRowSelect(request);
   };

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -20,7 +20,7 @@ import { fetchFrames, fetchResponseBody, fetchRequestBody } from "ui/actions/net
 import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import LoadingProgressBar from "../shared/LoadingProgressBar";
 import mixpanel from "mixpanel-browser";
-import { safeTrackEvent } from "ui/utils/mixpanel";
+import { trackEvent } from "ui/utils/telemetry";
 
 export const NetworkMonitor = ({
   currentTime,
@@ -46,10 +46,10 @@ export const NetworkMonitor = ({
   const toggleType = (type: CanonicalRequestType) => {
     const newTypes = new Set(types);
     if (newTypes.has(type)) {
-      safeTrackEvent("net_monitor.delete_type", { type });
+      trackEvent("net_monitor.delete_type", { type });
       newTypes.delete(type);
     } else {
-      safeTrackEvent("net_monitor.add_type", { type });
+      trackEvent("net_monitor.add_type", { type });
       newTypes.add(type);
     }
     setTypes(newTypes);
@@ -74,7 +74,7 @@ export const NetworkMonitor = ({
     );
   }
 
-  safeTrackEvent("net_monitor.open_network_monitor");
+  trackEvent("net_monitor.open_network_monitor");
 
   return (
     <Table events={events} requests={requests} types={types}>
@@ -92,7 +92,7 @@ export const NetworkMonitor = ({
                 data={data}
                 currentTime={currentTime}
                 onRowSelect={row => {
-                  safeTrackEvent("net_monitor.select_request_row");
+                  trackEvent("net_monitor.select_request_row");
                   fetchFrames(row.point);
                   if (row.hasResponseBody) {
                     fetchResponseBody(row.id);

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -9,7 +9,7 @@ import { selectors } from "../../reducers";
 import { actions } from "../../actions";
 import ReactDevtoolsPanel from "./ReactDevTools";
 import { UIState } from "ui/state";
-import { PanelName } from "ui/state/app";
+import { SecondaryPanelName } from "ui/state/app";
 import { isDemo } from "ui/utils/environment";
 import { Redacted } from "../Redacted";
 import ToolboxOptions from "./ToolboxOptions";
@@ -19,14 +19,15 @@ import "ui/setup/dynamic/inspector";
 import { UserSettings } from "ui/types";
 import NetworkMonitor from "../NetworkMonitor";
 import WaitForReduxSlice from "../WaitForReduxSlice";
+import { StartablePanelName } from "ui/utils/devtools-toolbox";
 
 const InspectorApp = React.lazy(() => import("devtools/client/inspector/components/App"));
 
 interface PanelButtonsProps {
   hasReactComponents: boolean;
   isNode: boolean;
-  selectedPanel: PanelName;
-  setSelectedPanel: (panel: PanelName) => any;
+  selectedPanel: SecondaryPanelName;
+  setSelectedPanel: (panel: SecondaryPanelName) => any;
 }
 
 function PanelButtons({
@@ -38,11 +39,13 @@ function PanelButtons({
   const { userSettings } = hooks.useGetUserSettings();
   const { enableNetworkMonitor, showReact, showElements } = userSettings;
 
-  const onClick = (panel: PanelName) => {
+  const onClick = (panel: SecondaryPanelName) => {
     setSelectedPanel(panel);
     trackEvent(`toolbox.secondary.${panel}_select`);
 
-    gToolbox.selectTool(panel);
+    if (["debugger", "inspector", "react-components"].includes(panel)) {
+      gToolbox.selectTool(panel as StartablePanelName);
+    }
   };
 
   return (

--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -19,7 +19,7 @@ function SidePanel({ selectedPrimaryPanel }: SidePanelProps) {
 
   if (selectedPrimaryPanel === "explorer") {
     sidepanel = <PrimaryPanes />;
-  } else if (selectedPrimaryPanel === "debug") {
+  } else if (selectedPrimaryPanel === "debugger") {
     sidepanel = <SecondaryPanes />;
   } else if (selectedPrimaryPanel === "comments") {
     sidepanel = <Transcript />;

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -11,7 +11,7 @@ import { isDemo } from "ui/utils/environment";
 
 // TODO [ryanjduffy]: Refactor shared styling more completely
 import { trackEvent } from "ui/utils/telemetry";
-import { PrimaryPanelName } from "ui/state/layout";
+import { PrimaryPanelName } from "ui/state/app";
 import classNames from "classnames";
 
 function ToolbarButtonTab({ active }: { active: boolean }) {
@@ -69,7 +69,7 @@ function ToolbarButton({
           handleClick={() => onClick(name)}
         />
       </div>
-      {isPaused && name == "debug" ? (
+      {isPaused && name == "debugger" ? (
         <div className="absolute bg-secondaryAccent top-1 left-3 rounded-full h-2 w-2 mr-2 mb-1 border-1.5 border-toolbarBackground" />
       ) : null}
     </div>
@@ -90,7 +90,7 @@ function Toolbar({ viewMode }: PropsFromRedux) {
           <>
             <ToolbarButton icon="description" name="explorer" label="Source Explorer" />
             <ToolbarButton icon="search" name="search" label="Search" />
-            <ToolbarButton icon="motion_photos_paused" name="debug" label="Pause Information" />
+            <ToolbarButton icon="motion_photos_paused" name="debugger" label="Pause Information" />
           </>
         ) : null}
       </div>

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -159,7 +159,7 @@ export default function UploadScreen({ recording, userSettings, onUpload }: Uplo
     setStatus("saving");
     const workspaceId = selectedWorkspaceId == "" ? null : selectedWorkspaceId;
 
-    trackEvent("create replay", { isDemo: isDemoReplay(recording) });
+    trackEvent("upload.create_replay", { isDemo: isDemoReplay(recording) });
     startUploadWaitTracking();
 
     await initializeRecording({

--- a/src/ui/components/shared/Onboarding/DownloadPage.tsx
+++ b/src/ui/components/shared/Onboarding/DownloadPage.tsx
@@ -21,15 +21,15 @@ function DownloadButtons({ onNext }: { onNext: () => void }) {
     onNext();
   };
   const handleMac = () => {
-    trackEvent("downloaded-mac");
+    trackEvent("onboarding.download_replay", { OS: "mac" });
     startDownload("https://static.replay.io/downloads/replay.dmg");
   };
   const handleLinux = () => {
-    trackEvent("downloaded-linux");
+    trackEvent("onboarding.download_replay", { OS: "linux" });
     startDownload("https://static.replay.io/downloads/linux-replay.tar.bz2");
   };
   const handleWindows = () => {
-    trackEvent("downloaded-windows");
+    trackEvent("onboarding.download_replay", { OS: "windows" });
     startDownload("https://static.replay.io/downloads/windows-replay.zip");
   };
 

--- a/src/ui/components/shared/OnboardingModal/DownloadReplayModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/DownloadReplayModal.tsx
@@ -48,7 +48,7 @@ function DownloadReplayModal({ hideModal, children }: PropsFromRedux & { childre
   const onSkipToLibrary = () => {
     removeUrlParameters();
     dismissNag(Nag.DOWNLOAD_REPLAY);
-    trackEvent("skipped-replay-download");
+    trackEvent("onboarding.skipped_replay_download");
     hideModal();
   };
   const onNext = () => {
@@ -57,7 +57,7 @@ function DownloadReplayModal({ hideModal, children }: PropsFromRedux & { childre
   };
   const onFinished = () => {
     removeUrlParameters();
-    trackEvent("finished-onboarding");
+    trackEvent("onboarding.finished_onboarding");
     hideModal();
   };
 

--- a/src/ui/components/shared/SharingModal/ReplayLink.tsx
+++ b/src/ui/components/shared/SharingModal/ReplayLink.tsx
@@ -10,7 +10,7 @@ export function CopyButton({ recording }: { recording: Recording }) {
 
   const onClick = () => {
     navigator.clipboard.writeText(url);
-    trackEvent("share.copy_link");
+    trackEvent("share_modal.copy_link");
 
     if (timeoutKey.current) {
       clearTimeout(timeoutKey.current);

--- a/src/ui/components/shared/TeamOnboarding.tsx
+++ b/src/ui/components/shared/TeamOnboarding.tsx
@@ -98,7 +98,7 @@ function TeamNamePage({
         planKey: organization ? "org-v1" : "team-v1",
       },
     });
-    trackEvent("created-team");
+    trackEvent("onboarding.created_team");
   };
 
   useEffect(() => {
@@ -174,7 +174,7 @@ function TeamMemberInvitationPage({
     setErrorMessage(null);
     setIsLoading(true);
     inviteNewWorkspaceMember({ variables: { workspaceId: newWorkspace!.id, email: inputValue } });
-    trackEvent("invited-team-member");
+    trackEvent("onboarding.invited_team_member");
   };
 
   return (
@@ -231,7 +231,7 @@ function TeamOnboarding(props: { organization?: boolean } & PropsFromRedux) {
   const [newWorkspace, setNewWorkspace] = useState<Workspace | null>(null);
 
   useEffect(() => {
-    trackEvent("started-onboarding");
+    trackEvent("onboarding.started_onboarding");
   }, []);
 
   const onNext = () => {
@@ -241,18 +241,18 @@ function TeamOnboarding(props: { organization?: boolean } & PropsFromRedux) {
   const onSkipToDownload = (location?: string) => {
     setCurrent(DOWNLOAD_PAGE_INDEX);
     if (location) {
-      trackEvent("skipped-create-team", { skippedFrom: location });
+      trackEvent("onboarding.skipped_create_team", { skippedFrom: location });
     }
     setRandomNumber(Math.random());
   };
   const onSkipToLibrary = () => {
     removeUrlParameters();
-    trackEvent("skipped-replay-download");
+    trackEvent("onboarding.skipped_replay_download");
     router.push("/");
   };
   const onFinished = () => {
     removeUrlParameters();
-    trackEvent("finished-onboarding");
+    trackEvent("onboarding.finished_onboarding");
     router.push("/");
   };
 

--- a/src/ui/hooks/comments/useAddComment.tsx
+++ b/src/ui/hooks/comments/useAddComment.tsx
@@ -26,7 +26,7 @@ export default function useAddComment() {
 
   return (comment: Comment) => {
     const temporaryId = new Date().toISOString();
-    trackEvent("create comment");
+    trackEvent("comments.create");
 
     addComment({
       variables: {

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -1,4 +1,4 @@
-import { AppState, EventKind, PanelName, ReplayEvent } from "ui/state/app";
+import { AppState, EventKind, PanelName, ReplayEvent, SecondaryPanelName } from "ui/state/app";
 import { AppActions } from "ui/actions/app";
 import { UIState } from "ui/state";
 import { SessionActions } from "ui/actions/session";
@@ -32,7 +32,7 @@ export const initialAppState: AppState = {
   recordingDuration: 0,
   recordingTarget: null,
   recordingWorkspace: null,
-  selectedPanel: prefs.selectedPanel as PanelName,
+  selectedPanel: prefs.selectedPanel as SecondaryPanelName,
   sessionId: null,
   theme: "theme-light",
   trialExpired: false,
@@ -215,7 +215,7 @@ export default function update(
 }
 
 export const getTheme = (state: UIState) => state.app.theme;
-export const getSelectedPanel = (state: UIState) => state.app.selectedPanel;
+export const getSelectedPanel = (state: UIState): SecondaryPanelName => state.app.selectedPanel;
 export const isInspectorSelected = (state: UIState) =>
   getViewMode(state) === "dev" && getSelectedPanel(state) == "inspector";
 export const getInitializedPanels = (state: UIState) => state.app.initializedPanels;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -13,14 +13,10 @@ import type { RecordingTarget } from "protocol/thread/thread";
 import { Workspace } from "ui/types";
 import { Reply } from "./comments";
 
-export type PanelName =
-  | "comments"
-  | "console"
-  | "debugger"
-  | "inspector"
-  | "network"
-  | "react-components"
-  | "viewer";
+export type PrimaryPanelName = "comments" | "debugger" | "explorer" | "events" | "search";
+export type SecondaryPanelName = "console" | "inspector" | "network" | "react-components";
+export type PanelName = PrimaryPanelName | SecondaryPanelName;
+
 export type ModalOptionsType = {
   recordingId?: string;
   view?: string;
@@ -91,7 +87,7 @@ export interface AppState {
   recordingDuration: number;
   recordingTarget: RecordingTarget | null;
   recordingWorkspace: Workspace | null;
-  selectedPanel: PanelName;
+  selectedPanel: SecondaryPanelName;
   sessionId: SessionId | null;
   theme: string;
   trialExpired: boolean;

--- a/src/ui/state/layout.ts
+++ b/src/ui/state/layout.ts
@@ -1,3 +1,5 @@
+import { PrimaryPanelName } from "ui/state/app";
+
 export type LayoutState = {
   showCommandPalette: boolean;
   showEditor: boolean;
@@ -6,5 +8,4 @@ export type LayoutState = {
   viewMode: ViewMode;
 };
 
-export type PrimaryPanelName = "explorer" | "debug" | "comments" | "events" | "search";
 export type ViewMode = "dev" | "non-dev";


### PR DESCRIPTION
This builds on the change @jaril started in #5079. Now, when adding calls to MixPanel either use an existing event, or add a new event type to the event list in `utils/mixpanel.ts`. This is nice for a few reasons:

- TSC will guarantee that there is no typo in the event names/details
- When adding a new event call, all *other* event calls are visible, so it's less likely that someone will add something like `open_dev_tools` when there is already an `open-dev-tools` event or something else very similar. (This is also a good example of the reason that I like to sort arrays and objects by default).

One thing I still have to figure out - we have a fair amount of events that did not conform to the format of things like underscores, common namespaces, etc. I think maybe I can make a mapping from the old events onto the new events and upload that to MixPanel, I'll figure that out tomorrow. Obviously it would be nice to have both clean data going forward and also historical data without having to account for differences across what events were called over time.

Fixes https://github.com/RecordReplay/devtools/issues/5089