### PR TITLE
Adding share link to replay info

### DIFF
--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -10,6 +10,7 @@ import { getUniqueDomains } from "../UploadScreen/Privacy";
 import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
 import { showDurationWarning, getRecordingId } from "ui/utils/recording";
+import PrivacyDropdown from "../shared/SharingModal/PrivacyDropdown";
 
 const Row = ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => {
   const classes = "flex flex-row space-x-2 p-1.5 px-3 items-center text-left overflow-hidden";
@@ -38,8 +39,8 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
   };
 
   return (
-    <div className="flex-grow overflow-auto overflow-x-hidden flex flex-column items-center bg-white border-splitter">
-      <div className="flex flex-col p-1.5 self-stretch space-y-1.5 w-full text-xs">
+    <div className="flex overflow-hidden flex flex-column items-center bg-white border-splitter">
+      <div className="flex flex-col p-1.5 self-stretch w-full text-xs pb-0 overflow-hidden">
         {recording.user ? (
           <Row>
             <AvatarImage className="h-5 w-5 rounded-full avatar" src={recording.user.picture} />
@@ -47,10 +48,16 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
             <div className="opacity-50">{time}</div>
           </Row>
         ) : null}
-        <Row>
-          <MaterialIcon iconSize="xl">{icon}</MaterialIcon>
-          <div>{summary}</div>
-        </Row>
+        <div className="group">
+          <Row>
+            <MaterialIcon iconSize="xl" className="group-hover:text-primaryAccent">
+              {icon}
+            </MaterialIcon>
+            <div>
+              <PrivacyDropdown {...{ recording }} />
+            </div>
+          </Row>
+        </div>
 
         <div className="group">
           <Row>

--- a/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
+++ b/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
@@ -10,8 +10,7 @@ import { isPublicDisabled } from "ui/utils/org";
 
 const WorkspacePrivacySummary = ({ workspace: { name } }: { workspace: Workspace }) => (
   <span>
-    {`Members of `}
-    <span className="underline">{name}</span>
+    <span className="font-bold">{name}</span>
     {` can view`}
   </span>
 );
@@ -35,7 +34,7 @@ export function getPrivacySummaryAndIcon(recording: Recording) {
 function DropdownButton({ disabled, children }: { disabled?: boolean; children: ReactNode }) {
   return (
     <div className="flex flex-row space-x-1">
-      <span className="text-xs overflow-hidden overflow-ellipsis whitespace-pre">{children}</span>
+      <span className="text-xs whitespace-pre">{children}</span>
       {!disabled ? (
         <div style={{ lineHeight: "0px" }}>
           <MaterialIcon>expand_more</MaterialIcon>
@@ -89,7 +88,9 @@ function useGetPrivacyOptions(
     options.push(
       <DropdownItem onClick={setPublic}>
         <DropdownItemContent icon="link" selected={!isPrivate}>
-          Anyone with the link
+          <span className="overflow-hidden overflow-ellipsis whitespace-pre text-xs">
+            Anyone with the link
+          </span>
         </DropdownItemContent>
       </DropdownItem>
     );
@@ -101,14 +102,16 @@ function useGetPrivacyOptions(
     options.push(
       <DropdownItem onClick={() => handleMoveToTeam(null)}>
         <DropdownItemContent icon="domain" selected={isPrivate && !workspaceId}>
-          Only people with access
+          <span className="overflow-hidden overflow-ellipsis whitespace-pre text-xs">
+            Only people with access
+          </span>
         </DropdownItemContent>
       </DropdownItem>,
       <div>
         {workspaces.map(({ id, name }) => (
           <DropdownItem onClick={() => handleMoveToTeam(id)} key={id}>
             <DropdownItemContent icon="group" selected={isPrivate && id === workspaceId}>
-              <span className="overflow-hidden overflow-ellipsis whitespace-pre">
+              <span className="overflow-hidden overflow-ellipsis whitespace-pre text-xs">
                 Members of {name}
               </span>
             </DropdownItemContent>
@@ -122,7 +125,7 @@ function useGetPrivacyOptions(
     options.push(
       <DropdownItem onClick={setPrivate}>
         <DropdownItemContent icon="group" selected={isPrivate}>
-          <span className="overflow-hidden overflow-ellipsis whitespace-pre">
+          <span className="overflow-hidden overflow-ellipsis whitespace-pre text-xs">
             Members of {recording.workspace?.name || "this team"}
           </span>
         </DropdownItemContent>


### PR DESCRIPTION
Addresses #5124

Old, without a link:
![image](https://user-images.githubusercontent.com/9154902/151245104-68959aa6-4ebc-4431-bff6-9ea2bbe3644e.png)

New, with a link:
![image](https://user-images.githubusercontent.com/9154902/151244908-39045c16-26a7-49d8-b2e0-3253c652c0e2.png)

One minute loom explaining design tradeoffs:
https://www.loom.com/share/b6443801e1204503a2eb301cb849f168