### PR TITLE
Fix mock tests (#5218)

### DIFF
--- a/.github/actions/mockTest/action.yml
+++ b/.github/actions/mockTest/action.yml
@@ -5,7 +5,6 @@ runs:
   steps:
     - name: Install dependencies
       run: npm install
-      working-directory: test
       shell: bash
     - run: mv macOS-replay-playwright/macOS-replay-playwright.tar.xz ./
       shell: bash

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -47,16 +47,6 @@ export function getAccessibleRecording(
   recordingId: string
 ): UIThunkAction<Promise<Recording | null>> {
   return async ({ dispatch }) => {
-    if (!validateUUID(recordingId)) {
-      dispatch(
-        setExpectedError({
-          message: "Invalid ID",
-          content: `"${recordingId}" is not a valid recording ID`,
-        })
-      );
-      return null;
-    }
-
     try {
       const [recording, userId] = await Promise.all([getRecording(recordingId), getUserId()]);
       if (!recording || recording.isInitialized) {

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -105,6 +105,10 @@ const GET_MY_RECORDINGS = gql`
   }
 `;
 
+export function useGetRawRecordingIdWithSlug() {
+  return useRouter().query.id;
+}
+
 export function useGetRecordingId() {
   const { id } = useRouter().query;
   return extractIdAndSlug(id).id!;

--- a/src/ui/utils/apolloClient.tsx
+++ b/src/ui/utils/apolloClient.tsx
@@ -46,7 +46,7 @@ export function ApolloWrapper({ children }: { children: ReactNode }) {
       <MockedProvider
         link={from([retryLink, errorLink, mockLink])}
         cache={createApolloCache()}
-        ref={mockRef => clientWaiter.resolve(mockRef!.state.client)}
+        ref={mockRef => mockRef && clientWaiter.resolve(mockRef!.state.client)}
       >
         <>{children}</>
       </MockedProvider>

--- a/test/mock/run.js
+++ b/test/mock/run.js
@@ -43,11 +43,14 @@ async function main() {
         },
       }
     );
-    if (rv.status) {
+    if (rv.status || rv.signal || rv.error) {
+      console.log(`Failed with status ${rv.status}, signal ${rv.signal} and error ${rv.error}`);
       const recordings = listAllRecordings();
       let url = "<recording unavailable";
       if (recordings.length) {
-        const recordingId = await uploadRecording(recordings[recordings.length - 1].id);
+        const recordingId = await uploadRecording(recordings[recordings.length - 1].id, {
+          apiKey: "rwk_7XPbO5fhz0bkhANYXtN2dkm74wNQCchXf2OxVgAerTQ",
+        });
         if (recordingId) {
           url = `https://app.replay.io/recording/${recordingId}`;
         }

--- a/test/mock/scripts/invalid-recording-01.ts
+++ b/test/mock/scripts/invalid-recording-01.ts
@@ -27,5 +27,5 @@ const bindings = basicBindings();
 runTest("invalidRecordingID", async (page: Page) => {
   await page.goto(devtoolsURL({ id: recordingId }));
   await installMockEnvironment(page, { graphqlMocks, messageHandlers, bindings });
-  await page.textContent("text=You don't have permission to view this replay");
+  await page.textContent("text=Sorry, you don't have permission!");
 });


### PR DESCRIPTION
- CI: runs `npm install` in the root folder instead of the `test` subfolder (this was the main issue preventing the mock tests from running in CI)
- fixes a bug where trying to open a recording with a recordingId that is not a UUID (plus slug) didn't show an error message
- fixes a bug if the `MockedProvider` passes a nullish `mockRef` to its callback
- fixes uploading of recordings for failed tests by adding our test API key
- fixes one of the tests that looked for an outdated error message