### PR TITLE
Allow any team member to see the dropdown for a node recording

### DIFF
--- a/src/ui/components/Library/MoveRecordingMenu.tsx
+++ b/src/ui/components/Library/MoveRecordingMenu.tsx
@@ -11,12 +11,14 @@ import { subscriptionExpired } from "ui/utils/workspace";
 type RecordingOptionsDropdownProps = PropsFromRedux & {
   onMoveRecording: (targetWorkspaceId: WorkspaceId | null) => void;
   workspaces: Workspace[];
+  disableLibrary: boolean;
 };
 
 function MoveRecordingMenu({
   currentWorkspaceId,
   onMoveRecording,
   workspaces,
+  disableLibrary,
 }: RecordingOptionsDropdownProps) {
   const { workspace, loading } = hooks.useGetWorkspace(currentWorkspaceId || "");
 
@@ -35,7 +37,7 @@ function MoveRecordingMenu({
       <div className="px-4 py-2 text-xs font-bold uppercase">Move to:</div>
       <DropdownDivider />
       <div className="max-h-48 overflow-y-auto">
-        {currentWorkspaceId !== null ? (
+        {!(currentWorkspaceId === null || disableLibrary) ? (
           <DropdownItem onClick={() => onMoveRecording(null)}>Your library</DropdownItem>
         ) : null}
         {availableWorkspaces.map(({ id, name }) => (

--- a/src/ui/components/Library/RecordingOptionsDropdown.tsx
+++ b/src/ui/components/Library/RecordingOptionsDropdown.tsx
@@ -11,46 +11,9 @@ import classNames from "classnames";
 import MoveRecordingMenu from "./MoveRecordingMenu";
 import { useConfirm } from "../shared/Confirm";
 import { useIsPublicEnabled } from "ui/utils/org";
-import { useGetNonPendingWorkspaces } from "ui/hooks/workspaces";
 import { getWorkspaceId } from "ui/reducers/app";
 import { setModal } from "ui/actions/app";
-
-export function useGetPermissions(recording: Recording) {
-  const { userId, loading: userIdLoading } = hooks.useGetUserId();
-  const { workspaces, loading: workspacesLoading } = useGetNonPendingWorkspaces();
-  const isOwner = userId == recording.user?.id;
-
-  if (userIdLoading || workspacesLoading) {
-    return {
-      loading: true,
-      permissions: {
-        move: false,
-        moveToLibrary: false,
-        privacy: false,
-        rename: false,
-        delete: false,
-      },
-    };
-  }
-
-  const sameTeam =
-    recording.workspace?.id && workspaces.find(w => w.id === recording.workspace?.id);
-  // Here we are inferring that recordings without a user are node recordings, since they've
-  // been update using the workspace's API key.
-  const isNodeRecording = !recording.user;
-  const isPrivilegedUser = isOwner || (isNodeRecording && sameTeam);
-
-  return {
-    loading: false,
-    permissions: {
-      move: isOwner,
-      moveToLibrary: isOwner,
-      privacy: isPrivilegedUser,
-      rename: isPrivilegedUser,
-      delete: isPrivilegedUser,
-    },
-  };
-}
+import { useGetUserPermissions } from "ui/hooks/users";
 
 function DeleteOption({
   onOptionClick,
@@ -151,7 +114,7 @@ function MoveRecordingOption({
   onOptionClick: () => void;
   recording: Recording;
 }) {
-  const { permissions } = useGetPermissions(recording);
+  const { permissions } = useGetUserPermissions(recording);
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
   const updateRecordingWorkspace = hooks.useUpdateRecordingWorkspace();
   const currentWorkspaceId = useSelector(getWorkspaceId);
@@ -176,7 +139,7 @@ function MoveRecordingOption({
 
 export default function RecordingOptionsDropdown({ recording }: { recording: Recording }) {
   const [expanded, setExpanded] = useState(false);
-  const { loading, permissions } = useGetPermissions(recording);
+  const { loading, permissions } = useGetUserPermissions(recording);
 
   if (loading) {
     return null;

--- a/src/ui/components/Library/RecordingRow.tsx
+++ b/src/ui/components/Library/RecordingRow.tsx
@@ -12,6 +12,7 @@ import { actions } from "ui/actions";
 import { getDisplayedUrl } from "ui/utils/environment";
 import { getRecordingURL } from "ui/utils/recording";
 import styles from "./Library.module.css";
+import { useGetUserPermissions } from "ui/hooks/users";
 
 export function getDurationString(durationMs: number) {
   const seconds = Math.round(durationMs / 1000);
@@ -74,9 +75,9 @@ function RecordingRow({
   removeSelectedId,
   addSelectedId,
 }: RecordingRowProps) {
-  const { userId, loading } = hooks.useGetUserId();
-  const isOwner = userId == recording.user?.id;
-  const allowSelecting = isEditing && isOwner;
+  const { permissions, loading: permissionsLoading } = useGetUserPermissions(recording);
+  const allowSelecting =
+    isEditing && (permissions.moveToLibrary || permissions.move || permissions.delete);
 
   const toggleChecked = () => {
     if (!allowSelecting) {
@@ -90,7 +91,7 @@ function RecordingRow({
     }
   };
 
-  if (loading) {
+  if (permissionsLoading) {
     return null;
   }
 

--- a/src/ui/components/Library/RecordingRow.tsx
+++ b/src/ui/components/Library/RecordingRow.tsx
@@ -165,7 +165,7 @@ function RecordingRow({
           className="relative flex w-6 flex-shrink-0 flex-row items-center justify-center py-3 pr-4"
           onClick={e => e.stopPropagation()}
         >
-          {isOwner && !isEditing ? <RecordingOptionsDropdown {...{ recording }} /> : null}
+          {!isEditing ? <RecordingOptionsDropdown {...{ recording }} /> : null}
         </div>
       </div>
     </RowWrapper>

--- a/src/ui/components/Library/Viewer.tsx
+++ b/src/ui/components/Library/Viewer.tsx
@@ -131,7 +131,11 @@ function ViewerContent({
           <TeamTrialEnd />
           {isEditing ? (
             <>
-              <BatchActionDropdown setSelectedIds={setSelectedIds} selectedIds={selectedIds} />
+              <BatchActionDropdown
+                setSelectedIds={setSelectedIds}
+                selectedIds={selectedIds}
+                recordings={sortedRecordings}
+              />
               <PrimaryButton color="blue" onClick={handleDoneEditing}>
                 Done
               </PrimaryButton>

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -47,6 +47,7 @@ const GET_WORKSPACE_RECORDINGS = gql`
                 }
               }
               workspace {
+                id
                 hasPaymentMethod
                 subscription {
                   status

--- a/src/ui/utils/org.ts
+++ b/src/ui/utils/org.ts
@@ -1,3 +1,6 @@
+import { useSelector } from "react-redux";
+import { useGetNonPendingWorkspaces } from "ui/hooks/workspaces";
+import { getWorkspaceId } from "ui/reducers/app";
 import { Workspace, WorkspaceSettings } from "ui/types";
 
 export function getDefaultOrganizationSettings(): WorkspaceSettings {
@@ -18,6 +21,17 @@ export function getDefaultOrganizationSettings(): WorkspaceSettings {
 export function getOrganizationSettings(workspaces: Workspace[]) {
   const org = workspaces.find(w => w.isOrganization);
   return org?.settings || getDefaultOrganizationSettings();
+}
+
+export function useIsPublicEnabled() {
+  const { workspaces, loading: loadingWorkspaces } = useGetNonPendingWorkspaces();
+  const currentWorkspaceId = useSelector(getWorkspaceId);
+
+  if (loadingWorkspaces) {
+    return false;
+  }
+
+  return !isPublicDisabled(workspaces, currentWorkspaceId);
 }
 
 export function isPublicDisabled(workspaces: Workspace[], selectedWorkspaceId: string | null) {


### PR DESCRIPTION
Fix #5332.

This makes it so that:
- every team member can see rename/delete/toggle privacy options for replays in the team.
- in the recording dropdown, users will only see the **Move to: Your Library** option if they're the owner of the recording.