### PR TITLE
Add back missing test prep function

### DIFF
--- a/src/devtools/shared/async-storage.ts
+++ b/src/devtools/shared/async-storage.ts
@@ -115,3 +115,20 @@ export const setItem = (itemKey: string, value: any) => {
     );
   });
 };
+
+export const clear = () => {
+  return new Promise((resolve, reject) => {
+    withStore(
+      "readwrite",
+      store => {
+        store.transaction.oncomplete = resolve;
+        const req = store.clear();
+        req.onerror = function clearOnError() {
+          console.error("Error in asyncStorage.clear():", req.error?.name);
+          reject(req.error);
+        };
+      },
+      reject
+    );
+  });
+};

--- a/src/test-prep.ts
+++ b/src/test-prep.ts
@@ -1,4 +1,5 @@
 import { requiresWindow } from "./ssr";
+import { clear as clearAsyncStorage } from "devtools/shared/async-storage";
 
 requiresWindow(win => {
   const url = new URL(win.location.href);
@@ -11,6 +12,6 @@ requiresWindow(win => {
   // local storage in that case.
   if (test && !url.searchParams.get("navigated")) {
     localStorage.clear();
-    require("devtools/shared/async-storage").clear();
+    clearAsyncStorage();
   }
 });


### PR DESCRIPTION
The `clear()` function was used during test setup, and deleting it in
6ec5e1e53498f8f484f973642def5e755401fb55 caused all E2E tests to fail
with an error:


![CleanShot 2022-03-08 at 11 54 41](https://user-images.githubusercontent.com/5903784/157315366-179525aa-df1c-42f4-b5ab-4630fa43641f.png)


This adds that method back.


Fixes https://github.com/RecordReplay/backend/issues/4861