### PR TITLE
Hide React DevTools behind a flag

### DIFF
--- a/src/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/ui/components/CommandPalette/CommandPalette.tsx
@@ -50,7 +50,7 @@ const COMMANDS: Command[] = [
   { key: "open_function_search", label: "Search for a function", shortcut: "CmdOrCtrl+Shift+P" },
   { key: "open_outline", label: "Open Outline" },
   { key: "open_print_statements", label: "Open Print Statements" },
-  { key: "open_react_devtools", label: "Open React DevTools" },
+  { key: "open_react_devtools", label: "Open React DevTools", settingKey: "showReact" },
   { key: "open_sources", label: "Open Sources" },
   { key: "show_comments", label: "Show Comments" },
   { key: "show_console_filters", label: "Show Console Filters" },

--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import classnames from "classnames";
 import hooks from "ui/hooks";
@@ -35,6 +35,9 @@ function PanelButtons({
   selectedPanel,
   setSelectedPanel,
 }: PanelButtonsProps) {
+  const { userSettings } = hooks.useGetUserSettings();
+  const { showReact } = userSettings;
+
   const onClick = (panel: SecondaryPanelName) => {
     setSelectedPanel(panel);
     trackEvent(`toolbox.secondary.${panel}_select`);
@@ -65,7 +68,7 @@ function PanelButtons({
           <div className="label">Elements</div>
         </button>
       )}
-      {hasReactComponents && (
+      {hasReactComponents && showReact && (
         <button
           className={classnames("components-panel-button", {
             expanded: selectedPanel === "react-components",
@@ -115,7 +118,12 @@ function SecondaryToolbox({
   recordingTarget,
   hasReactComponents,
 }: PropsFromRedux) {
+  const { userSettings } = hooks.useGetUserSettings();
   const isNode = recordingTarget === "node";
+
+  if (selectedPanel === "react-components" && !(userSettings.showReact && hasReactComponents)) {
+    setSelectedPanel("console");
+  }
 
   return (
     <div className={classnames(`secondary-toolbox rounded-lg`, { node: isNode })}>

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -13,6 +13,11 @@ interface ExperimentalSetting {
 
 const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
   {
+    label: "React DevTools",
+    description: "Inspect the React component tree",
+    key: "showReact",
+  },
+  {
     label: "Event Link",
     description: "Jump from an event to a line of code",
     key: "enableEventLink",
@@ -50,6 +55,7 @@ export default function ExperimentalSettings({}) {
 
   // TODO: This is bad and should be updated with a better generalized hook
   const updateEventLink = hooks.useUpdateUserSetting("enableEventLink", "Boolean");
+  const updateReact = hooks.useUpdateUserSetting("showReact", "Boolean");
 
   const [enableCommentAttachments, setEnableCommentAttachments] = useState(
     !!features.commentAttachments
@@ -61,6 +67,8 @@ export default function ExperimentalSettings({}) {
     } else if (key === "enableCommentAttachments") {
       features.commentAttachments = value;
       setEnableCommentAttachments(!!features.commentAttachments);
+    } else if (key === "showReact") {
+      updateReact({ variables: { newValue: value } });
     }
   };
 

--- a/src/ui/graphql/settings.ts
+++ b/src/ui/graphql/settings.ts
@@ -16,6 +16,7 @@ export const GET_USER_SETTINGS = gql`
         enableEventLink
         enableRepaint
         enableTeams
+        showReact
       }
       defaultWorkspace {
         id

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -17,6 +17,7 @@ const emptySettings: UserSettings = {
   disableLogRocket: false,
   enableEventLink: false,
   enableTeams: true,
+  showReact: false,
 };
 
 const testSettings: UserSettings = {
@@ -25,6 +26,7 @@ const testSettings: UserSettings = {
   disableLogRocket: false,
   enableEventLink: false,
   enableTeams: true,
+  showReact: true,
 };
 
 export async function getUserSettings(): Promise<UserSettings> {
@@ -94,6 +96,7 @@ function convertUserSettings(data: any): UserSettings {
     disableLogRocket: settings.disableLogRocket,
     enableEventLink: settings.enableEventLink,
     enableTeams: settings.enableTeams,
+    showReact: settings.showReact,
   };
 }
 

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -11,6 +11,7 @@ export type UserSettings = {
   disableLogRocket: boolean;
   enableEventLink: boolean;
   enableTeams: boolean;
+  showReact: boolean;
 };
 
 export type LocalUserSettings = {

--- a/test/mock/src/graphql/settings.ts
+++ b/test/mock/src/graphql/settings.ts
@@ -10,6 +10,7 @@ export function createUserSettingsMock(): MockedResponse[] {
     disableLogRocket: false,
     enableEventLink: false,
     enableTeams: true,
+    showReact: true,
   };
   const rv = {
     request: {


### PR DESCRIPTION
Fix #5241. 

React DevTools isn't quite stable yet. This hides it back behind a flag so we're setting expectations correctly.