### PR TITLE
Re-add babelrc. fixes #5169

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,15 @@
+{
+  "presets": [
+    [
+      "next/babel",
+      {
+        "preset-env": {
+          "targets": {
+            "chrome": "95"
+          }
+        }
+      }
+    ]
+  ],
+  "plugins": ["@babel/plugin-transform-react-display-name"]
+}


### PR DESCRIPTION
This is a temporary fix which for #5169.

I think the next version of Next.js will let us set a preset-env and go back to SWC.

In the meantime, we should re-add babel which will let us bring back native async/await which is a perf win and will make debugging significantly easier