### PR TITLE
Fix material icon loading detection

### DIFF
--- a/public/fonts/material_icons/material_icons.css
+++ b/public/fonts/material_icons/material_icons.css
@@ -17,12 +17,6 @@
     url(/fonts/material_icons/MaterialIconsOutlined-Regular.otf) format("opentype");
 }
 
-.material-icon-loaded .material-icons,
-.material-icon-loaded .material-icons-outlined {
-  opacity: 1;
-  width: unset;
-}
-
 .material-icons,
 .material-icons-outlined {
   font-weight: normal;
@@ -35,8 +29,6 @@
   word-wrap: normal;
   white-space: nowrap;
   direction: ltr;
-  opacity: 0;
-  width: 1rem;
 
   /* Support for all WebKit browsers. */
   -webkit-font-smoothing: antialiased;
@@ -58,12 +50,8 @@
   font-family: "Material Icons Outlined";
 }
 
-.material-icons,
-.material-icons-outlined {
-  visibility: hidden;
-}
-
-.material-icons,
-.material-icons-outlined {
-  visibility: visible;
+.material-icon-loading .material-icons,
+.material-icon-loading .material-icons-outlined {
+  opacity: 0;
+  width: 1rem;
 }

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import useAuth0 from "ui/utils/useAuth0";
 
@@ -32,6 +32,7 @@ import { shouldShowNag } from "ui/utils/user";
 import { trackEvent } from "ui/utils/telemetry";
 import SourcemapSetupModal from "./shared/Modals/SourcemapSetupModal";
 import RenameReplayModal from "./shared/Modals/RenameReplayModal";
+import { useMaterialIconCheck } from "./shared/MaterialIcon";
 
 function AppModal({ modal }: { modal: ModalType }) {
   switch (modal) {
@@ -93,6 +94,7 @@ function App({ children, modal, theme }: AppProps) {
   const auth = useAuth0();
   const dismissNag = hooks.useDismissNag();
   const userInfo = useGetUserInfo();
+  const { setAppNode } = useMaterialIconCheck();
 
   useEffect(() => {
     if (userInfo.nags && shouldShowNag(userInfo.nags, Nag.FIRST_LOG_IN)) {
@@ -135,7 +137,7 @@ function App({ children, modal, theme }: AppProps) {
   }
 
   return (
-    <div id="app-container">
+    <div id="app-container" className="material-icon-loading" ref={setAppNode}>
       {children}
       {modal ? <AppModal modal={modal} /> : null}
       <ConfirmRenderer />

--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -1,5 +1,5 @@
 import classnames from "classnames";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 const SIZE_STYLES = {
   xs: "text-xs",
@@ -19,14 +19,28 @@ type MaterialIconProps = React.HTMLProps<HTMLDivElement> & {
   iconSize?: keyof typeof SIZE_STYLES;
 };
 
-const useMaterialIconCheck = () => {
+export const useMaterialIconCheck = () => {
+  const [appNode, setAppNode] = useState<HTMLElement | null>(null);
+
   useEffect(() => {
-    (document as any).fonts.ready.then(() => {
-      if (typeof document === "object" && (document as any).fonts.check("12px Material Icons")) {
-        document.body.classList.add("material-icon-loaded");
-      }
-    });
-  }, []);
+    if (appNode && appNode.classList.contains("material-icon-loading")) {
+      (document as any).fonts.ready.then(async () => {
+        let retries = 10;
+        while (retries-- > 0) {
+          if (
+            typeof document === "object" &&
+            (document as any).fonts.check("12px Material Icons")
+          ) {
+            appNode.classList.remove("material-icon-loading");
+            break;
+          }
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        }
+      });
+    }
+  }, [appNode]);
+
+  return { setAppNode };
 };
 
 export default function MaterialIcon({
@@ -37,8 +51,6 @@ export default function MaterialIcon({
   iconSize = "base",
   ...rest
 }: MaterialIconProps) {
-  useMaterialIconCheck();
-
   return (
     <div
       {...rest}


### PR DESCRIPTION
## Issue

The added specificity of the `width` from `.material-icon-loaded .material-icon` was stomping on the tailwind specificity preventing easy assignment of the width to an icon

<img width="532" alt="image" src="https://user-images.githubusercontent.com/788456/154367610-9206a0d7-71ea-4347-a139-48cdcb91b92e.png">


## Resolution

* Refactoring the "loading" class to be applied by default and then removed when loaded ensures that the higher specificity is only applied when loading and is removed when loaded so the desired size can take effect then.
* Also changed the hook design a bit to keep everyone inside their own boundary:
  * class is now applied to the app root node instead of the body to stay within the app's boundary
  * root App component uses the hook and passes a ref to this node so the hook isn't reaching out beyond it's boundary
  * Added some retry logic so the fonts can be ready within the first 10 seconds of rendering the app

<img width="538" alt="image" src="https://user-images.githubusercontent.com/788456/154367656-0224dad0-afd1-408b-877a-5d7613bebf7c.png">
