### PR TITLE
Add a request access flow to the unauthorized error screen

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -95,7 +95,7 @@ function getRecordingNotAccessibleError(
     return {
       message: "Sorry, you don't have permission!",
       content: "Maybe you haven't been invited to this replay yet?",
-      action: "library",
+      action: "request-access",
     };
   }
 

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import useAuth0 from "ui/utils/useAuth0";
 import Modal from "ui/components/shared/NewModal";
-import { connect, ConnectedProps } from "react-redux";
+import { connect, ConnectedProps, useDispatch } from "react-redux";
 import * as selectors from "ui/reducers/app";
 import { UIState } from "ui/state";
 import classNames from "classnames";
@@ -13,6 +13,8 @@ import { PrimaryButton } from "./Button";
 import { useRouter } from "next/dist/client/router";
 import { BubbleViewportWrapper } from "./Viewport";
 import { getRecordingId } from "ui/utils/recording";
+import { setExpectedError } from "ui/actions/session";
+import { useRequestRecordingAccess } from "ui/hooks/recordings";
 
 export function PopupBlockedError() {
   return (
@@ -92,6 +94,31 @@ const billingConnector = connect(
 type BillingPropsFromRedux = ConnectedProps<typeof billingConnector>;
 const TeamBillingButton = billingConnector(TeamBillingButtonBase);
 
+function RequestRecordingAccessButton() {
+  const requestRecordingAccess = useRequestRecordingAccess();
+  const dispatch = useDispatch();
+
+  const onClick = () => {
+    requestRecordingAccess();
+
+    // Switch out the current error for one that will bring them back to the library
+    dispatch(
+      setExpectedError({
+        message: "Hang tight!",
+        content:
+          "We've let the owner know about your request. We'll notify you by e-mail once it's been accepted",
+        action: "library",
+      })
+    );
+  };
+
+  return (
+    <PrimaryButton color="blue" onClick={onClick}>
+      Request access
+    </PrimaryButton>
+  );
+}
+
 function ActionButton({ action }: { action: string }) {
   let button;
 
@@ -103,6 +130,8 @@ function ActionButton({ action }: { action: string }) {
     button = <LibraryButton />;
   } else if (action == "team-billing") {
     button = <TeamBillingButton />;
+  } else if (action == "request-access") {
+    button = <RequestRecordingAccessButton />;
   }
 
   return <div className="m-auto">{button}</div>;

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -122,15 +122,15 @@ function RequestRecordingAccessButton() {
 function ActionButton({ action }: { action: string }) {
   let button;
 
-  if (action == "refresh") {
+  if (action === "refresh") {
     button = <RefreshButton />;
-  } else if (action == "sign-in") {
+  } else if (action === "sign-in") {
     button = <SignInButton />;
-  } else if (action == "library") {
+  } else if (action === "library") {
     button = <LibraryButton />;
-  } else if (action == "team-billing") {
+  } else if (action === "team-billing") {
     button = <TeamBillingButton />;
-  } else if (action == "request-access") {
+  } else if (action === "request-access") {
     button = <RequestRecordingAccessButton />;
   }
 

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -62,7 +62,7 @@ function CollaboratorRequests({ recording }: { recording: Recording }) {
                 {c.user.name}
               </span>
             </div>
-            <PrimaryButton color="blue" onClick={() => acceptRecordingRequest(c.uuid)}>
+            <PrimaryButton color="blue" onClick={() => acceptRecordingRequest(c.id)}>
               Add
             </PrimaryButton>
           </div>

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -5,11 +5,13 @@ import { CopyButton } from "./ReplayLink";
 import hooks from "ui/hooks";
 import * as selectors from "ui/reducers/app";
 import { UIState } from "ui/state";
-import { Recording } from "ui/types";
+import { CollaboratorRequest, Recording } from "ui/types";
 import { actions } from "ui/actions";
 import Collaborators from "./Collaborators";
 import MaterialIcon from "../MaterialIcon";
 import PrivacyDropdown from "./PrivacyDropdown";
+import { AvatarImage } from "ui/components/Avatar";
+import { PrimaryButton } from "../Button";
 
 function SharingModalWrapper(props: PropsFromRedux) {
   const opts = props.modalOptions;
@@ -28,6 +30,48 @@ type SharingModalProps = PropsFromRedux & {
   recording: Recording;
 };
 
+function CollaboratorRequests({ recording }: { recording: Recording }) {
+  const acceptRecordingRequest = hooks.useAcceptRecordingRequest();
+  const { collaboratorRequests } = recording;
+
+  if (!collaboratorRequests?.length) {
+    return null;
+  }
+
+  // Remove duplicates
+  const displayedRequests = collaboratorRequests.reduce((acc: CollaboratorRequest[], request) => {
+    const userMatch = acc.find(r => r.user.id === request.user.id);
+
+    return userMatch ? acc : [...acc, request];
+  }, []);
+
+  return (
+    <section className="space-y-1.5">
+      <div className="font-bold">Requests to access this replay</div>
+      <div className="overflow-auto space-y-1.5" style={{ maxHeight: "160px" }}>
+        {displayedRequests.map((c, i) => (
+          <div
+            className="flex items-center space-x-2 p-2 hover:bg-gray-100 rounded-lg justify-between"
+            key={i}
+          >
+            <div className="flex items-center space-x-2">
+              <div className="w-8 flex-shrink-0 rounded-full overflow-hidden">
+                <AvatarImage src={c.user.picture} />
+              </div>
+              <span className="overflow-hidden whitespace-pre overflow-ellipsis">
+                {c.user.name}
+              </span>
+            </div>
+            <PrimaryButton color="blue" onClick={() => acceptRecordingRequest(c.uuid)}>
+              Add
+            </PrimaryButton>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function SharingModal({ recording, hideModal }: SharingModalProps) {
   return (
     <Modal options={{ maskTransparency: "translucent" }} onMaskClick={hideModal}>
@@ -37,9 +81,12 @@ function SharingModal({ recording, hideModal }: SharingModalProps) {
       >
         <section className="p-8 space-y-4">
           <div className="w-full justify-between flex flex-col space-y-3">
-            <div className="w-full space-y-1.5">
-              <div className="font-bold">Add People</div>
-              <Collaborators recordingId={recording.id} />
+            <div className="w-full space-y-4">
+              <div className="space-y-1.5">
+                <div className="font-bold">Add People</div>
+                <Collaborators recordingId={recording.id} />
+              </div>
+              <CollaboratorRequests recording={recording} />
             </div>
           </div>
         </section>

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -58,7 +58,6 @@ export const GET_RECORDING = gql`
         edges {
           node {
             ... on RecordingCollaboratorRequest {
-              uuid
               id
               user {
                 name

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -54,6 +54,20 @@ export const GET_RECORDING = gql`
           }
         }
       }
+      collaboratorRequests {
+        edges {
+          node {
+            ... on RecordingCollaboratorRequest {
+              uuid
+              id
+              user {
+                name
+                picture
+              }
+            }
+          }
+        }
+      }
     }
   }
 `;

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -809,8 +809,8 @@ export function useRequestRecordingAccess() {
 export function useAcceptRecordingRequest() {
   const [acceptRecordingRequest] = useMutation(
     gql`
-      mutation AcceptRecordingCollaboratorRequest($requestId: UUID!) {
-        acceptRecordingCollaboratorRequest(input: { uuid: $requestId }) {
+      mutation AcceptRecordingCollaboratorRequest($requestId: ID!) {
+        acceptRecordingCollaboratorRequest(input: { id: $requestId }) {
           success
         }
       }

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -114,6 +114,7 @@ export async function getRecording(recordingId: RecordingId) {
     query: GET_RECORDING,
     variables: { recordingId },
   });
+
   return convertRecording(result.data?.recording);
 }
 
@@ -159,6 +160,7 @@ function convertRecording(rec: any): Recording | undefined {
   const collaborators = rec.collaborators?.edges
     ?.filter((e: any) => e.node.user)
     .map((e: any) => e.node.user.id);
+  const collaboratorRequests = rec.collaboratorRequests?.edges.map((e: any) => e.node);
 
   return {
     id: rec.uuid,
@@ -174,6 +176,7 @@ function convertRecording(rec: any): Recording | undefined {
     workspace: rec.workspace,
     comments: rec.comments,
     collaborators,
+    collaboratorRequests,
     ownerNeedsInvite: rec.ownerNeedsInvite,
     userRole: rec.userRole,
     operations: rec.operations,
@@ -792,7 +795,7 @@ export function useRequestRecordingAccess() {
 
   const [requestRecordingAccess] = useMutation(
     gql`
-      mutation requestRecordingAccess($recordingId: ID!) {
+      mutation RequestRecordingAccess($recordingId: ID!) {
         requestRecordingAccess(input: { recordingId: $recordingId }) {
           success
         }
@@ -801,4 +804,21 @@ export function useRequestRecordingAccess() {
   );
 
   return () => requestRecordingAccess({ variables: { recordingId } });
+}
+
+export function useAcceptRecordingRequest() {
+  const [acceptRecordingRequest] = useMutation(
+    gql`
+      mutation AcceptRecordingCollaboratorRequest($requestId: UUID!) {
+        acceptRecordingCollaboratorRequest(input: { uuid: $requestId }) {
+          success
+        }
+      }
+    `,
+    {
+      refetchQueries: ["GetRecording"],
+    }
+  );
+
+  return (requestId: string) => acceptRecordingRequest({ variables: { requestId } });
 }

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -786,3 +786,19 @@ export async function getRecordingMetadata(id: string) {
     owner: json.data.recording.owner?.name || null,
   };
 }
+
+export function useRequestRecordingAccess() {
+  const recordingId = useGetRecordingId();
+
+  const [requestRecordingAccess] = useMutation(
+    gql`
+      mutation requestRecordingAccess($recordingId: ID!) {
+        requestRecordingAccess(input: { recordingId: $recordingId }) {
+          success
+        }
+      }
+    `
+  );
+
+  return () => requestRecordingAccess({ variables: { recordingId } });
+}

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -49,7 +49,7 @@ export type SettingsTabTitle =
 export interface ExpectedError {
   message: string;
   content: string;
-  action?: "sign-in" | "refresh" | "library";
+  action?: "sign-in" | "refresh" | "library" | "request-access";
 }
 
 export type UnexpectedError = {

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -133,6 +133,12 @@ export interface Recording {
   comments?: any;
   userRole?: RecordingRole;
   operations: OperationsData;
+  collaboratorRequests: CollaboratorRequest[];
+}
+
+export interface CollaboratorRequest {
+  user: User;
+  uuid: string;
 }
 
 export interface OperationsData {

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -138,7 +138,7 @@ export interface Recording {
 
 export interface CollaboratorRequest {
   user: User;
-  uuid: string;
+  id: string;
 }
 
 export interface OperationsData {


### PR DESCRIPTION
This adds the following:
- Show a request access button when a logged-in user is viewing a replay they're not authorized to.
- Show a list of collaborator requests in the sharing modal.

Let's add some docs (@ceceliacreates) here if we need to. Definitely get some qa wolf tests.

Demo: https://share.descript.com/view/r18vVVcnm4z

https://user-images.githubusercontent.com/15959269/151447826-a2d290c5-3504-4ffa-840f-c9114e9e0691.mov

