### PR TITLE
Start tracking guest flows in Mixpanel

### DIFF
--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -12,7 +12,7 @@ import { setAccessTokenInBrowserPrefs, setUserInBrowserPrefs } from "ui/utils/br
 import { getUserInfo } from "ui/hooks/users";
 import { getUserSettings } from "ui/hooks/settings";
 import { initLaunchDarkly } from "ui/utils/launchdarkly";
-import { maybeSetMixpanelContext } from "ui/utils/mixpanel";
+import { maybeSetGuestMixpanelContext, maybeSetMixpanelContext } from "ui/utils/mixpanel";
 import { getInitialLayoutState } from "ui/reducers/layout";
 
 declare global {
@@ -74,6 +74,8 @@ export async function bootstrapApp() {
 
       setTelemetryContext(userInfo);
       maybeSetMixpanelContext({ ...userInfo, workspaceId });
+    } else {
+      maybeSetGuestMixpanelContext();
     }
 
     initLaunchDarkly();

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -12,7 +12,7 @@ import { setAccessTokenInBrowserPrefs, setUserInBrowserPrefs } from "ui/utils/br
 import { getUserInfo } from "ui/hooks/users";
 import { getUserSettings } from "ui/hooks/settings";
 import { initLaunchDarkly } from "ui/utils/launchdarkly";
-import { maybeSetGuestMixpanelContext, maybeSetMixpanelContext } from "ui/utils/mixpanel";
+import { maybeSetMixpanelContext } from "ui/utils/mixpanel";
 import { getInitialLayoutState } from "ui/reducers/layout";
 
 declare global {
@@ -74,8 +74,6 @@ export async function bootstrapApp() {
 
       setTelemetryContext(userInfo);
       maybeSetMixpanelContext({ ...userInfo, workspaceId });
-    } else {
-      maybeSetGuestMixpanelContext();
     }
 
     initLaunchDarkly();

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -79,7 +79,7 @@ export function mockEnvironment() {
 }
 
 export function skipTelemetry() {
-  return isTest() || isMock() || isDevelopment() || isDeployPreview();
+  return isTest() || isDevelopment() || isDeployPreview();
 }
 
 export function isDeployPreview() {

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -135,6 +135,18 @@ export function maybeSetMixpanelContext(userInfo: TelemetryUser & { workspaceId:
   }
 }
 
+export function maybeSetGuestMixpanelContext() {
+  // This gives us an option to log telemetry events in development.
+  const forceEnableMixpanel = prefs.logTelemetryEvent;
+
+  if (skipTelemetry() && !forceEnableMixpanel) {
+    return;
+  }
+
+  mixpanel.identify();
+  enableMixpanel();
+}
+
 export const maybeTrackTeamChange = (newWorkspaceId: WorkspaceId | null) => {
   if (!mixpanelDisabled) {
     // We use the uuid here so it's easy to cross reference the id

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -97,15 +97,12 @@ type MixpanelEvent =
   | ["user_options.select_docs"]
   | ["user_options.select_settings"];
 
-const QA_EMAIL_ADDRESSES = ["mock@user.io"];
-
 // Keep mixpanel disabled until we know we have the user's info
 // to send along with events. This keeps events from tests from being
 // sent to mixpanel.
 let mixpanelDisabled = true;
 
 const enableMixpanel = () => (mixpanelDisabled = false);
-const disableMixpanel = () => (mixpanelDisabled = true);
 
 export function initializeMixpanel() {
   mixpanel.init("ffaeda9ef8fb976a520ca3a65bba5014");
@@ -116,35 +113,27 @@ export function initializeMixpanel() {
 }
 
 export function maybeSetMixpanelContext(userInfo: TelemetryUser & { workspaceId: string | null }) {
-  const { email, internal } = userInfo;
-  const isQAUser = email && QA_EMAIL_ADDRESSES.includes(email);
-  const isInternal = internal;
-  const shouldDisableMixpanel = isQAUser || isInternal || skipTelemetry();
+  const { internal: isInternal } = userInfo;
+  const forceEnableMixpanel = prefs.logTelemetryEvent
+  const shouldEnableMixpanel = (!isInternal && !skipTelemetry()) || forceEnableMixpanel;
 
-  // This gives us an option to log telemetry events in development.
-  const forceEnableMixpanel = prefs.logTelemetryEvent;
-
-  if (!shouldDisableMixpanel || forceEnableMixpanel) {
+  if (shouldEnableMixpanel) {
     setMixpanelContext(userInfo);
     enableMixpanel();
     trackMixpanelEvent("session_start", { workspaceId: userInfo.workspaceId });
     timeMixpanelEvent("session.devtools_start");
     setupSessionEndListener();
-  } else {
-    disableMixpanel();
   }
 }
 
 export function maybeSetGuestMixpanelContext() {
-  // This gives us an option to log telemetry events in development.
   const forceEnableMixpanel = prefs.logTelemetryEvent;
+  const shouldEnableMixpanel = !skipTelemetry() || forceEnableMixpanel;
 
-  if (skipTelemetry() && !forceEnableMixpanel) {
-    return;
+  if (shouldEnableMixpanel) {
+    mixpanel.identify();
+    enableMixpanel();
   }
-
-  mixpanel.identify();
-  enableMixpanel();
 }
 
 export const maybeTrackTeamChange = (newWorkspaceId: WorkspaceId | null) => {


### PR DESCRIPTION
Picking back up from #5485.

The last PR was reverted because there were too many anonymous users (~1k in ~6 hours). 

My current hunch is that those users are from QA Wolf tests where we're testing some anonymous user UX behavior. Since the anonymous user tracking is cookie-based, it's reasonable to assume that each test instance would count as one, and that contributed to the high numbers.

This delays tracking the user until after the login screen, which should alleviate it somewhat. But ideally we should be able to start identifying the user in `setup/index`. 

Checking this with Chris now to see what we can do about it. 