### PR TITLE
Remove duplicate redux actions for highlighting elements

### DIFF
--- a/src/devtools/client/debugger/src/actions/toolbox.js
+++ b/src/devtools/client/debugger/src/actions/toolbox.js
@@ -25,16 +25,3 @@ export function openInspector(grip) {
     toolbox.getPanel("debugger")?.openInspector();
   };
 }
-
-export function highlightDomElement(grip) {
-  return async ({ toolbox }) => {
-    const nodeFront = grip.getNodeFront();
-    toolbox.getPanel("debugger")?.highlightDomElement(nodeFront);
-  };
-}
-
-export function unHighlightDomElement(grip) {
-  return ({ toolbox }) => {
-    toolbox.getPanel("debugger")?.unHighlightDomElement(grip);
-  };
-}

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Scopes.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Scopes.js
@@ -7,6 +7,10 @@ import React, { PureComponent } from "react";
 import { showMenu } from "devtools/shared/contextmenu";
 import { connect } from "../../utils/connect";
 import actions from "../../actions";
+import {
+  highlightDomElement,
+  unHighlightDomElement,
+} from "devtools/client/webconsole/actions/toolbox";
 import { features } from "../../utils/prefs";
 
 import {
@@ -213,8 +217,8 @@ const mapStateToProps = state => {
 export default connect(mapStateToProps, {
   openLink: actions.openLink,
   openElementInInspector: actions.openElementInInspectorCommand,
-  highlightDomElement: actions.highlightDomElement,
-  unHighlightDomElement: actions.unHighlightDomElement,
+  highlightDomElement,
+  unHighlightDomElement,
   setExpandedScope: actions.setExpandedScope,
   addWatchpoint: actions.addWatchpoint,
   removeWatchpoint: actions.removeWatchpoint,


### PR DESCRIPTION
There were duplicate redux actions for highlighting elements:
https://github.com/RecordReplay/devtools/blob/a361cc5d705a19fcec24848ed4b6a69458e52e80/src/devtools/client/webconsole/actions/toolbox.js#L12-L33
https://github.com/RecordReplay/devtools/blob/a361cc5d705a19fcec24848ed4b6a69458e52e80/src/devtools/client/debugger/src/actions/toolbox.js#L29-L39

Devtools ended up using the latter, but that version didn't check the pause of the element to be highlighted, so hovering over an element from a different pause than the current one still highlighted that element, which makes no sense. After removing that version of `highlightDomElement()`, elements are only highlighted on hover if they are from the current pause.
