### PR TITLE
Make sure prototype properties are displayed below the object's properties

### DIFF
--- a/src/devtools/client/webconsole/utils/autocomplete.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete.ts
@@ -133,7 +133,7 @@ export function getPropertiesForObject(object?: ObjectFront | WiredObject | null
   // Recursively gather the properties through the prototype chain.
   if (prototype?.getObject()) {
     const prototypeProperties = getPropertiesForObject(prototype.getObject());
-    properties.unshift(...prototypeProperties);
+    properties.push(...prototypeProperties);
   }
 
   return properties;


### PR DESCRIPTION
Fix #5298.

<img width="1920" alt="image" src="https://user-images.githubusercontent.com/15959269/156078760-f8fd8d3d-6d7a-43db-bd07-df7851a37ca6.png">
