### PR TITLE
Small network monitor visual fixes

### DIFF
--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -36,10 +36,9 @@ const RequestDetailsTabs: FC<{ children?: ReactNode }> = ({ children }) => {
   return (
     <div
       className={classNames(
-        "sticky top-0 z-10 flex items-center justify-between border-b border-themeBorder bg-toolbarBackground",
+        "sticky top-0 z-10 flex items-center justify-between bg-toolbarBackground",
         styles.border
       )}
-      style={{ height: 25 }}
     >
       {children}
     </div>
@@ -298,10 +297,10 @@ const RequestDetails = ({
   }, [activeTab, activeTabs]);
 
   return (
-    <div className="min-w-full overflow-y-scroll bg-themeBodyBackground">
+    <div className="no-scrollbar min-w-full overflow-y-scroll border-l border-themeBorder bg-themeBodyBackground">
       <RequestDetailsTabs>
         <PanelTabs tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
-        <CloseButton buttonClass="mr-4" handleClick={closePanel} tooltip={"Close tab"} />
+        <CloseButton buttonClass="mr-2" handleClick={closePanel} tooltip={"Close tab"} />
       </RequestDetailsTabs>
       <div className={classNames("requestDetails", styles.requestDetails)}>
         <div>

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -121,21 +121,15 @@ export const NetworkMonitor = ({
               selectedRequest ? (
                 loadedRegions &&
                 getPointIsInLoadedRegion(loadedRegions, selectedRequest.point.point) ? (
-                  <div
-                    style={{
-                      borderLeft: "1px solid var(--theme-border)",
-                    }}
-                  >
-                    <RequestDetails
-                      closePanel={closePanel}
-                      cx={cx}
-                      request={selectedRequest}
-                      responseBody={responseBodies[selectedRequest.id]}
-                      requestBody={requestBodies[selectedRequest.id]}
-                      frames={frames[selectedRequest?.point.point]}
-                      selectFrame={selectFrame}
-                    />
-                  </div>
+                  <RequestDetails
+                    closePanel={closePanel}
+                    cx={cx}
+                    request={selectedRequest}
+                    responseBody={responseBodies[selectedRequest.id]}
+                    requestBody={requestBodies[selectedRequest.id]}
+                    frames={frames[selectedRequest?.point.point]}
+                    selectFrame={selectFrame}
+                  />
                 ) : (
                   <RequestDetailsUnavailable closePanel={closePanel} />
                 )


### PR DESCRIPTION
The request details were misbehaving when their content was not large enough to fill the container.

Before
---
![CleanShot 2022-03-09 at 16 35 32](https://user-images.githubusercontent.com/5903784/157563560-c9ca15e2-8261-4282-96e2-2da369eec7f4.png)

After
---
![CleanShot 2022-03-09 at 16 36 54](https://user-images.githubusercontent.com/5903784/157563608-6f60b135-5c97-4e9a-a382-192c6fb61023.png)
 