### PR TITLE
Fix FB call stack framework grouping

### DIFF
--- a/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.js
@@ -19,9 +19,20 @@ const libraryMap = [
     label: "Preact",
     pattern: /preact/i,
   },
+  // React in node_modules
   {
     label: "React",
-    pattern: /(node_modules\/(?:react|react-dom)\/)|(react(-dom)?(\.[a-z]+)*\.js$)/,
+    pattern: /node_modules\/(?:react|react-dom)\//,
+  },
+  // React in a shared library, but not part of a filename
+  {
+    label: "React",
+    pattern: /[^\.]react(\.[a-zA-Z]+)*\.js$/,
+  },
+  // FB's internal ReactDOM filename
+  {
+    label: "React",
+    pattern: /(ReactDOM(-dev)?(\.[a-z]+)*\.js$)/,
   },
   {
     label: "React",

--- a/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.test.js
+++ b/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.test.js
@@ -1,0 +1,19 @@
+import { getLibraryFromUrl } from "./getLibraryFromUrl";
+
+describe("getLibraryFromUrl", () => {
+  test("FB ReactDOM", () => {
+    expect(
+      getLibraryFromUrl({ source: { url: "https://www.foo.com/bar/ReactDOM-dev.classic.js" } })
+    ).toEqual("React");
+  });
+  test("foo.react.js components", () => {
+    expect(getLibraryFromUrl({ source: { url: "https://www.foo.com/bar/foo.react.js" } })).toEqual(
+      null
+    );
+  });
+  test("shared/react.js", () => {
+    expect(
+      getLibraryFromUrl({ source: { url: "https://www.foo.com/bar/shared/react.js" } })
+    ).toEqual("React");
+  });
+});


### PR DESCRIPTION
Fixes some framework grouping to handle a couple of edge cases we're seeing in the fb callstacks