### PR TITLE
Hide the collaborators section in the sharing modal for certain users

### DIFF
--- a/src/ui/components/Header/ShareDropdown.tsx
+++ b/src/ui/components/Header/ShareDropdown.tsx
@@ -1,0 +1,174 @@
+import React, { useState } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import { useGetUserInfo } from "ui/hooks/users";
+import {
+  useIsOwner,
+  useGetRecording,
+  useToggleIsPrivate,
+  useGetRecordingId,
+} from "ui/hooks/recordings";
+import * as actions from "ui/actions/app";
+import Dropdown from "ui/components/shared/Dropdown";
+import ExternalLink from "../shared/ExternalLink";
+
+function CopyUrl() {
+  const recordingId = useGetRecordingId();
+  const [copyClicked, setCopyClicked] = useState(false);
+
+  const handleCopyClick = () => {
+    navigator.clipboard.writeText(`https://app.replay.io/recording/${recordingId}`);
+    setCopyClicked(true);
+    setTimeout(() => setCopyClicked(false), 2000);
+  };
+
+  if (copyClicked) {
+    return (
+      <div className="row link">
+        <div className="status">
+          <div className="success">Link copied</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="row link">
+      <input
+        type="text"
+        value={`https://app.replay.io/recording/${recordingId}`}
+        onKeyPress={e => e.preventDefault()}
+        onChange={e => e.preventDefault()}
+      />
+      <button onClick={handleCopyClick}>
+        <div className="img link" />
+        <div className="label">Copy Link</div>
+      </button>
+    </div>
+  );
+}
+
+function Privacy({ isPrivate, toggleIsPrivate }: { isPrivate: boolean; toggleIsPrivate(): void }) {
+  return (
+    <div className="row privacy" onClick={toggleIsPrivate}>
+      <div className={`icon img ${isPrivate ? "locked" : "unlocked"}`} />
+      {isPrivate ? (
+        <div className="label">
+          <div className="label-title">Private</div>
+          <div className="label-description">Only you and your collaborators can view</div>
+        </div>
+      ) : (
+        <div className="label">
+          <div className="label-title">Public</div>
+          <div className="label-description">Anyone with this link can view</div>
+        </div>
+      )}
+      <button className={`toggle ${isPrivate ? "off" : "on"}`}>
+        <div className="switch" />
+      </button>
+    </div>
+  );
+}
+
+function PrivacyNote({ isPrivate, isOwner }: { isPrivate: boolean; isOwner: boolean }) {
+  if (!isOwner) {
+    return null;
+  }
+
+  return (
+    <div className={`row privacy-note ${isPrivate ? "is-private" : "is-public"}`}>
+      <div style={{ width: "52px" }} />
+      <div className="label">
+        <div className="label-title">Note</div>
+        <div className="label-description">
+          Replay records everything including passwords you&#39;ve typed and sensitive data
+          you&#39;re viewing.{" "}
+          <ExternalLink href="https://replayio.notion.site/Sharing-replays-2af70ebdfb1c47e5b9246f25ca377ef2">
+            Learn more
+          </ExternalLink>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Collaborators({
+  setExpanded,
+  setModal,
+}: PropsFromRedux & { setExpanded(expanded: boolean): void }) {
+  const recordingId = useGetRecordingId();
+  const { id } = useGetUserInfo();
+  if (!id) {
+    return null;
+  }
+
+  const handleClick = () => {
+    setModal("sharing", { recordingId });
+    setExpanded(false);
+  };
+
+  return (
+    <div className="row collaborators">
+      <div className="icon img users" />
+      <div className="label">
+        <div className="label-title">Invite collaborators</div>
+        <div className="label-description">Collaborate privately with others</div>
+      </div>
+      <button className="open-modal" onClick={handleClick}>
+        <div className="img invite" />
+      </button>
+    </div>
+  );
+}
+
+interface OwnerSettingsProps {
+  isPrivate: boolean;
+  isOwner: boolean;
+}
+
+function OwnerSettings({ isPrivate, isOwner }: OwnerSettingsProps) {
+  const recordingId = useGetRecordingId();
+  const updateIsPrivate = useToggleIsPrivate(recordingId, isPrivate);
+
+  if (!isOwner) {
+    return null;
+  }
+
+  return (
+    <>
+      <Privacy isPrivate={isPrivate} toggleIsPrivate={updateIsPrivate} />
+    </>
+  );
+}
+
+function ShareDropdown({ setModal }: PropsFromRedux) {
+  const recordingId = useGetRecordingId();
+  const [expanded, setExpanded] = useState(false);
+  const isOwner = useIsOwner();
+  const { recording } = useGetRecording(recordingId);
+
+  const isPrivate = !!recording?.private;
+  const buttonContent = <div className="img share" />;
+
+  return (
+    <div className="share">
+      <Dropdown
+        buttonContent={buttonContent}
+        buttonStyle="secondary"
+        setExpanded={setExpanded}
+        expanded={expanded}
+      >
+        <CopyUrl />
+        <OwnerSettings isPrivate={isPrivate} isOwner={isOwner} />
+        <PrivacyNote isPrivate={isPrivate} isOwner={isOwner} />
+        <Collaborators setExpanded={setExpanded} setModal={setModal} />
+      </Dropdown>
+    </div>
+  );
+}
+
+const connector = connect(null, {
+  setModal: actions.setModal,
+});
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export default connector(ShareDropdown);

--- a/src/ui/components/Header/UserOptions.tsx
+++ b/src/ui/components/Header/UserOptions.tsx
@@ -22,7 +22,7 @@ function UserOptions({ setModal, noBrowserItem }: UserOptionsProps) {
   const { show } = useIntercom();
   const { isAuthenticated } = useAuth0();
 
-  const isOwner = hooks.useIsOwner(recordingId || "00000000-0000-0000-0000-000000000000");
+  const isOwner = hooks.useIsOwner();
   const isCollaborator =
     hooks.useIsCollaborator(recordingId || "00000000-0000-0000-0000-000000000000") &&
     isAuthenticated;

--- a/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
+++ b/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
@@ -51,7 +51,7 @@ function useGetPrivacyOptions(
   const isPrivate = recording.private;
   const workspaceId = recording.workspace?.id || null;
   const { workspaces } = hooks.useGetNonPendingWorkspaces();
-  const isOwner = hooks.useIsOwner(recording.id || "00000000-0000-0000-0000-000000000000");
+  const isOwner = hooks.useIsOwner();
 
   const userBelongsToTeam = workspaceId && workspaces.find(w => w.id === workspaceId);
 

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -12,6 +12,7 @@ import MaterialIcon from "../MaterialIcon";
 import PrivacyDropdown from "./PrivacyDropdown";
 import { AvatarImage } from "ui/components/Avatar";
 import { PrimaryButton } from "../Button";
+import { useHasNoRole } from "ui/hooks/recordings";
 
 function SharingModalWrapper(props: PropsFromRedux) {
   const opts = props.modalOptions;
@@ -72,6 +73,28 @@ function CollaboratorRequests({ recording }: { recording: Recording }) {
   );
 }
 
+function CollaboratorsSection({ recording }: { recording: Recording }) {
+  const { hasNoRole, loading } = useHasNoRole();
+
+  if (hasNoRole || loading) {
+    return null;
+  }
+
+  return (
+    <section className="p-8 space-y-4">
+      <div className="w-full justify-between flex flex-col space-y-3">
+        <div className="w-full space-y-4">
+          <div className="space-y-1.5">
+            <div className="font-bold">Add People</div>
+            <Collaborators recordingId={recording.id} />
+          </div>
+          <CollaboratorRequests recording={recording} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function SharingModal({ recording, hideModal }: SharingModalProps) {
   return (
     <Modal options={{ maskTransparency: "translucent" }} onMaskClick={hideModal}>
@@ -79,17 +102,7 @@ function SharingModal({ recording, hideModal }: SharingModalProps) {
         className="sharing-modal space-y-0 relative flex flex-col bg-white rounded-lg text-sm overflow-hidden"
         style={{ width: "460px" }}
       >
-        <section className="p-8 space-y-4">
-          <div className="w-full justify-between flex flex-col space-y-3">
-            <div className="w-full space-y-4">
-              <div className="space-y-1.5">
-                <div className="font-bold">Add People</div>
-                <Collaborators recordingId={recording.id} />
-              </div>
-              <CollaboratorRequests recording={recording} />
-            </div>
-          </div>
-        </section>
+        <CollaboratorsSection recording={recording} />
         <section className="p-8 flex flex-row space-x-2 bg-gray-100 items-center justify-between">
           <div className="flex flex-row space-x-3 items-center overflow-hidden">
             <div className="h-8 w-8 bg-purple-200 rounded-full font-bold flex-shrink-0 flex items-center justify-center">

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -9,6 +9,7 @@ import { GET_RECORDING, GET_RECORDING_USER_ID } from "ui/graphql/recordings";
 import { useRouter } from "next/router";
 import { extractIdAndSlug } from "ui/utils/helpers";
 import { getRecordingId } from "ui/utils/recording";
+import { ColorSwatchIcon } from "@heroicons/react/solid";
 
 function isTest() {
   return new URL(window.location.href).searchParams.get("test");
@@ -150,6 +151,21 @@ export function useIsTeamDeveloper() {
   }
 
   return { isTeamDeveloper: data?.recording.userRole !== "team-user", loading };
+}
+
+// If the user has no role, then they're either viewing a non-team recording they
+// don't own, or a team recording for a team that they don't belong to.
+export function useHasNoRole() {
+  const recordingId = getRecordingId();
+  const { data, error, loading } = useQuery(GET_RECORDING, {
+    variables: { recordingId },
+  });
+
+  if (error) {
+    console.error("Apollo error while getting the user's role", error);
+  }
+
+  return { hasNoRole: data?.recording.userRole === "none", loading };
 }
 
 function convertRecording(rec: any): Recording | undefined {
@@ -335,7 +351,8 @@ export function useUpdateIsPrivate() {
     updateIsPrivate({ variables: { recordingId, isPrivate } });
 }
 
-export function useIsOwner(recordingId: RecordingId) {
+export function useIsOwner() {
+  const recordingId = useGetRecordingId();
   const { userId } = useGetUserId();
   const { data, loading, error } = useQuery(GET_RECORDING_USER_ID, {
     variables: { recordingId },


### PR DESCRIPTION
Fix #5161.

As mentioned in https://github.com/RecordReplay/backend/issues/4402, there are two situations in which a user can't add collaborators to a replay, or see them in the first place:
1) User A views User B's public replay from their library
2) User A views User B's replay from User B's Team C library (which User A doesn't belong to!)

Currently, even though we have these limitations, we still show all of the collaborators UI which leads to bugs.

This PR makes it so that we just don't show the collaborators UI in the sharing modal in those cases.

Demo: https://share.descript.com/view/EvSnAdcMnTJ