### PR TITLE
Add Storybook to CI on PRs

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,13 @@
+name: Storybook
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  build-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Deps
+        run: npm install
+      - name: Build Storybook
+        run: npm run build-storybook


### PR DESCRIPTION
Based on https://github.com/RecordReplay/devtools/pull/5668#discussion_r822208891, this adds Storybook to CI as a job that enables us to catch when we break Storybook asap.