### PR TITLE
Add an eval id for when getting autocomplete property matches

### DIFF
--- a/src/devtools/client/webconsole/components/Input/JSTerm.tsx
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.tsx
@@ -40,13 +40,22 @@ function useGetScopeMatches(expression: string) {
 }
 function useGetEvalMatches(value: string) {
   const [matches, setMatches] = useState<string[]>([]);
+  const evalIdRef = useRef(0);
 
   useEffect(() => {
     async function updateMatches() {
+      setMatches([]);
       const propertyExpression = getPropertyExpression(value);
 
-      if (propertyExpression) {
-        const evaluatedProperties = await getEvaluatedProperties(propertyExpression.left);
+      if (!propertyExpression) {
+        return;
+      }
+
+      evalIdRef.current++;
+      const evalId = evalIdRef.current;
+
+      const evaluatedProperties = await getEvaluatedProperties(propertyExpression.left);
+      if (evalIdRef.current === evalId) {
         setMatches(evaluatedProperties);
       }
     }


### PR DESCRIPTION
This adds an `evalId` for whenever we perform eager evaluation for autocomplete purposes. This makes sure that only the latest set of matches are saved in the hook's state.