### PR TITLE
Fix hovering in the tooltip smart gap

### DIFF
--- a/src/devtools/client/debugger/src/components/shared/Popover.js
+++ b/src/devtools/client/debugger/src/components/shared/Popover.js
@@ -57,7 +57,7 @@ class Popover extends Component {
   }
 
   onTimeout = () => {
-    const isHoveredOnGap = this.$gap && window.elementIsHovered(this.$gap);
+    const isHoveredOnGap = this.$gap && this.$gap.matches(":hover");
     const isHoveredOnPopover =
       this.$popoverPreview && window.elementIsHovered(this.$popoverPreview);
     const isHoveredOnTooltip = this.$tooltip && window.elementIsHovered(this.$tooltip);


### PR DESCRIPTION
Fix #4774.

Turns out we had this fancy smart gap polygon thing for hovering between the gap of the token and the tooltip, but the hovering wasn't being handled correctly since it (`elementIsHovered()`) relied on the bounding box. This was fixed when we just checked if the gap had matched the `:hover` selector instead.

