### PR TITLE
Don't scroll CodeMirror on space press

### DIFF
--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -107,12 +107,24 @@ function App({ children, modal }: AppProps) {
   useEffect(() => {
     // Stop space bar from being used as a universal "scroll down" operator
     // We have a big play/pause interface, so space makes way more sense for that.
-    window.addEventListener("keydown", function (e) {
-      if (e.code === "Space" && e.target === document.body) {
+
+    const stopCodeMirrorScroll = (e: KeyboardEvent) => {
+      if (e.code !== "Space") {
+        return;
+      }
+
+      if (
+        e.target === document.body ||
+        (e.target?.hasOwnProperty("classList") &&
+          (e.target as Element).classList.contains(".CodeMirror-scroll"))
+      ) {
         e.preventDefault();
       }
-    });
-  });
+    };
+
+    window.addEventListener("keydown", stopCodeMirrorScroll);
+    return () => window.removeEventListener("keydown", stopCodeMirrorScroll);
+  }, []);
 
   useEffect(() => {
     document.body.parentElement!.className = enableDarkMode ? "theme-dark" : "theme-light";


### PR DESCRIPTION
I *mostly* fixed this months ago in https://github.com/RecordReplay/devtools/commit/cdaea8c11500f563749e6bb552be8b5533e2f1fe but over the past few days I noticed that I still sometimes scroll the editor when I'm trying to toggle play/pause in the video editor. It turns out that when you click on a breakpoint inside of a breakpoint panel the element that gets focus is `CodeMirror-scroll`. I'm not sure why that thing gets focus, but if I had to guess I would say that CodeMirror detects a click on itself and tries to get ready to scroll (which would be a pretty reasonable shortcut in most cases). In our case, though, it's really annoying to scroll the editor when you instead mean to play or pause the video.