### PR TITLE
Playwright bump (1.10.6 → 1.18.3) and move to dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "^7.15.0",
         "@babel/types": "^7.14.8",
+        "@recordreplay/playwright": "^1.18.3",
         "@recordreplay/recordings-cli": "^0.9.0",
         "@recordreplay/sourcemap-upload-cli": "^0.1.1",
         "@storybook/addon-actions": "^6.4.19",
@@ -145,9 +146,6 @@
         "webpack": "^5.68.0",
         "webpack-cli": "^4.9.2",
         "webpack-retry-chunk-load-plugin": "^3.0.0"
-      },
-      "optionalDependencies": {
-        "@recordreplay/playwright": "^1.10.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3767,13 +3765,12 @@
       "link": true
     },
     "node_modules/@recordreplay/playwright": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/@recordreplay/playwright/-/playwright-1.10.6.tgz",
-      "integrity": "sha512-OMdl8jDV9UCL0EiMKA+huVC98ykBJB7efarfqNk3tRbSh8C1buN3zJRMd8AolyFjIBn7475BhUFJtaQyITeXYg==",
-      "hasInstallScript": true,
-      "optional": true,
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@recordreplay/playwright/-/playwright-1.18.3.tgz",
+      "integrity": "sha512-ZYLyi/RmTD+sYFDvL8Iz7ehJq/3ONeXqDuPfMvFzfviXhSJg6ySL6PwbLemo3RNYZRSEHSpfMTKp7kWPutybPw==",
+      "dev": true,
       "dependencies": {
-        "commander": "^6.1.0",
+        "commander": "^8.2.0",
         "debug": "^4.1.1",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -3784,14 +3781,26 @@
         "proper-lockfile": "^4.1.1",
         "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
+        "socks-proxy-agent": "^6.1.0",
         "stack-utils": "^2.0.3",
-        "ws": "^7.3.1"
+        "ws": "^7.4.6",
+        "yauzl": "^2.10.0",
+        "yazl": "^2.5.1"
       },
       "bin": {
-        "playwright": "lib/cli/cli.js"
+        "replay-playwright": "cli.js"
       },
       "engines": {
-        "node": ">=10.17.0"
+        "node": ">=12"
+      }
+    },
+    "node_modules/@recordreplay/playwright/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@recordreplay/protocol": {
@@ -12385,6 +12394,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
       "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -14703,7 +14713,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "optional": true,
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -15433,7 +15443,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -16832,7 +16842,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -18123,7 +18133,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -18143,7 +18153,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -18295,7 +18305,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -22537,7 +22547,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
       "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==",
-      "optional": true
+      "dev": true
     },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
@@ -23393,7 +23403,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -24963,7 +24973,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "optional": true
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -24993,7 +25003,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-      "optional": true,
+      "dev": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -25580,7 +25590,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "optional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -25667,7 +25677,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
@@ -25809,7 +25819,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "optional": true
+      "dev": true
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -25846,7 +25856,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -27115,7 +27125,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "optional": true,
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -27770,6 +27780,16 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -27915,6 +27935,34 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/socks": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "dev": true,
+      "dependencies": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/source-list-map": {
       "version": "2.0.1",
@@ -31011,10 +31059,19 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
       }
     },
     "node_modules/yn": {
@@ -33581,12 +33638,12 @@
       }
     },
     "@recordreplay/playwright": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/@recordreplay/playwright/-/playwright-1.10.6.tgz",
