### PR TITLE
Remove Splitter border

### DIFF
--- a/src/devtools/packages/devtools-splitter/src/SplitBox.js
+++ b/src/devtools/packages/devtools-splitter/src/SplitBox.js
@@ -228,7 +228,6 @@ class SplitBox extends Component {
     // Calculate splitter size
     const splitterStyle = {
       flex: `0 0 ${splitterSize}px`,
-      borderRight: `1px solid var(--theme-tab-background)`,
     };
 
     const startPanelDiv =

--- a/src/devtools/packages/devtools-splitter/src/SplitBox.js
+++ b/src/devtools/packages/devtools-splitter/src/SplitBox.js
@@ -8,6 +8,7 @@ const Draggable = React.createFactory(require("./Draggable"));
 const { Component } = React;
 const PropTypes = require("prop-types");
 const dom = require("react-dom-factories");
+import cx from "classnames";
 
 /**
  * This component represents a Splitter. The splitter supports vertical
@@ -212,16 +213,10 @@ class SplitBox extends Component {
       splitterSize,
       splitterClass,
       endPanelCollapsed,
+      className,
     } = this.props;
 
     const style = Object.assign({}, this.props.style);
-
-    // Calculate class names list.
-    let classNames = ["split-box"];
-    classNames.push(vert ? "vert" : "horz");
-    if (this.props.className) {
-      classNames = classNames.concat(this.props.className.split(" "));
-    }
 
     const { leftPanelStyle, rightPanelStyle } = this.preparePanelStyles();
 
@@ -260,7 +255,14 @@ class SplitBox extends Component {
 
     return dom.div(
       {
-        className: classNames.join(" "),
+        className: cx(
+          "split-box",
+          {
+            vert: vert,
+            horz: !vert,
+          },
+          className
+        ),
         style: style,
       },
       startPanelDiv,


### PR DESCRIPTION
Notice the line between Elements and Viewer, immediately to Viewer.

Before:
<img width="1041" alt="image" src="https://user-images.githubusercontent.com/1355455/157274889-1981a2a4-4872-4da9-80c3-09def2823250.png">

After:
<img width="805" alt="image" src="https://user-images.githubusercontent.com/1355455/157274989-bc667354-e50e-4470-9b2a-bf2b159fd9d6.png">

---

Small fix for class names string filtering.

Before:

<img width="213" alt="image" src="https://user-images.githubusercontent.com/1355455/157277220-513f048f-0f93-4e37-ad6f-b561e79a3814.png">


After:

<img width="202" alt="image" src="https://user-images.githubusercontent.com/1355455/157277027-73193f9d-0ab5-4236-a1bf-3c4b0defb317.png">

