### PR TITLE
The dangers of using Objects as Maps

### DIFF
--- a/src/devtools/packages/devtools-reps/object-inspector/utils/value.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/utils/value.tsx
@@ -124,13 +124,13 @@ export class ValueItem implements IItem {
 
     const value = this.contents;
     const previewValues = value.previewValueMap();
-    const rv: Item[] = Object.entries(previewValues).map(
+    const rv: Item[] = [...previewValues.entries()].map(
       ([name, contents]) => new ValueItem({ parent: this, name, contents })
     );
-    const knownProperties = new Set(Object.keys(previewValues));
+    const knownProperties = new Set(previewValues.keys());
     value.traversePrototypeChain(current => {
       const getters = current.previewGetters();
-      for (const name of Object.keys(getters)) {
+      for (const name of getters.keys()) {
         if (!knownProperties.has(name)) {
           rv.push(new GetterItem({ parent: this, name }));
           knownProperties.add(name);
@@ -201,7 +201,7 @@ export class ValueItem implements IItem {
 }
 
 function getChildValues(parentValue: ValueFront): ValueFront[] {
-  const rv = Object.values(parentValue.previewValueMap());
+  const rv = [...parentValue.previewValueMap().values()];
 
   if (parentValue.className() === "Promise") {
     const result = parentValue.previewPromiseState();

--- a/src/devtools/packages/devtools-reps/reps/array.js
+++ b/src/devtools/packages/devtools-reps/reps/array.js
@@ -75,7 +75,7 @@ function getArrayLikeLength(object) {
     return object.containerEntryCount();
   }
   const propertyValues = object.previewValueMap();
-  return propertyValues.length.primitive();
+  return propertyValues.get("length").primitive();
 }
 
 function getTitle(props, object) {
@@ -112,7 +112,7 @@ function arrayIterator(props, array, max) {
     if (containerEntries && i < containerEntries.length) {
       elem = containerEntries[i].value;
     } else {
-      elem = propertyValues[i];
+      elem = propertyValues.get(i.toString());
     }
     if (!elem) {
       elem = createPrimitiveValueFront(null);

--- a/src/devtools/packages/devtools-reps/reps/error.js
+++ b/src/devtools/packages/devtools-reps/reps/error.js
@@ -37,7 +37,7 @@ function ErrorRep(props) {
       name = "DOMException";
       break;
     default:
-      name = preview.name.primitive();
+      name = preview.get("name").primitive();
       break;
   }
   const content = [];
@@ -45,12 +45,12 @@ function ErrorRep(props) {
   if (mode === MODE.TINY) {
     content.push(name);
   } else {
-    content.push(`${name}: "${preview.message.primitive()}"`);
+    content.push(`${name}: "${preview.get("message").primitive()}"`);
   }
 
-  if (preview.stack && mode !== MODE.TINY && mode !== MODE.SHORT) {
+  if (preview.get("stack") && mode !== MODE.TINY && mode !== MODE.SHORT) {
     const stacktrace = props.renderStacktrace
-      ? props.renderStacktrace(parseStackString(preview.stack.primitive()))
+      ? props.renderStacktrace(parseStackString(preview.get("stack").primitive()))
       : getStacktraceElements(props, preview);
 
     if (!isEvaluationError(stacktrace)) {
@@ -85,11 +85,11 @@ function ErrorRep(props) {
  */
 function getStacktraceElements(props, preview) {
   const stack = [];
-  if (!preview.stack) {
+  if (!preview.get("stack")) {
     return stack;
   }
 
-  parseStackString(preview.stack.primitive()).forEach((frame, index, frames) => {
+  parseStackString(preview.get("stack").primitive()).forEach((frame, index, frames) => {
     let onLocationClick;
     const { filename, lineNumber, columnNumber, functionName, location } = frame;
 

--- a/src/devtools/packages/devtools-reps/reps/event.js
+++ b/src/devtools/packages/devtools-reps/reps/event.js
@@ -70,14 +70,14 @@ function getProperties(props) {
   const preview = props.object.previewValueMap();
 
   propertyNames.forEach((name, i) => {
-    if (preview[name]) {
+    if (preview.get(name)) {
       elements.push(
         PropRep({
           ...props,
           key: name,
           mode: MODE.TINY,
           name,
-          object: preview[name],
+          object: preview.get(name),
           equal: ": ",
         })
       );
@@ -101,7 +101,7 @@ function getKeyboardEventModifiers(preview) {
 
   const modifiers = [];
   for (const [property, name] of Object.entries(keysToModifiersMap)) {
-    if (preview[property].primitive()) {
+    if (preview.get(property).primitive()) {
       modifiers.push(name);
     }
   }
@@ -110,7 +110,7 @@ function getKeyboardEventModifiers(preview) {
 
 function getTitle(props) {
   const preview = props.object.previewValueMap();
-  let title = preview.type.primitive();
+  let title = preview.get("type").primitive();
 
   if (props.object.className() == "KeyboardEvent") {
     const modifiers = getKeyboardEventModifiers(preview);

--- a/src/devtools/packages/devtools-reps/reps/grip.js
+++ b/src/devtools/packages/devtools-reps/reps/grip.js
@@ -224,10 +224,10 @@ function getProps(componentProps, properties, indexes, suppressQuotes) {
     return a - b;
   });
 
-  const propertiesKeys = Object.keys(properties);
+  const propertiesKeys = [...properties.keys()];
   return indexes.map(i => {
     const name = propertiesKeys[i];
-    const value = properties[name];
+    const value = properties.get(name);
 
     return PropRep({
       ...componentProps,
@@ -256,14 +256,14 @@ function getPropIndexes(properties, max, filter) {
 
   try {
     let i = 0;
-    for (const name in properties) {
+    for (const name of properties.keys()) {
       if (indexes.length >= max) {
         return indexes;
       }
 
       // Type is specified in grip's "class" field and for primitive
       // values use typeof.
-      const value = properties[name];
+      const value = properties.get(name);
       let type = value.isObject() ? value.className() : typeof value.primitive();
       type = type.toLowerCase();
 

--- a/src/devtools/packages/devtools-reps/reps/rep-utils.js
+++ b/src/devtools/packages/devtools-reps/reps/rep-utils.js
@@ -347,8 +347,8 @@ function getGripPreviewItems(grip) {
   const rv = [];
 
   const properties = grip.previewValueMap();
-  for (const name in properties) {
-    rv.push(createPrimitiveValueFront(name), properties[name]);
+  for (const name of properties.keys()) {
+    rv.push(createPrimitiveValueFront(name), properties.get(name));
   }
 
   const containerEntries = grip.previewContainerEntries();

--- a/src/protocol/event-listeners.ts
+++ b/src/protocol/event-listeners.ts
@@ -13,14 +13,14 @@ export interface FrameworkEventListener {
 export async function getFrameworkEventListeners(node: NodeFront) {
   const obj = node.getObjectFront();
   await obj.loadProperties();
-  const props = Object.entries(obj.previewValueMap());
+  const props = [...obj.previewValueMap().entries()];
   const reactProp = props.find(([key]) => key.startsWith("__reactEventHandlers$"));
   if (!reactProp) {
     return [];
   }
 
   await reactProp[1].loadProperties();
-  const handlerProps = Object.entries(reactProp[1].previewValueMap());
+  const handlerProps = [...reactProp[1].previewValueMap().entries()];
   return handlerProps
     .filter(([, contents]) => {
       return contents.isObject() && contents.className() == "Function";

--- a/src/protocol/find-tests.ts
+++ b/src/protocol/find-tests.ts
@@ -215,7 +215,7 @@ class JestTestState {
         const exceptionValue = new ValueFront(pause, exception);
 
         const exceptionContents = exceptionValue.previewValueMap();
-        const exceptionProperty = exceptionContents.message || exceptionContents.name;
+        const exceptionProperty = exceptionContents.get("message") || exceptionContents.get("name");
         if (exceptionProperty && exceptionProperty.isString()) {
           test.errorText = String(exceptionProperty.primitive());
         } else {

--- a/src/protocol/logpoint.ts
+++ b/src/protocol/logpoint.ts
@@ -478,7 +478,7 @@ async function findFrameworkListeners(
 ) {
   const locations = [];
   await frameworkListeners.loadProperties();
-  const propertyValues = Object.values(frameworkListeners.previewValueMap());
+  const propertyValues = frameworkListeners.previewValueMap().values();
   for (const value of propertyValues) {
     if (value.isObject() && value.className() == "Function") {
       locations.push(value.functionLocationFromLogpoint()!);


### PR DESCRIPTION
... especially when writing a javascript debugger:
While working on support for getters in the ObjectInspector I saw this in a simple example recording:
![Screenshot_2022-03-04_15-06-40](https://user-images.githubusercontent.com/16060807/156778165-25047cd6-10c6-421b-bfbc-e821c424ba6a.png)
These getters (except `foobar`) look like the properties of a `ValueFront`, but this was not a recording of Replay and the example didn't contain these getters anywhere, so what happened?
I was collecting the getters in an Object (code slightly simplified):
```
const rv = {};
for (const { name, get } of this._object.preview.properties) {
  if (get) {
    rv[name] = get;
  }
}
return rv;
```
But the object whose getters I was collecting contained a getter named `__proto__`, so I was effectively doing `rv.__proto__ = get` where `get` is of type `ValueFront`.
Then the ObjectInspector iterated over `rv` using `for ... in` and ... :boom:

This PR changes `ValueFront.previewValueMap()` and `ValueFront.previewGetters()` to return a Map instead of an Object.
