### PR TITLE
Find jest test entry points in batches

### DIFF
--- a/src/protocol/analysisManager.ts
+++ b/src/protocol/analysisManager.ts
@@ -126,7 +126,11 @@ class AnalysisManager {
     return handler.onFinished?.();
   }
 
-  async runAnalysisBatches(params: AnalysisParams, handler: AnalysisHandler<T>, maxPoints: number) {
+  async runAnalysisBatches<T>(
+    params: AnalysisParams,
+    handler: AnalysisHandler<T>,
+    maxPoints: number
+  ) {
     assert(!handler.onAnalysisPoints);
     assert(handler.onAnalysisResult);
 
@@ -136,7 +140,9 @@ class AnalysisManager {
     pointsHandler.onAnalysisPoints = points => allPoints.push(...points);
     await this.runAnalysis(params, pointsHandler);
 
-    for (let i = 0; i < allPoints.length; i += MaxPointsPerBatch) {
+    const numPoints = Math.min(allPoints.length, maxPoints);
+
+    for (let i = 0; i < numPoints; i += MaxPointsPerBatch) {
       const batchPoints = allPoints.slice(i, i + MaxPointsPerBatch);
 
       const batchParams: AnalysisParams = {

--- a/src/protocol/analysisManager.ts
+++ b/src/protocol/analysisManager.ts
@@ -39,6 +39,9 @@ export interface AnalysisHandler<T> {
   onFinished?(): T;
 }
 
+// When running analyses in batches, limit on the points to use in each batch.
+const MaxPointsPerBatch = 200;
+
 class AnalysisManager {
   private handlers = new Map<AnalysisId, AnalysisHandler<any>>();
 
@@ -121,6 +124,30 @@ class AnalysisManager {
     }
 
     return handler.onFinished?.();
+  }
+
+  async runAnalysisBatches(params: AnalysisParams, handler: AnalysisHandler<T>, maxPoints: number) {
+    assert(!handler.onAnalysisPoints);
+    assert(handler.onAnalysisResult);
+
+    const pointsHandler: AnalysisHandler<void> = {};
+    const allPoints: PointDescription[] = [];
+
+    pointsHandler.onAnalysisPoints = points => allPoints.push(...points);
+    await this.runAnalysis(params, pointsHandler);
+
+    for (let i = 0; i < allPoints.length; i += MaxPointsPerBatch) {
+      const batchPoints = allPoints.slice(i, i + MaxPointsPerBatch);
+
+      const batchParams: AnalysisParams = {
+        sessionId: params.sessionId,
+        mapper: params.mapper,
+        effectful: true,
+        points: batchPoints.map(p => p.point),
+      };
+
+      await this.runAnalysis(batchParams, handler);
+    }
   }
 
   private readonly onAnalysisResult = ({ analysisId, results }: analysisResult) => {

--- a/src/protocol/find-tests.ts
+++ b/src/protocol/find-tests.ts
@@ -86,6 +86,10 @@ return [{
 }];
 `;
 
+// Limit on the number of points we will look for the starting point of tests at.
+// If hooks are running, the maximum number of actual tests we find will be lower.
+const MaxTestPoints = 1000;
+
 // Manages the state associated with any jest tests within the recording.
 class JestTestState {
   sessionId: string;
@@ -121,7 +125,7 @@ class JestTestState {
     const handler: AnalysisHandler<void> = {};
     handler.onAnalysisResult = results => analysisResults.push(...results);
 
-    await analysisManager.runAnalysis(params, handler);
+    await analysisManager.runAnalysisBatches(params, handler, MaxTestPoints);
 
     await Promise.all(
       analysisResults.map(async ({ key: callPoint, value: { names } }) => {


### PR DESCRIPTION
For https://github.com/RecordReplay/customer-support/issues/44.  This PR avoids running analyses to find the entry points of jest tests against too many points at once.  We run against at most 200 points at a time (which could be hooks instead of tests), and limit the total number of points we run at to 1000.