### PR TITLE
Fetch the selected frame from the store for eager eval purposes

### DIFF
--- a/src/devtools/client/debugger/src/selectors/index.d.ts
+++ b/src/devtools/client/debugger/src/selectors/index.d.ts
@@ -9,6 +9,8 @@ export interface UrlLocation extends Location {
 
 export interface SelectedFrame {
   id: string;
+  protocolId: string;
+  asyncIndex: number;
   displayName: string;
   location: UrlLocation;
 }
@@ -27,4 +29,4 @@ export function hasFrames(state: UIState): boolean;
 export function getSelectedSourceWithContent(state: UIState): any;
 export function getSymbols(state: UIState, source: any): any;
 export function getCursorPosition(state: UIState): any;
-export function getSelectedFrame(state: UIState): any;
+export function getSelectedFrame(state: UIState): SelectedFrame;

--- a/src/devtools/client/webconsole/components/Input/EagerEvalFooter.tsx
+++ b/src/devtools/client/webconsole/components/Input/EagerEvalFooter.tsx
@@ -1,11 +1,12 @@
 import React, { FC, useEffect, useRef, useState } from "react";
 import { ValueFront } from "protocol/thread";
 import ObjectInspector from "devtools/client/webconsole/utils/connected-object-inspector";
-import { eagerEvaluateExpression } from "../../utils/autocomplete-eager";
+import { useEagerEvaluateExpression } from "../../utils/autocomplete-eager";
 
 function useEagerEvalPreview(expression: string) {
   const [value, setValue] = useState<ValueFront | null>(null);
   const expressionRef = useRef(expression);
+  const eagerEvaluateExpression = useEagerEvaluateExpression();
 
   useEffect(() => {
     expressionRef.current = expression;

--- a/src/devtools/client/webconsole/components/Input/EagerEvalFooter.tsx
+++ b/src/devtools/client/webconsole/components/Input/EagerEvalFooter.tsx
@@ -20,7 +20,7 @@ function useEagerEvalPreview(expression: string) {
         setValue(rv);
       }
     })();
-  }, [expression]);
+  }, [expression, eagerEvaluateExpression]);
 
   return value;
 }

--- a/src/devtools/client/webconsole/components/Input/useAutocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/useAutocomplete.tsx
@@ -10,7 +10,7 @@ import uniq from "lodash/uniq";
 import { useSelector } from "react-redux";
 import { getFrameScope } from "devtools/client/debugger/src/reducers/pause";
 import { UIState } from "ui/state";
