### PR TITLE
Fix the initial size for the devtools toolbar

### DIFF
--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -181,8 +181,8 @@ class Debugger extends Component {
     const { startPanelCollapsed, toolboxLayout } = this.props;
 
     const isIde = toolboxLayout == "ide";
-    const onResize = num => {
-      prefs.sidePanelSize = `${num}px`;
+    const onResize = pxString => {
+      prefs.sidePanelSize = pxString;
     };
 
     return (


### PR DESCRIPTION
The `num` being passed into `onResize` was already a string, but this line assumed that it was a number that needed to be converted to a string (e.g. `123px`).

Fix #5733.