### PR TITLE
Manually redirect to home after auth callback

### DIFF
--- a/pages/callback.tsx
+++ b/pages/callback.tsx
@@ -17,12 +17,21 @@ export default function Connection() {
       return;
     }
 
-    auth0.getAccessTokenSilently({ connection, redirect_uri: home }).catch(e =>
-      auth0.loginWithRedirect({
-        connection,
-        redirectUri: home,
+    auth0
+      .getAccessTokenSilently({ connection })
+      .then(() => {
+        // We used to use `redirect_url` but it introduced an odd race
+        // condition in which the auth0 client would not find the identity after
+        // the redirect but then would after the user refreshed. This works
+        // around that but may still need revisited later.
+        window.location.href = home;
       })
-    );
+      .catch(e =>
+        auth0.loginWithRedirect({
+          connection,
+          redirectUri: home,
+        })
+      );
   }, [auth0, connection, router]);
 
   return <LoadingScreen />;

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -87,7 +87,6 @@ function ViewerRouter(props: ViewerRouterProps) {
   useEffect(() => {
     if (currentWorkspaceId === null && !features.library && !loading && !nonPendingLoading) {
       if (!workspaces.length) {
-        sendTelemetryEvent("DevToolsNoActiveTeam", { userId });
         // This shouldn't be reachable because the library can only be disabled
         // by a workspace setting which means the user must be in a workspace
         setUnexpectedError({


### PR DESCRIPTION
* Manually redirects to the home page after enterprise auth callback
* Removes the extra telemetry event I added but which wasn't adding any value to narrow down this bug