### PR TITLE
Fixing icons loading

### DIFF
--- a/public/fonts/material_icons/material_icons.css
+++ b/public/fonts/material_icons/material_icons.css
@@ -2,7 +2,7 @@
   font-family: "Material Icons";
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
   src: local("Material Icons"), local("MaterialIcons-Regular"),
     url(/fonts/material_icons/MaterialIcons-Regular.woff2) format("woff2"),
     url(/fonts/material_icons/MaterialIcons-Regular.ttf) format("truetype");
@@ -12,7 +12,7 @@
   font-family: "Material Icons Outlined";
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
   src: url(/fonts/material_icons/MaterialIconsOutlined-Regular.woff2) format("woff2"),
     url(/fonts/material_icons/MaterialIconsOutlined-Regular.otf) format("opentype");
 }
@@ -22,6 +22,8 @@
   font-weight: normal;
   font-style: normal;
   font-size: 24px; /* Preferred icon size */
+  width: 1em;
+  overflow: hidden;
   display: inline-block;
   line-height: 1;
   text-transform: none;
@@ -48,9 +50,4 @@
 
 .material-icons-outlined {
   font-family: "Material Icons Outlined";
-}
-
-.material-icon-loading .material-icons,
-.material-icon-loading .material-icons-outlined {
-  opacity: 0;
 }

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -32,7 +32,6 @@ import { shouldShowNag } from "ui/utils/user";
 import { trackEvent } from "ui/utils/telemetry";
 import SourcemapSetupModal from "./shared/Modals/SourcemapSetupModal";
 import RenameReplayModal from "./shared/Modals/RenameReplayModal";
