### PR TITLE
Polished events rows

### DIFF
--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -65,7 +65,7 @@ export default function Event({
       onKeyDown={onKeyDown}
       className={classNames(
         "event flex flex-row justify-between items-center mb-1 mt-1 user-select-none",
-        "group block p-1 pl-3 pr-2 w-full rounded-lg hover:bg-gray-100 focus:outline-none cursor-pointer",
+        "group block py-1 pl-3 pr-2 w-full rounded-lg hover:bg-gray-100 focus:outline-none cursor-pointer",
         {
           "text-lightGrey": currentTime < time,
           "text-primaryAccent font-semibold": isPaused,

--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -64,8 +64,8 @@ export default function Event({
       onClick={onClick}
       onKeyDown={onKeyDown}
       className={classNames(
-        "event flex flex-row justify-between items-center space-x-2 user-select-none",
-        "group block p-3 w-full rounded-lg hover:bg-gray-100 focus:outline-none cursor-pointer",
+        "event flex flex-row justify-between items-center mb-1 mt-1 user-select-none",
+        "group block p-1 pl-3 pr-2 w-full rounded-lg hover:bg-gray-100 focus:outline-none cursor-pointer",
         {
           "text-lightGrey": currentTime < time,
           "text-primaryAccent font-semibold": isPaused,


### PR DESCRIPTION
Here's a 30 second demonstration of what I changed:
https://www.loom.com/share/27d4bdb715ed4c52a4cd8e6bb6a71022

The red line in our events was inelegantly touching the grey background, so I added some more space to look nicer.