### PR TITLE
Fix edit button styles

### DIFF
--- a/src/ui/components/Library/BatchActionDropdown.tsx
+++ b/src/ui/components/Library/BatchActionDropdown.tsx
@@ -67,7 +67,7 @@ function BatchActionDropdown({
 
   if (!selectedIds.length) {
     return (
-      <DisabledButton>
+      <DisabledButton className="space-x-1 leading-4">
         <MaterialIcon outlined className="font-bold" iconSize="sm">
           expand_more
         </MaterialIcon>

--- a/src/ui/components/Library/Viewer.tsx
+++ b/src/ui/components/Library/Viewer.tsx
@@ -125,7 +125,7 @@ function ViewerContent({
           {isEditing ? (
             <>
               <BatchActionDropdown setSelectedIds={setSelectedIds} selectedIds={selectedIds} />
-              <PrimaryButton className="bg-white" color="blue" onClick={handleDoneEditing}>
+              <PrimaryButton color="blue" onClick={handleDoneEditing}>
                 Done
               </PrimaryButton>
             </>

--- a/src/ui/components/shared/Button.tsx
+++ b/src/ui/components/shared/Button.tsx
@@ -7,14 +7,14 @@ type ColorScale = 50 | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
 type Colors = "gray" | "blue" | "red" | "yellow" | "green" | "indigo" | "purple" | "pink" | "white";
 
 const STANDARD_CLASSES = {
-  sm: "flex-shrink-0 items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded",
-  md: "flex-shrink-0 items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md",
-  lg: "flex-shrink-0 items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md",
-  xl: "flex-shrink-0 items-center px-4 py-2 border border-transparent text-base font-medium rounded-md",
+  sm: "inline-flex flex-shrink-0 items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded",
+  md: "inline-flex flex-shrink-0 items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md",
+  lg: "inline-flex flex-shrink-0 items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md",
+  xl: "inline-flex flex-shrink-0 items-center px-4 py-2 border border-transparent text-base font-medium rounded-md",
   "2xl":
-    "flex-shrink-0 items-center px-6 py-3 border border-transparent text-base font-medium rounded-md",
+    "inline-flex flex-shrink-0 items-center px-6 py-3 border border-transparent text-base font-medium rounded-md",
   "3xl":
-    "flex-shrink-0 items-center px-6 py-3 border border-transparent text-2xl font-medium rounded-md",
+    "inline-flex flex-shrink-0 items-center px-6 py-3 border border-transparent text-2xl font-medium rounded-md",
 };
 
 function getColorCode(color: Colors, num: ColorScale) {
@@ -131,6 +131,12 @@ export const PrimaryButton = (props: ButtonProps & { color: Colors }) => (
 export const SecondaryButton = (props: ButtonProps & { color: Colors }) => (
   <Button {...props} size="md" style="secondary" />
 );
-export const DisabledButton = (props: ButtonProps) => (
-  <Button {...props} size="md" style="disabled" className="cursor-default" color="gray" />
+export const DisabledButton = ({ className, ...rest }: ButtonProps) => (
+  <Button
+    {...rest}
+    size="md"
+    style="disabled"
+    className={classNames(className, "cursor-default")}
+    color="gray"
+  />
 );


### PR DESCRIPTION
## Issue

* The edit button is white on white
* The down arrow on the selection dropdown is too tight to the text and misaligned

<img width="921" alt="image" src="https://user-images.githubusercontent.com/788456/156633452-4170cc19-62b8-431a-8f0e-f170fd48dbaa.png">

## Resolution

* Remove the `bg-white` class from the button. Interestingly, this class has been there a long time but was overridden by `bg-primaryAccent` on the button until recently when the CSS was rendered in a different order changing the precedence.
* Undoes a bit of #5336 to bring back the `inline-flex` styling on buttons so we can align the contents more easily.