### PR TITLE
Add messaging when adding a team member fails

### DIFF
--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -37,6 +37,7 @@ type MixpanelEvent =
   | ["error.unauthenticated_viewer"]
   | ["error.unauthorized_viewer"]
   | ["error.reactdevtools.set_protocol_failed"]
+  | ["error.add_member_error"]
   | ["gutter.add_comment"]
   | ["header.open_share"]
   | ["header.edit_title"]


### PR DESCRIPTION
## Issue

Adding a member to a team can fail and we don't message it at all. This was worse when the backend threw when adding members to expired teams but can still occur.

Fixes #5346

## Resolution

* Catch errors and display a message
* Call `trackEvent` to track failures
