### PR TITLE
Add resubscription UI to workspace settings

### DIFF
--- a/src/ui/components/shared/WorkspaceSettingsModal/AddPaymentMethod.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/AddPaymentMethod.tsx
@@ -20,7 +20,7 @@ export function EnterPaymentMethod({
   stripePromise,
 }: {
   onCancel: () => void;
-  onSave: () => void;
+  onSave: (billingDetails: { paymentMethodBillingId: string | null }) => void;
   workspaceId: string;
   stripePromise: Promise<any>;
 }) {
@@ -88,7 +88,7 @@ export function EnterPaymentMethod({
         throw confirm.error;
       }
 
-      onSave();
+      onSave({ paymentMethodBillingId: confirm.setupIntent.payment_method });
     } catch (e) {
       console.error(e);
       setError("Failed to create payment method. Please try again later.");

--- a/src/ui/components/shared/WorkspaceSettingsModal/BillingBanners.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/BillingBanners.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { Subscription } from "ui/types";
-import { getFeatureFlag } from "ui/utils/launchdarkly";
+import { Subscription, Workspace } from "ui/types";
 import MaterialIcon from "../MaterialIcon";
 import { Banner } from "./Banner";
 import { isSubscriptionCancelled } from "./utils";
@@ -8,11 +7,15 @@ import { formatDate } from "./formatDate";
 
 export function BillingBanners({
   confirmed,
-  subscription,
+  workspace,
+  onResubscribe,
 }: {
   confirmed?: boolean;
-  subscription: Subscription;
+  workspace: Workspace;
+  onResubscribe: () => void;
 }) {
+  const subscription = workspace.subscription;
+
   if (confirmed) {
     return (
       <Banner icon={<MaterialIcon iconSize="xl">check_circle_outline</MaterialIcon>} type="primary">
@@ -21,7 +24,7 @@ export function BillingBanners({
     );
   }
 
-  if (subscription.plan.key === "beta-v1") {
+  if (subscription?.plan.key === "beta-v1") {
     return (
       <Banner icon={<span className="text-3xl">😍</span>} type="primary">
         We’ve gifted you a team plan for being a beta tester. Thank you!
@@ -29,7 +32,7 @@ export function BillingBanners({
     );
   }
 
-  if (subscription.status === "trialing") {
+  if (subscription?.status === "trialing") {
     return (
       <Banner icon={<MaterialIcon iconSize="xl">access_time</MaterialIcon>} type="warning">
         Trial ends {formatDate(subscription.trialEnds!)}
@@ -37,11 +40,20 @@ export function BillingBanners({
     );
   }
 
-  if (isSubscriptionCancelled(subscription)) {
+  if (subscription && isSubscriptionCancelled(subscription)) {
     const past = Date.now() - new Date(subscription.effectiveUntil!).getTime() > 0;
     return (
       <Banner icon={<MaterialIcon iconSize="xl">access_time</MaterialIcon>} type="warning">
-        Subscription {past ? "ended" : "ends"} {formatDate(subscription.effectiveUntil!)}.
+        {past ? (
+          <div className="flex flex-row justify-between">
+            <span>Subscription expired.</span>
+            <button className="text-blue-500 underline" onClick={onResubscribe}>
+              {workspace.hasPaymentMethod ? "Resume Subscription" : "Add payment method"}
+            </button>
+          </div>
+        ) : (
+          `Subscription ends ${formatDate(subscription.effectiveUntil!)}.`
+        )}
       </Banner>
     );
   }

--- a/src/ui/components/shared/WorkspaceSettingsModal/DeleteConfirmation.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/DeleteConfirmation.tsx
@@ -19,11 +19,11 @@ export function DeleteConfirmation({
     deleteWorkspacePaymentMethod({
       variables: {
         workspaceId,
-        paymentMethodId: subscription.paymentMethods[0].id,
+        paymentMethodId: subscription.paymentMethods![0].id,
       },
     }).then(onDone);
 
-  if (error) {
+  if (error || subscription.paymentMethods == null) {
     return <section className="text-red">Unable to remove a payment method at this time.</section>;
   }
 

--- a/src/ui/components/shared/WorkspaceSettingsModal/Details.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/Details.tsx
@@ -97,14 +97,18 @@ function SubscriptionDetails({
 
 export function Details({
   subscription,
-  setView,
+  onAddPaymentMethod,
+  onDeletePaymentMethod,
+  onResubscribe,
   workspace,
   confirmed,
 }: {
   confirmed?: boolean;
   subscription: SubscriptionWithPricing;
   workspace: Workspace;
-  setView: (view: Views) => void;
+  onAddPaymentMethod: () => void;
+  onDeletePaymentMethod: () => void;
+  onResubscribe: () => void;
 }) {
   if (inUnpaidFreeTrial(workspace)) {
     const expiresIn = subscriptionEndsIn(workspace);
@@ -113,7 +117,7 @@ export function Details({
       <TrialDetails
         workspace={workspace}
         expiresIn={expiresIn}
-        onSelectPricing={() => setView("add-payment-method")}
+        onSelectPricing={onAddPaymentMethod}
       />
     );
   }
@@ -121,11 +125,11 @@ export function Details({
   return (
     <>
       <SettingsHeader>{`${subscription.displayName} Plan`}</SettingsHeader>
-      <BillingBanners subscription={subscription} confirmed={confirmed} />
+      <BillingBanners workspace={workspace} confirmed={confirmed} onResubscribe={onResubscribe} />
       <SubscriptionDetails
         subscription={subscription}
-        onAddPaymentMethod={() => setView("add-payment-method")}
-        onDeletePaymentMethod={() => setView("delete-payment-method")}
+        onAddPaymentMethod={onAddPaymentMethod}
+        onDeletePaymentMethod={onDeletePaymentMethod}
       />
     </>
   );

--- a/src/ui/components/shared/WorkspaceSettingsModal/Details.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/Details.tsx
@@ -76,7 +76,7 @@ function SubscriptionDetails({
         <div className="border-color-gray-50 flex flex-row items-center justify-between border-b py-2">
           <span>Payment Method</span>
           <span className="flex flex-col items-end">
-            {subscription.paymentMethods.length > 0 ? (
+            {subscription.paymentMethods && subscription.paymentMethods.length > 0 ? (
               <button
                 className="text-primaryAccent hover:underline"
                 onClick={onDeletePaymentMethod}

--- a/src/ui/components/shared/WorkspaceSettingsModal/ExpirationRow.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/ExpirationRow.tsx
@@ -3,7 +3,7 @@ import { Subscription } from "ui/types";
 import { formatDate } from "./formatDate";
 
 export function ExpirationRow({ subscription }: { subscription: Subscription }) {
-  if (subscription.plan.key.includes("beta") || !subscription.trialEnds) {
+  if (subscription.plan.key.includes("beta") || !subscription.effectiveUntil) {
     return null;
   }
 
@@ -18,7 +18,7 @@ export function ExpirationRow({ subscription }: { subscription: Subscription }) 
   return (
     <div className="border-color-gray-50 flex flex-row items-center justify-between border-b py-2">
       <span>{label}</span>
-      <span>{formatDate(subscription.trialEnds, "long")}</span>
+      <span>{formatDate(subscription.effectiveUntil, "long")}</span>
     </div>
   );
 }

--- a/src/ui/components/shared/WorkspaceSettingsModal/ExpirationRow.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/ExpirationRow.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Subscription } from "ui/types";
 import { formatDate } from "./formatDate";
+import { isTrial } from "./utils";
 
 export function ExpirationRow({ subscription }: { subscription: Subscription }) {
   if (subscription.plan.key.includes("beta") || !subscription.effectiveUntil) {
@@ -9,7 +10,7 @@ export function ExpirationRow({ subscription }: { subscription: Subscription }) 
 
   let label = "Renewal date";
 
-  if (subscription.status === "trialing" && subscription.paymentMethods.length === 0) {
+  if (isTrial(subscription)) {
     label = "Your team’s start date";
   } else if (subscription.status === "canceled") {
     label = "Subscription end date";

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSubscription.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSubscription.tsx
@@ -89,7 +89,7 @@ export default function WorkspaceSubscription({ workspaceId }: { workspaceId: st
   }) => {
     try {
       const planKey = workspace.subscription?.plan.key;
-      assert(planKey === "beta-v1", "Workspace does not have a planKey");
+      assert(planKey, "Workspace does not have a planKey");
 
       setView("details");
       setConfirmed(true);

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSubscription.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSubscription.tsx
@@ -57,13 +57,16 @@ export default function WorkspaceSubscription({ workspaceId }: { workspaceId: st
 
   const handleResubscribe = async () => {
     try {
-      const planKey = workspace.subscription?.plan.key;
+      const subscription = data.node.subscription;
+      const planKey = subscription.plan.key;
       assert(planKey, "Workspace does not have a planKey");
 
-      if (workspace.hasPaymentMethod) {
+      if (subscription.paymentMethods?.length) {
+        assert(subscription.paymentMethods?.[0]?.id, "Payment method was not found");
         await activateWorkspaceSubscription({
           variables: {
             planKey,
+            paymentMethodBillingId: subscription.paymentMethods[0].id,
           },
         });
       } else {

--- a/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
@@ -13,7 +13,11 @@ export function isSubscriptionCancelled(subscription: Subscription) {
 }
 
 export const isTrial = (subscription: Subscription): boolean => {
-  return subscription.status === "trialing" && subscription.paymentMethods.length === 0;
+  return (
+    subscription.status === "trialing" &&
+    subscription.paymentMethods != null &&
+    subscription.paymentMethods.length === 0
+  );
 };
 
 export function formatPaymentMethod(paymentMethod: PaymentMethod) {

--- a/src/ui/graphql/workspaces.ts
+++ b/src/ui/graphql/workspaces.ts
@@ -120,15 +120,14 @@ export const ACTIVATE_WORKSPACE_SUBSCRIPTION = gql`
   mutation ActivateWorkspaceSubscription(
     $workspaceId: ID!
     $planKey: String!
-    $paymentMethodBillingId: String
+    $paymentMethodBillingId: String!
   ) {
-    activateWorkspaceSubscription(
-      input: {
-        workspaceId: $workspaceId
-        planKey: $planKey
-        paymentMethodBillingId: $paymentMethodBillingId
-      }
+    setWorkspaceDefaultPaymentMethod(
+      input: { workspaceId: $workspaceId, paymentMethodId: $paymentMethodBillingId }
     ) {
+      success
+    }
+    activateWorkspaceSubscription(input: { workspaceId: $workspaceId, planKey: $planKey }) {
       success
       subscription {
         effectiveUntil

--- a/src/ui/graphql/workspaces.ts
+++ b/src/ui/graphql/workspaces.ts
@@ -115,3 +115,25 @@ export const CANCEL_WORKSPACE_SUBSCRIPTION = gql`
     }
   }
 `;
+
+export const ACTIVATE_WORKSPACE_SUBSCRIPTION = gql`
+  mutation ActivateWorkspaceSubscription(
+    $workspaceId: ID!
+    $planKey: String!
+    $paymentMethodBillingId: String
+  ) {
+    activateWorkspaceSubscription(
+      input: {
+        workspaceId: $workspaceId
+        planKey: $planKey
+        paymentMethodBillingId: $paymentMethodBillingId
+      }
+    ) {
+      success
+      subscription {
+        effectiveUntil
+        status
+      }
+    }
+  }
+`;

--- a/src/ui/hooks/workspaces.ts
+++ b/src/ui/hooks/workspaces.ts
@@ -1,5 +1,6 @@
 import { gql, useQuery, useMutation } from "@apollo/client";
 import {
+  ACTIVATE_WORKSPACE_SUBSCRIPTION,
   ADD_WORKSPACE_API_KEY,
   CANCEL_WORKSPACE_SUBSCRIPTION,
   DELETE_WORKSPACE_API_KEY,
@@ -178,6 +179,9 @@ export function useGetNonPendingWorkspaces(): { workspaces: Workspace[]; loading
                   status
                   trialEnds
                   effectiveUntil
+                  plan {
+                    key
+                  }
                 }
                 settings {
                   motd
@@ -296,6 +300,18 @@ export function useUpdateWorkspaceMemberRole() {
   });
 
   return { updateWorkspaceMemberRole, loading, error };
+}
+
+export function useActivateWorkspaceSubscription(workspaceId: string) {
+  const [activateWorkspaceSubscription, { loading, error }] = useMutation<{
+    activateWorkspaceSubscription: {
+      subscription: Pick<Subscription, "status" | "effectiveUntil">;
+    };
+  }>(ACTIVATE_WORKSPACE_SUBSCRIPTION, {
+    variables: { workspaceId },
+  });
+
+  return { activateWorkspaceSubscription, loading, error };
 }
 
 export function useGetWorkspaceSubscription(workspaceId: string) {

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -82,7 +82,7 @@ export interface Subscription {
     key: PlanKey;
     createdAt: string;
   };
-  paymentMethods: PaymentMethod[];
+  paymentMethods?: PaymentMethod[];
 }
 
 export type BillingSchedule = "annual" | "monthly" | "contract";


### PR DESCRIPTION
Blocked by https://github.com/RecordReplay/backend/pull/4703

## Issue

Subscriptions that have lapsed (either by an expired trial or canceled by removing the payment method while active) cannot be resubscribed without admin intervention

## Resolution

* Update the expired banner to include a link to add a payment method or resubscribe (if the payment method already exists)
* Add a hook to activate a workspace subscription
* Invoke the new hook with the `planKey` from the prior subscription
* Add some better error messaging since more things can go wrong now
* Some refactoring to plumb all the right data elements through the componentry.

<img width="830" alt="image" src="https://user-images.githubusercontent.com/788456/154771743-37be383a-f90f-4741-865d-019f37a3dc38.png">
