### PR TITLE
Add pauseId to the getterValue key

### DIFF
--- a/src/devtools/packages/devtools-reps/object-inspector/utils/getter.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/utils/getter.tsx
@@ -5,7 +5,7 @@ import { LabelAndValue, ValueItem } from ".";
 import { ObjectInspectorItemProps } from "../components/ObjectInspectorItem";
 
 function getterValueKey(object: ValueFront, property: string) {
-  return `${object.objectId()}:${property}`;
+  return `${object.getPause()?.pauseId}:${object.objectId()}:${property}`;
 }
 const getterValues = new Map<string, ValueFront | "loading" | "failed">();
 


### PR DESCRIPTION
Otherwise an object would show the loaded getter values from another object with the same `objectId` but from a different pause. 