### PR TITLE
Refactor analysisPoints -> analysisPoint

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/modify.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/modify.js
@@ -152,14 +152,14 @@ export function runAnalysis(cx, initialLocation, options) {
       return;
     }
 
-    // Don't run the analysis if we already have the analysis points for that
+    // Don't run the analysis if we already have the analysis point for that
     // location.
-    const analysisPoints = selectors.getAnalysisPointsForLocation(
+    const analysisPoint = selectors.getAnalysisPointForLocation(
       getState(),
       location,
       options.condition
     );
-    if (analysisPoints) {
+    if (analysisPoint) {
       return;
     }
 

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -28,7 +28,7 @@ function getPanelWidth({ editor }) {
 }
 
 function Panel({
-  analysisPoints,
+  analysisPoint,
   breakpoint,
   currentTime,
   editor,
@@ -42,7 +42,7 @@ function Panel({
   const [width, setWidth] = useState(getPanelWidth(editor));
   const [inputToFocus, setInputToFocus] = useState("logValue");
   const dismissNag = hooks.useDismissNag();
-  const error = analysisPoints === "error";
+  const { points, errors } = analysisPoint;
   const pausedOnHit =
     !error &&
     !!analysisPoints?.find(({ point, time }) => point == executionPoint && time == currentTime);
@@ -129,7 +129,7 @@ function Panel({
 
 export default connect(
   (state, { breakpoint }) => ({
-    analysisPoints: selectors.getAnalysisPointsForLocation(
+    analysisPoints: selectors.getAnalysisPointForLocation(
       state,
       breakpoint.location,
       breakpoint.options.condition

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -69,7 +69,7 @@ export default function LineNumberTooltip({ editor }: { editor: any }) {
   const lastHoveredLineNumber = useRef<number | null>(null);
 
   const indexed = useSelector(selectors.getIndexed);
-  const analysisPoints = useSelector(selectors.getPointsForHoveredLineNumber);
+  const { points: analysisPoints } = useSelector(selectors.getPointForHoveredLineNumber);
 
   const setHoveredLineNumber = ({
     lineNumber,

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -109,7 +109,6 @@ function ToggleWidgetButton({ editor, toggleLogpoint, cx, breakpoints }: ToggleW
 const connector = connect(
   (state: UIState) => ({
     indexed: selectors.getIndexed(state),
-    analysisPoints: selectors.getPointsForHoveredLineNumber(state),
     cx: selectors.getThreadContext(state),
     breakpoints: getBreakpointsForSource(state, getSelectedSource(state).id),
   }),

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -8,6 +8,7 @@ import { actions } from "ui/actions";
 import { connect } from "devtools/client/debugger/src/utils/connect";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 const { trackEvent } = require("ui/utils/telemetry");
+import { AnalysisPointError } from "ui/state/app";
 
 import BreakpointTimeline from "./BreakpointTimeline";
 
@@ -114,14 +115,15 @@ function BreakpointNavigationCommands({ prev, next, navigateToPoint }) {
   );
 }
 
-function BreakpointNavigationStatus({ executionPoint, analysisPoints, indexed }) {
+function BreakpointNavigationStatus({ executionPoint, analysisPoint, indexed }) {
   let status = "";
+  const { points, errors } = analysisPoint;
   let maxStatusLength = 0;
   if (!indexed) {
     status = "Indexing";
-  } else if (!analysisPoints || !executionPoint) {
+  } else if (!points || !executionPoint) {
     status = "Loading";
-  } else if (analysisPoints === "error") {
+  } else if (errors.includes(AnalysisPointError.HITS_ERROR)) {
     // This error is currently caused by how the backend limits the returned
     // hits to 10k. Lines with more than 10k hits don't get returned.
     status = "10k+ hits";
@@ -147,7 +149,7 @@ function BreakpointNavigationStatus({ executionPoint, analysisPoints, indexed })
 }
 
 const mapStateToProps = (state, { breakpoint }) => ({
-  analysisPoints: selectors.getAnalysisPointsForLocation(
+  analysisPoint: selectors.getAnalysisPointForLocation(
     state,
     breakpoint.location,
     breakpoint.options.condition

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.tsx
@@ -62,7 +62,7 @@ type Coordinates = {
 
 function BreakpointTimeline({
   breakpoint,
-  analysisPoints,
+  analysisPoint,
   zoomRegion,
   currentTime,
   hoveredItem,
@@ -70,6 +70,7 @@ function BreakpointTimeline({
 }: BreakpointTimelineProps) {
   const [hoveredTime, setHoveredTime] = useState<number | null>(null);
   const timelineRef = useRef<HTMLDivElement | null>(null);
+  const { points, errors } = analysisPoint;
   const onClick = (e: React.MouseEvent) => {
     if (!hoveredTime) return;
 
@@ -108,12 +109,8 @@ function BreakpointTimeline({
           <div className="progress-line full" />
           <div className="progress-line preview-min" style={{ width: hoverPercent }} />
           <div className="progress-line" style={{ width: `${percent}%` }} />
-          {analysisPoints && analysisPoints !== "error" ? (
-            <Points
-              analysisPoints={analysisPoints}
-              breakpoint={breakpoint}
-              hoveredItem={hoveredItem}
-            />
+          {points && !errors.length ? (
+            <Points analysisPoints={points} breakpoint={breakpoint} hoveredItem={hoveredItem} />
           ) : null}
         </div>
       </PortalTooltip>
@@ -123,7 +120,7 @@ function BreakpointTimeline({
 
 const connector = connect(
   (state: UIState, { breakpoint }: { breakpoint: any }) => ({
-    analysisPoints: selectors.getAnalysisPointsForLocation(
+    analysisPoint: selectors.getAnalysisPointForLocation(
       state,
       breakpoint.location,
       breakpoint.options.condition

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimelinePoint.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimelinePoint.js
@@ -3,7 +3,6 @@ import { connect } from "devtools/client/debugger/src/utils/connect";
 import classnames from "classnames";
 import { selectors } from "ui/reducers";
 import { timelineMarkerWidth as pointWidth } from "ui/constants";
-const { getAnalysisPointsForLocation } = selectors;
 import { actions } from "ui/actions";
 import { Circle } from "ui/components/Timeline/Marker";
 import { inBreakpointPanel } from "devtools/client/debugger/src/utils/editor";
@@ -30,7 +29,7 @@ function BreakpointTimelinePoint({
   breakpoint,
   point,
   index,
-  analysisPoints,
+  analysisPoint,
   executionPoint,
   zoomRegion,
   seek,
@@ -68,7 +67,7 @@ function BreakpointTimelinePoint({
         "primary-highlight": hasPrimaryHighlight({ hoveredItem, point }),
         "secondary-highlight": hasSecondaryHighlighted({ hoveredItem, breakpoint }),
       })}
-      title={`${index + 1}/${analysisPoints.length}`}
+      title={`${index + 1}/${analysisPoint.points.length}`}
       onClick={onClick}
       style={{ left: `calc(${leftPercentOffset}% - ${pointWidth / 2}px)` }}
       onMouseEnter={onMouseEnter}
@@ -106,7 +105,7 @@ const MemoizedBreakpointTimelinePoint = React.memo(
 
 export default connect(
   (state, { breakpoint }) => ({
-    analysisPoints: getAnalysisPointsForLocation(
+    analysisPoint: getAnalysisPointForLocation(
       state,
       breakpoint.location,
       breakpoint.options.condition

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -21,6 +21,7 @@ import {
   EventKind,
   ReplayEvent,
   ReplayNavigationEvent,
+  AnalysisPointError,
 } from "ui/state/app";
 import { Workspace } from "ui/types";
 import { client, sendMessage } from "protocol/socket";
@@ -66,6 +67,7 @@ export type SetAnalysisPointsAction = Action<"set_analysis_points"> & {
 export type SetAnalysisErrorAction = Action<"set_analysis_error"> & {
   location: Location;
   condition: string;
+  error: AnalysisPointError;
 };
 export type SetEventsForType = Action<"set_events"> & {
   events: (MouseEvent | KeyboardEvent | ReplayNavigationEvent)[];
@@ -287,11 +289,16 @@ export function setAnalysisPoints(
   };
 }
 
-export function setAnalysisError(location: Location, condition = ""): SetAnalysisErrorAction {
+export function setAnalysisError(
+  location: Location,
+  condition = "",
+  error: AnalysisPointError
+): SetAnalysisErrorAction {
   return {
     type: "set_analysis_error",
     location,
     condition,
+    error,
   };
 }
 

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -247,19 +247,16 @@ class Timeline extends Component<PropsFromRedux> {
   }
 
   renderPreviewMarkers() {
-    const { pointsForHoveredLineNumber, currentTime, hoveredItem, zoomRegion } = this.props;
+    const { pointForHoveredLineNumber, currentTime, hoveredItem, zoomRegion } = this.props;
+    const { points, errors } = pointForHoveredLineNumber;
 
-    if (
-      !pointsForHoveredLineNumber ||
-      pointsForHoveredLineNumber === "error" ||
-      pointsForHoveredLineNumber.length > prefs.maxHitsDisplayed
-    ) {
+    if (!points || errors.length || points.length > prefs.maxHitsDisplayed) {
       return [];
     }
 
     return (
       <div className="preview-markers-container">
-        {pointsForHoveredLineNumber.map((point: PointDescription, index: number) => {
+        {points.map((point: PointDescription, index: number) => {
           const isPrimaryHighlighted = hoveredItem?.point === point.point;
           const isSecondaryHighlighted = getIsSecondaryHighlighted(hoveredItem, point.frame?.[0]);
 
@@ -412,7 +409,7 @@ const connector = connect(
     messages: selectors.getMessagesForTimeline(state),
     viewMode: selectors.getViewMode(state),
     selectedPanel: selectors.getSelectedPanel(state),
-    pointsForHoveredLineNumber: selectors.getPointsForHoveredLineNumber(state),
+    pointForHoveredLineNumber: selectors.getPointForHoveredLineNumber(state),
     hoveredItem: selectors.getHoveredItem(state),
     hoveredComment: selectors.getHoveredComment(state),
     clickEvents: selectors.getEventsForType(state, "mousedown"),

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -99,7 +99,15 @@ export interface AppState {
 }
 
 export interface AnalysisPoints {
-  [key: string]: PointDescription[] | "error";
+  [key: string]: AnalysisPoint;
+}
+interface AnalysisPoint {
+  points: PointDescription[];
+  errors: AnalysisPointError[];
+}
+export enum AnalysisPointError {
+  HITS_ERROR = "hits-error",
+  RESULTS_ERROR = "results-error",
 }
 
 interface Events {


### PR DESCRIPTION
Fix https://github.com/RecordReplay/customer-support/issues/18

We used to have `analysisPoints` in Redux correspond to a collection that had the location as they key and an array of its "analysis points" as its value. That is, until we hit an error while doing an analysis. The two distinct cases are:
1) Analysis to get the points, e.g. we're trying to find the number of hits to show in the tooltip
2) Analysis to get the results, e.g. we're evaluating an expression to show its results in the console.

Right now, the code is written such that an error for either replaces the array (whether existing or not) value in `analysisPoints` with the string `"error"`. Kinda janky but it works. Well, actually, not so much since we don't make a distinction between a points error, and a results error. That's bad since ideally we'd like to treat those things separately in the UI.

Another bad thing about it is that it an error when getting the results can completely torpedo the points count that's already saved in Redux, which is what's happening in [this issue](https://github.com/RecordReplay/customer-support/issues/18).

This tries to introduce a wrapper object around the array of `analysisPoints`, and an `errors` array where we can store the error that occured (1, or 2, or 1 and 2).

Note: the interface is super awkward so I'm open to naming suggestions :)