### PR TITLE
Fix showing active team error while loading

### DIFF
--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -11,6 +11,7 @@ import { MY_LIBRARY } from "../UploadScreen/Sharing";
 import { actions } from "ui/actions";
 import { BlankViewportWrapper } from "../shared/Viewport";
 import Base64Image from "../shared/Base64Image";
+import { sendTelemetryEvent } from "ui/utils/telemetry";
 
 function ViewerLoader() {
   return (
@@ -80,12 +81,13 @@ type ViewerRouterProps = PropsFromRedux & {
 
 function ViewerRouter(props: ViewerRouterProps) {
   const { workspaces, loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
-  const { features, loading } = hooks.useGetUserInfo();
+  const { id: userId, features, loading } = hooks.useGetUserInfo();
   const { currentWorkspaceId, setUnexpectedError, setWorkspaceId } = props;
 
   useEffect(() => {
     if (currentWorkspaceId === null && !features.library && !loading && !nonPendingLoading) {
       if (!workspaces.length) {
+        sendTelemetryEvent("DevToolsNoActiveTeam", { userId });
         // This shouldn't be reachable because the library can only be disabled
         // by a workspace setting which means the user must be in a workspace
         setUnexpectedError({

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -81,14 +81,14 @@ type ViewerRouterProps = PropsFromRedux & {
 function ViewerRouter(props: ViewerRouterProps) {
   const { workspaces, loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
   const { features, loading } = hooks.useGetUserInfo();
-  const { currentWorkspaceId } = props;
+  const { currentWorkspaceId, setUnexpectedError, setWorkspaceId } = props;
 
   useEffect(() => {
-    if (currentWorkspaceId === null && !features.library && !nonPendingLoading) {
+    if (currentWorkspaceId === null && !features.library && !loading && !nonPendingLoading) {
       if (!workspaces.length) {
         // This shouldn't be reachable because the library can only be disabled
         // by a workspace setting which means the user must be in a workspace
-        props.setUnexpectedError({
+        setUnexpectedError({
           message: "Unexpected error",
           content: "Unable to find an active team",
         });
@@ -96,9 +96,17 @@ function ViewerRouter(props: ViewerRouterProps) {
         return;
       }
 
-      props.setWorkspaceId(workspaces[0].id);
+      setWorkspaceId(workspaces[0].id);
     }
-  });
+  }, [
+    currentWorkspaceId,
+    loading,
+    features,
+    nonPendingLoading,
+    setUnexpectedError,
+    setWorkspaceId,
+    workspaces,
+  ]);
 
   if (loading) {
     return <BlankViewportWrapper />;


### PR DESCRIPTION
## Issue

My theory is that there's a race condition in which `features` hasn't been loaded when the `useEffect` runs causing the error to be messaged too early

## Resolution

Add `loading` to the hook's evaluation