### PR TITLE
Use custom login page from other login buttons

### DIFF
--- a/src/ui/components/LoginButton.tsx
+++ b/src/ui/components/LoginButton.tsx
@@ -2,9 +2,10 @@ import React from "react";
 import useAuth0 from "ui/utils/useAuth0";
 import Avatar from "ui/components/Avatar";
 import { handleIntercomLogout } from "ui/utils/intercom";
+import { useRouter } from "next/router";
 
 const LoginButton = () => {
-  const { loginWithRedirect, isAuthenticated, logout, user } = useAuth0();
+  const { loginAndReturn, isAuthenticated, logout, user } = useAuth0();
 
   if (isAuthenticated) {
     return (
@@ -18,11 +19,7 @@ const LoginButton = () => {
   return (
     <button
       className="inline-flex items-center rounded-md border border-transparent bg-primaryAccent px-3 py-1.5 text-sm font-medium leading-4 text-white hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-      onClick={() =>
-        loginWithRedirect({
-          appState: { returnTo: window.location.pathname + window.location.search },
-        })
-      }
+      onClick={() => loginAndReturn()}
       color="blue"
     >
       Sign In

--- a/src/ui/components/shared/LoginModal.tsx
+++ b/src/ui/components/shared/LoginModal.tsx
@@ -3,13 +3,7 @@ import useAuth0 from "ui/utils/useAuth0";
 import Modal from "ui/components/shared/Modal";
 
 function LoginModal() {
-  const { loginWithRedirect } = useAuth0();
-
-  const onClick: React.MouseEventHandler = e => {
-    loginWithRedirect({
-      appState: { returnTo: window.location.pathname + window.location.search },
-    });
-  };
+  const { loginAndReturn } = useAuth0();
 
   return (
     <div className="login-modal">
@@ -25,7 +19,7 @@ function LoginModal() {
           <div className="flex flex-col items-center">
             <button
               type="button"
-              onClick={onClick}
+              onClick={() => loginAndReturn()}
               className="inline-flex items-center rounded-md border border-transparent bg-primaryAccent px-3 py-1.5 text-lg font-medium text-white shadow-sm hover:bg-primaryAccentHover focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
             >
               Sign In

--- a/src/ui/utils/useAuth0.ts
+++ b/src/ui/utils/useAuth0.ts
@@ -1,4 +1,5 @@
 import { useAuth0 as useOrigAuth0, Auth0ContextInterface, LogoutOptions } from "@auth0/auth0-react";
+import { useRouter } from "next/router";
 import { useGetUserInfo } from "ui/hooks/users";
 import { setAccessTokenInBrowserPrefs } from "./browser";
 import { isTest, isMock } from "./environment";
@@ -14,6 +15,7 @@ const TEST_AUTH = {
     picture:
       "https://s.gravatar.com/avatar/579464588a2bb4fb0bc1bae7d2df22ae?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fe2.png",
   },
+  loginAndReturn: () => {},
   loginWithRedirect: () => {},
   logout: () => {},
   getAccessTokenSilently: () => Promise.resolve(),
@@ -25,9 +27,19 @@ export type AuthContext = Auth0ContextInterface | typeof TEST_AUTH;
  * A wrapper around useAuth0() that returns dummy data in tests
  */
 export default function useAuth0() {
+  const router = useRouter();
   const auth = useOrigAuth0();
   const { loading, email } = useGetUserInfo();
   const { token, external } = useToken();
+
+  const loginAndReturn = () => {
+    router.push({
+      pathname: "/login",
+      query: {
+        returnTo: window.location.pathname + window.location.search,
+      },
+    });
+  };
 
   if (external && token) {
     return {
@@ -39,6 +51,7 @@ export default function useAuth0() {
             sub: "external-auth",
             email,
           },
+      loginAndReturn,
       loginWithRedirect: auth.loginWithRedirect,
       logout: (options?: LogoutOptions) => {
         if (window.__IS_RECORD_REPLAY_RUNTIME__) {
@@ -54,5 +67,5 @@ export default function useAuth0() {
     return TEST_AUTH;
   }
 
-  return auth;
+  return { ...auth, loginAndReturn };
 }


### PR DESCRIPTION
## Issue

Fixed #5432 - A couple login buttons do not redirect through our login page and instead go directly to auth0

## Resolution

Add `loginAndReturn` to our custom `useAuth0` hook which consolidates the `returnTo` query param calculation and uses the nextjs router to redirect to our custom login page.