### PR TITLE
Manual Vercel deployment

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,13 @@
+name: Storybook
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  build-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Deps
+        run: npm install
+      - name: Build Storybook
+        run: npm run build-storybook

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Run test suites
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   download-browser:
@@ -39,19 +44,25 @@ jobs:
           name: replay-driver
           path: macOS-recordreplay.so
   preview-branch:
-    name: Wait for Vercel Preview Branch
+    name: Vercel Preview Build
     runs-on: ubuntu-latest
     steps:
-      - name: Waiting for 200 from the Vercel Preview
-        uses: patrickedqvist/wait-for-vercel-preview@v1.1.1
-        id: waitFor200
+      - uses: actions/checkout@v2
+      - uses: amondnet/vercel-action@v20
+        id: vercel-deploy
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 500
-          check_interval: 30
-      - run: echo ${{steps.waitFor200.outputs.url}}
+          # for posting a comment upon completion
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-token: "redacted"
+          vercel-org-id: "redacted"
+          vercel-project-id: "redacted"
+          # an additiona; param for prod deployments
+          vercel-args: ${{ fromJSON('["", "--prod"]')[github.ref == 'refs/heads/master'] }}
+          # vercel-project-name required for the right scope
+          # see https://github.com/amondnet/vercel-action/issues/4
+          vercel-project-name: devtools
     outputs:
-      url: ${{ steps.waitFor200.outputs.url }}
+      url: ${{ steps.vercel-deploy.outputs.preview-url }}
   test0:
     name: End-to-end tests (1)
     runs-on: macos-latest

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ out
 tsconfig.tsbuildinfo
 yarn.lock
 .nova/
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
This PR changes how the deployment onto Vercel works.

The problem was that Vercel deployments got triggered automatically via Github app for Vercel, but there are some of the GHA jobs that are dependent on the preview build being available. To make sure the order is correct (deployment first and then tests that depend on it), we had a job that would poll for a preview build's availability. However, this behavior and the action we used were quite unreliable and would often time out, and that would cause the tests to fail, rendering most of CI pretty useless.

Instead of relying on automatic deployment, we now actually disable them with `vercel.json`'s `github.enabled` flag, and we use a different Github action ([vercel-action](https://github.com/amondnet/vercel-action#readme)) to manually trigger deployments. Internally, that action uses just a regular [Vercel CLI](https://vercel.com/docs/cli). This makes it possible to not poll for availability, but instead, have a completely natural order of deployment steps and jobs that simply follow one after the other. This should make the entire process much more reliable, and arguably more controllable.

Work:
- [ ] move secrets to `secrets` and please the linters (do a force push to clean up the git history)
- [x] make it work for preview builds of PRs
- [x] make it work for `master`
- [x] add Storybook step (this is just extra)