### PR TITLE
Reducing text

### DIFF
--- a/src/ui/components/shared/TrimmingModal/TrimmingModal.tsx
+++ b/src/ui/components/shared/TrimmingModal/TrimmingModal.tsx
@@ -28,16 +28,7 @@ function TrimmingModal({ hideModal }: PropsFromRedux) {
             <div className="text-lg">Trimming mode</div>
           </div>
           <p>
-            Trimming allows you to focus on specific parts of the replay that are relevant to you.
-            It also helps us helps us make your debugging experience more performant.
-          </p>
-          <p>
-            Use the <strong>left and right handlebars</strong> in the timeline to indicate which
-            part of the replay you would like to focus on.
-          </p>
-          <p>
-            Your changes are saved automatically. Once you are finished, click anywhere to exit
-            trimming mode.
+            Use the <strong>left and right handlebars</strong> in the timeline to focus your replay.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Dialog text should be as succinct as possible while still getting across the core information.

Removed:
* Explaining what trimming is
* Explaining that it makes things more performant
* Explaining that changes are saved automatically
* Explaining that you can click anywhere to dismiss

Kept:
* Explaining how to change the focus window

Implied:
* It's very common to click away from a screen to get out of the view
* The timeline will show dotted lines to show where the window is

