### PR TITLE
Track the number of hits when previewing a breakpoint

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -57,6 +57,7 @@ function PanelSummary({
 
   const focusInput = (input: Input) => {
     if (isEditable) {
+      trackEvent("breakpoint.start_edit", { input, hitsCount: analysisPoints?.length || null });
       toggleEditingOn();
       setInputToFocus(input);
     }

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -109,10 +109,12 @@ export default function LineNumberTooltip({ editor }: { editor: any }) {
   }, []);
 
   useEffect(() => {
-    if (analysisPoints)
+    if (analysisPoints) {
       trackEvent(
         analysisPoints.length ? "breakpoint.preview_has_hits" : "breakpoint.preview_no_hits"
       );
+      trackEvent("breakpoint.preview_hits", { hitsCount: analysisPoints?.length || null });
+    }
   }, [analysisPoints]);
 
   if (!targetNode) {

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -9,16 +9,19 @@ import { CanonicalRequestType } from "ui/components/NetworkMonitor/utils";
 import { WorkspaceId, WorkspaceUuid } from "ui/state/app";
 import { InspectorActiveTab } from "devtools/client/inspector/state";
 import { decodeWorkspaceId } from "./workspace";
+import { Input } from "devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary";
 
 type MixpanelEvent =
   | ["breakpoint.add_comment"]
   | ["breakpoint.minus_click"]
   | ["breakpoint.plus_click"]
+  | ["breakpoint.preview_hits", { hitsCount: number | null }]
   | ["breakpoint.preview_has_hits"]
   | ["breakpoint.preview_no_hits"]
   | ["breakpoint.remove"]
   | ["breakpoint.set_condition"]
   | ["breakpoint.set_log"]
+  | ["breakpoint.start_edit", { input: Input; hitsCount: number | null }]
   | ["breakpoint.too_many_points"]
   | ["comments.create"]
   | ["comments.delete"]


### PR DESCRIPTION
This should give us a better idea of what kind of hit counts users are looking at when they 1) are previewing a line, or 2) editing the print statement expression.