### PR TITLE
Add github check run permissions for trunk check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,6 @@ jobs:
         run: npm install
       - name: Trunk Check
         uses: trunk-io/trunk-action@v0.4.0-beta
+    permissions:
+      checks: write
+


### PR DESCRIPTION
Trunk will post annotations to your PRs for all new issues it finds, but it needs permission to do so.