### PR TITLE
Fix the hooks for deleting comments (#5146)

### DIFF
--- a/src/ui/hooks/comments/useDeleteComment.tsx
+++ b/src/ui/hooks/comments/useDeleteComment.tsx
@@ -20,7 +20,7 @@ export default function useDeleteComment() {
   return (commentId: string, recordingId: RecordingId) => {
     deleteComment({
       variables: { commentId },
-      optimisticResponse: {},
+      optimisticResponse: { deleteComment: { success: true } },
       update: cache => {
         const data: any = cache.readQuery({
           query: GET_COMMENTS,

--- a/src/ui/hooks/comments/useDeleteCommentReply.tsx
+++ b/src/ui/hooks/comments/useDeleteCommentReply.tsx
@@ -20,7 +20,7 @@ export default function useDeleteCommentReply() {
   return (commentReplyId: string, recordingId: RecordingId) => {
     deleteCommentReply({
       variables: { commentReplyId },
-      optimisticResponse: {},
+      optimisticResponse: { deleteCommentReply: { success: true } },
       update: cache => {
         const data: any = cache.readQuery({
           query: GET_COMMENTS,
@@ -30,6 +30,9 @@ export default function useDeleteCommentReply() {
         const parentComment = data.recording.comments.find((c: any) =>
           c.replies.find((r: any) => r.id === commentReplyId)
         );
+        if (!parentComment) {
+          return;
+        }
 
         const newParentComment = {
           ...parentComment,


### PR DESCRIPTION
1. fix the `optimisticResponse` - this was generating errors in the browser console (but only in dev)
2. the `update` function in `deleteCommentReply` doesn't always find the `parentComment` (it is called twice for every deletion and in the second run the cached reply *sometimes* has already been deleted - see https://app.replay.io/recording/no-parent-comment--2acaefb3-2cd2-49ea-bc83-fb2c6feb335a)