### PR TITLE
Continue to here

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -2,6 +2,7 @@ import { PointDescription } from "@recordreplay/protocol";
 import React, { useRef, useState, useEffect, ReactNode } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setHoveredLineNumberLocation } from "ui/actions/app";
+import { KeyModifiers } from "ui/components/KeyModifiers";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
@@ -63,11 +64,11 @@ function Wrapper({
   return <div className="static-tooltip-content bg-gray-700">{children}</div>;
 }
 
-export default function LineNumberTooltip({ editor }: { editor: any }) {
+export default function LineNumberTooltip({ editor, keyModifiers }: { editor: any; keyModifiers: KeyModifiers }) {
   const dispatch = useDispatch();
   const [targetNode, setTargetNode] = useState<HTMLElement | null>(null);
   const lastHoveredLineNumber = useRef<number | null>(null);
-  const isMetaActive = useSelector(selectors.getIsMetaActive);
+  const isMetaActive = keyModifiers.meta;
 
   const indexed = useSelector(selectors.getIndexed);
   const analysisPoints = useSelector(selectors.getPointsForHoveredLineNumber);

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -67,6 +67,7 @@ export default function LineNumberTooltip({ editor }: { editor: any }) {
   const dispatch = useDispatch();
   const [targetNode, setTargetNode] = useState<HTMLElement | null>(null);
   const lastHoveredLineNumber = useRef<number | null>(null);
+  const isMetaActive = useSelector(selectors.getIsMetaActive);
 
   const indexed = useSelector(selectors.getIndexed);
   const analysisPoints = useSelector(selectors.getPointsForHoveredLineNumber);
@@ -117,7 +118,7 @@ export default function LineNumberTooltip({ editor }: { editor: any }) {
     }
   }, [analysisPoints]);
 
-  if (!targetNode) {
+  if (!targetNode || isMetaActive) {
     return null;
   }
 

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -64,7 +64,13 @@ function Wrapper({
   return <div className="static-tooltip-content bg-gray-700">{children}</div>;
 }
 
-export default function LineNumberTooltip({ editor, keyModifiers }: { editor: any; keyModifiers: KeyModifiers }) {
+export default function LineNumberTooltip({
+  editor,
+  keyModifiers,
+}: {
+  editor: any;
+  keyModifiers: KeyModifiers;
+}) {
   const dispatch = useDispatch();
   const [targetNode, setTargetNode] = useState<HTMLElement | null>(null);
   const lastHoveredLineNumber = useRef<number | null>(null);

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -13,6 +13,7 @@ import hooks from "ui/hooks";
 import { shouldShowNag } from "ui/utils/user";
 import { Nag } from "ui/hooks/users";
 import { AWESOME_BACKGROUND } from "./LineNumberTooltip";
+import { KeyModifiers, KeyModifiersContext } from "ui/components/KeyModifiers";
 
 const { runAnalysisOnLine } = require("devtools/client/debugger/src/actions/breakpoints/index");
 const {
@@ -22,16 +23,18 @@ const {
 function ToggleButton({
   onClick,
   onMouseDown,
+  keyModifiers,
   targetNode,
   breakpoint,
 }: {
   onClick: MouseEventHandler;
   onMouseDown: MouseEventHandler;
+  keyModifiers: KeyModifiers;
   targetNode: HTMLElement;
   breakpoint?: Breakpoint;
 }) {
-  const isMetaActive = useSelector(selectors.getIsMetaActive);
-  const isShiftActive = useSelector(selectors.getIsShiftActive);
+  const isMetaActive = keyModifiers.meta;
+  const isShiftActive = keyModifiers.shift;
   const { nags } = hooks.useGetUserInfo();
   const showNag = shouldShowNag(nags, Nag.FIRST_BREAKPOINT_ADD);
 
@@ -134,12 +137,17 @@ function ToggleWidgetButton({ editor, toggleLogpoint, cx, breakpoints }: ToggleW
   }
 
   return ReactDOM.createPortal(
-    <ToggleButton
-      onClick={onClick}
-      onMouseDown={onMouseDown}
-      targetNode={targetNode}
-      breakpoint={bp}
-    />,
+    <KeyModifiersContext.Consumer>
+      {keyModifiers => (
+        <ToggleButton
+          onClick={onClick}
+          onMouseDown={onMouseDown}
+          targetNode={targetNode}
+          breakpoint={bp}
+          keyModifiers={keyModifiers}
+        />
+      )}
+    </KeyModifiersContext.Consumer>,
     targetNode
   );
 }

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from "react-dom";
-import React, { useState, useEffect, MouseEventHandler } from "react";
-import { connect, ConnectedProps, useSelector } from "react-redux";
+import React, { useState, useEffect, MouseEventHandler, FC, ReactNode } from "react";
+import { connect, ConnectedProps, useDispatch, useSelector } from "react-redux";
 import { actions } from "ui/actions";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { selectors } from "ui/reducers";
@@ -14,76 +14,127 @@ import { shouldShowNag } from "ui/utils/user";
 import { Nag } from "ui/hooks/users";
 import { AWESOME_BACKGROUND } from "./LineNumberTooltip";
 import { KeyModifiers, KeyModifiersContext } from "ui/components/KeyModifiers";
+import findLast from "lodash/findLast";
+import find from "lodash/find";
+import { getPointsForHoveredLineNumber } from "ui/reducers/app";
+import { compareNumericStrings } from "protocol/utils";
+import { getExecutionPoint } from "../../reducers/pause";
+import { PointDescription } from "@recordreplay/protocol";
+import { seek } from "ui/actions/timeline";
 
 const { runAnalysisOnLine } = require("devtools/client/debugger/src/actions/breakpoints/index");
 const {
   updateHoveredLineNumber,
 } = require("devtools/client/debugger/src/actions/breakpoints/index");
 
-function ToggleButton({
+const QuickActionButton: FC<{
+  showNag: boolean;
+  children: ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}> = ({ showNag, disabled, children, onClick }) => {
+  return (
+    <button
+      className={classNames(
+        "toggle-widget",
+        "flex rounded-md p-px leading-3 text-white shadow-lg transition hover:scale-125",
+        `${disabled ? "bg-gray-600" : "bg-primaryAccent"}`
+      )}
+      onClick={disabled ? () => {} : onClick}
+      style={{ background: showNag ? AWESOME_BACKGROUND : "" }}
+    >
+      {children}
+    </button>
+  );
+};
+
+const ContinueToPrevious: FC<{ showNag: boolean; onClick: () => void; disabled: boolean }> = ({
+  showNag,
   onClick,
-  onMouseDown,
+  disabled,
+}) => (
+  <QuickActionButton showNag={showNag} onClick={onClick} disabled={disabled}>
+    <MaterialIcon>navigate_before</MaterialIcon>
+  </QuickActionButton>
+);
+const ContinueToNext: FC<{ showNag: boolean; onClick: () => void; disabled: boolean }> = ({
+  showNag,
+  onClick,
+  disabled,
+}) => (
+  <QuickActionButton showNag={showNag} onClick={onClick} disabled={disabled}>
+    <MaterialIcon>navigate_next</MaterialIcon>
+  </QuickActionButton>
+);
+const AddLogpoint: FC<{ showNag: boolean; onClick: () => void; breakpoint?: Breakpoint }> = ({
+  showNag,
+  onClick,
+  breakpoint,
+}) => {
+  const icon = breakpoint?.options.logValue ? "remove" : "add";
+
+  return (
+    <QuickActionButton showNag={showNag} onClick={onClick}>
+      <MaterialIcon>{icon}</MaterialIcon>
+    </QuickActionButton>
+  );
+};
+
+function QuickActions({
+  hoveredLineNumber,
   keyModifiers,
   targetNode,
   breakpoint,
+  cx,
 }: {
-  onClick: MouseEventHandler;
+  hoveredLineNumber: number;
   onMouseDown: MouseEventHandler;
   keyModifiers: KeyModifiers;
   targetNode: HTMLElement;
   breakpoint?: Breakpoint;
+  cx: any;
 }) {
   const isMetaActive = keyModifiers.meta;
   const isShiftActive = keyModifiers.shift;
+  const dispatch = useDispatch();
+  const analysisPoints = useSelector(getPointsForHoveredLineNumber);
+  const executionPoint = useSelector(getExecutionPoint);
   const { nags } = hooks.useGetUserInfo();
   const showNag = shouldShowNag(nags, Nag.FIRST_BREAKPOINT_ADD);
-
-  const icon = breakpoint?.options.logValue ? "remove" : "add";
   const { height } = targetNode.getBoundingClientRect();
-  const style = {
-    background: showNag ? AWESOME_BACKGROUND : "",
+
+  const onAddLogpoint = () => {
+    dispatch(toggleLogpoint(cx, hoveredLineNumber, breakpoint));
+  };
+
+  let prev: PointDescription | undefined, next: PointDescription | undefined;
+
+  if (analysisPoints && analysisPoints !== "error" && executionPoint) {
+    prev = findLast(analysisPoints, p => compareNumericStrings(p.point, executionPoint) < 0);
+    next = find(analysisPoints, p => compareNumericStrings(p.point, executionPoint) > 0);
+  }
+
+  const onContinueToNext = () => {
+    if (next) {
+      dispatch(seek(next.point, next.time, true));
+    }
+  };
+  const onContinueToPrevious = () => {
+    if (prev) {
+      dispatch(seek(prev.point, prev.time, true));
+    }
   };
 
   let button;
 
   if (isMetaActive && isShiftActive) {
     button = (
-      <button
-        className={classNames(
-          "toggle-widget bg-primaryAccent",
-          "flex rounded-md p-px leading-3 text-white shadow-lg transition hover:scale-125"
-        )}
-        style={style}
-      >
-        <MaterialIcon>navigate_before</MaterialIcon>
-      </button>
+      <ContinueToPrevious showNag={showNag} onClick={onContinueToPrevious} disabled={!prev} />
     );
   } else if (isMetaActive) {
-    button = (
-      <button
-        className={classNames(
-          "toggle-widget bg-primaryAccent",
-          "flex rounded-md p-px leading-3 text-white shadow-lg transition hover:scale-125"
-        )}
-        style={style}
-      >
-        <MaterialIcon>navigate_next</MaterialIcon>
-      </button>
-    );
+    button = <ContinueToNext showNag={showNag} onClick={onContinueToNext} disabled={!next} />;
   } else {
-    button = (
-      <button
-        className={classNames(
-          "toggle-widget bg-primaryAccent",
-          "flex rounded-md p-px leading-3 text-white shadow-lg transition hover:scale-125"
-        )}
-        style={style}
-        onClick={onClick}
-        onMouseDown={onMouseDown}
-      >
-        <MaterialIcon>{icon}</MaterialIcon>
-      </button>
-    );
+    button = <AddLogpoint breakpoint={breakpoint} showNag={showNag} onClick={onAddLogpoint} />;
   }
 
   return (
@@ -98,7 +149,7 @@ function ToggleButton({
 
 type ToggleWidgetButtonProps = PropsFromRedux & { editor: any };
 
-function ToggleWidgetButton({ editor, toggleLogpoint, cx, breakpoints }: ToggleWidgetButtonProps) {
+function ToggleWidgetButton({ editor, cx, breakpoints }: ToggleWidgetButtonProps) {
   const [targetNode, setTargetNode] = useState<HTMLElement | null>(null);
   const [hoveredLineNumber, setHoveredLineNumber] = useState<number | null>(null);
 
@@ -115,14 +166,6 @@ function ToggleWidgetButton({ editor, toggleLogpoint, cx, breakpoints }: ToggleW
     // This keeps the cursor in CodeMirror from moving after clicking on the button.
     e.stopPropagation();
   };
-  const onClick = () => {
-    if (!hoveredLineNumber) {
-      return;
-    }
-
-    toggleLogpoint(cx, hoveredLineNumber, bp);
-  };
-
   useEffect(() => {
     editor.codeMirror.on("lineMouseEnter", onLineEnter);
     editor.codeMirror.on("lineMouseLeave", onLineLeave);
@@ -132,18 +175,19 @@ function ToggleWidgetButton({ editor, toggleLogpoint, cx, breakpoints }: ToggleW
     };
   }, []);
 
-  if (!targetNode) {
+  if (!targetNode || !hoveredLineNumber) {
     return null;
   }
 
   return ReactDOM.createPortal(
     <KeyModifiersContext.Consumer>
       {keyModifiers => (
-        <ToggleButton
-          onClick={onClick}
+        <QuickActions
+          hoveredLineNumber={hoveredLineNumber}
           onMouseDown={onMouseDown}
           targetNode={targetNode}
           breakpoint={bp}
+          cx={cx}
           keyModifiers={keyModifiers}
         />
       )}
@@ -155,7 +199,6 @@ function ToggleWidgetButton({ editor, toggleLogpoint, cx, breakpoints }: ToggleW
 const connector = connect(
   (state: UIState) => ({
     indexed: selectors.getIndexed(state),
-    analysisPoints: selectors.getPointsForHoveredLineNumber(state),
     cx: selectors.getThreadContext(state),
     breakpoints: getBreakpointsForSource(state, getSelectedSource(state).id),
   }),
@@ -163,7 +206,6 @@ const connector = connect(
     runAnalysisOnLine: runAnalysisOnLine,
     setHoveredLineNumberLocation: actions.setHoveredLineNumberLocation,
     updateHoveredLineNumber: updateHoveredLineNumber,
-    toggleLogpoint,
   }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from "react-dom";
 import React, { useState, useEffect, MouseEventHandler } from "react";
-import { connect, ConnectedProps } from "react-redux";
+import { connect, ConnectedProps, useSelector } from "react-redux";
 import { actions } from "ui/actions";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { selectors } from "ui/reducers";
@@ -30,28 +30,66 @@ function ToggleButton({
   targetNode: HTMLElement;
   breakpoint?: Breakpoint;
 }) {
+  const isMetaActive = useSelector(selectors.getIsMetaActive);
+  const isShiftActive = useSelector(selectors.getIsShiftActive);
   const { nags } = hooks.useGetUserInfo();
   const showNag = shouldShowNag(nags, Nag.FIRST_BREAKPOINT_ADD);
 
   const icon = breakpoint?.options.logValue ? "remove" : "add";
   const { height } = targetNode.getBoundingClientRect();
   const style = {
-    top: `${(1 / 2) * height}px`,
     background: showNag ? AWESOME_BACKGROUND : "",
   };
 
+  let button;
+
+  if (isMetaActive && isShiftActive) {
+    button = (
+      <button
+        className={classNames(
+          "toggle-widget bg-primaryAccent",
+          "flex rounded-md p-px leading-3 text-white shadow-lg transition hover:scale-125"
+        )}
+        style={style}
+      >
+        <MaterialIcon>navigate_before</MaterialIcon>
+      </button>
+    );
+  } else if (isMetaActive) {
+    button = (
+      <button
+        className={classNames(
+          "toggle-widget bg-primaryAccent",
+          "flex rounded-md p-px leading-3 text-white shadow-lg transition hover:scale-125"
+        )}
+        style={style}
+      >
+        <MaterialIcon>navigate_next</MaterialIcon>
+      </button>
+    );
+  } else {
+    button = (
+      <button
+        className={classNames(
+          "toggle-widget bg-primaryAccent",
+          "flex rounded-md p-px leading-3 text-white shadow-lg transition hover:scale-125"
+        )}
+        style={style}
+        onClick={onClick}
+        onMouseDown={onMouseDown}
+      >
+        <MaterialIcon>{icon}</MaterialIcon>
+      </button>
+    );
+  }
+
   return (
-    <button
-      className={classNames(
-        "toggle-widget bg-primaryAccent",
-        "absolute z-50 flex -translate-y-1/2 transform rounded-md p-px leading-3 text-white shadow-lg transition hover:scale-125"
-      )}
-      style={style}
-      onClick={onClick}
-      onMouseDown={onMouseDown}
+    <div
+      className="absolute z-50 flex flex-row space-x-px transform -translate-y-1/2"
+      style={{ top: `${(1 / 2) * height}px` }}
     >
-      <MaterialIcon>{icon}</MaterialIcon>
-    </button>
+      {button}
+    </div>
   );
 }
 

--- a/src/devtools/client/debugger/src/components/Editor/index.js
+++ b/src/devtools/client/debugger/src/components/Editor/index.js
@@ -32,7 +32,7 @@ import HighlightLine from "./HighlightLine";
 import HighlightLines from "./HighlightLines";
 import EditorLoadingBar from "./EditorLoadingBar";
 import { EditorNag } from "ui/components/shared/Nags/Nags";
-import WelcomeBox from "../WelcomeBox";
+import { KeyModifiersContext } from "ui/components/KeyModifiers";
 
 import {
   showSourceText,
@@ -437,7 +437,11 @@ class Editor extends PureComponent {
         <EmptyLines editor={editor} />
         <Breakpoints editor={editor} cx={cx} />
         <Preview editor={editor} editorRef={this.$editorWrapper} />
-        <LineNumberTooltip editor={editor} />
+        {
+          <KeyModifiersContext.Consumer>
+            {keyModifiers => <LineNumberTooltip editor={editor} keyModifiers={keyModifiers} />}
+          </KeyModifiersContext.Consumer>
+        }
         <ToggleWidgetButton editor={editor} />
         <HighlightLines editor={editor} />
         {

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -21,7 +21,6 @@ import {
   EventKind,
   ReplayEvent,
   ReplayNavigationEvent,
-  KeyModifiers,
 } from "ui/state/app";
 import { Workspace } from "ui/types";
 import { client, sendMessage } from "protocol/socket";
@@ -94,10 +93,6 @@ export type SetRecordingWorkspaceAction = Action<"set_recording_workspace"> & {
 export type SetLoadedRegions = Action<"set_loaded_regions"> & {
   parameters: loadedRegions;
 };
-export type SetMetaKeyActiveAction = Action<"set_key_modifier"> & {
-  value: boolean;
-  key: keyof KeyModifiers;
-};
 export type SetMouseTargetsLoading = Action<"mouse_targets_loading"> & {
   loading: boolean;
 };
@@ -127,8 +122,7 @@ export type AppActions =
   | SetRecordingTargetAction
   | SetRecordingWorkspaceAction
   | SetLoadedRegions
-  | SetAwaitingSourcemapsAction
-  | SetMetaKeyActiveAction;
+  | SetAwaitingSourcemapsAction;
 
 export function setupApp(store: UIStore) {
   if (!isTest()) {
@@ -357,13 +351,6 @@ export function loadMouseTargets(): UIThunkAction {
       dispatch(setIsNodePickerActive(true));
     }
   };
-}
-
-export function setMetaKeyActive(value: boolean): SetMetaKeyActiveAction {
-  return { type: "set_key_modifier", key: "meta", value };
-}
-export function setShiftKeyActive(value: boolean): SetMetaKeyActiveAction {
-  return { type: "set_key_modifier", key: "shift", value };
 }
 
 export function executeCommand(key: CommandKey): UIThunkAction {

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -21,6 +21,7 @@ import {
   EventKind,
   ReplayEvent,
   ReplayNavigationEvent,
+  KeyModifiers,
 } from "ui/state/app";
 import { Workspace } from "ui/types";
 import { client, sendMessage } from "protocol/socket";
@@ -93,7 +94,10 @@ export type SetRecordingWorkspaceAction = Action<"set_recording_workspace"> & {
 export type SetLoadedRegions = Action<"set_loaded_regions"> & {
   parameters: loadedRegions;
 };
-
+export type SetMetaKeyActiveAction = Action<"set_key_modifier"> & {
+  value: boolean;
+  key: keyof KeyModifiers;
+};
 export type SetMouseTargetsLoading = Action<"mouse_targets_loading"> & {
   loading: boolean;
 };
@@ -123,7 +127,8 @@ export type AppActions =
   | SetRecordingTargetAction
   | SetRecordingWorkspaceAction
   | SetLoadedRegions
-  | SetAwaitingSourcemapsAction;
+  | SetAwaitingSourcemapsAction
+  | SetMetaKeyActiveAction;
 
 export function setupApp(store: UIStore) {
   if (!isTest()) {
@@ -352,6 +357,13 @@ export function loadMouseTargets(): UIThunkAction {
       dispatch(setIsNodePickerActive(true));
     }
   };
+}
+
+export function setMetaKeyActive(value: boolean): SetMetaKeyActiveAction {
+  return { type: "set_key_modifier", key: "meta", value };
+}
+export function setShiftKeyActive(value: boolean): SetMetaKeyActiveAction {
+  return { type: "set_key_modifier", key: "shift", value };
 }
 
 export function executeCommand(key: CommandKey): UIThunkAction {

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -27,6 +27,7 @@ import KeyboardShortcuts from "./KeyboardShortcuts";
 import { useUserIsAuthor } from "ui/hooks/users";
 import { CommandPaletteModal } from "./CommandPalette/CommandPaletteModal";
 import useAuth0 from "ui/utils/useAuth0";
+import { KeyModifiers } from "./KeyModifiers";
 
 const DevView = React.lazy(() => import("./Views/DevView"));
 
@@ -130,6 +131,7 @@ function _DevTools({
       )}
       {showCommandPalette ? <CommandPaletteModal /> : null}
       <KeyboardShortcuts />
+      <KeyModifiers />
     </>
   );
 }

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -120,7 +120,7 @@ function _DevTools({
   }
 
   return (
-    <>
+    <KeyModifiers>
       <Header />
       {viewMode == "dev" ? (
         <React.Suspense fallback={<ViewLoader />}>
@@ -131,8 +131,7 @@ function _DevTools({
       )}
       {showCommandPalette ? <CommandPaletteModal /> : null}
       <KeyboardShortcuts />
-      <KeyModifiers />
-    </>
+    </KeyModifiers>
   );
 }
 

--- a/src/ui/components/KeyModifiers.tsx
+++ b/src/ui/components/KeyModifiers.tsx
@@ -28,14 +28,13 @@ export const KeyModifiers: FC<{ children: ReactNode }> = ({ children }) => {
       setShift(false);
     }
   };
-  const onMouseMove = debounce((e: MouseEvent) => {
-    console.log("Reset");
+  const onMouseMove = (e: MouseEvent) => {
     if (!e.metaKey) {
       setMeta(false);
     } else if (!e.shiftKey) {
       setShift(false);
     }
-  }, 100);
+  };
 
   useEffect(() => {
     window.addEventListener("keydown", onKeyDown);

--- a/src/ui/components/KeyModifiers.tsx
+++ b/src/ui/components/KeyModifiers.tsx
@@ -1,0 +1,53 @@
+import { FC, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { setMetaKeyActive, setShiftKeyActive } from "ui/actions/app";
+import { getIsMetaActive, getIsShiftActive } from "ui/reducers/app";
+
+export const KeyModifiers: FC = () => {
+  const dispatch = useDispatch();
+  const isMetaActive = useSelector(getIsMetaActive);
+  const isShiftActive = useSelector(getIsShiftActive);
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.metaKey) {
+      dispatch(setMetaKeyActive(true));
+    }
+    if (e.shiftKey) {
+      dispatch(setShiftKeyActive(true));
+    }
+  };
+  const onKeyUp = (e: KeyboardEvent) => {
+    if (e.key === "Meta") {
+      dispatch(setMetaKeyActive(false));
+    } else if (e.key === "Shift") {
+      dispatch(setShiftKeyActive(false));
+    }
+  };
+  const onMouseMove = (e: MouseEvent) => {
+    if (!e.metaKey) {
+      dispatch(setMetaKeyActive(false));
+    } else if (!e.shiftKey) {
+      dispatch(setShiftKeyActive(false));
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+
+    if (isMetaActive || isShiftActive) {
+      window.addEventListener("mousemove", onMouseMove);
+    }
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+
+      if (isMetaActive || isShiftActive) {
+        window.removeEventListener("mousemove", onMouseMove);
+      }
+    };
+  });
+
+  return null;
+};

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import KeyShortcuts from "devtools/client/shared/key-shortcuts";
 import { usesWindow } from "ssr";
 import { connect, ConnectedProps } from "react-redux";

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -2,7 +2,6 @@ import { AppState, EventKind, ReplayEvent } from "ui/state/app";
 import { AppActions } from "ui/actions/app";
 import { UIState } from "ui/state";
 import { SessionActions } from "ui/actions/session";
-import { features } from "../utils/prefs";
 import { Location } from "@recordreplay/protocol";
 import { getLocationAndConditionKey } from "devtools/client/debugger/src/utils/breakpoint";
 import { isInTrimSpan, isSameTimeStampedPointRange } from "ui/utils/timeline";
@@ -41,7 +40,6 @@ export const initialAppState: AppState = {
   videoUrl: null,
   workspaceId: null,
   currentPoint: null,
-  keyModifiers: { shift: false, meta: false },
 };
 
 export default function update(
@@ -212,13 +210,6 @@ export default function update(
       };
     }
 
-    case "set_key_modifier": {
-      return {
-        ...state,
-        keyModifiers: { ...state.keyModifiers, [action.key]: action.value },
-      };
-    }
-
     default: {
       return state;
     }
@@ -333,5 +324,3 @@ export const isFinishedLoadingRegions = (state: UIState) => {
 export const getIsFocusing = (state: UIState) => getModal(state) === "focusing";
 export const areMouseTargetsLoading = (state: UIState) => state.app.mouseTargetsLoading;
 export const getCurrentPoint = (state: UIState) => state.app.currentPoint;
-export const getIsMetaActive = (state: UIState) => state.app.keyModifiers.meta;
-export const getIsShiftActive = (state: UIState) => state.app.keyModifiers.shift;

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -41,6 +41,7 @@ export const initialAppState: AppState = {
   videoUrl: null,
   workspaceId: null,
   currentPoint: null,
+  keyModifiers: { shift: false, meta: false },
 };
 
 export default function update(
@@ -211,6 +212,13 @@ export default function update(
       };
     }
 
+    case "set_key_modifier": {
+      return {
+        ...state,
+        keyModifiers: { ...state.keyModifiers, [action.key]: action.value },
+      };
+    }
+
     default: {
       return state;
     }
@@ -325,3 +333,5 @@ export const isFinishedLoadingRegions = (state: UIState) => {
 export const getIsFocusing = (state: UIState) => getModal(state) === "focusing";
 export const areMouseTargetsLoading = (state: UIState) => state.app.mouseTargetsLoading;
 export const getCurrentPoint = (state: UIState) => state.app.currentPoint;
+export const getIsMetaActive = (state: UIState) => state.app.keyModifiers.meta;
+export const getIsShiftActive = (state: UIState) => state.app.keyModifiers.shift;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -98,6 +98,12 @@ export interface AppState {
   workspaceId: WorkspaceId | null;
   mouseTargetsLoading: boolean;
   currentPoint: ExecutionPoint | null;
+  keyModifiers: KeyModifiers;
+}
+
+export interface KeyModifiers {
+  meta: boolean;
+  shift: boolean;
 }
 
 export interface AnalysisPoints {

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -98,12 +98,6 @@ export interface AppState {
   workspaceId: WorkspaceId | null;
   mouseTargetsLoading: boolean;
   currentPoint: ExecutionPoint | null;
-  keyModifiers: KeyModifiers;
-}
-
-export interface KeyModifiers {
-  meta: boolean;
-  shift: boolean;
 }
 
 export interface AnalysisPoints {


### PR DESCRIPTION
This adds a shortcut for getting a "Continue to here" button:
- We currently show a `+` when hovering over a line in the editor
- Holding down **Cmd/Ctrl** will swap the `+` for a "Fast-forward to this line" button
- Holding down **Cmd+Shift/Ctrl+Shift** will swap the `+` for a "Rewind to line" button
- Buttons are grayed out if:
  1. The hits for that line are still being loaded
  2. The action is not-applicable, i.e. user cannot fast forward to a line if there are no future hits from the current pause point.

Follow up items:
- Clicking on the button does not block CodeMirror click events. This leads to weird behavior like multiple cursors (Cmd+Click), or highlighting ranges (Cmd+Shift+Click). Not sure what to do here but didn't want it to block this shipping. Either there's some way to have a click on the button to not trigger CodeMirror click events, or we refactor the button so that it's rendered as an overlay that's not a child of the CodeMirror element.

https://user-images.githubusercontent.com/15959269/157912886-b22248cc-8605-43a4-9b39-7d270f31b534.mov


