### PR TITLE
Follow up before announcing focus mode

### DIFF
--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -10,6 +10,7 @@ import { PENDING_COMMENT_ID } from "ui/reducers/comments";
 import { RecordingId } from "@recordreplay/protocol";
 import { User } from "ui/types";
 import { setSelectedPrimaryPanel } from "./layout";
+import { getFocusRegion } from "ui/reducers/timeline";
 const { getFilenameFromURL } = require("devtools/client/debugger/src/utils/sources-tree/getURL");
 const { getTextAtLocation } = require("devtools/client/debugger/src/reducers/sources");
 const { findClosestFunction } = require("devtools/client/debugger/src/utils/ast");
@@ -177,6 +178,12 @@ export function editItem(item: Reply | Comment): UIThunkAction {
 export function seekToComment(item: Comment | Reply | PendingComment["comment"]): UIThunkAction {
   return ({ dispatch, getState }) => {
     dispatch(clearPendingComment());
+    const focusRegion = getFocusRegion(getState());
+
+    if (focusRegion && (item.time < focusRegion.startTime || item.time > focusRegion.endTime)) {
+      console.error("Cannot seek outside the current focused region", focusRegion, item);
+      return;
+    }
 
     let cx = selectors.getThreadContext(getState());
     dispatch(actions.seek(item.point, item.time, item.hasFrames));

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -253,8 +253,14 @@ export function seek(
   hasFrames: boolean,
   pauseId?: PauseId
 ): UIThunkAction<boolean> {
-  return ({ dispatch }) => {
+  return ({ dispatch, getState }) => {
+    const focusRegion = getFocusRegion(getState());
     const pause = pauseId !== undefined ? Pause.getById(pauseId) : undefined;
+
+    if (focusRegion && (time < focusRegion.startTime || time > focusRegion.endTime)) {
+      console.error("Cannot seek outside the current focused region");
+      return false;
+    }
 
     updateUrl({ point, time, hasFrames });
     dispatch({ type: "CLEAR_FRAME_POSITIONS" });

--- a/src/ui/components/Comments/Comments.css
+++ b/src/ui/components/Comments/Comments.css
@@ -4,6 +4,7 @@
   width: 100%;
   top: 9px; /* Arbitrary value to push the markers away from the bottom of the overlay container */
   height: 17px; /* Corresponds with the height of the comment marker */
+  z-index: var(--z-index-1--timeline-comment);
 }
 
 .comments-container > * {

--- a/src/ui/components/Comments/Comments.css
+++ b/src/ui/components/Comments/Comments.css
@@ -4,7 +4,6 @@
   width: 100%;
   top: 9px; /* Arbitrary value to push the markers away from the bottom of the overlay container */
   height: 17px; /* Corresponds with the height of the comment marker */
-  z-index: var(--z-index-1--timeline-comment);
 }
 
 .comments-container > * {

--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { connect, ConnectedProps } from "react-redux";
+import { connect, ConnectedProps, useSelector } from "react-redux";
 import classNames from "classnames";
 import { UIState } from "ui/state";
 import { selectors } from "ui/reducers";
@@ -16,6 +16,7 @@ import { trackEvent } from "ui/utils/telemetry";
 import { commentKeys, formatRelativeTime } from "ui/utils/comments";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { features } from "ui/utils/prefs";
+import { getFocusRegion } from "ui/reducers/timeline";
 const { getExecutionPoint } = require("devtools/client/debugger/src/reducers/pause");
 
 function BorderBridge({
@@ -123,6 +124,8 @@ function CommentCard({
   setHoveredComment,
 }: CommentCardProps) {
   const isPaused = currentTime === comment.time && executionPoint === comment.point;
+  const focusRegion = useSelector(getFocusRegion);
+  const isOutsideFocusedRegion = focusRegion && (comment.time < focusRegion.startTime || comment.time > focusRegion.endTime);
 
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
@@ -166,12 +169,12 @@ function CommentCard({
   return (
     <div
       className={classNames(
-        `comment-card relative mx-auto w-full cursor-pointer border-b border-splitter bg-themeBodyBackground transition`
-        // hoveredComment === comment.id ? "bg-toolbarBackground" : "bg-themeBodyBackground"
+        `comment-card relative mx-auto w-full cursor-pointer border-b border-splitter transition`, isOutsideFocusedRegion ? "bg-gray-100" : "bg-themeBodyBackground"
       )}
       onMouseDown={e => {
         seekToComment(comment);
       }}
+      title={isOutsideFocusedRegion ? "This comment is currently outside of the focused region" : ""}
       onMouseEnter={() => setHoveredComment(comment.id)}
       onMouseLeave={() => setHoveredComment(null)}
     >

--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -125,7 +125,8 @@ function CommentCard({
 }: CommentCardProps) {
   const isPaused = currentTime === comment.time && executionPoint === comment.point;
   const focusRegion = useSelector(getFocusRegion);
-  const isOutsideFocusedRegion = focusRegion && (comment.time < focusRegion.startTime || comment.time > focusRegion.endTime);
+  const isOutsideFocusedRegion =
+    focusRegion && (comment.time < focusRegion.startTime || comment.time > focusRegion.endTime);
 
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
@@ -169,12 +170,15 @@ function CommentCard({
   return (
     <div
       className={classNames(
-        `comment-card relative mx-auto w-full cursor-pointer border-b border-splitter transition`, isOutsideFocusedRegion ? "bg-gray-100" : "bg-themeBodyBackground"
+        `comment-card relative mx-auto w-full cursor-pointer border-b border-splitter transition`,
+        isOutsideFocusedRegion ? "bg-gray-100" : "bg-themeBodyBackground"
       )}
       onMouseDown={e => {
         seekToComment(comment);
       }}
-      title={isOutsideFocusedRegion ? "This comment is currently outside of the focused region" : ""}
+      title={
+        isOutsideFocusedRegion ? "This comment is currently outside of the focused region" : ""
+      }
       onMouseEnter={() => setHoveredComment(comment.id)}
       onMouseLeave={() => setHoveredComment(null)}
     >

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -63,7 +63,7 @@ export const NetworkMonitor = ({
     if (container.current) {
       resizeObserver.current.observe(container.current);
     }
-  }, [container.current]);
+  });
 
   useEffect(() => {
     // If the selected request has been filtered out by the focus region, unselect it.

--- a/src/ui/components/Timeline/EditFocusButton.tsx
+++ b/src/ui/components/Timeline/EditFocusButton.tsx
@@ -2,14 +2,15 @@ import classNames from "classnames";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as actions from "ui/actions/app";
-import { useFeature } from "ui/hooks/settings";
 import { getIsFocusing } from "ui/reducers/app";
+import { getIsInFocusMode } from "ui/reducers/timeline";
 import { trackEvent } from "ui/utils/telemetry";
 import MaterialIcon from "../shared/MaterialIcon";
 
 export const EditFocusButton = () => {
   const dispatch = useDispatch();
   const isFocusing = useSelector(getIsFocusing);
+  const isInFocusMode = useSelector(getIsInFocusMode);
 
   const onClick = () => {
     if (isFocusing) {
@@ -24,13 +25,13 @@ export const EditFocusButton = () => {
   return (
     <button
       className={classNames(
-        "flex",
-        isFocusing ? "text-primaryAccent" : "text-themeToolbarPanelIconColor"
+        "flex text-white rounded-full h-6 w-6 justify-center items-center",
+        isInFocusMode ? "bg-primaryAccent" : "bg-themeToolbarPanelIconColor"
       )}
       onClick={onClick}
       title={isFocusing ? "Save current focus" : "Start focus edit mode"}
     >
-      <MaterialIcon iconSize="2xl">center_focus_strong</MaterialIcon>
+      <MaterialIcon iconSize="lg">center_focus_strong</MaterialIcon>
     </button>
   );
 };

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -14,16 +14,13 @@ export default function Transcript() {
   const { comments } = hooks.useGetComments(recordingId);
   const { loading } = hooks.useGetRecording(recordingId);
   const pendingComment = useSelector(selectors.getPendingComment);
-  const focusRegion = useSelector(selectors.getFocusRegion);
   const { isAuthenticated } = useAuth0();
 
   if (loading) {
     return null;
   }
 
-  const displayedComments: Comment[] = [...comments].filter(
-    e => !focusRegion || (e.time > focusRegion.startTime && e.time < focusRegion.endTime)
-  );
+  const displayedComments: Comment[] = [...comments];
 
   if (pendingComment?.type == "new_comment") {
     displayedComments.push(pendingComment.comment);

--- a/src/ui/components/shared/FocusModal/FocusModal.tsx
+++ b/src/ui/components/shared/FocusModal/FocusModal.tsx
@@ -25,7 +25,7 @@ function FocusingModal({ hideModal }: PropsFromRedux) {
             <div className="h-6 w-6 rounded-full bg-primaryAccent p-1 text-white">
               <MaterialIcon>center_focus_strong</MaterialIcon>
             </div>
-            <div className="text-lg">Focus mode</div>
+            <div className="text-lg">Edit Focus mode</div>
           </div>
           <p>
             Use the <strong>left and right handlebars</strong> in the timeline to focus your replay.

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -13,6 +13,7 @@ import { getSources } from "devtools/client/debugger/src/reducers/sources";
 import { formatCallStackFrames } from "devtools/client/debugger/src/selectors/getCallStackFrames";
 import sortBy from "lodash/sortBy";
 import sortedUniqBy from "lodash/sortedUniqBy";
+import { getFocusRegion } from "./timeline";
 
 export type NetworkState = {
   events: RequestEventInfo[];
@@ -89,6 +90,22 @@ const update = (state: NetworkState = initialState(), action: NetworkAction): Ne
 export const getEvents = (state: UIState) => state.network.events;
 export const getRequests = (state: UIState) => state.network.requests;
 export const getFrames = (state: UIState) => state.network.frames;
+export const getFocusedEvents = (state: UIState) => {
+  const events = getEvents(state);
+  const focusRegion = getFocusRegion(state);
+
+  return events.filter(
+    e => !focusRegion || (e.time > focusRegion.startTime && e.time <= focusRegion.endTime)
+  );
+};
+export const getFocusedRequests = (state: UIState) => {
+  const requests = getRequests(state);
+  const focusRegion = getFocusRegion(state);
+
+  return requests.filter(
+    r => !focusRegion || (r.time > focusRegion.startTime && r.time <= focusRegion.endTime)
+  );
+};
 
 export const getFormattedFrames = createSelector(getFrames, getSources, (frames, sources) => {
   return Object.keys(frames).reduce((acc: Record<string, WiredFrame[]>, frame) => {

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -65,3 +65,7 @@ export const getTimelineDimensions = (state: UIState) => state.timeline.timeline
 export const getHoveredItem = (state: UIState) => state.timeline.hoveredItem;
 export const getPlaybackPrecachedTime = (state: UIState) => state.timeline.playbackPrecachedTime;
 export const getFocusRegion = (state: UIState) => state.timeline.focusRegion;
+export const getIsInFocusMode = (state: UIState) =>
+  state.timeline.focusRegion &&
+  (state.timeline.focusRegion.startTime !== 0 ||
+  state.timeline.focusRegion.endTime !== state.timeline.zoomRegion.endTime);

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -68,4 +68,4 @@ export const getFocusRegion = (state: UIState) => state.timeline.focusRegion;
 export const getIsInFocusMode = (state: UIState) =>
   state.timeline.focusRegion &&
   (state.timeline.focusRegion.startTime !== 0 ||
-  state.timeline.focusRegion.endTime !== state.timeline.zoomRegion.endTime);
+    state.timeline.focusRegion.endTime !== state.timeline.zoomRegion.endTime);


### PR DESCRIPTION
- Color the button blue when in focus mode
- Makes sure comments appear below the focuser during focus edit mode
- Filter the network requests based on the current focused region
- Don't show comments in the timeline when they're not focused