### PR TITLE
Debounce loading sources for a longer time

### DIFF
--- a/src/devtools/client/debugger/src/utils/source-queue.js
+++ b/src/devtools/client/debugger/src/utils/source-queue.js
@@ -16,7 +16,7 @@ async function dispatchNewSources() {
   currentWork = await newQueuedSources(sources);
 }
 
-const queue = throttle(dispatchNewSources, 100);
+const queue = throttle(dispatchNewSources, 1000);
 
 export default {
   initialize: actions => {


### PR DESCRIPTION
This took way longer than it should have to figure out, especially after [Logan's comment about it](https://github.com/RecordReplay/customer-support/issues/20#issuecomment-1036695905). I was fooled because we *are* debouncing source loading, but we were only debouncing it for 100ms. If you have a *lot* of sources (more than ~30,000 on my machine) and there is more than 100ms between them even once, then this whole thing will run every time after that (because it will take more than 100ms). So for a recording where we have 50,000 sources, on my machine we hit this pretty expensive function 20,000 times. I've bumped this up to a second, which should be safe, at least on moderately safe machines, but if we run into this again we should probably consider full-on batching these things from the backend.