### PR TITLE
Load the global object's properties/variables for autocomplete

### DIFF
--- a/src/devtools/client/webconsole/utils/autocomplete.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete.ts
@@ -149,8 +149,31 @@ function getBinding(name: string, scope: Scope) {
 function getBindingNames(scope: Scope): string[] {
   return scope.bindings.map(b => b.name);
 }
+function getGlobalActor(scopes: Scope) {
+  let globalActor = scopes;
+
+  while (globalActor.parent) {
+    globalActor = globalActor.parent;
+  }
+
+  return globalActor;
+}
 function getGlobalVariables(scopes: Scope) {
-  return getPropertiesForObject(scopes.parent.object?.getObject());
+  const globalActor = getGlobalActor(scopes);
+  const globalFront = globalActor.object;
+
+  if (!globalFront) {
+    return [];
+  }
+
+  // This gets the global object's children in the background. This happen
+  // async, but we don't await it so that the loading happens in the background.
+  // Once the children are loaded, they will be available in the globalFront the
+  // next time this function runs and we attempt to get the properties for it.
+  globalFront.loadDirectChildren();
+
+  const rv = getPropertiesForObject(globalFront.getObject());
+  return rv;
 }
 
 function getPropertyValue(property: StringLiteral | Identifier) {

--- a/src/protocol/thread/value.ts
+++ b/src/protocol/thread/value.ts
@@ -382,6 +382,16 @@ export class ValueFront {
     return rv;
   }
 
+  async loadDirectChildren() {
+    // Make sure we know all this node's children.
+    if (this.isObject() && this.hasPreviewOverflow()) {
+      await this.getPause()!.getObjectPreview(this._object!.objectId);
+      assert(!this.hasPreviewOverflow());
+    }
+
+    return this.getChildren();
+  }
+
   async loadChildren() {
     // Make sure we know all this node's children.
     if (this.isObject() && this.hasPreviewOverflow()) {


### PR DESCRIPTION
This builds off of #5294, but instead of using `loadChildren()`, it uses `loadDirectChildren()`. This was, we only fetch the global object's direct children, instead of recursively getting all of its childrens' properties and hammering the backend.

