### PR TITLE
Track anonymous user usage in mixpanel

### DIFF
--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -12,7 +12,7 @@ import { setAccessTokenInBrowserPrefs, setUserInBrowserPrefs } from "ui/utils/br
 import { getUserInfo } from "ui/hooks/users";
 import { getUserSettings } from "ui/hooks/settings";
 import { initLaunchDarkly } from "ui/utils/launchdarkly";
-import { maybeSetMixpanelContext } from "ui/utils/mixpanel";
+import { maybeSetGuestMixpanelContext, maybeSetMixpanelContext } from "ui/utils/mixpanel";
 import { getInitialLayoutState } from "ui/reducers/layout";
 
 declare global {
@@ -74,6 +74,8 @@ export async function bootstrapApp() {
 
       setTelemetryContext(userInfo);
       maybeSetMixpanelContext({ ...userInfo, workspaceId });
+    } else {
+      maybeSetGuestMixpanelContext();
     }
 
     initLaunchDarkly();

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -135,6 +135,18 @@ export function maybeSetMixpanelContext(userInfo: TelemetryUser & { workspaceId:
   }
 }
 
+export function maybeSetGuestMixpanelContext() {
+  // This gives us an option to log telemetry events in development.
+  const forceEnableMixpanel = prefs.logTelemetryEvent;
+
+  if (skipTelemetry() && !forceEnableMixpanel) {
+    return;
+  }
+
+  mixpanel.identify();
+  enableMixpanel();
+}
+
 export const maybeTrackTeamChange = (newWorkspaceId: WorkspaceId | null) => {
   if (!mixpanelDisabled) {
     // We use the uuid here so it's easy to cross reference the id


### PR DESCRIPTION
Fix #4684.

Right now we only start tracking user activity once we confirm that the user is authenticated. This makes it so that we do the same for anonymous users.

https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelidentify

Some notes:
- Mixpanel saves a distinct ID in cookies that it uses to identify a user.
- Without any user info (which is the case for anonymous users), Mixpanel will identify a user using that distinct ID.
- Mixpanel is [smart enough](https://help.mixpanel.com/hc/en-us/articles/360039133851) to notice when a previously-signed in person is logged out by matching the distinct IDs. This means we will continue to get events properly for joe@schmoe.com in case he's using replay but forgot to log in.
- Cookies are cookies so these IDs are very finicky. For example, two separate incognito sessions opening the same replay  resulted in two anonymous users being identified. It's possible that this ends up hammering our Mixpanel headcount so gotta keep an eye on it.