### PR TITLE
Ignore "500" response codes

### DIFF
--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -14,6 +14,7 @@ export function setupTelemetry() {
     "Current thread has changed",
     "Failed to load Stripe.js",
     "Stripe.js not available",
+    "Received status code 500",
   ];
   // We always initialize mixpanel here. This allows us to force enable mixpanel events even if
   // telemetry events are being skipped for any reason, e.g. development, test, etc.


### PR DESCRIPTION
Ignore response 500 errors coming through `@apollo/client`; related Sentry: https://sentry.io/organizations/replay/issues/2791294424/).

---

Considered creating a wrapper around `getQuery` (e.g. `useSafeQuery`) to catch 500 response, but that would mean we have to always remember to use that hook instead of the original one. Also then considered using `<ErrorBoundary>` that we have from before, but it would be a passthrough handling, so no new logic there, so we can just let it bubble without handling and then simply ignore it.