### PR TITLE
Make the background a real gradient

### DIFF
--- a/src/devtools/client/debugger/src/components/App.css
+++ b/src/devtools/client/debugger/src/components/App.css
@@ -32,6 +32,13 @@ button {
 
 .editor-container {
   width: 100%;
+  background: linear-gradient(
+    25deg,
+    rgba(255, 255, 255, 1) 0%,
+    rgba(255, 255, 255, 1) 30%,
+    rgba(176, 229, 245, 1) 67%,
+    rgba(235, 186, 202, 1) 95%
+  );
 }
 
 /* Utils */

--- a/src/devtools/client/debugger/src/components/WelcomeBox.tsx
+++ b/src/devtools/client/debugger/src/components/WelcomeBox.tsx
@@ -8,11 +8,8 @@ import CommandPalette from "ui/components/CommandPalette";
 export default function WelcomeBox() {
   return (
     <div className="flex h-full w-full flex-col items-center overflow-hidden">
-      <div className="relative flex w-full justify-center px-8 pt-14">
-        <div className="pointer-events-none absolute">
-          <img src="/images/bubble.svg" className="editor-bg" style={{ transform: "scale(2.4)" }} />
-        </div>
-        <div className="relative flex w-full flex-col items-center">
+      <div className="relative flex h-full w-full justify-center px-8 pt-14">
+        <div className="relative flex h-full w-full flex-col items-center">
           <CommandPalette />
         </div>
       </div>

--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -500,14 +500,6 @@ checkbox:-moz-focusring {
 
 /* Images */
 
-.editor-bg {
-  transform: scale(2.4);
-  position: relative;
-  max-width: none;
-  left: -340px;
-  top: 400px;
-}
-
 .top-bubble {
   left: 100px;
   position: absolute;

--- a/src/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/ui/components/CommandPalette/CommandPalette.tsx
@@ -67,6 +67,9 @@ const DEFAULT_COMMANDS: readonly CommandKey[] = [
   "open_sources",
 ] as const;
 
+const COMMAND_HEIGHT = 36;
+const ITEMS_TO_SHOW = 4;
+
 function getShownCommands(searchString: string, hasReactComponents: boolean) {
   const { userSettings } = hooks.useGetUserSettings();
 
@@ -141,8 +144,8 @@ function CommandPalette({
 
   return (
     <div
-      className="flex h-52 w-full flex-col overflow-hidden rounded-md bg-gray-50 shadow-xl"
-      style={{ maxWidth: "400px", minWidth: "320px" }}
+      className="flex w-full flex-col overflow-hidden rounded-md bg-gray-50 shadow-xl"
+      style={{ maxWidth: 400, minWidth: 320 }}
     >
       <div className="border-b border-gray-300 p-3">
         <div className="relative flex items-center text-primaryAccent">
@@ -155,7 +158,12 @@ function CommandPalette({
           <PaletteShortcut />
         </div>
       </div>
-      <div className="mb-2 flex flex-grow flex-col overflow-auto text-sm">
+      <div
+        className="flex flex-grow flex-col overflow-auto text-sm"
+        // By making sure there is always a fraction of an item showing we show
+        // that there is more to scroll to "beyond the fold"
+        style={{ maxHeight: COMMAND_HEIGHT * ITEMS_TO_SHOW }}
+      >
         {shownCommands.map((command: Command, index: number) => (
           <CommandButton active={index == activeIndex} command={command} key={command.label} />
         ))}


### PR DESCRIPTION
This is a small change, but on my ultra wide monitor I've noticed that
the edge of the nebula that we use as a background image ends up peeking
out and looking kind of janky. This changes that container to have a
true CSS gradient background, which should both give us more control and
also make it feel more versatile across a lot of screen sizes.

I've also tried to make the way that we style the initial height of the
command panel explicit.

https://www.loom.com/share/92dcb8f76fcd493f92ddf06c2dcc85de

I did change the gradient stops a little from the loom, here's the current version:


![CleanShot 2022-02-18 at 13 55 23](https://user-images.githubusercontent.com/5903784/154766593-eb672e48-7330-4e75-a15f-1266e78d03f3.png)

