### PR TITLE
Fix Download Replay onboarding copy

### DIFF
--- a/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
@@ -75,8 +75,7 @@ function SingleInviteModal({ workspace }: SingleInviteModalProps) {
     <DownloadReplayModal>
       {`You've been added to the team `}
       <strong>{name}</strong>
-      {` by `}
-      <strong>{inviterEmail}</strong>
+      {inviterEmail ? <strong>{` by ${inviterEmail}`}</strong> : null}
       {`. Would you like to go that team, or download Replay?`}
     </DownloadReplayModal>
   );


### PR DESCRIPTION
Don't show an inviter if there's no inviter in the first place. That happens when a user joins replay using an invite link to a team.