### PR TITLE
Show navigation details in events pane

### DIFF
--- a/src/ui/components/Events/Event.tsx
+++ b/src/ui/components/Events/Event.tsx
@@ -36,6 +36,11 @@ const getEventLabel = (event: ReplayEvent) => {
   const { kind } = event;
   const { label } = getReplayEvent(kind);
 
+  if (kind === "navigation") {
+    const url = new URL(event.url);
+    return <span title={event.url}>{url.host}</span>;
+  }
+
   if ("key" in event) {
     return `${label} ${event.key}`;
   }


### PR DESCRIPTION
This might be a controversial take since we're removing the "Navigation" label, but i think the value more than makes up for the ambiguity. 

<img width="287" alt="Screen Shot 2022-02-26 at 6 18 57 PM" src="https://user-images.githubusercontent.com/254562/155865626-1b7aa834-6799-49d7-af1e-0693ee82f1bd.png">
