### PR TITLE
Move the invitation code to a route

### DIFF
--- a/pages/team/invitation/[id].tsx
+++ b/pages/team/invitation/[id].tsx
@@ -1,0 +1,30 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { setExpectedError } from "ui/actions/session";
+import hooks from "ui/hooks";
+
+export default function Share() {
+  const { push, query } = useRouter();
+  const dispatch = useDispatch();
+  const [invitationCode] = Array.isArray(query.id) ? query.id : [query.id];
+  const claimTeamInvitationCode = hooks.useClaimTeamInvitationCode(onCompleted, onError);
+
+  function onCompleted() {
+    push("/");
+  }
+  function onError() {
+    dispatch(
+      setExpectedError({
+        message: "This team invitation code is invalid",
+        content:
+          "There seems to be a problem with your team invitation link. Please ask your team administrator to send you an up-to-date link.",
+        action: "library",
+      })
+    );
+  }
+
+  useEffect(function handleTeamInvitationCode() {
+    claimTeamInvitationCode({ variables: { code: invitationCode } });
+  }, []);
+}

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -60,29 +60,12 @@ function FilterBar({
 }
 
 function LibraryLoader(props: PropsFromRedux) {
-  const [renderLibrary, setRenderLibrary] = useState(false);
-  const [showClaimError, setShowClaimError] = useState(false);
-
   const auth = useAuth0();
   const { userSettings, loading: userSettingsLoading } = hooks.useGetUserSettings();
   const userInfo = hooks.useGetUserInfo();
   const { workspaces, loading: loading1 } = hooks.useGetNonPendingWorkspaces();
   const { pendingWorkspaces, loading: loading2 } = hooks.useGetPendingWorkspaces();
   const { nags, loading: loading3 } = useGetUserInfo();
-  const claimTeamInvitationCode = hooks.useClaimTeamInvitationCode(onCompleted, onError);
-
-  function onCompleted() {
-    // This allows the server enough time to refresh the pending workspaces
-    // with the new team before we render the Library.
-    setTimeout(() => {
-      removeUrlParameters();
-      setRenderLibrary(true);
-    }, 1000);
-  }
-  function onError() {
-    // If there's an error while claiming a code, don't go ahead and render the library.
-    setShowClaimError(true);
-  }
 
   useEffect(() => {
     if (!userInfo.loading && !userSettingsLoading) {
@@ -90,33 +73,7 @@ function LibraryLoader(props: PropsFromRedux) {
     }
   }, [auth, userInfo, userSettings, userSettingsLoading]);
 
-  useEffect(function handleTeamInvitationCode() {
-    const code = hasTeamInvitationCode();
-
-    if (!code) {
-      setRenderLibrary(true);
-      return;
-    }
-
-    claimTeamInvitationCode({ variables: { code } });
-  }, []);
-  useEffect(
-    function handleInvalidTeamInvitationCode() {
-      if (!showClaimError) {
-        return;
-      }
-
-      props.setExpectedError({
-        message: "This team invitation code is invalid",
-        content:
-          "There seems to be a problem with your team invitation link. Please ask your team administrator to send you an up-to-date link.",
-        action: "library",
-      });
-    },
-    [showClaimError]
-  );
-
-  if (loading1 || loading2 || loading3 || !renderLibrary) {
+  if (loading1 || loading2 || loading3) {
     return <LoadingScreen />;
   }
 

--- a/src/ui/hooks/workspaces_user.ts
+++ b/src/ui/hooks/workspaces_user.ts
@@ -111,7 +111,7 @@ export function useClaimTeamInvitationCode(onCompleted: () => void, onError: () 
         }
       }
     `,
-    { refetchQueries: ["GetPendingWorkspaces"], onCompleted, onError }
+    { onCompleted, onError }
   );
 
   return inviteNewWorkspaceMember;


### PR DESCRIPTION
The way we previously handled team invitation codes was by doing some logic as the person opens the Library that checks the query params for the invitation code.

This PR moves all of that to its own route that handles the team invitation, and then once the invitation has been added to the user, redirects them to the library.

Fix #5271.

**Follow-up:**
Right after shipping, this requires a change in Courier to change the format of our team invite links from `https://app.replay.io/?invitationcode=165460bd-069e-4fb3-be4a-466c4567fc1e` to `https://app.replay.io/team/invitation/165460bd-069e-4fb3-be4a-466c4567fc1e`

https://user-images.githubusercontent.com/15959269/153479865-20eea6e1-cdf6-4a30-ae53-9d97874bc541.mov
