### PR TITLE
Improved IDB connection handling

### DIFF
--- a/src/devtools/shared/async-storage.ts
+++ b/src/devtools/shared/async-storage.ts
@@ -67,8 +67,8 @@ const withStore = (
   dbConn.onsuccess = () => {
     const db = dbConn.result;
     const transaction = db.transaction(STORENAME, type);
+    const store = transaction.objectStore(STORENAME);
     transaction.oncomplete = () => {
-      const store = transaction.objectStore(STORENAME);
       onsuccess(store);
       db.close();
     };

--- a/src/devtools/shared/async-storage.ts
+++ b/src/devtools/shared/async-storage.ts
@@ -101,13 +101,15 @@ export const setItem = (itemKey: string, value: any) => {
     withStore(
       "readwrite",
       (store, db) => {
-        store.transaction.oncomplete = resolve;
+        store.transaction.oncomplete = () => {
+          db.close();
+          resolve(undefined);
+        };
         const req = store.put(value, itemKey);
         req.onerror = () => {
           console.error("Error in asyncStorage.setItem():", req.error?.name);
           reject(req.error);
         };
-        db.close();
       },
       reject
     );


### PR DESCRIPTION
We were previously relying on a single `IDBDatabase` object being present at all times, or potentially recreated if needed. The problem was exactly for periods where the previous instance was being closed and a new transaction was fired, that saw the previous instance, but it was practically unavailable. Closing db connections can happen due to various uncontrolled reasons out of devs' control (the browser decides is low on memory e.g.), as per docs https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/close.

So we need to be able to handle this case.

The actual recommended way to work with IDB API is to recreate a DB connection for every transaction. The cost of that op is insignificant and this makes sure that we're always working with a "fresh" (unclosing) db connection. The connection is always recreated, and for the sake of proper API usage, closed once we're done with it.