### PR TITLE
Retain the material icon's width while it's loading

### DIFF
--- a/public/fonts/material_icons/material_icons.css
+++ b/public/fonts/material_icons/material_icons.css
@@ -53,5 +53,4 @@
 .material-icon-loading .material-icons,
 .material-icon-loading .material-icons-outlined {
   opacity: 0;
-  width: 1rem;
 }

--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -38,7 +38,10 @@ export const useMaterialIconCheck = () => {
           await new Promise(resolve => setTimeout(resolve, 1000));
         }
 
-        trackEvent("error.font_loading_timeout");
+        if (retries === 0) {
+          console.error("There was an error while loading Material Icons");
+          trackEvent("error.font_loading_timeout");
+        }
       });
     }
   }, [appNode]);


### PR DESCRIPTION
This keeps the UI from jerking as the icons are loaded.

Before:

https://user-images.githubusercontent.com/15959269/155203001-8dee9b7c-2b29-47bd-8a5e-39c8976f11e5.mov

After:

https://user-images.githubusercontent.com/15959269/155203008-cae88fc7-3055-4725-9e10-a6f4f0e8e9ac.mov
