### PR TITLE
Breakpoints and highlights

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoint.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/Breakpoint.css
@@ -57,7 +57,7 @@
 }
 
 .breakpoints-list .breakpoint:hover {
-  background: var(--grey-20);
+  background: var(--theme-toolbar-background-alt);
 }
 
 .breakpoints-list .breakpoint-heading {

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -517,7 +517,7 @@
   --theme-warning-color: hsl(43, 94%, 81%);
 
   /* Flashing colors used to highlight updates */
-  --theme-contrast-background: #4f4b1f; /* = Yellow 50-a20 on body background */
+  --theme-contrast-background: #1a4380;
   --theme-contrast-background-alpha: rgba(255, 233, 0, 0.15); /* Yellow 50-a15 */
   --theme-contrast-color: white;
   --theme-contrast-border: var(--yellow-65);


### PR DESCRIPTION
We were using a white hover state for breakpoints and a gross yellow highlight. Neither look good in dark theme, so I fixed 'em. Here's a Loom: https://www.loom.com/share/56287a2d8e9742e38437c6d93bab1ee8