### PR TITLE
Add "Jump to definition" button to getters (#5617)

### DIFF
--- a/src/devtools/client/debugger/src/actions/preview.js
+++ b/src/devtools/client/debugger/src/actions/preview.js
@@ -5,7 +5,7 @@
 import { isConsole } from "../utils/preview";
 import { getExpressionFromCoords } from "../utils/editor/get-expression";
 import { createPrimitiveValueFront } from "protocol/thread";
-import { ValueItem, loadChildren } from "devtools/packages/devtools-reps";
+import { ValueItem } from "devtools/packages/devtools-reps";
 
 import {
   getPreview,
@@ -78,7 +78,7 @@ export function setPreview(cx, expression, location, tokenPos, cursorPos, target
       path: expression,
       contents: result,
     });
-    const properties = await loadChildren(root);
+    const properties = await root.loadChildren();
 
     // The first time a popup is rendered, the mouse should be hovered
     // on the token. If it happens to be hovered on whitespace, it should

--- a/src/devtools/packages/devtools-reps/index.ts
+++ b/src/devtools/packages/devtools-reps/index.ts
@@ -8,7 +8,6 @@ import {
   LoadingItem,
   Item,
   KeyValueItem,
-  loadChildren,
 } from "./object-inspector/utils";
 
 export type { Item };
@@ -23,5 +22,4 @@ export {
   ValueItem,
   KeyValueItem,
   getGripPreviewItems,
-  loadChildren,
 };

--- a/src/devtools/packages/devtools-reps/object-inspector/components/ObjectInspectorItem.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/components/ObjectInspectorItem.tsx
@@ -8,6 +8,7 @@ import React, { HTMLProps, PureComponent, ReactNode } from "react";
 import classnames from "classnames";
 import { Item, documentHasSelection } from "../utils";
 import { trackEvent } from "ui/utils/telemetry";
+import { DebuggerLocation } from "devtools/client/webconsole/actions";
 
 export interface ObjectInspectorItemProps {
   item: Item;
@@ -32,6 +33,7 @@ export interface ObjectInspectorItemProps {
       setExpanded: (item: Item, expand: boolean) => void;
     }
   ) => void;
+  onViewSourceInDebugger: (location: DebuggerLocation) => void;
   renderItemActions: (item: Item) => ReactNode;
   forceUpdate: () => void;
 }

--- a/src/devtools/packages/devtools-reps/object-inspector/utils/container.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/utils/container.tsx
@@ -1,3 +1,4 @@
+import { assert } from "protocol/utils";
 import { IItem, Item, LabelAndValue } from ".";
 
 export class ContainerItem implements IItem {
@@ -22,5 +23,10 @@ export class ContainerItem implements IItem {
 
   getChildren(): Item[] {
     return this.contents;
+  }
+
+  shouldUpdate(prevItem: Item) {
+    assert(this.type === prevItem.type, "OI items for the same path must have the same type");
+    return false;
   }
 }

--- a/src/devtools/packages/devtools-reps/object-inspector/utils/keyValue.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/utils/keyValue.tsx
@@ -1,5 +1,6 @@
 import { ValueFront } from "protocol/thread";
-import { IItem, Item, LabelAndValue, ValueItem } from ".";
+import { assert } from "protocol/utils";
+import { IItem, isValueLoaded, Item, LabelAndValue, ValueItem } from ".";
 import { ObjectInspectorItemProps } from "../components/ObjectInspectorItem";
 const PropRep = require("../../reps/prop-rep");
 
@@ -9,12 +10,14 @@ export class KeyValueItem implements IItem {
   path: string;
   key: ValueFront;
   value: ValueFront;
+  childrenLoaded: boolean;
 
   constructor(opts: { name: string; path: string; key: ValueFront; value: ValueFront }) {
     this.name = opts.name;
     this.path = opts.path;
     this.key = opts.key;
     this.value = opts.value;
+    this.childrenLoaded = isValueLoaded(this.key) && isValueLoaded(this.value);
   }
 
   isPrimitive(): boolean {
@@ -44,5 +47,10 @@ export class KeyValueItem implements IItem {
       new ValueItem({ parent: this, name: "<key>", contents: this.key }),
       new ValueItem({ parent: this, name: "<value>", contents: this.value }),
     ];
+  }
+
+  shouldUpdate(prevItem: Item) {
+    assert(this.type === prevItem.type, "OI items for the same path must have the same type");
+    return this.childrenLoaded !== prevItem.childrenLoaded;
   }
 }

--- a/src/devtools/packages/devtools-reps/object-inspector/utils/loading.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/utils/loading.tsx
@@ -1,3 +1,4 @@
+import { assert } from "protocol/utils";
 import { IItem, Item, LabelAndValue } from ".";
 
 export class LoadingItem implements IItem {
@@ -19,5 +20,10 @@ export class LoadingItem implements IItem {
 
   getChildren(): Item[] {
     return [];
+  }
+
+  shouldUpdate(prevItem: Item) {
+    assert(this.type === prevItem.type, "OI items for the same path must have the same type");
+    return false;
   }
 }


### PR DESCRIPTION
- adds "Jump to definition" button to getters
- implicitly adds the same button to functions appearing in the Scopes panel (by adding onViewSourceInDebugger to the ObjectInspector props) - previously they were only present in the console and the popup that appears when hovering over a variable in a paused source
- moves the logic for loading children to the ValueItem class
- moves the logic deciding whether an item needs to be rerendered to the *Item classes
- fixes updating key-value items