### PR TITLE
Polishing timeline hit targets (Fitts’ Law of UX)

### DIFF
--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -128,10 +128,10 @@
 .timeline .progress-line,
 .breakpoint-navigation-timeline .progress-line {
   width: 0%;
-  height: 3px;
+  height: 5px;
   border-radius: 4px;
   /* border-top: 3px dashed var(--primary-accent); */
-  border-top: 3px solid var(--primary-accent);
+  border-top: 5px solid var(--primary-accent);
   position: absolute;
   pointer-events: none;
   margin-top: auto;
@@ -182,13 +182,20 @@
 }
 
 .timeline .progress-line-paused {
-  height: 9px;
-  width: 9px;
+  height: 11px;
+  width: 11px;
   border-radius: 50%;
   background: var(--secondary-accent);
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
+  cursor: grab;
+}
+
+.timeline .progress-line-paused:hover {
+  width: 15px;
+  height: 15px;
+  cursor: grab;
 }
 
 /* Timeline timestamp */


### PR DESCRIPTION
**Background:**
* Our loading screen has a thicker loader bar and this change aligns our timeline with it.
* It's important that these targets be larger for easier grabbing
* It's also good to change the cursor into a gripper on something grippable


Old:
![image](https://user-images.githubusercontent.com/9154902/152891864-624d4aa0-f50b-4cf6-bc0c-77c73de1b1a1.jpeg)

New:
![image](https://user-images.githubusercontent.com/9154902/152892100-f361800a-30a7-48c0-9b03-51afa13ab397.jpeg)
