### PR TITLE
Add basic types to WaitForReduxSlice

### DIFF
--- a/src/ui/components/WaitForReduxSlice.tsx
+++ b/src/ui/components/WaitForReduxSlice.tsx
@@ -3,7 +3,7 @@ import { connect, ConnectedProps } from "react-redux";
 import LoadingScreen from "./shared/LoadingScreen";
 
 interface PropsFromParent {
-  slice: string;
+  slice: "inspector" | "messages";
   children: ReactNode;
 }
 


### PR DESCRIPTION
Fix #5300.

This isn't a full fix since the error state in the replay added to the issue only happened because we were messing around with slice names. Since that change wasn't merged this isn't technically broken, but this should keep us somewhat safer next time.