### PR TITLE
Add improved login page

### DIFF
--- a/src/ui/components/shared/Login/Login.tsx
+++ b/src/ui/components/shared/Login/Login.tsx
@@ -1,5 +1,7 @@
-import React, { useEffect } from "react";
+import { gql } from "@apollo/client";
+import React, { useEffect, useState } from "react";
 
+import { query } from "ui/utils/apolloClient";
 import { setUserInBrowserPrefs } from "ui/utils/browser";
 import { isTeamMemberInvite } from "ui/utils/onboarding";
 import useAuth0 from "ui/utils/useAuth0";
@@ -7,18 +9,120 @@ import useAuth0 from "ui/utils/useAuth0";
 import { PrimaryLgButton } from "../Button";
 import { OnboardingContentWrapper, OnboardingModalContainer } from "../Onboarding";
 
-export default function Login() {
+const GET_CONNECTION = gql`
+  query GetConnection($email: String!) {
+    auth {
+      connection(email: $email)
+    }
+  }
+`;
+
+function SSOLogin({ onLogin }: { onLogin: () => void }) {
   const { loginWithRedirect } = useAuth0();
-  const forceOpenAuth = new URLSearchParams(window.location.search).get("signin");
-  const onLogin = () =>
-    loginWithRedirect({
-      appState: { returnTo: window.location.pathname + window.location.search },
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | boolean>(false);
+
+  const onEnterpriseLogin = async () => {
+    const resp = await query({
+      query: GET_CONNECTION,
+      variables: {
+        email,
+      },
     });
 
-  if (forceOpenAuth) {
-    onLogin();
-    return null;
-  }
+    if (resp.data?.auth.connection) {
+      loginWithRedirect({
+        connection: resp.data.auth.connection,
+        appState: { returnTo: window.location.pathname + window.location.search },
+      });
+    } else {
+      setError(resp.errors?.find(e => e.message)?.message || true);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <p className="text-center text-base">
+        Enter your email to be redirected to your SSO provider.
+      </p>
+      {error ? (
+        <p className="text-center text-base text-red-500">
+          {typeof error === "string"
+            ? "We were unable to find your SSO provider right now. Please try again later."
+            : "We couldn't find an SSO provider for your email."}
+        </p>
+      ) : null}
+      <div className="flex flex-row space-x-3">
+        <input
+          type="email"
+          className="flex-grow rounded-md"
+          placeholder="user@company.com"
+          value={email}
+          onKeyPress={e => (e.key === "Enter" ? onEnterpriseLogin() : null)}
+          onChange={e => setEmail(e.currentTarget.value)}
+        />
+
+        <PrimaryLgButton color="blue" onClick={onEnterpriseLogin} className="justify-center">
+          Sign in
+        </PrimaryLgButton>
+      </div>
+      <button
+        className="w-full justify-center text-primaryAccent underline text-sm font-bold"
+        onClick={onLogin}
+      >
+        Sign in with Google
+      </button>
+    </div>
+  );
+}
+
+function SocialLogin({
+  onShowSSOLogin,
+  onLogin,
+}: {
+  onShowSSOLogin: () => void;
+  onLogin: () => void;
+}) {
+  return (
+    <div className="space-y-6">
+      {isTeamMemberInvite() ? <h1 className="text-2xl font-extrabold">Almost there!</h1> : null}
+      <div className="text-base space-y-4 self-start">
+        {isTeamMemberInvite() ? (
+          <p>In order to join your team, we first need you to sign in.</p>
+        ) : (
+          <>
+            <p className="text-center">
+              Replay captures everything you need for the perfect bug report, all in one link.{" "}
+              <a href="https://replay.io" className="underline pointer-hand">
+                Learn more
+              </a>
+            </p>
+            <p></p>
+          </>
+        )}
+      </div>
+      <PrimaryLgButton color="blue" onClick={onLogin} className="w-full justify-center">
+        Sign in with Google
+      </PrimaryLgButton>
+      <button
+        className="w-full justify-center text-primaryAccent underline text-sm font-bold"
+        onClick={onShowSSOLogin}
+      >
+        Enterprise Users: Sign in with SSO
+      </button>
+    </div>
+  );
+}
+
+export default function Login() {
+  const { loginWithRedirect } = useAuth0();
+  const [sso, setSSO] = useState(false);
+
+  const onLogin = () =>
+    loginWithRedirect({
+      connection: "google-oauth2",
+      appState: { returnTo: window.location.pathname + window.location.search },
+    });
 
   useEffect(() => {
     setUserInBrowserPrefs(null);
@@ -27,25 +131,11 @@ export default function Login() {
   return (
     <OnboardingModalContainer theme="light">
       <OnboardingContentWrapper overlay>
-        {isTeamMemberInvite() ? <h1 className="text-2xl font-extrabold">Almost there!</h1> : null}
-        <div className="text-base space-y-4 self-start">
-          {isTeamMemberInvite() ? (
-            <p>In order to join your team, we first need you to sign in.</p>
-          ) : (
-            <>
-              <p className="text-center">
-                Replay captures everything you need for the perfect bug report, all in one link.{" "}
-                <a href="https://replay.io" className="underline pointer-hand">
-                  Learn more
-                </a>
-              </p>
-              <p></p>
-            </>
-          )}
-        </div>
-        <PrimaryLgButton color="blue" onClick={onLogin} className="w-full justify-center">
-          {isTeamMemberInvite() ? "Sign in with Google" : "Log in"}
-        </PrimaryLgButton>
+        {sso ? (
+          <SSOLogin onLogin={onLogin} />
+        ) : (
+          <SocialLogin onShowSSOLogin={() => setSSO(true)} onLogin={onLogin} />
+        )}
       </OnboardingContentWrapper>
     </OnboardingModalContainer>
   );


### PR DESCRIPTION
Fix #5065.

## Issue

Our current login flow confuses users because non-SSO users think they should enter their email but that falls flat

## Resolution

Make Google auth the primary call to action and do home realm discovery ourselves for SSO customers

Blocked by https://github.com/RecordReplay/backend/pull/4441

https://user-images.githubusercontent.com/788456/152045690-3291551e-b949-4a58-ab56-822b48adcbef.mp4
