### PR TITLE
Refresh token when switching to authenticated after app has loaded

### DIFF
--- a/pages/callback.tsx
+++ b/pages/callback.tsx
@@ -17,21 +17,12 @@ export default function Connection() {
       return;
     }
 
-    auth0
-      .getAccessTokenSilently({ connection })
-      .then(() => {
-        // We used to use `redirect_url` but it introduced an odd race
-        // condition in which the auth0 client would not find the identity after
-        // the redirect but then would after the user refreshed. This works
-        // around that but may still need revisited later.
-        window.location.href = home;
+    auth0.getAccessTokenSilently({ connection, redirect_uri: home }).catch(e =>
+      auth0.loginWithRedirect({
+        connection,
+        redirectUri: home,
       })
-      .catch(e =>
-        auth0.loginWithRedirect({
-          connection,
-          redirectUri: home,
-        })
-      );
+    );
   }, [auth0, connection, router]);
 
   return <LoadingScreen />;

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useRef } from "react";
+import React, { ReactNode, useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import useAuth0 from "ui/utils/useAuth0";
 
@@ -21,7 +21,7 @@ import FirstReplayModal from "./shared/FirstReplayModal";
 import TOSScreen, { LATEST_TOS_VERSION } from "./TOSScreen";
 import SingleInviteModal from "./shared/OnboardingModal/SingleInviteModal";
 import FocusModal from "./shared/FocusModal/FocusModal";
-import { migratePrefToSettings, useFeature } from "ui/hooks/settings";
+import { useFeature } from "ui/hooks/settings";
 import { ConfirmRenderer } from "./shared/Confirm";
 import PrivacyModal from "./shared/PrivacyModal";
 import LoomModal from "./shared/LoomModal";
@@ -128,12 +128,6 @@ function App({ children, modal }: AppProps) {
   useEffect(() => {
     document.body.parentElement!.className = enableDarkMode ? "theme-dark" : "theme-light";
   }, [enableDarkMode]);
-
-  useEffect(() => {
-    if (!isTest() && auth.isAuthenticated) {
-      migratePrefToSettings("devtools.disableLogRocket", "disableLogRocket");
-    }
-  }, [auth.isAuthenticated]);
 
   if (auth.isLoading || userInfo.loading) {
     return <LoadingScreen />;

--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -83,7 +83,10 @@ class TokenManager {
             setTimeout(() => {
               if (apiKey) {
                 this.setExternalAuth(apiKey);
-              } else if (!this.currentState) {
+              } else if (
+                !this.currentState ||
+                (!this.currentState.token && this.auth0Client?.isAuthenticated)
+              ) {
                 this.update(false);
               }
             }, 0);


### PR DESCRIPTION
## Issue

The "inactive team" error is still occurring but the page refresh unblocks users

## Analysis

https://app.replay.io/recording/replay-of-dev-83501448oktacom--7d237f0b-6582-4c11-81e1-66971f03bcf6

## Resolution

Reverts most of #5659 and replaces it with a change in the condition for updating the token.

https://app.replay.io/recording/replay-of-dev-83501448oktacom--e167cf48-9a30-4e3d-b438-aa512e19989b