### PR TITLE
Set a min height for the error screen text

### DIFF
--- a/src/ui/components/shared/Dialog.tsx
+++ b/src/ui/components/shared/Dialog.tsx
@@ -34,7 +34,11 @@ export const DialogDescription = ({
   ...props
 }: HTMLProps<HTMLParagraphElement>) => {
   return (
-    <p {...props} className="mb-2 text-center text-gray-500 text-sm">
+    <p
+      {...props}
+      className="mb-2 text-center text-gray-500 text-sm"
+      style={{ minHeight: "2.5rem" }}
+    >
       {children}
     </p>
   );


### PR DESCRIPTION
This gives us ~40px of minimum height to keep the error screen fairly standard.