### PR TITLE
Put a loader in place of the console terminal when paused on an unloaded region

### DIFF
--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -435,7 +435,8 @@ html #webconsole-notificationbox {
 }
 
 /* CodeMirror-powered JsTerm */
-.jsterm-input-container .CodeMirror {
+.jsterm-input-container .CodeMirror,
+.jsterm-input-container .load-container {
   /* aim for a 32px left space (a descendent has 4px padding) */
   padding-inline-start: calc(var(--console-inline-start-gutter) - 4px);
   /* Create a new stacking context */

--- a/src/devtools/client/webconsole/components/App.js
+++ b/src/devtools/client/webconsole/components/App.js
@@ -57,7 +57,7 @@ class App extends React.Component {
       return;
     }
 
-    window.jsterm.editor.focus();
+    window.jsterm?.editor.focus();
   };
 
   render() {

--- a/src/devtools/client/webconsole/components/Input/JSTerm.tsx
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
 import { getCursorIndex, getRemainingCompletedTextAfterCursor } from "../../utils/autocomplete";
 import AutocompleteMatches from "./AutocompleteMatches";
@@ -8,6 +8,8 @@ import { evaluateExpression, paywallExpression } from "../../actions/input";
 import EagerEvalFooter from "./EagerEvalFooter";
 import useAutocomplete from "./useAutocomplete";
 import useEvaluationHistory from "./useEvaluationHistory";
+import { getIsInLoadedRegion } from "ui/reducers/timeline";
+import Spinner from "ui/components/shared/Spinner";
 
 enum Keys {
   BACKSPACE = "Backspace",
@@ -33,6 +35,7 @@ export default function JSTerm() {
   const dispatch = useDispatch();
   const recordingId = useGetRecordingId();
   const { recording } = useGetRecording(recordingId);
+  const isInLoadedRegion = useSelector(getIsInLoadedRegion);
 
   const [value, setValue] = useState("");
   const inputNode = useRef<HTMLDivElement | null>(null);
@@ -129,21 +132,29 @@ export default function JSTerm() {
           tabIndex={-1}
           ref={inputNode}
         >
-          <CodeMirror
-            onKeyPress={onKeyPress}
-            value={value}
-            onSelection={onSelection}
-            setValue={setValue}
-            execute={execute}
-          />
-          {shouldShowAutocomplete ? (
-            <div
-              className="absolute ml-8 opacity-50"
-              style={{ left: `${value.length}ch`, top: `5px` }}
-            >
-              {getRemainingCompletedTextAfterCursor(value, matches[autocompleteIndex])}
+          {isInLoadedRegion ? (
+            <>
+              <CodeMirror
+                onKeyPress={onKeyPress}
+                value={value}
+                onSelection={onSelection}
+                setValue={setValue}
+                execute={execute}
+              />
+              {shouldShowAutocomplete ? (
+                <div
+                  className="absolute ml-8 opacity-50"
+                  style={{ left: `${value.length}ch`, top: `5px` }}
+                >
+                  {getRemainingCompletedTextAfterCursor(value, matches[autocompleteIndex])}
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <div className="load-container flex items-center h-full italic text-gray-400">
+              Loading…
             </div>
-          ) : null}
+          )}
         </div>
         {shouldShowAutocomplete ? (
           <AutocompleteMatches

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -1,6 +1,8 @@
+import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
 import { TimelineActions } from "ui/actions/timeline";
 import { UIState } from "ui/state";
 import { TimelineState } from "ui/state/timeline";
+import { getLoadedRegions } from "./app";
 
 function initialTimelineState(): TimelineState {
   return {
@@ -69,3 +71,19 @@ export const getIsInFocusMode = (state: UIState) =>
   state.timeline.focusRegion &&
   (state.timeline.focusRegion.startTime !== 0 ||
     state.timeline.focusRegion.endTime !== state.timeline.zoomRegion.endTime);
+export const getIsInLoadedRegion = (state: UIState) => {
+  const currentPausePoint = getExecutionPoint(state);
+  const loadedRegions = getLoadedRegions(state)?.loaded;
+
+  if (!currentPausePoint || !loadedRegions || loadedRegions.length === 0) {
+    return false;
+  }
+
+  const isInLoadedRegion = loadedRegions.find(
+    r =>
+      BigInt(currentPausePoint) >= BigInt(r.begin.point) &&
+      BigInt(currentPausePoint) <= BigInt(r.end.point)
+  );
+
+  return isInLoadedRegion;
+};


### PR DESCRIPTION
Fix #5211.

Console evaluations don't work while paused in an unloaded region, which means that the whole evaluation gets dropped and the experience just feels broken.

This keeps us from being in a state where the user is able to evaluate something in the console while paused in a problematic pause point in the first place.

<img width="1799" alt="image" src="https://user-images.githubusercontent.com/15959269/156634321-207c751d-bd29-495e-9fc4-86f74dc16ae9.png">