### PR TITLE
Add messaging for when a selected request is in an unloaded region

### DIFF
--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { FC, ReactNode, useEffect, useMemo, useState } from "react";
 import { findHeader, RequestSummary } from "./utils";
 import styles from "./RequestDetails.module.css";
 import classNames from "classnames";
@@ -16,6 +16,32 @@ interface Detail {
   name: string;
   value: string | React.ReactChild;
 }
+
+export const RequestDetailsUnavailable: FC<{ closePanel: () => void }> = ({ closePanel }) => {
+  return (
+    <div className="w-full h-full flex flex-col">
+      <RequestDetailsTabs>
+        <div className="flex-grow flex justify-end">
+          <CloseButton buttonClass="mr-4" handleClick={closePanel} tooltip={"Close tab"} />
+        </div>
+      </RequestDetailsTabs>
+      <div className="flex-grow relative">
+        <div className="m-2">Request details currently unavailable</div>
+      </div>
+    </div>
+  );
+};
+
+const RequestDetailsTabs: FC<{ children?: ReactNode }> = ({ children }) => {
+  return (
+    <div
+      className="sticky top-0 z-10 flex items-center justify-between border-b bg-toolbarBackground"
+      style={{ height: 25 }}
+    >
+      {children}
+    </div>
+  );
+};
 
 function FormattedUrl({ url }: { url: string }) {
   const parsedUrl = new URL(url);
@@ -264,13 +290,10 @@ const RequestDetails = ({
 
   return (
     <div className="min-w-full overflow-scroll border-l bg-themeBodyBackground">
-      <div
-        className="sticky top-0 z-10 flex items-center justify-between border-b bg-toolbarBackground"
-        style={{ height: 25 }}
-      >
+      <RequestDetailsTabs>
         <PanelTabs tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
         <CloseButton buttonClass="mr-4" handleClick={closePanel} tooltip={"Close tab"} />
-      </div>
+      </RequestDetailsTabs>
       <div className={classNames("requestDetails", styles.requestDetails)}>
         <div>
           {activeTab === "headers" && <HeadersPanel request={request} />}

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -2,6 +2,7 @@ import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
 import { TimelineActions } from "ui/actions/timeline";
 import { UIState } from "ui/state";
 import { TimelineState } from "ui/state/timeline";
+import { getPointIsInLoadedRegion } from "ui/utils/timeline";
 import { getLoadedRegions } from "./app";
 
 function initialTimelineState(): TimelineState {
@@ -79,11 +80,5 @@ export const getIsInLoadedRegion = (state: UIState) => {
     return false;
   }
 
-  const isInLoadedRegion = loadedRegions.find(
-    r =>
-      BigInt(currentPausePoint) >= BigInt(r.begin.point) &&
-      BigInt(currentPausePoint) <= BigInt(r.end.point)
-  );
-
-  return isInLoadedRegion;
+  return getPointIsInLoadedRegion(loadedRegions, currentPausePoint);
 };

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -139,3 +139,9 @@ export function isInTrimSpan(time: number, focusRegion: FocusRegion) {
 
   return time >= startTime && time <= endTime;
 }
+
+export function getPointIsInLoadedRegion(loadedRegions: TimeStampedPointRange[], point: string) {
+  return loadedRegions.find(
+    r => BigInt(point) >= BigInt(r.begin.point) && BigInt(point) <= BigInt(r.end.point)
+  );
+}


### PR DESCRIPTION
Fix #5282, fix #5604.

https://user-images.githubusercontent.com/15959269/156775235-48145689-3e8b-4c0e-ae17-d99e94a4019f.mov

Right now it's possible to select a network request, try to fetch its response/request body, and because it's in an unloaded region, the fetch fails.

This PR makes it so that in the case the user tries to select a network request in an unloaded region, we don't send the fetch request and instead show a different screen in place of the request details explaining what had happened.

This is a half measure. Ideally there should be a follow-up action including (but not limited to):
- A link to docs about loaded/unloaded regions and why it affects things you can see in the UI.
- If the current unloaded region will eventually be loaded, then some auto-refresh capability so the request details show up immediately once it's ready.
- If the current unloaded region has been permanently yanked away by the backend, some explanation about what had happened and how they should probably use focus mode so that we can load what they're interested in.

Will file a follow up for those items #5606.