### PR TITLE
Ensure that only one session is created

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -9,7 +9,6 @@ import * as selectors from "ui/reducers/app";
 import { ThreadFront } from "protocol/thread";
 import { findAutomatedTests } from "protocol/find-tests";
 import { assert, waitForTime } from "protocol/utils";
-import { validateUUID } from "ui/utils/helpers";
 import { prefs } from "ui/utils/prefs";
 import { getTest, isDevelopment, isTest, isMock } from "ui/utils/environment";
 import LogRocket from "ui/utils/logrocket";
@@ -105,6 +104,12 @@ function getRecordingNotAccessibleError(
 export function createSession(recordingId: string): UIThunkAction {
   return async ({ getState, dispatch }) => {
     try {
+      if (ThreadFront.recordingId) {
+        assert(recordingId === ThreadFront.recordingId);
+        return;
+      }
+      ThreadFront.recordingId = recordingId;
+
       const userSettings = await getUserSettings();
       const [userInfo, recording] = await Promise.all([getUserInfo(), getRecording(recordingId)]);
       assert(recording);
@@ -133,7 +138,6 @@ export function createSession(recordingId: string): UIThunkAction {
       }
 
       ThreadFront.setTest(getTest() || undefined);
-      ThreadFront.recordingId = recordingId;
 
       dispatch(showLoadingProgress());
 


### PR DESCRIPTION
We call `createSession()` from a react component that is currently rendered twice when the devtools start up.
As a result, we were creating two sessions for the recording and in tests the test script was run twice in parallel (obviously leading to some test failures).