### PR TITLE
Fix jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,12 @@ module.exports = {
 
     // Handle module aliases
     "^@/components/(.*)$": "<rootDir>/components/$1",
+
+    "devtools/(.*)": "<rootDir>/src/devtools/$1",
+
+    "protocol/(.*)": "<rootDir>/src/protocol/$1",
+
+    ssr: "<rootDir>/src/ssr",
   },
   testEnvironment: "jsdom",
   testMatch: [

--- a/src/devtools/client/webconsole/utils/autocomplete.test.js
+++ b/src/devtools/client/webconsole/utils/autocomplete.test.js
@@ -1,15 +1,16 @@
 import { getAutocompleteMatches } from "./autocomplete";
+import { ValueFront } from "../../../../protocol/value";
 
 const MOCK_SCOPE = {
   bindings: [
     {
       name: "foo",
-      value: {
-        getObject: () => ({
+      value: new ValueFront(null, {
+        _object: {
           className: "Object",
           preview: { properties: [{ name: "bar" }, { name: "baz" }] },
-        }),
-      },
+        },
+      }),
     },
   ],
   parent: {},


### PR DESCRIPTION
- [x] extended jest module mappings
- [ ] fix the autocomplete test failing because the mock value is not a real `ValueFront`