### PR TITLE
Run e2e tests on pushes to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Run test suites
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   download-browser:


### PR DESCRIPTION
We should run our test suite on all pushes to master.  This would make it easier to understand what is going on with https://github.com/RecordReplay/devtools/issues/5562