### PR TITLE
Adjust dark theme to have more contrast

### DIFF
--- a/src/devtools/client/themes/dark-theme.css
+++ b/src/devtools/client/themes/dark-theme.css
@@ -75,7 +75,7 @@
 }
 
 .cm-s-mozilla .cm-property {
-  color: var(--theme-highlight-green);
+  color: var(--cm-property);
 }
 
 .CodeMirror-Tern-completion-object:before {
@@ -117,7 +117,7 @@
 .variable-or-property .token-boolean,
 .variable-or-property .token-domnode,
 .variable-or-property[exception] > .title > .name {
-  color: var(--theme-highlight-red);
+  color: var(--cm-atom);
 }
 
 .CodeMirror-Tern-completion-bool:before {

--- a/src/devtools/client/themes/light-theme.css
+++ b/src/devtools/client/themes/light-theme.css
@@ -67,7 +67,7 @@
 
 .cm-s-mozilla .cm-def,
 .cm-s-mozilla .cm-variable-2 {
-  color: var(--blue-55);
+  color: var(--cm-def);
 }
 
 .cm-s-mozilla .cm-variable {
@@ -75,7 +75,7 @@
 }
 
 .cm-s-mozilla .cm-property {
-  color: var(--theme-highlight-green);
+  color: var(--cm-property);
 }
 
 .CodeMirror-Tern-completion-object:before {
@@ -100,7 +100,7 @@
 .cm-s-mozilla .cm-string-2,
 .variable-or-property .token-string,
 .CodeMirror-Tern-farg {
-  color: var(--theme-highlight-purple);
+  color: var(--cm-string);
 }
 
 .CodeMirror-Tern-completion-string:before,
@@ -114,7 +114,7 @@
 .variable-or-property .token-boolean,
 .variable-or-property .token-domnode,
 .variable-or-property[exception] > .title > .name {
-  color: var(--theme-highlight-red);
+  color: var(--cm-atom);
 }
 
 .CodeMirror-Tern-completion-bool:before {

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -139,15 +139,6 @@
 }
 
 :root.theme-light {
-  /* TOP LEVEL STYLES (DEBUG) */
-  --theme-base-100: hsl(40, 50%, 95%);
-  --theme-base-95: hsl(140, 50%, 95%);
-  --theme-base-90: hsl(140, 50%, 90%);
-  --theme-base-85: hsl(140, 50%, 85%);
-  --theme-base-80: hsl(140, 50%, 80%);
-  --theme-base-70: hsl(140, 50%, 70%);
-  --theme-base-60: hsl(140, 50%, 60%);
-
   /* TOP LEVEL STYLES */
   --theme-base-100: hsl(0, 0%, 100%);
   --theme-base-95: hsl(0, 0%, 95%);
@@ -335,15 +326,6 @@
 }
 
 :root.theme-dark {
-  /* TOP LEVEL STYLES (DEBUG) */
-  --theme-base-100: #ff0000; /* background chrome */
-  --theme-base-95: #ff2525; /* tab bars */
-  --theme-base-90: #ff5c5c; /* editor and selected tab */
-  --theme-base-85: #ff3c3c; /* textfields */
-  --theme-base-80: #ff5c5c;
-  --theme-base-70: #ff8282;
-  --theme-base-60: #ffa3a3;
-
   /* TOP LEVEL STYLES */
   --theme-base-100: #000000; /* background chrome */
   --theme-base-95: #252525; /* tab bars */
@@ -354,20 +336,20 @@
   --theme-base-60: #a3a3a3;
 
   /* AUDITED */
-  --chrome: var(--theme-base-95); /* bg app */
+  --chrome: #1c1c1c; /* bg app */
   --theme-tab-background: var(--theme-base-100); /* bg tabs */
 
   --tab-bgcolor: var(--theme-base-100);
   --tab-color: var(--theme-base-40);
-  --tab-selected-bgcolor: var(--theme-base-90);
+  --tab-selected-bgcolor: var(--theme-base-95);
   --tab-selected-color: #fff;
   --tab-hover-bgcolor: var(--theme-base-85);
   --tab-hover-color: var(--tab-selected-color);
 
-  --theme-body-background: var(--theme-base-90); /* bg text */
-  --theme-tab-background-alt-subtle: var(--theme-base-90); /* info, events */
+  --theme-body-background: var(--theme-base-95); /* bg text */
+  --theme-tab-background-alt-subtle: var(--theme-base-95); /* info, events */
   --theme-sidebar-background: var(--theme-body-background);
-  --theme-toggle: var(--theme-base-80);
+  --theme-toggle: var(--theme-base-85);
   --theme-toggle-handle: var(--theme-base-100);
   --icon-color: var(--theme-body-color);
   --theme-text-field: var(--theme-base-95);
@@ -379,41 +361,28 @@
 
   --unloaded-region-img: url("/images/dotted-mask-dark.svg");
   --theme-trimmer: white;
-  /* TO AUDIT NEXT */
-
-  /*
-  --tab-standard-color: var(--theme-base-90);
-  --theme-toolbar-hover: #fff;
-  --tab-standard-color: rgba(0, 0, 0, 0.5);
-  
-  --tab-standard-hover-bgcolor: var(--theme-toolbar-hover);
-  --theme-menu-highlight: #f3f4f6;
-  --icon-color: var(--theme-body-color);
-  --theme-border: #d2d5da;
-  --theme-text-field: #f3f4f6;
-  --theme-toggle-inner: var(--cool-gray-200);
-  --theme-toggle-selected: white;
-  --toolbarbutton-focus-background: var(--grey-20);
-
-  --tab-standard-hover-textcolor: white;
-  --tab-selected-color: var(--tab-standard-hover-bgcolor);
-  --tab-standard-hover-bgcolor: var(--theme-toolbar-hover);
-  --theme-menu-highlight: #4b4747;
-  --icon-color: var(--theme-body-color);
-  --theme-border: var(--console-message-border);
-  --theme-text-field: #363b3b;
-  --theme-toggle-inner: #4b4747;
-  --theme-toggle-selected: var(--chrome);
-  --toolbarbutton-focus-background: black;
-  */
 
   /* CODE MIRROR */
+
+  /* THEME ONE */
   --cm-linenumber: var(--grey-40);
-  --cm-keyword: #ff5353;
-  --cm-variable: #c9d1d9;
-  --cm-def: #fca657;
-  --cm-string: #a2d2fa;
-  --cm-number: green;
+  --cm-keyword: #fff;
+  --cm-def: #ff42a8;
+  --cm-string: #ff98eb;
+  --cm-variable: #01acfd;
+  --cm-number: yellow;
+  --cm-property: #fff;
+  --cm-atom: #fff;
+
+  /* THEME TWO */
+  --cm-linenumber: var(--grey-40);
+  --cm-keyword: #ff98eb;
+  --cm-def: #ff42a8;
+  --cm-string: #58e0ff;
+  --cm-variable: #01acfd;
+  --cm-number: yellow;
+  --cm-property: #fff;
+  --cm-atom: #fff;
 
   /* Toolbar */
   --theme-tab-toolbar-background: var(--grey-90);


### PR DESCRIPTION
On production:
![image](https://user-images.githubusercontent.com/9154902/156243475-1b1b066b-808a-4a8b-8849-427b5f92e006.png)

This PR:
![image](https://user-images.githubusercontent.com/9154902/156243503-911dc1a1-8b29-4245-973e-c63bfbbd3357.png)

* Cleared out some old debugging code
* Made the editor background darker, which allows the text to pop more
* Adjusted colours to be more pinky and blue-y to align more with our brand colours
* Note: we're going to continue fine-tuning these colours, this isn't the final theme