### PR TITLE
Only wait for the first 5 seconds of video

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -158,7 +158,6 @@ export function setupApp(store: UIStore) {
   });
 
   ThreadFront.ensureProcessed("executionIndexed").then(() => {
-    console.log("indexed");
     store.dispatch(setIndexing(100));
   });
 

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -8,7 +8,6 @@ import * as actions from "ui/actions/app";
 import * as selectors from "ui/reducers/app";
 import { ThreadFront } from "protocol/thread";
 import { assert, waitForTime } from "protocol/utils";
-import { validateUUID } from "ui/utils/helpers";
 import { prefs } from "ui/utils/prefs";
 import { getTest, isDevelopment, isTest, isMock } from "ui/utils/environment";
 import LogRocket from "ui/utils/logrocket";
@@ -19,13 +18,14 @@ import { ExpectedError, UnexpectedError } from "ui/state/app";
 import { getRecording } from "ui/hooks/recordings";
 import { getRecordingId } from "ui/utils/recording";
 import { getUserId, getUserInfo } from "ui/hooks/users";
-import { jumpToInitialPausePoint } from "./timeline";
+import { jumpToInitialPausePoint, seekToTime, startPlayback } from "./timeline";
 import { Recording } from "ui/types";
 import { subscriptionExpired } from "ui/utils/workspace";
 import { ApolloError } from "@apollo/client";
 import { getUserSettings } from "ui/hooks/settings";
 import { setViewMode } from "./layout";
 import { getSelectedPanel } from "ui/reducers/layout";
+import { videoReady } from "protocol/graphics";
 
 export type SetUnexpectedErrorAction = Action<"set_unexpected_error"> & {
   error: UnexpectedError;
@@ -133,7 +133,8 @@ export function createSession(recordingId: string): UIThunkAction {
       ThreadFront.setTest(getTest() || undefined);
       ThreadFront.recordingId = recordingId;
 
-      dispatch(showLoadingProgress()).then(() => {
+      dispatch(showLoadingProgress());
+      videoReady.promise.then(() => {
         dispatch(onLoadingFinished());
       });
 


### PR DESCRIPTION
OK! Believe it or not it took me a week to write these 50 lines of code 😅 

Originally, I thought that this PR was going to be using the new backend paints work to load paints separately from the rest of the basic processing resources and get the user into the viewer immediately. When I thought that was going to be the approach, there was a problem:

- We wait on the dispatcher promise that gets returned from `findPaints` to know when it's ok to do things like trying to get paint contents, play video, etc. and on the dispatcher side, that promise gets blocked by the rest of basic processing data, even though from a linker perspective they are gathered separately and don't have all that much to do with each other anymore. In that world there were more dispatcher changes required to do anything like what we're doing here.
- It turns out a lot of that is not necessary, and in fact, speeding up the end of the `findPaints` promise isn't even the best case if it was an easy thing to do. Instead, the insight here is this: the user waits a long time right now to view long replays, with long basic processing times (usually a bad run-to-point ratio). But *while they are waiting the front-end is receiving all of the data it needs to do video things for most of the video*. It doesn't matter when the paints promise resolves, because we're getting lots of useful paints well before it resolves.
- The second insight is something like this: previously we blocked on getting paint *points*, before we even attempted to get paint *data*. Now, as soon as we start getting points, we also start fetching contents (at least for the first five seconds of the video, so that at least we can show the user *something* to confirm that the recording worked, etc). Once they are in the viewer, they can click around the timeline, but if they go past the end of the paint points that we currently know about, we'll pause to buffer up to that point before playing the video.
- There's probably more to do here, for instance, being in the DevTools is not particularly enjoyable while they are loading (although, to our credit, it's not really *that* broken and some stuff like Network Monitor data already loads asynchronously).
- Also, we can probably do more to signal to the user the various states of loading that we are in at any time. As I discussed with @jasonLaster , it's theoretically possible for paints to come in out of order, such that we are missing a chunk of paint points in the middle of the recording, and we accidentally try to play the video over them, which would result in the video being stuck in the last retrieved frame for the duration of the missing section. This should be pretty rare, and only happen if something bizarre happens like several crashes in one paints branch.

This has also made me think more about our video loading in general and after getting some feedback from @jasonLaster  I suspect there are some major improvements to be made by doing something like sending paints region-by-region (or branch section by branch section) as compressed data rather than one at a time, uncompressed over the socket.