### PR TITLE
ObjectInspector: load the children of getters

### DIFF
--- a/public/test/examples/doc_rr_objects.html
+++ b/public/test/examples/doc_rr_objects.html
@@ -5,6 +5,10 @@ function recordingFinished() {
   console.log("ExampleFinished");
 }
 
+class C {
+  get foo() { return "bar"; }
+}
+
 function foo() {
 // Create various objects which the debugger must be able to show in the scopes
 // pane using only the pause data, i.e. without additional debugger requests.
@@ -41,6 +45,7 @@ var n = new Proxy({ a: 0 }, {
 var o = Symbol();
 var p = Symbol("symbol");
 var q = { [o]: 42, [p]: o };
+var r = { get c() { return new C(); } }
 console.log(a);
 console.log(b);
 console.log(c);
@@ -58,6 +63,7 @@ console.log(n);
 console.log(o);
 console.log(p);
 console.log(q);
+console.log(r);
 console.log("Done");
 window.setTimeout(recordingFinished);
 }

--- a/public/test/scripts/object_preview-01.js
+++ b/public/test/scripts/object_preview-01.js
@@ -31,6 +31,9 @@ Test.describe(`expressions in the console after time warping.`, async () => {
   await Test.waitForMessage("Symbol(symbol)");
   await Test.waitForMessage(`Object { "Symbol()": 42, "Symbol(symbol)": "Symbol()" }`);
 
+  msg = await Test.waitForMessage("Object {  }");
+  await Test.checkMessageObjectContents(msg, ["c: {}", 'foo: "bar"'], ["c", "foo"]);
+
   await Test.warpToMessage("Done");
 
   await Test.executeInConsole("Error('helo')");

--- a/src/devtools/packages/devtools-reps/object-inspector/components/ObjectInspector.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/components/ObjectInspector.tsx
@@ -114,7 +114,14 @@ class OI extends PureComponent<ObjectInspectorProps> {
     }
     this.forceUpdate();
 
-    if (expand && item.type === "value" && item.needsToLoadChildren()) {
+    if (!expand) {
+      return;
+    }
+
+    if (item.type === "getter" && item.valueItem) {
+      item = item.valueItem;
+    }
+    if (item.type === "value" && item.needsToLoadChildren()) {
       try {
         await loadChildren(item);
       } catch {

--- a/src/devtools/packages/devtools-reps/object-inspector/utils/getter.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/utils/getter.tsx
@@ -21,16 +21,20 @@ export class GetterItem {
   // - "failed" - if loading failed
   // - ValueFront - the getter's value once it's been loaded
   readonly loadingState: undefined | "loading" | "failed" | ValueFront;
+  readonly valueItem?: ValueItem;
 
   constructor(opts: { parent: ValueItem; name: string }) {
     this.name = opts.name;
     this.path = `${opts.parent.path}/${opts.name}`;
     this.object = opts.parent.contents;
     this.loadingState = getterValues.get(getterValueKey(this.object, this.name));
-  }
-
-  getLoadingState() {
-    return this.loadingState;
+    if (this.loadingState instanceof ValueFront) {
+      this.valueItem = new ValueItem({
+        name: this.name,
+        contents: this.loadingState,
+        path: this.path,
+      });
+    }
   }
 
   isPrimitive() {
@@ -66,19 +70,12 @@ export class GetterItem {
       }
 
       default: {
-        return new ValueItem({
-          name: this.name,
-          contents: this.loadingState,
-          path: "",
-        }).getLabelAndValue(props);
+        return this.valueItem!.getLabelAndValue(props);
       }
     }
   }
 
   getChildren() {
-    if (!(this.loadingState instanceof ValueFront)) {
-      return [];
-    }
-    return new ValueItem({ contents: this.loadingState, path: "" }).getChildren();
+    return this.valueItem?.getChildren() || [];
   }
 }

--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -493,7 +493,15 @@ async function checkMessageObjectContents(msg, expected, expandList = []) {
     const labelNode = await waitUntil(() => findObjectInspectorNode(oi, label), {
       waitingFor: `findObjectInspectorNode(${oi}, ${label})`,
     });
-    await toggleObjectInspectorNode(labelNode);
+    const getterButton = labelNode.querySelector(".invoke-getter");
+    if (getterButton) {
+      getterButton.click();
+      await waitUntil(() => labelNode.querySelector(".objectBox"), "The getter's value is shown");
+    }
+    const expandButton = labelNode.querySelector(".arrow");
+    if (expandButton) {
+      expandButton.click();
+    }
   }
 
   await waitUntil(


### PR DESCRIPTION
When a getter's value was an object, that object's children were not loaded, so it showed up as an empty object.
This PR also adds getters to one of our e2e tests (that's how I found the bug in the first place).