-import { useMaterialIconCheck } from "./shared/MaterialIcon";
 
 function AppModal({ modal }: { modal: ModalType }) {
   switch (modal) {
@@ -94,7 +93,6 @@ function App({ children, modal }: AppProps) {
   const auth = useAuth0();
   const dismissNag = hooks.useDismissNag();
   const userInfo = useGetUserInfo();
-  const { setAppNode } = useMaterialIconCheck();
   const { value: enableDarkMode } = useFeature("darkMode");
 
   useEffect(() => {
@@ -150,7 +148,7 @@ function App({ children, modal }: AppProps) {
   }
 
   return (
-    <div id="app-container" className="material-icon-loading" ref={setAppNode}>
+    <div id="app-container">
       {children}
       {modal ? <AppModal modal={modal} /> : null}
       <ConfirmRenderer />

--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -1,6 +1,5 @@
 import classnames from "classnames";
-import React, { useEffect, useState } from "react";
-import { trackEvent } from "ui/utils/telemetry";
+import React from "react";
 
 const SIZE_STYLES = {
   xs: "text-xs",
@@ -10,7 +9,7 @@ const SIZE_STYLES = {
   xl: "text-xl",
   "2xl": "text-2xl",
   "4xl": "text-4xl",
-};
+} as const;
 
 type MaterialIconProps = React.HTMLProps<HTMLDivElement> & {
   children: string;

--- a/src/ui/components/shared/MaterialIcon.tsx
+++ b/src/ui/components/shared/MaterialIcon.tsx
@@ -20,35 +20,6 @@ type MaterialIconProps = React.HTMLProps<HTMLDivElement> & {
   iconSize?: keyof typeof SIZE_STYLES;
 };
 
-export const useMaterialIconCheck = () => {
-  const [appNode, setAppNode] = useState<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (appNode && appNode.classList.contains("material-icon-loading")) {
-      (document as any).fonts.ready.then(async () => {
-        let retries = 10;
-        while (retries-- > 0) {
-          if (
-            typeof document === "object" &&
-            (document as any).fonts.check("12px Material Icons")
-          ) {
-            appNode.classList.remove("material-icon-loading");
-            break;
-          }
-          await new Promise(resolve => setTimeout(resolve, 1000));
-        }
-
-        if (retries === 0) {
-          console.error("There was an error while loading Material Icons");
-          trackEvent("error.font_loading_timeout");
-        }
-      });
-    }
-  }, [appNode]);
-
-  return { setAppNode };
-};
-
 export default function MaterialIcon({
   children,
   className,


### PR DESCRIPTION
### The problem

The first (current) approach manually controls hiding/unhiding icons.

We have `#app-container` with `.material-icon-loading`, whose style is:

```css
.material-icon-loading .material-icons {
  opacity: 0;
}
```

This effectively hides icons (opacity of zero) while we have that class attached to the root container.

We detect loading of the icons, and then remove the class, by using `useMaterialIconCheck` hook:

```ts
const useMaterialIconCheck = (containerId: string) => {
  useEffect(() => {
    (document as any).fonts.ready.then(() => {
      document.getElementById(containerId)?.classList.remove("material-icon-loading");
    });
    // ...
  }, []);
};
```

However, it's important to not call this hook too early, because if we do, `fonts.ready()` will get triggered before we even started loading any fonts. If that happens, `material-icon-loading` never gets removed and even though we've loaded icons font later, they're still hidden by the CSS, and the UI remains broken.

We counter this by also spawning delayed checks (`setTimeout` or `setInterval`), but (for some reason (?)) we still don't manage to capture things properly and get stuck with loaded, but still hidden icons.

This still happens sometimes depending on how things progress and when assets start loading, so we still get broken UI from time to time.

---

### The solution

An alternative is to not control fonts loading at all, and instead let the browser do its thing.

This approach simply tries to load the font and does nothing to manually hide/unhide icons, and is the officially preferred way by [Material Icons](https://google.github.io/material-design-icons/#icon-font-for-the-web).

We see in [Material Icons styles](https://fonts.googleapis.com/icon?family=Material+Icons) that they don't set [`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display), and instead, just leave it to its default value (`auto` - which is usually `block`). By comparing [`block`](https://developers.google.com/web/updates/2016/02/font-display#block) and [`swap`](https://developers.google.com/web/updates/2016/02/font-display#swap), we can see that `block` is actually more correct for our use case, because we don't want to show any ordinary text, and by using `block`, that pretty much acts like manually changing opacity to show/hide the font.

The problem that exists even if we use `block`, is that it still falls back onto a font that doesn't have advanced ligatures so the UI still gets broken by stretching icon containers, even though there is no text visible. But we know that our icons are always square and controlled by `font-size`, so setting a `width: 1em` will ensure that is always the case, irrelevant to the font being used.

(An alternative solution to stretching would be to simply never introduce stretching problem by not relying on ligatures, and instead use HTML character codes. Then every icon would be of fixed width (`1ch` basically) and would never stretch its container. See [this section](https://developers.google.com/fonts/docs/material_icons#using_the_icons_in_html) in docs.)

---

### The summary (tldr)

- **problem:** not wanting to display any text until icons are loaded
  - **fix:** we countered this by manually changing `opacity`, but this fix uses `font-display: block`
- **problem:** even if we "hide" the text until icons load, the UI still gets stretched by invisible text because it usually doesn't have advanced ligatures
  - **fix:** we counter this by making sure icons are always square via `width: 1em`

---

### Tests

Here are tests with a throttled network to better see what happens.

Current implementation with React hook (this is live), has both stretching and visibility issues (see **~0:22-0:26**):

https://user-images.githubusercontent.com/1355455/155742429-82ad8fa3-1cb3-46a4-9a47-64c1459042af.mp4

Using `font-display: swap`, without React hook, has stretching issue and shows ugly font (at ~**1:41**):

https://user-images.githubusercontent.com/1355455/155730387-b0f0fbba-ea19-4a27-9780-33d0c780d492.mp4

Using `font-display: block`, without React hook, has stretching issue, but no issues with visibility or ugly text (at ~**1:41**):

https://user-images.githubusercontent.com/1355455/155730410-cdb8e59b-17f9-481f-b3d6-d66795b2c942.mp4

Using `font-display: block` and `width: 1em`, without React hook, has none of the issues (at ~**1:40**):

https://user-images.githubusercontent.com/1355455/155730436-0ebb57fc-0600-48ef-afd6-95362838ee48.mp4


