### PR TITLE
Dark theme prep 3

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/SourcemapToggle.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/SourcemapToggle.tsx
@@ -46,7 +46,7 @@ export function Toggle({
         checked={enabled}
         onChange={onChange}
         className={classNames(
-          enabled ? "bg-primaryAccent" : "bg-gray-200",
+          enabled ? "bg-primaryAccent" : "bg-themeToggle",
           "relative inline-flex h-4 w-7 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
         )}
       >

--- a/src/devtools/client/debugger/src/components/Editor/SourcemapVisualizerLink.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/SourcemapVisualizerLink.tsx
@@ -25,7 +25,7 @@ function SourcemapVisualizerLink({ selectedSource, alternateSource }: PropsFromR
         <Icon
           size="small"
           filename="external"
-          className="cursor-pointer bg-gray-800 group-hover:bg-primaryAccent"
+          className="cursor-pointer bg-iconColor group-hover:bg-primaryAccent"
         />{" "}
         Source Map
       </a>

--- a/src/devtools/client/debugger/src/components/FullTextSearch/FullTextFilter.js
+++ b/src/devtools/client/debugger/src/components/FullTextSearch/FullTextFilter.js
@@ -51,7 +51,7 @@ export function FullTextFilter({
         <input
           style={{ boxShadow: "unset" }}
           placeholder="Find in files…"
-          className="flex-grow border-0 bg-themeTextField p-0 text-xs focus:outline-none"
+          className="flex-grow border-0 bg-themeTextField p-0 text-xs text-themeTextFieldColor focus:outline-none"
           type="text"
           value={value}
           onChange={e => setValue(e.target.value)}

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/OutlineFilter.js
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/OutlineFilter.js
@@ -35,7 +35,7 @@ export default class OutlineFilter extends Component {
       <div className="outline-filter px-3 pt-1">
         <form>
           <input
-            className="h-full w-full rounded-md border-none bg-themeTextField px-2 py-1 text-xs focus:ring-gray-300"
+            className="h-full w-full rounded-md border-none bg-themeTextField px-2 py-1 text-xs text-themeTextFieldColor focus:ring-gray-300"
             onFocus={() => this.setFocus(true)}
             onBlur={() => this.setFocus(false)}
             placeholder={"Filter functions"}

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/Sources.css
@@ -11,7 +11,7 @@
 }
 
 .sources-list {
-  /* height: 100%; */
+  height: 100%;
 }
 
 .sources-list .img.blackBox {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
@@ -47,6 +47,7 @@
 .breakpoint-navigation-status {
   border-radius: 4px;
   padding: 2px 6px;
+  background-color: Orange;
 }
 
 .breakpoint-navigation-timeline-container {
@@ -116,4 +117,9 @@
   .breakpoint-navigation-timeline-point.primary-highlight:not(.pause)
   .fill {
   fill: var(--new-blue-900);
+}
+
+.time-tooltip {
+  background-color: var(--tab-selected-bgcolor);
+  color: var(--tab-selected-color);
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
@@ -47,7 +47,6 @@
 .breakpoint-navigation-status {
   border-radius: 4px;
   padding: 2px 6px;
-  background-color: Orange;
 }
 
 .breakpoint-navigation-timeline-container {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.css
@@ -123,3 +123,7 @@
   background-color: var(--tab-selected-bgcolor);
   color: var(--tab-selected-color);
 }
+
+.breakpoint-navigation :focus-visible {
+  outline: none;
+}

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/TimeTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/TimeTooltip.tsx
@@ -10,7 +10,7 @@ export default function TimeTooltip({ time }: { time: number | null }) {
   const minutes = date.getMinutes();
 
   return (
-    <div className="bottom-1 rounded-md border border-splitter bg-toolbarBackground p-1 py-0.5 text-xs">
+    <div className="time-tooltip bottom-1 rounded-md border border-splitter p-1 py-0.5 text-xs">
       {`${minutes}:${seconds}`}
     </div>
   );

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/EventListeners.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/EventListeners.js
@@ -115,9 +115,12 @@ class EventListeners extends Component {
     return (
       <form className="event-search-form" onSubmit={e => e.preventDefault()}>
         <input
-          className={classnames("event-search-input w-full bg-themeTextField px-2 py-1", {
-            focused,
-          })}
+          className={classnames(
+            "event-search-input w-full bg-themeTextField px-2 py-1 text-themeTextFieldColor",
+            {
+              focused,
+            }
+          )}
           placeholder={placeholder}
           value={searchText}
           onChange={this.onInputChange}

--- a/src/devtools/client/debugger/src/components/shared/SearchInput.css
+++ b/src/devtools/client/debugger/src/components/shared/SearchInput.css
@@ -11,6 +11,7 @@
   min-height: 28px;
   width: 100%;
   background-color: var(--theme-text-field);
+  color: var(--theme-text-field-color);
 }
 
 .search-field .img.search {
@@ -54,7 +55,7 @@
   line-height: 16px;
   font-family: inherit;
   font-size: inherit;
-  color: var(--theme-body-color);
+  color: var(--theme-text-field-color);
   background-color: transparent;
 }
 

--- a/src/devtools/client/inspector/computed/components/ComputedToolbar.tsx
+++ b/src/devtools/client/inspector/computed/components/ComputedToolbar.tsx
@@ -21,7 +21,7 @@ function ComputedToolbar(props: PropsFromRedux) {
 
   return (
     <div id="computed-toolbar" className="devtools-toolbar devtools-input-toolbar">
-      <div id="computed-search" className="devtools-searchbox">
+      <div id="computed-search" className="devtools-searchbox text-themeTextFieldColor">
         <input
           id="computed-searchbox"
           className="devtools-filterinput"

--- a/src/devtools/client/inspector/markup/components/MarkupApp.tsx
+++ b/src/devtools/client/inspector/markup/components/MarkupApp.tsx
@@ -29,7 +29,7 @@ function MarkupApp(props: PropsFromRedux & { inspector: Inspector }) {
     <div className="devtools-inspector-tab-panel">
       <div id="inspector-main-content" className="devtools-main-content">
         <div id="inspector-toolbar" className="devtools-toolbar devtools-input-toolbar">
-          <div id="inspector-search" className="devtools-searchbox">
+          <div id="inspector-search" className="devtools-searchbox text-themeTextFieldColor">
             <input
               id="inspector-searchbox"
               className="devtools-searchinput"

--- a/src/devtools/client/inspector/rules/components/SearchBox.tsx
+++ b/src/devtools/client/inspector/rules/components/SearchBox.tsx
@@ -7,12 +7,12 @@ type SearchBoxProps = {
 
 export const SearchBox: FC<SearchBoxProps> = ({ query, onQueryChange }) => {
   return (
-    <div id="ruleview-search" className="devtools-searchbox">
+    <div id="ruleview-search" className="devtools-searchbox text-themeTextFieldColor">
       <input
         id="ruleview-searchbox"
         type="text"
         autoComplete="off"
-        className="devtools-filterinput"
+        className="devtools-filterinput text-themeTextFieldColor"
         placeholder="Filter Styles"
         value={query}
         onChange={e => onQueryChange(e.target.value)}

--- a/src/devtools/client/themes/common.css
+++ b/src/devtools/client/themes/common.css
@@ -524,7 +524,7 @@ checkbox:-moz-focusring {
   font: inherit;
   border: 1px solid transparent;
   background-color: var(--theme-body-background);
-  color: var(--theme-body-color);
+  color: var(--theme-body-background-color);
   flex-grow: 1;
 }
 

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -198,7 +198,7 @@
   --theme-border: #d2d5da;
   --theme-toggle-inner: var(--cool-gray-200);
   --theme-toggle-selected: white;
-  --toolbarbutton-focus-background: var(--grey-20);
+  --toolbarbutton-focus-background: var(--theme-base-90);
 
   --checkbox: #fff;
   --checkbox-border: var(--theme-base-80);
@@ -395,6 +395,8 @@
   --theme-border: var(--theme-base-100);
   --checkbox: var(--theme-base-80);
   --checkbox-border: var(--theme-base-90);
+
+  --toolbarbutton-focus-background: var(--theme-base-90);
 
   /* CODE MIRROR (DARK) */
 

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -214,6 +214,8 @@
   --debug-line-border: #037aff;
   --debug-line-background: #e9f3ff;
 
+  --theme-toggle: var(--grey-20);
+
   /* Toolbar */
   --theme-tab-toolbar-background: var(--grey-20);
   --theme-toolbar-background: var(--grey-10);
@@ -409,8 +411,8 @@
   --debug-line-background: var(--theme-base-100);
 
   /* Toolbar */
+  --theme-toolbar-panel-icon-color: var(--icon-color);
   --theme-tab-toolbar-background: var(--grey-90);
-
   --theme-toolbar-background: #18181a;
   --theme-toolbar-color: var(--grey-20);
   --theme-toolbar-selected-color: white;

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -168,6 +168,7 @@
   --theme-toggle-handle: var(--theme-base-100);
   --icon-color: var(--theme-body-color);
   --theme-text-field: var(--theme-base-95);
+  --theme-text-field-color: var(--theme-body-color);
   --theme-console-input: var(--theme-body-background);
 
   --progressbar-preview-min: var(--theme-base-80);
@@ -372,6 +373,7 @@
   --theme-toggle-handle: var(--theme-base-100);
   --icon-color: var(--theme-body-color);
   --theme-text-field: var(--theme-base-85);
+  --theme-text-field-color: #fff;
   --theme-console-input: var(--theme-base-95);
 
   --progressbar-preview-min: var(--theme-base-80);

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -214,7 +214,7 @@
   --debug-line-border: #037aff;
   --debug-line-background: #e9f3ff;
 
-  --theme-toggle: var(--grey-20);
+  --theme-toggle: var(--theme-base-80);
 
   /* Toolbar */
   --theme-tab-toolbar-background: var(--grey-20);

--- a/src/devtools/client/webconsole/components/FilterBar/FilterSearchBox.tsx
+++ b/src/devtools/client/webconsole/components/FilterBar/FilterSearchBox.tsx
@@ -30,13 +30,16 @@ export function FilterSearchBox({ filterTextSet }: { filterTextSet: any }) {
 
   return (
     <div className="devtools-searchbox relative flex flex-grow items-center">
-      <div className="flex w-full flex-row rounded-md bg-themeTextField px-2 py-1 text-gray-500 focus:ring-primaryAccent">
+      <div className="flex w-full flex-row rounded-md bg-themeTextField px-2 py-1 text-themeTextFieldColor focus:ring-primaryAccent">
         <TextInput
           value={searchString}
           onChange={onChange}
           onKeyDown={onKeyDown}
           placeholder="Filter Output"
-          style={{ backgroundColor: "var(--bg-themeTextField)" }}
+          style={{
+            backgroundColor: "var(--bg-themeTextField)",
+            color: "var(--bg-themeTextFieldColor)",
+          }}
         />
         {searchString ? (
           <button className="flex" onClick={clearInput}>

--- a/src/ui/components/Header/ViewToggle.css
+++ b/src/ui/components/Header/ViewToggle.css
@@ -45,6 +45,6 @@
 }
 
 .view-toggle .active {
-  color: var(--theme-body-color);
+  color: var(--tab-selected-color);
   font-weight: 400;
 }

--- a/src/ui/components/NetworkMonitor/FilterBar.tsx
+++ b/src/ui/components/NetworkMonitor/FilterBar.tsx
@@ -21,7 +21,7 @@ export default function FilterBar({
       <input
         placeholder="Filter requests"
         onChange={e => table.setGlobalFilter(e.target.value)}
-        className="w-full bg-transparent px-1  focus:outline-none"
+        className="w-full bg-transparent px-1 text-themeTextFieldColor focus:outline-none"
       />
     </div>
   );

--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -128,7 +128,7 @@
 .timeline .progress-line,
 .breakpoint-navigation-timeline .progress-line {
   width: 0%;
-  height: 5px;
+  height: 4px;
   /* border-top: 3px dashed var(--primary-accent); */
   border-top: 5px solid var(--primary-accent);
   position: absolute;
@@ -137,6 +137,7 @@
   margin-bottom: auto;
   top: 0;
   bottom: 0;
+  border-radius: 4px;
 }
 
 .timeline .overlay-container:hover .progress-line {

--- a/src/ui/components/UploadScreen/Privacy.tsx
+++ b/src/ui/components/UploadScreen/Privacy.tsx
@@ -49,7 +49,7 @@ function FavIcon({ url }: { url: string }) {
         <MaterialIcon>public</MaterialIcon>
       </div>
       <img
-        className="absolute top-0 left-0 h-4 w-4 bg-white"
+        className="absolute top-0 left-0 h-4 w-4 bg-transparent"
         src={`https://www.google.com/s2/favicons?domain=${url}`}
       />
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,6 +37,7 @@ module.exports = {
         breakpointStatus: "var(--breakpoint-status)",
         checkbox: "var(--checkbox)",
         checkboxBorder: "var(--checkbox-border)",
+        themeToggle: "var(--theme-toggle)",
       },
       lineHeight: {
         "comment-text": "1.125rem",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,7 @@ module.exports = {
         iconColorDisabled: "var(--theme-text-field)",
         themeBorder: "var(--theme-border)",
         themeTextField: "var(--theme-text-field)",
+        themeTextFieldColor: "var(--theme-text-field-color)",
         themeFocuser: "var(--theme-focuser)",
         breakpointEditfieldHover: "var(--breakpoint-editfield-hover)",
         breakpointEditfieldActive: "var(--breakpoint-editfield-active)",


### PR DESCRIPTION
Here's a Loom showing the standardisation I did in the textfields: https://www.loom.com/share/9d340a575bc44f53944907989e36f652

Here are some other items fixed in this PR:

- [x]  Source map toggle is broken
- [x]  Source map icon
- [x]  Privacy icons have white BG
- [x]  Left-hand hover states are way too dim in light theme
- [x]  Left-hand icons are very bright — dial them back
- [x]  Print statement panel (timestamp)
- [x]  Multiple focus borders
- [x]  Timeline is boxy
- [x]  Search boxes have inconsistent text

Tracking remaining items here: https://github.com/RecordReplay/devtools/issues/5665