### PR TITLE
Use debounce instead of throttle in the QuickOpenModal

### DIFF
--- a/src/devtools/client/debugger/src/components/QuickOpenModal.js
+++ b/src/devtools/client/debugger/src/components/QuickOpenModal.js
@@ -7,7 +7,7 @@ import React, { Component } from "react";
 import { connect } from "../utils/connect";
 import fuzzyAldrin from "fuzzaldrin-plus";
 import { basename } from "../utils/path";
-import throttle from "lodash/throttle";
+import debounce from "lodash/debounce";
 import actions from "../actions";
 import {
   getSourceList,
@@ -50,7 +50,6 @@ function filter(values, query) {
     key: "value",
     maxResults,
     preparedQuery,
-    usePathScoring: false,
   });
 }
 
@@ -155,7 +154,7 @@ export class QuickOpenModal extends Component {
     }
   };
 
-  updateResults = throttle(query => {
+  updateResults = debounce(query => {
     if (this.isGotoQuery()) {
       return;
     }


### PR DESCRIPTION
Fix #5164. 

This is a follow up to #5130. In the interest of speed, that patch turned off path scoring and increased the throttle duration. Both changes made the overall experience less clunky. The increased throttle duration made it so that you can keep typing without the UI stuttering, and the reduced processing after turning off path scoring made it so that the stuttering was limited when it did happen.

This patch puts back path scoring, since the results aren't very helpful without it. That brings the stuttering to where it was before. However, because it's being debounced, the stutter doesn't really happen until the user is finished typing. Because of that it's much less noticeable.

Switching this to a debounce since that's the standard mechanic for most search UIs (instead of a throttle!).