### PR TITLE
Fixing loading screen for dark theme

### DIFF
--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -24,7 +24,7 @@ export function LoadingScreenTemplate({
 }) {
   return (
     <BubbleViewportWrapper>
-      <div className="relative flex w-96 flex-col items-center space-y-8 rounded-lg bg-white bg-opacity-80 p-8 py-4">
+      <div className="relative flex w-96 flex-col items-center space-y-8 rounded-lg bg-white/75 p-8 py-4">
         <div className="flex flex-col items-center space-y-2">
           <ReplayLogo wide size="lg" />
           {children}

--- a/src/ui/components/shared/LoadingTip.tsx
+++ b/src/ui/components/shared/LoadingTip.tsx
@@ -49,7 +49,7 @@ export default function LoadingTip() {
 
   return (
     <div className="h-32 w-96 space-y-8">
-      <div className="flex max-w-lg items-center space-x-4 rounded-lg bg-jellyfish px-8 py-4 align-middle">
+      <div className="flex max-w-lg items-center space-x-4 rounded-lg bg-white/75 px-8 py-4 align-middle text-gray-800">
         <img className="h-16 p-2" src={`/images/${icon}`} />
         <div className="flex flex-col space-y-2">
           <div className="text-sm font-bold">{title}</div>


### PR DESCRIPTION
The loading screen had some opacity issues in dark mode:

<img width="454" alt="image" src="https://user-images.githubusercontent.com/9154902/155650193-a491a6fc-1b4c-4e2f-88cd-2f70d7d8e202.png">

Now it looks like this:

<img width="438" alt="image" src="https://user-images.githubusercontent.com/9154902/155650164-b1da68c5-6d59-4223-a846-b205b9ca27aa.png">
