### PR TITLE
Switch from padding to margin in Replay Info

### DIFF
--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -40,7 +40,7 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
 
   return (
     <div className="flex overflow-hidden flex flex-column items-center bg-white border-splitter">
-      <div className="flex flex-col p-1.5 self-stretch w-full text-xs pb-0 overflow-hidden">
+      <div className="flex flex-col my-1.5 px-1.5 self-stretch w-full text-xs pb-0 overflow-hidden">
         {recording.user ? (
           <Row>
             <AvatarImage className="h-5 w-5 rounded-full avatar" src={recording.user.picture} />


### PR DESCRIPTION
If we use padding here there's a flexbox oddity (not sure if it's
officially a bug or not, though there are definitely some flexbox
padding bugs) where the height gets incorrectly calculated.

### Before

https://user-images.githubusercontent.com/5903784/151436054-117ba3e5-2fd5-4f7b-8224-b9462ce7d50d.mp4

### After


https://user-images.githubusercontent.com/5903784/151436075-7877b9a5-e26d-4e20-a120-77f69a0ad820.mp4


