### PR TITLE
Keep the hits count from disappearing if the analysis result throws

### DIFF
--- a/src/protocol/logpoint.ts
+++ b/src/protocol/logpoint.ts
@@ -274,7 +274,8 @@ async function setMultiSourceLogpoint(
     }
   };
 
-  if (condition || (showInConsole && !primitives)) {
+  const shouldGetResults = condition || (showInConsole && !primitives);
+  if (shouldGetResults) {
     handler.onAnalysisResult = result => {
       results.push(...result);
       if (showInConsole && (condition || !primitives)) {
@@ -286,7 +287,12 @@ async function setMultiSourceLogpoint(
   try {
     await analysisManager.runAnalysis(params, handler);
   } catch {
-    saveAnalysisError(locations, condition);
+    // Only save the error if we're only grabbing the points for a location.
+    // This means that we're not handling cases where the full analysis
+    // throws. We should add that as a follow-up.
+    if (!shouldGetResults) {
+      saveAnalysisError(locations, condition);
+    }
     return;
   }
 


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/customer-support/issues/18.

We have a [hard-coded limit for a full analysis on the backend](https://github.com/RecordReplay/backend/blob/cbb48ebfd2de92d4463fcfb5a9691ccfd40da028/src/control/handlers/analysis.ts#L313). When that throws, it ends up rewriting the existing data about the corresponding location, which is why we have that weird "10k+ hits" behavior.

We could handle that specific full-analysis-for-200+  error separately, or even better, just not be in a place where that's the case in the first place (see follow-up item #5222).

