### PR TITLE
Allow response bodies without `response` events

### DIFF
--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -150,7 +150,7 @@ export const partialRequestsToCompleteSummaries = (
         domain: host(request.event.requestUrl),
         firstByte: response?.time,
         end: requestDone?.time,
-        hasResponseBody: Boolean(response && r.events["response-body"]),
+        hasResponseBody: Boolean(r.events["response-body"]),
         hasRequestBody: Boolean(r.events["request-body"]),
         id: r.id,
         method: request.event.requestMethod,


### PR DESCRIPTION
This was blocking response bodies for `POST`s from forms.

Fixes https://github.com/RecordReplay/customer-support/issues/25