### PR TITLE
Replay Info polish

### DIFF
--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -84,8 +84,8 @@ function Toolbar({ viewMode }: PropsFromRedux) {
   return (
     <div className="toolbox-toolbar-container flex flex-col items-center justify-between py-1">
       <div id="toolbox-toolbar space-y-1">
+        <ToolbarButton icon="info" label="Replay Info" name="events" />
         <ToolbarButton icon="forum" label="Comments" name="comments" />
-        <ToolbarButton icon="list" label="Events" name="events" />
         {viewMode == "dev" ? (
           <>
             <ToolbarButton icon="description" name="explorer" label="Source Explorer" />


### PR DESCRIPTION
**Changes in this PR**

1. Rename "Events" to "Replay Info"
2. Attach more accurate icon to Replay Info
3. Make the Replay Info icon first, since that's what we default to in most cases

Prod:
![image](https://user-images.githubusercontent.com/9154902/152910869-e56ce0ad-5de3-4d3e-a7c9-528e75ee3a26.png)

New:
![image](https://user-images.githubusercontent.com/9154902/152910904-4a253e16-2731-4ef3-8176-5cc91a237432.png)
