### PR TITLE
Disable telemetry on preview branches

### DIFF
--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -10,7 +10,7 @@ import NewWorkspaceModal from "./shared/NewWorkspaceModal";
 import WorkspaceSettingsModal from "./shared/WorkspaceSettingsModal";
 import UserSettingsModal from "./shared/UserSettingsModal";
 import OnboardingModal from "./shared/OnboardingModal/index";
-import { isDeployPreview, isTest } from "ui/utils/environment";
+import { isTest } from "ui/utils/environment";
 import * as selectors from "ui/reducers/app";
 import { UIState } from "ui/state";
 import { ModalType } from "ui/state/app";
@@ -121,7 +121,7 @@ function App({ children, modal, theme }: AppProps) {
     }
   }, [auth.isAuthenticated]);
 
-  if (!isDeployPreview() && (auth.isLoading || userInfo.loading)) {
+  if (auth.isLoading || userInfo.loading) {
     return <LoadingScreen />;
   }
 

--- a/src/ui/components/Header/UserOptions.tsx
+++ b/src/ui/components/Header/UserOptions.tsx
@@ -6,7 +6,6 @@ import LoginButton from "ui/components/LoginButton";
 import Dropdown from "ui/components/shared/Dropdown";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import Icon from "ui/components/shared/Icon";
-import { isDeployPreview } from "ui/utils/environment";
 import useAuth0 from "ui/utils/useAuth0";
 import { features } from "ui/utils/prefs";
 import { trackEvent } from "ui/utils/telemetry";
@@ -26,11 +25,6 @@ function UserOptions({ setModal, noBrowserItem }: UserOptionsProps) {
   const isCollaborator =
     hooks.useIsCollaborator(recordingId || "00000000-0000-0000-0000-000000000000") &&
     isAuthenticated;
-  const showShare = isOwner || isCollaborator;
-
-  if (isDeployPreview()) {
-    return null;
-  }
 
   if (!isAuthenticated) {
     return <LoginButton />;

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -77,11 +77,11 @@ export function mockEnvironment() {
 }
 
 export function skipTelemetry() {
-  return isTest() || isMock() || isDevelopment();
+  return isTest() || isMock() || isDevelopment() || isDeployPreview();
 }
 
 export function isDeployPreview() {
-  return url.hostname.includes("replay-devtools.netlify.app");
+  return process.env.NEXT_PUBLIC_VERCEL_ENV === "preview";
 }
 
 // The loading param is currently used to wait for resources


### PR DESCRIPTION
* Clean up usage of `isDeployPreview()`
* Add `isDeployPreview()` to `skipTelemetry()` so we don't send prod errors from preview branches