### PR TITLE
Use a for loop when loading sources

### DIFF
--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -357,8 +357,6 @@ class _ThreadFront {
     });
 
     await this.ensureAllSources();
-    console.log({ ensureAllSources: performance.now() - then, totalTime });
-    const beforeLoop = performance.now();
     const keys = this.sources.keys;
     for (let i = 0; i < keys.length; i++) {
       //@ts-ignore

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -357,7 +357,12 @@ class _ThreadFront {
     });
 
     await this.ensureAllSources();
-    for (const [sourceId, source] of this.sources) {
+    console.log({ ensureAllSources: performance.now() - then, totalTime });
+    const beforeLoop = performance.now();
+    const keys = this.sources.keys;
+    for (let i = 0; i < keys.length; i++) {
+      //@ts-ignore
+      const [sourceId, source] = this.sources.get(keys[i]);
       if (sourceId === this.getCorrespondingSourceIds(sourceId)[0]) {
         onSource({ sourceId, ...source });
       }


### PR DESCRIPTION
Ummmm... do not ask me how I decided to try this change, I honestly have no idea. I think I've just spent a lot of time on JS twitter recently and that made me suspicious of what the `for ... of` was doing under the hood. So I tried to change it to a regular for loop.

Before:
I tried to time it, but I couldn't get it to work, because my tabs kept crashing

After:
The `await ensureAllSources` and the loop took `9741ms`.
And the memory of the process did not spike at all.

I think there are other wins here, but this one seems huge?