### PR TITLE
Decouple SourcemapToggle from the current pause (#4766)

### DIFF
--- a/src/devtools/client/debugger/src/utils/source.d.ts
+++ b/src/devtools/client/debugger/src/utils/source.d.ts
@@ -1,0 +1,11 @@
+import { SourceId } from "@recordreplay/protocol";
+import { Source } from "../reducers/sources";
+
+export function getSourcemapVisualizerURL(
+  selectedSource: Source,
+  alternateSource: Source
+): string | null;
+export function getUniqueAlternateSourceId(sourceId: SourceId): {
+  sourceId?: SourceId;
+  why?: "no-sourcemap" | "not-unique";
+};

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -1066,7 +1066,7 @@ class _ThreadFront {
           return { sourceId: id };
         }
         kind = minifiedInfo.kind;
-        assert(kind != "prettyPrinted", "source kind must be prettyPrinted");
+        assert(kind != "prettyPrinted", "source kind must not be prettyPrinted");
       }
       if (kind == "sourceMapped") {
         originalId = id;
@@ -1077,7 +1077,7 @@ class _ThreadFront {
     }
 
     if (!generatedId) {
-      assert(originalId, "there should be no originalId");
+      assert(originalId, "there should be an originalId");
       return { sourceId: originalId };
     }
 
@@ -1106,7 +1106,7 @@ class _ThreadFront {
     const groups = [];
     while (sourceIds.length) {
       const id = sourceIds[0];
-      const group = [...this._getAlternateSourceIds(id)].filter(id => sourceIds.includes(id));
+      const group = [...this.getAlternateSourceIds(id)].filter(id => sourceIds.includes(id));
       groups.push(group);
       sourceIds = sourceIds.filter(id => !group.includes(id));
     }
@@ -1114,7 +1114,7 @@ class _ThreadFront {
   }
 
   // Get all original/generated IDs which can represent a location in sourceId.
-  private _getAlternateSourceIds(sourceId: SourceId) {
+  getAlternateSourceIds(sourceId: SourceId) {
     if (this.alternateSourceIds.has(sourceId)) {
       return this.alternateSourceIds.get(sourceId)!;
     }
@@ -1173,7 +1173,7 @@ class _ThreadFront {
     return kind == "sourceMapped";
   }
 
-  preferSource(sourceId: SourceId, value: SourceId) {
+  preferSource(sourceId: SourceId, value: boolean) {
     assert(!this.isSourceMappedSource(sourceId), "source is not sourceMapped");
     if (value) {
       this.preferredGeneratedSources.add(sourceId);

--- a/src/ui/components/shared/Modals/SourcemapSetupModal.tsx
+++ b/src/ui/components/shared/Modals/SourcemapSetupModal.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import { isNextUrl } from "devtools/client/debugger/src/components/Editor/SourcemapToggle";
 import { getSelectedSourceWithContent } from "devtools/client/debugger/src/selectors";
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
@@ -8,6 +7,8 @@ import { UIState } from "ui/state";
 import { PrimaryButton } from "../Button";
 import { Dialog, DialogActions, DialogDescription, DialogLogo, DialogTitle } from "../Dialog";
 import Modal from "../NewModal";
+
+const isNextUrl = (url: string | undefined) => url && url.includes("/_next/");
 
 function SourcemapSetupModal({ hideModal, selectedSource }: PropsFromRedux) {
   const { url } = selectedSource;


### PR DESCRIPTION
Currently it is only possible to switch to an alternate source if we're paused in the current source.
With this PR, if we're not paused in the current source we try to find a unique alternate source and allow the user to switch to that.
If there are no alternate sources, the "No sourcemaps found" message is shown.
If there are multiple alternate sources, the SourcemapToggle is hidden.
This also fixes #5345 (and some assertion messages and types in `ThreadFront`).