### PR TITLE
Add a mixpanel tracker for whenever font loading times out

### DIFF
--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -1,5 +1,6 @@
 import classnames from "classnames";
 import React, { useEffect, useState } from "react";
+import { trackEvent } from "ui/utils/telemetry";
 
 const SIZE_STYLES = {
   xs: "text-xs",
@@ -36,6 +37,8 @@ export const useMaterialIconCheck = () => {
           }
           await new Promise(resolve => setTimeout(resolve, 1000));
         }
+
+        trackEvent("error.font_loading_timeout");
       });
     }
   }, [appNode]);

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -32,6 +32,7 @@ type MixpanelEvent =
   | ["console.overflow"]
   | ["events_timeline.select"]
   | ["events_timeline.select_source"]
+  | ["error.font_loading_timeout"]
   | ["error.unauthenticated_viewer"]
   | ["error.unauthorized_viewer"]
   | ["error.reactdevtools.set_protocol_failed"]


### PR DESCRIPTION
I'm occasionally seeing fonts just never come in properly. This should give us some idea of how often that's happening.