### PR TITLE
Revert "Remove unecessary sources code (#5350)"

### DIFF
--- a/src/devtools/client/debugger/src/actions/sources/newSources.js
+++ b/src/devtools/client/debugger/src/actions/sources/newSources.js
@@ -116,13 +116,86 @@ function restoreBlackBoxedSources(cx, sources) {
   };
 }
 
-export function newSources(sources) {
+export function newQueuedSources(sourceInfo) {
+  return async ({ dispatch }) => {
+    const generated = [];
+    const original = [];
+    for (const source of sourceInfo) {
+      if (source.type === "generated") {
+        generated.push(source.data);
+      } else {
+        original.push(source.data);
+      }
+    }
+
+    if (generated.length > 0) {
+      await dispatch(newGeneratedSources(generated));
+    }
+    if (original.length > 0) {
+      await dispatch(newOriginalSources(original));
+    }
+  };
+}
+
+export function newOriginalSource(sourceInfo) {
+  return async ({ dispatch }) => {
+    const sources = await dispatch(newOriginalSources([sourceInfo]));
+    return sources[0];
+  };
+}
+export function newOriginalSources(sourceInfo) {
+  return async ({ dispatch, getState }) => {
+    const state = getState();
+    const seen = new Set();
+    const sources = [];
+
+    for (const { id, url } of sourceInfo) {
+      if (seen.has(id) || getSource(state, id)) {
+        continue;
+      }
+
+      seen.add(id);
+
+      sources.push({
+        id,
+        url,
+        relativeUrl: url,
+        isPrettyPrinted: false,
+        isBlackBoxed: false,
+        introductionUrl: null,
+        introductionType: undefined,
+        isExtension: false,
+        extensionName: null,
+        isOriginal: true,
+      });
+    }
+
+    const cx = getContext(state);
+    dispatch(addSources(cx, sources));
+
+    await dispatch(checkNewSources(cx, sources));
+
+    for (const source of sources) {
+      dispatch(checkPendingBreakpoints(cx, source.id));
+    }
+
+    return sources;
+  };
+}
+
+export function newGeneratedSource(sourceInfo) {
+  return async ({ dispatch }) => {
+    const sources = await dispatch(newGeneratedSources([sourceInfo]));
+    return sources[0];
+  };
+}
+export function newGeneratedSources(sourceInfo) {
   return async ({ dispatch, getState, client }) => {
     const resultIds = [];
     const newSourcesObj = {};
     const newSourceActors = [];
 
-    for (const { thread, isServiceWorker, source, id } of sources) {
+    for (const { thread, isServiceWorker, source, id } of sourceInfo) {
       const newId = id || makeSourceId(source, isServiceWorker);
 
       const kind = ThreadFront.getSourceKind(source.actor);

--- a/src/devtools/client/debugger/src/client/events.js
+++ b/src/devtools/client/debugger/src/client/events.js
@@ -31,7 +31,10 @@ function resumed() {
 }
 
 function newSource(_, { source }) {
-  sourceQueue.queue(prepareSourcePayload(source));
+  sourceQueue.queue({
+    type: "generated",
+    data: prepareSourcePayload(source),
+  });
 }
 
 const clientEvents = {

--- a/src/devtools/client/debugger/src/utils/source-queue.js
+++ b/src/devtools/client/debugger/src/utils/source-queue.js
@@ -6,21 +6,21 @@
 
 import throttle from "lodash/throttle";
 
-let newSources;
+let newQueuedSources;
 let queuedSources;
 let currentWork;
 
 async function dispatchNewSources() {
   const sources = queuedSources;
   queuedSources = [];
-  currentWork = await newSources(sources);
+  currentWork = await newQueuedSources(sources);
 }
 
 const queue = throttle(dispatchNewSources, 1000);
 
 export default {
   initialize: actions => {
-    newSources = actions.newSources;
+    newQueuedSources = actions.newQueuedSources;
     queuedSources = [];
   },
   queue: source => {

--- a/src/devtools/client/debugger/src/utils/test-head.js
+++ b/src/devtools/client/debugger/src/utils/test-head.js
@@ -1,0 +1,262 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+//
+
+/**
+ * Utils for Jest
+ * @module utils/test-head
+ */
+
+import { combineReducers } from "redux";
+import sourceMaps from "devtools-source-map";
+import reducers from "../reducers";
+import actions from "../actions";
+import * as selectors from "../selectors";
+import { getHistory } from "../test/utils/history";
+import { parserWorker, evaluationsParser } from "../test/tests-setup";
+import configureStore from "../actions/utils/create-store";
+import sourceQueue from "../utils/source-queue";
+
+/**
+ * This file contains older interfaces used by tests that have not been
+ * converted to use test-mockup.js
+ */
+
+/**
+ * @memberof utils/test-head
+ * @static
+ */
+function createStore(client, initialState = {}, sourceMapsMock) {
+  const store = configureStore({
+    log: false,
+    history: getHistory(),
+    makeThunkArgs: args => {
+      return {
+        ...args,
+        client,
+        sourceMaps: sourceMapsMock !== undefined ? sourceMapsMock : sourceMaps,
+        parser: parserWorker,
+        evaluationsParser,
+      };
+    },
+  })(combineReducers(reducers), initialState);
+  sourceQueue.clear();
+  sourceQueue.initialize({
+    newQueuedSources: sources => store.dispatch(actions.newQueuedSources(sources)),
+  });
+
+  store.thunkArgs = () => ({
+    dispatch: store.dispatch,
+    getState: store.getState,
+    client,
+    sourceMaps,
+    panel: {},
+  });
+
+  // Put the initial context in the store, for convenience to unit tests.
+  store.cx = selectors.getThreadContext(store.getState());
+
+  return store;
+}
+
+/**
+ * @memberof utils/test-head
+ * @static
+ */
+function commonLog(msg, data = {}) {
+  console.log(`[INFO] ${msg} ${JSON.stringify(data)}`);
+}
+
+function makeFrame({ id, sourceId, thread }, opts = {}) {
+  return {
+    id,
+    scope: { bindings: { variables: {}, arguments: [] } },
+    location: { sourceId, line: 4 },
+    thread: thread || "FakeThread",
+    ...opts,
+  };
+}
+
+function createSourceObject(filename, props = {}) {
+  return {
+    id: filename,
+    url: makeSourceURL(filename),
+    isBlackBoxed: !!props.isBlackBoxed,
+    isPrettyPrinted: false,
+    introductionUrl: props.introductionUrl || null,
+    introductionType: props.introductionType || null,
+    isExtension: false,
+    isOriginal: filename.includes("originalSource"),
+  };
+}
+
+function createOriginalSourceObject(generated) {
+  const rv = {
+    ...generated,
+    id: `${generated.id}/originalSource`,
+  };
+
+  return rv;
+}
+
+function makeSourceURL(filename) {
+  return `http://localhost:8000/examples/${filename}`;
+}
+
+function createMakeSource() {
+  const indicies = {};
+
+  return function (name, props = {}) {
+    const index = (indicies[name] | 0) + 1;
+    indicies[name] = index;
+
+    return {
+      id: name,
+      thread: "FakeThread",
+      source: {
+        actor: `${name}-${index}-actor`,
+        url: `http://localhost:8000/examples/${name}`,
+        sourceMapURL: props.sourceMapURL || null,
+        introductionType: props.introductionType || null,
+        introductionUrl: props.introductionUrl || null,
+        isBlackBoxed: !!props.isBlackBoxed,
+        extensionName: null,
+      },
+      isServiceWorker: false,
+    };
+  };
+}
+
+/**
+ * @memberof utils/test-head
+ * @static
+ */
+let creator;
+beforeEach(() => {
+  creator = createMakeSource();
+});
+afterEach(() => {
+  creator = null;
+});
+function makeSource(name, props) {
+  if (!creator) {
+    throw new Error("makeSource() cannot be called outside of a test");
+  }
+
+  return creator(name, props);
+}
+
+function makeOriginalSource(source) {
+  return {
+    id: `${source.id}/originalSource`,
+    url: `${source.url}-original`,
+  };
+}
+
+function makeFuncLocation(startLine, endLine) {
+  if (!endLine) {
+    endLine = startLine + 1;
+  }
+  return {
+    start: {
+      line: startLine,
+    },
+    end: {
+      line: endLine,
+    },
+  };
+}
+
+function makeSymbolDeclaration(name, start, end, klass) {
+  return {
+    id: `${name}:${start}`,
+    name,
+    location: makeFuncLocation(start, end),
+    klass,
+  };
+}
+
+/**
+ * @memberof utils/test-head
+ * @static
+ */
+function waitForState(store, predicate) {
+  return new Promise(resolve => {
+    let ret = predicate(store.getState());
+    if (ret) {
+      resolve(ret);
+    }
+
+    const unsubscribe = store.subscribe(() => {
+      ret = predicate(store.getState());
+      if (ret) {
+        unsubscribe();
+        // NOTE: memoizableAction adds an additional tick for validating context
+        setTimeout(() => resolve(ret));
+      }
+    });
+  });
+}
+
+function watchForState(store, predicate) {
+  let sawState = false;
+  const checkState = function () {
+    if (!sawState && predicate(store.getState())) {
+      sawState = true;
+    }
+    return sawState;
+  };
+
+  let unsubscribe;
+  if (!checkState()) {
+    unsubscribe = store.subscribe(() => {
+      if (checkState()) {
+        unsubscribe();
+      }
+    });
+  }
+
+  return function read() {
+    if (unsubscribe) {
+      unsubscribe();
+    }
+
+    return sawState;
+  };
+}
+
+function getTelemetryEvents(eventName) {
+  return window.dbg._telemetry.events[eventName] || [];
+}
+
+function waitATick(callback) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      callback();
+      resolve();
+    });
+  });
+}
+
+export {
+  actions,
+  selectors,
+  reducers,
+  createStore,
+  commonLog,
+  getTelemetryEvents,
+  makeFrame,
+  createSourceObject,
+  createOriginalSourceObject,
+  createMakeSource,
+  makeSourceURL,
+  makeSource,
+  makeOriginalSource,
+  makeSymbolDeclaration,
+  waitForState,
+  watchForState,
+  getHistory,
+  waitATick,
+};


### PR DESCRIPTION
This reverts commit 4856970341ac4e2e078cd28a20ad17e228878d32.

Was seeing this bug: https://app.replay.io/recording/what-is-this-sourcemap-error--1363310a-7d37-4f4c-9be9-1db1bc1d1bd2?point=18497557561419090466109470070014025&time=7821.187132625835&hasFrames=true

I can reproduce reliably, so I'm going to see if it's gone on the preview branch and then we should know.