### PR TITLE
Coloring the icons in console

### DIFF
--- a/src/image/image.css
+++ b/src/image/image.css
@@ -94,22 +94,28 @@
   background-image: url(~devtools/client/themes/images/dropmarker.svg) !important;
 }
 .message.command > .icon {
-  background-image: url(~devtools/client/themes/images/webconsole/input.svg) !important;
+  -webkit-mask-image: url(~devtools/client/themes/images/webconsole/input.svg) !important;
+  background-color: var(--icon-color);
 }
 .message.result > .icon {
-  background-image: url(~devtools/client/themes/images/webconsole/return.svg) !important;
+  -webkit-mask-image: url(~devtools/client/themes/images/webconsole/return.svg) !important;
+  background-color: var(--icon-color);
 }
 .message.info > .icon {
-  background-image: url(~devtools/client/themes/images/info-small.svg) !important;
+  -webkit-mask-image: url(~devtools/client/themes/images/info-small.svg) !important;
+  background-color: var(--icon-color);
 }
 .message.error > .icon {
-  background-image: url(~devtools/client/themes/images/error-small.svg) !important;
+  -webkit-mask-image: url(~devtools/client/themes/images/error-small.svg) !important;
+  background-color: var(--icon-color);
 }
 .message.warn > .icon {
-  background-image: url(~devtools/client/themes/images/alert-small.svg) !important;
+  -webkit-mask-image: url(~devtools/client/themes/images/alert-small.svg) !important;
+  background-color: var(--icon-color);
 }
 .message.navigationMarker > .icon {
-  background-image: url(~devtools/client/themes/images/webconsole/navigation.svg) !important;
+  -webkit-mask-image: url(~devtools/client/themes/images/webconsole/navigation.svg) !important;
+  background-color: var(--icon-color);
 }
 #split-console-close-button::before {
   background-image: url(~devtools/client/themes/images/close.svg) !important;


### PR DESCRIPTION
Loom: https://www.loom.com/share/4cb71c2f29b6474dac5845e6754e0ebd

Our icons used to look too dark, like this:
![image](https://user-images.githubusercontent.com/9154902/156079612-67a8672d-4294-47d1-8136-4d27d53c77fe.png)

Now they'll look like this:
![image](https://user-images.githubusercontent.com/9154902/156079642-c0d1d8b4-94f3-4897-993c-7019e8693af5.png)
