### PR TITLE
ThreadFront event types

### DIFF
--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -99,6 +99,8 @@ function getRecordingTarget(buildId: string): RecordingTarget {
   return RecordingTarget.unknown;
 }
 
+type ThreadFrontEvent = "paused" | "resumed";
+
 declare global {
   interface Window {
     Test?: any;
@@ -198,10 +200,10 @@ class _ThreadFront {
   testName: string | undefined;
 
   // added by EventEmitter.decorate(ThreadFront)
-  eventListeners!: Map<string, ((value?: any) => void)[]>;
-  on!: (name: string, handler: (value?: any) => void) => void;
-  off!: (name: string, handler: (value?: any) => void) => void;
-  emit!: (name: string, value?: any) => void;
+  eventListeners!: Map<ThreadFrontEvent, ((value?: any) => void)[]>;
+  on!: (name: ThreadFrontEvent, handler: (value?: any) => void) => void;
+  off!: (name: ThreadFrontEvent, handler: (value?: any) => void) => void;
+  emit!: (name: ThreadFrontEvent, value?: any) => void;
 
   constructor() {
     client.Debugger.addSearchSourceContentsMatchesListener(
@@ -1264,4 +1266,4 @@ class _ThreadFront {
 }
 
 export const ThreadFront = new _ThreadFront();
-EventEmitter.decorate(ThreadFront);
+EventEmitter.decorate<any, ThreadFrontEvent>(ThreadFront);

--- a/src/protocol/utils.ts
+++ b/src/protocol/utils.ts
@@ -117,16 +117,16 @@ export const DisallowEverythingProxyHandler: ProxyHandler<object> = {
   },
 };
 
-export interface EventEmitter<T> {
-  eventListeners: Map<string, ((value?: T) => void)[]>;
-  on: (name: string, handler: (value?: T) => void) => void;
-  off: (name: string, handler: (value?: T) => void) => void;
-  emit: (name: string, value?: T) => void;
+export interface EventEmitter<T, E = string> {
+  eventListeners: Map<E, ((value?: T) => void)[]>;
+  on: (name: E, handler: (value?: T) => void) => void;
+  off: (name: E, handler: (value?: T) => void) => void;
+  emit: (name: E, value?: T) => void;
 }
 
 export const EventEmitter = {
-  decorate<T>(obj: EventEmitter<T>) {
-    obj.eventListeners = new Map<string, ((value?: T) => void)[]>();
+  decorate<T, E = string>(obj: EventEmitter<T, E>) {
+    obj.eventListeners = new Map<E, ((value?: T) => void)[]>();
 
     obj.on = (name, handler) => {
       if (obj.eventListeners.has(name)) {


### PR DESCRIPTION
Only ThreadFront uses this EventEmitter implementation, and all the other objects use the one from `src/devtools/shared/event-emitter.js`. Tried typing that one, but it's a pain, so leaving for later.