### PR TITLE
Fix API screen in dark mode

### DIFF
--- a/src/ui/components/shared/APIKeys.tsx
+++ b/src/ui/components/shared/APIKeys.tsx
@@ -23,7 +23,7 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
     <>
       <div className="flex items-center justify-between space-x-3">
         <div className="w-0 flex-auto">
-          <div className="flex h-9 w-full items-center rounded-md border border-textFieldBorder bg-blue-100 px-2.5">
+          <div className="flex h-9 w-full items-center rounded-md border border-textFieldBorder bg-blue-100 px-2.5 text-blue-800">
             <input
               readOnly
               value={keyValue}
@@ -50,7 +50,7 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
           Done
         </button>
       </div>
-      <div className="flex items-center rounded-md border border-textFieldBorder bg-red-100 p-2.5">
+      <div className="flex items-center rounded-md border border-textFieldBorder bg-red-100 p-2.5 text-red-800">
         Make sure to copy your API key now. You won{"'"}t be able to see it again!
       </div>
     </>

--- a/src/ui/components/shared/APIKeys.tsx
+++ b/src/ui/components/shared/APIKeys.tsx
@@ -23,11 +23,11 @@ function NewApiKey({ keyValue, onDone }: { keyValue: string; onDone: () => void 
     <>
       <div className="flex items-center justify-between space-x-3">
         <div className="w-0 flex-auto">
-          <div className="flex h-9 w-full items-center rounded-md border border-textFieldBorder bg-blue-100 px-2.5 text-blue-800">
+          <div className="flex h-9 w-full items-center rounded-md border border-textFieldBorder bg-blue-50 px-2.5 text-primaryAccent">
             <input
               readOnly
               value={keyValue}
-              className="flex-auto truncate bg-blue-100 focus:outline-none"
+              className="flex-auto truncate bg-blue-50 focus:outline-none"
               onFocus={ev => ev.target.setSelectionRange(0, keyValue.length)}
             />
             {copied ? (


### PR DESCRIPTION
Fixes #5786


Was:
![image](https://user-images.githubusercontent.com/9154902/158303328-d92c420f-81e3-41d0-a7b6-7505ffdb1159.png)

Now:
![image](https://user-images.githubusercontent.com/9154902/158303359-98c2da6c-b810-46a1-808b-ef6c256bcde0.png)

And here's light theme -- we don't even need to special-case it, because we're dealing with the textfields themselves, apart from the theme colours picked:

![image](https://user-images.githubusercontent.com/9154902/158303459-00d79094-a70e-46f5-90f9-1c42931df3b1.png)
