### PR TITLE
Logged out users don't need to see the sharing dropdown

### DIFF
--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -50,18 +50,18 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
             <div className="opacity-50">{time}</div>
           </Row>
         ) : null}
-
         {isAuthenticated ? (
           <div className="group">
             <Row>
               <MaterialIcon iconSize="xl" className="group-hover:text-primaryAccent">
                 {icon}
               </MaterialIcon>
-              <div><PrivacyDropdown {...{ recording }} /></div>
+              <div>
+                <PrivacyDropdown {...{ recording }} />
+              </div>
             </Row>
           </div>
         ) : null}
-
         <div className="group">
           <Row>
             <MaterialIcon iconSize="xl" className="group-hover:text-primaryAccent">

--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -11,6 +11,7 @@ import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
 import { showDurationWarning, getRecordingId } from "ui/utils/recording";
 import PrivacyDropdown from "../shared/SharingModal/PrivacyDropdown";
+import useAuth0 from "ui/utils/useAuth0";
 
 const Row = ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => {
   const classes = "flex flex-row space-x-2 p-1.5 px-3 items-center text-left overflow-hidden";
@@ -28,6 +29,7 @@ const Row = ({ children, onClick }: { children: ReactNode; onClick?: () => void 
 
 function ReplayInfo({ setModal }: PropsFromRedux) {
   const { recording } = hooks.useGetRecording(getRecordingId()!);
+  const { isAuthenticated } = useAuth0();
 
   if (!recording) return null;
 
@@ -48,16 +50,17 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
             <div className="opacity-50">{time}</div>
           </Row>
         ) : null}
-        <div className="group">
-          <Row>
-            <MaterialIcon iconSize="xl" className="group-hover:text-primaryAccent">
-              {icon}
-            </MaterialIcon>
-            <div>
-              <PrivacyDropdown {...{ recording }} />
-            </div>
-          </Row>
-        </div>
+
+        {isAuthenticated ? (
+          <div className="group">
+            <Row>
+              <MaterialIcon iconSize="xl" className="group-hover:text-primaryAccent">
+                {icon}
+              </MaterialIcon>
+              <div><PrivacyDropdown {...{ recording }} /></div>
+            </Row>
+          </div>
+        ) : null}
 
         <div className="group">
           <Row>

--- a/src/ui/components/Events/ReplayInfo.tsx
+++ b/src/ui/components/Events/ReplayInfo.tsx
@@ -50,8 +50,9 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
             <div className="opacity-50">{time}</div>
           </Row>
         ) : null}
-        {isAuthenticated ? (
-          <div className="group">
+
+        <div className="group">
+          {isAuthenticated ? (
             <Row>
               <MaterialIcon iconSize="xl" className="group-hover:text-primaryAccent">
                 {icon}
@@ -60,8 +61,8 @@ function ReplayInfo({ setModal }: PropsFromRedux) {
                 <PrivacyDropdown {...{ recording }} />
               </div>
             </Row>
-          </div>
-        ) : null}
+          ) : null}
+        </div>
         <div className="group">
           <Row>
             <MaterialIcon iconSize="xl" className="group-hover:text-primaryAccent">


### PR DESCRIPTION
We were in a strange state where logged out users were seeing a sharing dropdown. Now it looks like this, with logged out users seeing the view on the right:

![image](https://user-images.githubusercontent.com/9154902/151488830-f7cdc7e5-5764-4507-a858-2fe65356635d.png)

Logged out users don't need to see sharing settings. Fixed! 