### PR TITLE
Dont show unexpected errors in the sourcemap visualizer. fixes #5447

### DIFF
--- a/pages/recording/[id]/sourcemap/[sourceId].tsx
+++ b/pages/recording/[id]/sourcemap/[sourceId].tsx
@@ -1,10 +1,10 @@
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 import { initSocket, client } from "protocol/socket";
-import { useStore } from "react-redux";
+import { useDispatch, useStore } from "react-redux";
 import { UIStore } from "ui/actions";
 import { ExpectedError } from "ui/state/app";
-import { onUnprocessedRegions } from "ui/actions/app";
+import { onUnprocessedRegions, setAppMode } from "ui/actions/app";
 import { getAccessibleRecording, showLoadingProgress } from "ui/actions/session";
 import tokenManager from "ui/utils/tokenManager";
 import { useGetRecordingId } from "ui/hooks/recordings";
@@ -96,8 +96,11 @@ function SourcemapVisualizer({
   map: string;
   url: string | undefined;
 }) {
+  const dispatch = useDispatch();
+
   useEffect(() => {
     document.body.className = "sourcemap-visualizer";
+    dispatch(setAppMode("sourcemap-visualizer"));
     renderSourcemap(source, map, url, document);
   }, []);
 

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -21,6 +21,7 @@ import {
   EventKind,
   ReplayEvent,
   ReplayNavigationEvent,
+  AppMode,
 } from "ui/state/app";
 import { Workspace } from "ui/types";
 import { client, sendMessage } from "protocol/socket";
@@ -102,6 +103,7 @@ export type SetLoadedRegions = Action<"set_loaded_regions"> & {
 export type SetMouseTargetsLoading = Action<"mouse_targets_loading"> & {
   loading: boolean;
 };
+export type SetAppModeAction = Action<"set_app_mode"> & { mode: AppMode };
 
 export type AppActions =
   | SetRecordingDurationAction
@@ -127,7 +129,8 @@ export type AppActions =
   | SetRecordingTargetAction
   | SetRecordingWorkspaceAction
   | SetLoadedRegions
-  | SetAwaitingSourcemapsAction;
+  | SetAwaitingSourcemapsAction
+  | SetAppModeAction;
 
 export function setupApp(store: UIStore) {
   if (!isTest()) {
@@ -445,4 +448,8 @@ export function executeCommand(key: CommandKey): UIThunkAction {
       dispatch(hideCommandPalette());
     }
   };
+}
+
+export function setAppMode(mode: AppMode): SetAppModeAction {
+  return { type: "set_app_mode", mode };
 }

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -218,6 +218,13 @@ export default function update(
       };
     }
 
+    case "set_app_mode": {
+      return {
+        ...state,
+        mode: action.mode,
+      };
+    }
+
     default: {
       return state;
     }

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -69,6 +69,7 @@ export interface UploadInfo {
 }
 
 export interface AppState {
+  mode: AppMode;
   analysisPoints: AnalysisPoints;
   awaitingSourcemaps: boolean;
   canvas: Canvas | null;
@@ -109,6 +110,7 @@ export enum AnalysisError {
   TooManyPoints = "too-many-points",
   Default = "default",
 }
+export type AppMode = "devtools" | "sourcemap-visualizer";
 
 interface Events {
   [key: string]: ReplayEvent[];


### PR DESCRIPTION
Small fix to avoid showing error modals from unexpected errors in the visualizer. Fix #5447.