### PR TITLE
Fixes to big dark theme PR

### DIFF
--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -145,7 +145,7 @@
   /* Jon's new tab work */
 
   --chrome: #f6f7f7;
-  --theme-toolbar-hover: #fff;
+  --theme-toolbar-hover: var(--grey-20);
   --tab-standard-color: rgba(0, 0, 0, 0.5);
   --theme-tab-background: #ececec;
   --tab-selected-color: var(--tab-standard-hover-bgcolor);
@@ -158,11 +158,11 @@
   --theme-toggle-selected: white;
 
   /* Toolbar */
-  --theme-tab-toolbar-background: var(--grey-10);
+  --theme-tab-toolbar-background: var(--grey-20);
   --theme-toolbar-background: var(--grey-10);
 
   --theme-tab-background-alt-subtle: var(--theme-sidebar-background);
-  --theme-toolbar-selected-color: var(--tab-selected-color);
+  --theme-toolbar-selected-color: var(--theme-body-color);
   --theme-toolbar-highlighted-color: var(--green-60);
   --theme-toolbar-background-hover: rgba(221, 225, 228, 0.66);
   --theme-toolbar-background-alt: #f5f5f5;


### PR DESCRIPTION
Found a few bugs:

Notice the white box here because the text colour is wrong:
![image](https://user-images.githubusercontent.com/9154902/155222882-96450999-1cb6-4afe-846a-4982bc92d3b9.png)

And the same class is messing up here:
![image](https://user-images.githubusercontent.com/9154902/155223086-a14d6ed8-297d-4441-8acf-6104ecba8a9b.png)

And the same class is used on the left-hand side, leading to this very light hover state:
![image](https://user-images.githubusercontent.com/9154902/155223596-225dfffd-fc8a-4b90-aef2-caf5f8c5999f.png)

--- After some changes... --

Now it looks like this:
![image](https://user-images.githubusercontent.com/9154902/155223329-ad43dbc3-dfef-4f79-b08b-1dc0b82d6eeb.png)

And this:
![image](https://user-images.githubusercontent.com/9154902/155223392-1e3fd1ce-a369-4d6f-8d7d-713bf2abb0b7.png)

And this:
![image](https://user-images.githubusercontent.com/9154902/155225129-75b25bec-9f0c-4607-abc2-7538a2d29927.png)
