### PR TITLE
Expand the console filter drawer by default

### DIFF
--- a/src/devtools/client/webconsole/reducers/ui.js
+++ b/src/devtools/client/webconsole/reducers/ui.js
@@ -28,7 +28,7 @@ const UiState = overrides =>
         zoomEndTime: Number.POSITIVE_INFINITY,
         showEditorOnboarding: false,
         filterBarDisplayMode: FILTERBAR_DISPLAY_MODES.WIDE,
-        collapseFilterDrawer: true,
+        collapseFilterDrawer: false,
       },
       overrides
     )


### PR DESCRIPTION
Fix #5427.

<img width="1920" alt="image" src="https://user-images.githubusercontent.com/15959269/155629031-f69266c2-c958-4782-81bb-fd8392e32532.png">