-import { getEvaluatedProperties } from "../../utils/autocomplete-eager";
+import { useGetEvaluatedProperties } from "../../utils/autocomplete-eager";
 
 function useGetScopeMatches(expression: string) {
   const frameScope = useSelector((state: UIState) => getFrameScope(state, "0:0"));
@@ -26,6 +26,7 @@ function useGetScopeMatches(expression: string) {
 function useGetEvalMatches(expression: string) {
   const [matches, setMatches] = useState<string[]>([]);
   const expressionRef = useRef(expression);
+  const getEvaluatedProperties = useGetEvaluatedProperties();
 
   useEffect(() => {
     expressionRef.current = expression;
@@ -40,7 +41,7 @@ function useGetEvalMatches(expression: string) {
 
       const evaluatedProperties = await getEvaluatedProperties(propertyExpression.left);
 
-      if (expressionRef.current === expression) {
+      if (evaluatedProperties && expressionRef.current === expression) {
         setMatches(fuzzyFilter(evaluatedProperties, normalizeString(propertyExpression.right)));
       }
     }

--- a/src/devtools/client/webconsole/components/Input/useAutocomplete.tsx
+++ b/src/devtools/client/webconsole/components/Input/useAutocomplete.tsx
@@ -47,7 +47,7 @@ function useGetEvalMatches(expression: string) {
     }
 
     updateMatches();
-  }, [expression]);
+  }, [expression, getEvaluatedProperties]);
 
   return matches;
 }

--- a/src/devtools/client/webconsole/utils/autocomplete-eager.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete-eager.ts
@@ -1,5 +1,6 @@
 import { getSelectedFrame } from "devtools/client/debugger/src/selectors";
 import { ThreadFront, ValueFront } from "protocol/thread";
+import { useCallback } from "react";
 import { useSelector } from "react-redux";
 import { getPropertiesForObject } from "./autocomplete";
 
@@ -58,21 +59,21 @@ async function eagerEvaluateExpression(
 
 export function useGetEvaluatedProperties() {
   const frame = useSelector(getSelectedFrame);
+  const callback = useCallback(
+    (expression: string) =>
+      frame ? getEvaluatedProperties(expression, frame.asyncIndex, frame.protocolId) : null,
+    [frame]
+  );
 
-  if (!frame) {
-    return () => null;
-  }
-
-  return async (expression: string) =>
-    await getEvaluatedProperties(expression, frame.asyncIndex, frame.protocolId);
+  return callback;
 }
 export function useEagerEvaluateExpression() {
   const frame = useSelector(getSelectedFrame);
+  const callback = useCallback(
+    (expression: string) =>
+      frame ? eagerEvaluateExpression(expression, frame.asyncIndex, frame.protocolId) : null,
+    [frame]
+  );
 
-  if (!frame) {
-    return () => null;
-  }
-
-  return async (expression: string) =>
-    await eagerEvaluateExpression(expression, frame.asyncIndex, frame.protocolId);
+  return callback;
 }

--- a/src/devtools/client/webconsole/utils/autocomplete-eager.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete-eager.ts
@@ -1,10 +1,10 @@
+import { getSelectedFrame } from "devtools/client/debugger/src/selectors";
 import { ThreadFront, ValueFront } from "protocol/thread";
+import { useSelector } from "react-redux";
 import { getPropertiesForObject } from "./autocomplete";
 
 // Use eager eval to get the properties of the last complete object in the expression.
-export async function getEvaluatedProperties(expression: string): Promise<string[]> {
-  const { asyncIndex, frameId } = gToolbox.getPanel("debugger")!.getFrameId();
-
+async function getEvaluatedProperties(expression: string, asyncIndex: number, frameId?: string): Promise<string[]> {
   try {
     const { returned, exception, failed } = await ThreadFront.evaluate({
       asyncIndex,
@@ -26,9 +26,7 @@ export async function getEvaluatedProperties(expression: string): Promise<string
   return [];
 }
 
-export async function eagerEvaluateExpression(expression: string): Promise<ValueFront | null> {
-  const { asyncIndex, frameId } = gToolbox.getPanel("debugger")!.getFrameId();
-
+async function eagerEvaluateExpression(expression: string, asyncIndex: number, frameId?: string): Promise<ValueFront | null> {
   try {
     const { returned, exception, failed } = await ThreadFront.evaluate({
       asyncIndex,
@@ -48,4 +46,23 @@ export async function eagerEvaluateExpression(expression: string): Promise<Value
   }
 
   return null;
+}
+
+export function useGetEvaluatedProperties() {
+  const frame = useSelector(getSelectedFrame);
+
+  if (!frame) {
+    return () => null;
+  }
+
+  return async (expression: string) => await getEvaluatedProperties(expression, frame.asyncIndex, frame.protocolId);
+}
+export function useEagerEvaluateExpression() {
+  const frame = useSelector(getSelectedFrame);
+
+  if (!frame) {
+    return () => null;
+  }
+
+  return async (expression: string) => await eagerEvaluateExpression(expression, frame.asyncIndex, frame.protocolId)
 }

--- a/src/devtools/client/webconsole/utils/autocomplete-eager.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete-eager.ts
@@ -4,7 +4,11 @@ import { useSelector } from "react-redux";
 import { getPropertiesForObject } from "./autocomplete";
 
 // Use eager eval to get the properties of the last complete object in the expression.
-async function getEvaluatedProperties(expression: string, asyncIndex: number, frameId?: string): Promise<string[]> {
+async function getEvaluatedProperties(
+  expression: string,
+  asyncIndex: number,
+  frameId?: string
+): Promise<string[]> {
   try {
     const { returned, exception, failed } = await ThreadFront.evaluate({
       asyncIndex,
@@ -26,7 +30,11 @@ async function getEvaluatedProperties(expression: string, asyncIndex: number, fr
   return [];
 }
 
-async function eagerEvaluateExpression(expression: string, asyncIndex: number, frameId?: string): Promise<ValueFront | null> {
+async function eagerEvaluateExpression(
+  expression: string,
+  asyncIndex: number,
+  frameId?: string
+): Promise<ValueFront | null> {
   try {
     const { returned, exception, failed } = await ThreadFront.evaluate({
       asyncIndex,
@@ -55,7 +63,8 @@ export function useGetEvaluatedProperties() {
     return () => null;
   }
 
-  return async (expression: string) => await getEvaluatedProperties(expression, frame.asyncIndex, frame.protocolId);
+  return async (expression: string) =>
+    await getEvaluatedProperties(expression, frame.asyncIndex, frame.protocolId);
 }
 export function useEagerEvaluateExpression() {
   const frame = useSelector(getSelectedFrame);
@@ -64,5 +73,6 @@ export function useEagerEvaluateExpression() {
     return () => null;
   }
 
-  return async (expression: string) => await eagerEvaluateExpression(expression, frame.asyncIndex, frame.protocolId)
+  return async (expression: string) =>
+    await eagerEvaluateExpression(expression, frame.asyncIndex, frame.protocolId);
 }


### PR DESCRIPTION
Re-do of #5550.

@jasonLaster the previous patch doesn't really work well as an action. This wraps the util in a hook so that we can (in effect) do the same thing, where we fetch the selected frame from the store and use that value to perform the evaluation.

Demo: https://share.descript.com/view/abrz2fWpGUQ