### PR TITLE
Track anonymous users in Mixpanel

### DIFF
--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -10,7 +10,11 @@ import NonDevView from "./Views/NonDevView";
 import WaitForReduxSlice from "./WaitForReduxSlice";
 import ReplayLogo from "./shared/ReplayLogo";
 
-import { endUploadWaitTracking, maybeSetGuestMixpanelContext, trackEventOnce } from "ui/utils/mixpanel";
+import {
+  endUploadWaitTracking,
+  maybeSetGuestMixpanelContext,
+  trackEventOnce,
+} from "ui/utils/mixpanel";
 import KeyboardShortcuts from "./KeyboardShortcuts";
 import { useUserIsAuthor } from "ui/hooks/users";
 import { CommandPaletteModal } from "./CommandPalette/CommandPaletteModal";
@@ -67,7 +71,7 @@ function _DevTools({
     if (!isAuthenticated) {
       maybeSetGuestMixpanelContext();
     }
-  }, [isAuthenticated])
+  }, [isAuthenticated]);
 
   useEffect(() => {
     if (loading) {

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -12,7 +12,7 @@ import { setAccessTokenInBrowserPrefs, setUserInBrowserPrefs } from "ui/utils/br
 import { getUserInfo } from "ui/hooks/users";
 import { getUserSettings } from "ui/hooks/settings";
 import { initLaunchDarkly } from "ui/utils/launchdarkly";
-import { maybeSetGuestMixpanelContext, maybeSetMixpanelContext } from "ui/utils/mixpanel";
+import { maybeSetMixpanelContext } from "ui/utils/mixpanel";
 import { getInitialLayoutState } from "ui/reducers/layout";
 import { getInitialTabsState } from "devtools/client/debugger/src/reducers/tabs";
 
@@ -76,8 +76,6 @@ export async function bootstrapApp() {
 
       setTelemetryContext(userInfo);
       maybeSetMixpanelContext({ ...userInfo, workspaceId });
-    } else {
-      maybeSetGuestMixpanelContext();
     }
 
     initLaunchDarkly();

--- a/src/ui/setup/index.ts
+++ b/src/ui/setup/index.ts
@@ -12,7 +12,7 @@ import { setAccessTokenInBrowserPrefs, setUserInBrowserPrefs } from "ui/utils/br
 import { getUserInfo } from "ui/hooks/users";
 import { getUserSettings } from "ui/hooks/settings";
 import { initLaunchDarkly } from "ui/utils/launchdarkly";
-import { maybeSetMixpanelContext } from "ui/utils/mixpanel";
+import { maybeSetGuestMixpanelContext, maybeSetMixpanelContext } from "ui/utils/mixpanel";
 import { getInitialLayoutState } from "ui/reducers/layout";
 import { getInitialTabsState } from "devtools/client/debugger/src/reducers/tabs";
 
@@ -76,6 +76,8 @@ export async function bootstrapApp() {
 
       setTelemetryContext(userInfo);
       maybeSetMixpanelContext({ ...userInfo, workspaceId });
+    } else {
+      maybeSetGuestMixpanelContext();
     }
 
     initLaunchDarkly();

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -79,7 +79,7 @@ export function mockEnvironment() {
 }
 
 export function skipTelemetry() {
-  return isTest() || isMock() || isDevelopment() || isDeployPreview();
+  return isTest() || isDevelopment() || isDeployPreview();
 }
 
 export function isDeployPreview() {

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -142,6 +142,18 @@ export function maybeSetMixpanelContext(userInfo: TelemetryUser & { workspaceId:
   }
 }
 
+export function maybeSetGuestMixpanelContext() {
+  // This gives us an option to log telemetry events in development.
+  const forceEnableMixpanel = prefs.logTelemetryEvent;
+
+  if (skipTelemetry() && !forceEnableMixpanel) {
+    return;
+  }
+
+  mixpanel.identify();
+  enableMixpanel();
+}
+
 export const maybeTrackTeamChange = (newWorkspaceId: WorkspaceId | null) => {
   if (!mixpanelDisabled) {
     // We use the uuid here so it's easy to cross reference the id

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -121,7 +121,7 @@ export function initializeMixpanel() {
 
 export function maybeSetMixpanelContext(userInfo: TelemetryUser & { workspaceId: string | null }) {
   const { internal: isInternal } = userInfo;
-  const forceEnableMixpanel = prefs.logTelemetryEvent
+  const forceEnableMixpanel = prefs.logTelemetryEvent;
   const shouldEnableMixpanel = (!isInternal && !skipTelemetry()) || forceEnableMixpanel;
 
   if (shouldEnableMixpanel) {

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -104,15 +104,12 @@ type MixpanelEvent =
   | ["user_options.select_docs"]
   | ["user_options.select_settings"];
 
-const QA_EMAIL_ADDRESSES = ["mock@user.io"];
-
 // Keep mixpanel disabled until we know we have the user's info
 // to send along with events. This keeps events from tests from being
 // sent to mixpanel.
 let mixpanelDisabled = true;
 
 const enableMixpanel = () => (mixpanelDisabled = false);
-const disableMixpanel = () => (mixpanelDisabled = true);
 
 export function initializeMixpanel() {
   mixpanel.init("ffaeda9ef8fb976a520ca3a65bba5014");
@@ -123,35 +120,27 @@ export function initializeMixpanel() {
 }
 
 export function maybeSetMixpanelContext(userInfo: TelemetryUser & { workspaceId: string | null }) {
-  const { email, internal } = userInfo;
-  const isQAUser = email && QA_EMAIL_ADDRESSES.includes(email);
-  const isInternal = internal;
-  const shouldDisableMixpanel = isQAUser || isInternal || skipTelemetry();
+  const { internal: isInternal } = userInfo;
+  const forceEnableMixpanel = prefs.logTelemetryEvent
+  const shouldEnableMixpanel = (!isInternal && !skipTelemetry()) || forceEnableMixpanel;
 
-  // This gives us an option to log telemetry events in development.
-  const forceEnableMixpanel = prefs.logTelemetryEvent;
-
-  if (!shouldDisableMixpanel || forceEnableMixpanel) {
+  if (shouldEnableMixpanel) {
     setMixpanelContext(userInfo);
     enableMixpanel();
     trackMixpanelEvent("session_start", { workspaceId: userInfo.workspaceId });
     timeMixpanelEvent("session.devtools_start");
     setupSessionEndListener();
-  } else {
-    disableMixpanel();
   }
 }
 
 export function maybeSetGuestMixpanelContext() {
-  // This gives us an option to log telemetry events in development.
   const forceEnableMixpanel = prefs.logTelemetryEvent;
+  const shouldEnableMixpanel = !skipTelemetry() || forceEnableMixpanel;
 
-  if (skipTelemetry() && !forceEnableMixpanel) {
-    return;
+  if (shouldEnableMixpanel) {
+    mixpanel.identify();
+    enableMixpanel();
   }
-
-  mixpanel.identify();
-  enableMixpanel();
 }
 
 export const maybeTrackTeamChange = (newWorkspaceId: WorkspaceId | null) => {


### PR DESCRIPTION
Fix #4684.

Previous attempts for this PR had problems because there was no easy way to flag anonymous users from test runners (eg QA Wolf).

This gets around that by only tracking anonymous users if they're looking at a replay that's recorded by a non-internal user.