### PR TITLE
Fix the hook for adding a comment reply (#5146)

### DIFF
--- a/src/ui/hooks/comments/useAddCommentReply.tsx
+++ b/src/ui/hooks/comments/useAddCommentReply.tsx
@@ -64,6 +64,9 @@ export default function useAddCommentReply() {
         });
 
         const parentComment = data.recording.comments.find((r: any) => r.id === reply.parentId);
+        if (!parentComment) {
+          return;
+        }
         const newReply = {
           id: commentReply.id,
           content: reply.content,


### PR DESCRIPTION
#5173 didn't fully fix #5146, the issue keeps popping up in Sentry. Although I couldn't reproduce this, I think the reason can only be in the hook for adding comment replies, fixed by this PR.