-      "integrity": "sha512-OMdl8jDV9UCL0EiMKA+huVC98ykBJB7efarfqNk3tRbSh8C1buN3zJRMd8AolyFjIBn7475BhUFJtaQyITeXYg==",
-      "optional": true,
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@recordreplay/playwright/-/playwright-1.18.3.tgz",
+      "integrity": "sha512-ZYLyi/RmTD+sYFDvL8Iz7ehJq/3ONeXqDuPfMvFzfviXhSJg6ySL6PwbLemo3RNYZRSEHSpfMTKp7kWPutybPw==",
+      "dev": true,
       "requires": {
-        "commander": "^6.1.0",
+        "commander": "^8.2.0",
         "debug": "^4.1.1",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -33597,8 +33654,19 @@
         "proper-lockfile": "^4.1.1",
         "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
+        "socks-proxy-agent": "^6.1.0",
         "stack-utils": "^2.0.3",
-        "ws": "^7.3.1"
+        "ws": "^7.4.6",
+        "yauzl": "^2.10.0",
+        "yazl": "^2.5.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+          "dev": true
+        }
       }
     },
     "@recordreplay/protocol": {
@@ -40055,6 +40123,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
       "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "dev": true,
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -41841,7 +41910,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "optional": true
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -42406,7 +42475,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "devOptional": true
+      "dev": true
     },
     "common-path-prefix": {
       "version": "3.0.0",
@@ -43531,7 +43600,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -44536,7 +44605,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
@@ -44548,7 +44617,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
           "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -44685,7 +44754,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "optional": true,
+      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -47817,7 +47886,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
       "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==",
-      "optional": true
+      "dev": true
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -48520,7 +48589,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "devOptional": true
+      "dev": true
     },
     "mime-db": {
       "version": "1.50.0",
@@ -49754,7 +49823,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "optional": true
+      "dev": true
     },
     "picocolors": {
       "version": "1.0.0",
@@ -49775,7 +49844,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
       "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-      "optional": true
+      "dev": true
     },
     "pnp-webpack-plugin": {
       "version": "1.6.4",
@@ -50205,7 +50274,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "optional": true
+      "dev": true
     },
     "promise": {
       "version": "7.3.1",
@@ -50274,7 +50343,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
@@ -50406,7 +50475,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "optional": true
+      "dev": true
     },
     "prr": {
       "version": "1.0.1",
@@ -50445,7 +50514,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -51401,7 +51470,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "optional": true
+      "dev": true
     },
     "reusify": {
       "version": "1.0.4",
@@ -51904,6 +51973,12 @@
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
       "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -52024,6 +52099,27 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "socks": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
       }
     },
     "source-list-map": {
@@ -54390,10 +54486,19 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "optional": true,
+      "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3"
       }
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",
     "@babel/types": "^7.14.8",
+    "@recordreplay/playwright": "^1.18.3",
     "@recordreplay/recordings-cli": "^0.9.0",
     "@recordreplay/sourcemap-upload-cli": "^0.1.1",
     "@storybook/addon-actions": "^6.4.19",
@@ -160,9 +161,6 @@
     "webpack": "^5.68.0",
     "webpack-cli": "^4.9.2",
     "webpack-retry-chunk-load-plugin": "^3.0.0"
-  },
-  "optionalDependencies": {
-    "@recordreplay/playwright": "^1.10.6"
   },
   "browserslist": [
     "defaults"

--- a/test/mock/src/runTest.ts
+++ b/test/mock/src/runTest.ts
@@ -74,16 +74,17 @@ function bindPageActions(page: Page) {
 const action = wrapped(async cbk => await cbk());
 
 export const runTest = wrapped(async cbk => {
+  // @ts-ignore
   const browser = await playwright[browserName].launch(launchOptions);
   const context = await browser.newContext();
   const page = await context.newPage();
   const pageLog = (...args: string[]) => {
     log(...args);
     page
-      .evaluate(extArgs => {
+      .evaluate((...extArgs: any[]) => {
         console.log("Test Step:", ...extArgs);
       }, args)
-      .catch(e => {});
+      .catch(() => {});
   };
 
   pageLog("Browser launched");


### PR DESCRIPTION
Tested on a M1 machine, that the installation goes without hiccups, so seems safe to move to dev deps again.

related: https://github.com/RecordReplay/devtools/pull/4650/