### PR TITLE
Fetch all hit counts at the same time

### DIFF
--- a/src/devtools/client/debugger/src/actions/sources/breakableLines.js
+++ b/src/devtools/client/debugger/src/actions/sources/breakableLines.js
@@ -4,28 +4,28 @@
 
 //
 
-import { getSourceActorsForSource, getBreakableLines } from "../../selectors";
-import { setBreakpointPositions } from "../breakpoints/breakpointPositions";
-import { loadSourceActorBreakableLines } from "../source-actors";
-
-function calculateBreakableLines(positions) {
-  const lines = [];
-  for (const line in positions) {
-    if (positions[line].length > 0) {
-      lines.push(Number(line));
-    }
-  }
-
-  return lines;
-}
+import { getSourceActorsForSource } from "../../selectors";
+import {
+  loadSourceActorBreakableLines,
+  loadSourceActorBreakpointHitCounts,
+} from "../source-actors";
 
 export function setBreakableLines(cx, sourceId) {
-  return async (dispatch, getState, { client }) => {
-    let breakableLines;
+  return async (dispatch, getState) => {
     const actors = getSourceActorsForSource(getState(), sourceId);
 
     await Promise.all(
       actors.map(actor => dispatch(loadSourceActorBreakableLines({ id: actor.id, cx })))
+    );
+  };
+}
+
+export function setBreakpointHitCounts(sourceId) {
+  return async (dispatch, getState) => {
+    const actors = getSourceActorsForSource(getState(), sourceId);
+
+    await Promise.all(
+      actors.map(actor => dispatch(loadSourceActorBreakpointHitCounts({ id: actor.id })))
     );
   };
 }

--- a/src/devtools/client/debugger/src/actions/sources/newSources.js
+++ b/src/devtools/client/debugger/src/actions/sources/newSources.js
@@ -9,7 +9,6 @@
  * @module actions/sources
  */
 
-import { stringToSourceActorId } from "../../reducers/source-actors";
 import { insertSourceActors } from "../../actions/source-actors";
 import { makeSourceId } from "../../client/create";
 import { toggleBlackBox } from "./blackbox";
@@ -229,13 +228,11 @@ export function newGeneratedSources(sourceInfo) {
         };
       }
 
-      const actorId = stringToSourceActorId(source.actor);
-
       // We are sometimes notified about a new source multiple times if we
       // request a new source list and also get a source event from the server.
-      if (!hasSourceActor(getState(), actorId)) {
+      if (!hasSourceActor(getState(), source.actor)) {
         newSourceActors.push({
-          id: actorId,
+          id: source.actor,
           actor: source.actor,
           thread,
           source: newId,

--- a/src/devtools/client/debugger/src/actions/sources/select.js
+++ b/src/devtools/client/debugger/src/actions/sources/select.js
@@ -15,7 +15,7 @@ import { setSymbols } from "./symbols";
 import { closeActiveSearch, updateActiveFileSearch } from "../ui";
 import { addTab } from "../tabs";
 import { loadSourceText } from "./loadSourceText";
-import { setBreakableLines } from ".";
+import { setBreakableLines, setBreakpointHitCounts } from ".";
 
 import { createLocation } from "../../utils/location";
 import { getToolboxLayout } from "ui/reducers/layout";
@@ -24,6 +24,8 @@ import { trackEvent } from "ui/utils/telemetry";
 import { paused } from "../pause/paused";
 
 import { ThreadFront } from "protocol/thread";
+
+import { prefs } from "devtools/shared/services";
 
 import {
   getSource,
@@ -139,7 +141,6 @@ export function selectLocation(cx, location, openSourcesTab = true) {
 
     await dispatch(loadSourceText({ source }));
     await dispatch(setBreakableLines(cx, source.id));
-
     // Set shownSource to null first, then the actual source to trigger
     // a proper re-render in the SourcesTree component
     dispatch({ type: "SHOW_SOURCE", source: null });

--- a/src/devtools/client/debugger/src/client/commands.js
+++ b/src/devtools/client/debugger/src/client/commands.js
@@ -332,6 +332,11 @@ async function getSourceActorBreakableLines({ actor }) {
   return positions.map(({ line }) => line);
 }
 
+async function getSourceActorBreakpointHitCounts({ actor, id }) {
+  const locations = await ThreadFront.getBreakpointPositionsCompressed(id);
+  return ThreadFront.getHitCounts(id, locations);
+}
+
 function getFrontByID(actorID) {
   return devToolsClient.getFrontByID(actorID);
 }
@@ -360,6 +365,7 @@ const clientCommands = {
   getSourceForActor,
   getSourceActorBreakpointPositions,
   getSourceActorBreakableLines,
+  getSourceActorBreakpointHitCounts,
   hasBreakpoint,
   setBreakpoint,
   setXHRBreakpoint,

--- a/src/devtools/client/debugger/src/reducers/sources.d.ts
+++ b/src/devtools/client/debugger/src/reducers/sources.d.ts
@@ -27,9 +27,11 @@ type SelectedLocation = {
   column?: number;
   sourceUrl: string;
 };
+export type HitCounts = any;
 
 export function getSelectedSourceWithContent(state: UIState): Source;
 export function getIsSourceMappedSource(state: UIState): boolean;
 export function getSources(state: UIState): Source[];
 export function getSelectedSource(state: UIState): Source;
 export function getSelectedLocation(state: UIState): SelectedLocation;
+export function getHitCounts(state: UIState): HitCounts;

--- a/src/devtools/client/debugger/src/reducers/sources.js
+++ b/src/devtools/client/debugger/src/reducers/sources.js
@@ -32,6 +32,7 @@ import {
   getSourceActor,
   getSourceActors,
   getBreakableLinesForSourceActors,
+  getSourceActorBreakpointHitCounts,
 } from "./source-actors";
 import uniq from "lodash/uniq";
 
@@ -554,6 +555,11 @@ export function getSourceContent(state, id) {
 export function getSelectedSourceId(state) {
   const source = getSelectedSource(state);
   return source && source.id;
+}
+
+export function getHitCounts(state) {
+  const id = getSelectedSourceId(state);
+  return getSourceActorBreakpointHitCounts(state, state.sources.actors[id]);
 }
 
 export const getDisplayedSources = createSelector(

--- a/src/devtools/client/debugger/src/selectors/index.d.ts
+++ b/src/devtools/client/debugger/src/selectors/index.d.ts
@@ -17,16 +17,17 @@ export interface SelectedFrame {
 
 export function getActiveSearch(state: UIState): any;
 export function getContext(state: UIState): any;
+export function getCursorPosition(state: UIState): any;
 export function getDebugLineLocation(state: UIState): UrlLocation | undefined;
 export function getPaneCollapse(state: UIState): boolean;
 export function getPausePreviewLocation(state: UIState): UrlLocation;
+export function getSelectedFrame(state: UIState): SelectedFrame;
 export function getSelectedPrimaryPaneTab(state: UIState): any;
+export function getSelectedSourceWithContent(state: UIState): any;
+export function getSourceActorsForSource(state: UIState, sourceId: string): any;
 export function getSourceWithContent(state: UIState, sourceId: string): any;
 export function getSourcesCollapsed(state: UIState): any;
+export function getSymbols(state: UIState, source: any): any;
 export function getThreadContext(state: UIState): any;
 export function getVisibleSelectedFrame(state: UIState): SelectedFrame | null;
 export function hasFrames(state: UIState): boolean;
-export function getSelectedSourceWithContent(state: UIState): any;
-export function getSymbols(state: UIState, source: any): any;
-export function getCursorPosition(state: UIState): any;
-export function getSelectedFrame(state: UIState): SelectedFrame | null;

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -36,7 +36,7 @@ import {
   responseBodyData,
   requestBodyData,
 } from "@recordreplay/protocol";
-import { client, log, addEventListener } from "../socket";
+import { client, log, addEventListener, sendMessage } from "../socket";
 import { defer, assert, EventEmitter, ArrayMap } from "../utils";
 import { MappedLocationCache } from "../mapped-location-cache";
 import { ValueFront } from "./value";
@@ -248,7 +248,6 @@ class _ThreadFront {
 
   async initializeToolbox() {
     await this.waitForSession();
-
     await this.initializedWaiter.promise;
     await this.ensureAllSources();
     this.ensureCurrentPause();
@@ -475,6 +474,16 @@ class _ThreadFront {
       this.sessionId
     );
     return { contents, contentType };
+  }
+
+  async getHitCounts(sourceId: SourceId, locations: SameLineSourceLocations[]) {
+    // @ts-ignore
+    return sendMessage(
+      // @ts-ignore
+      "Debugger.getHitCounts",
+      { sourceId, locations, maxHits: 10000 },
+      this.sessionId!
+    );
   }
 
   getBreakpointPositionsCompressed(

--- a/src/ui/components/shared/Forms/Checkbox.tsx
+++ b/src/ui/components/shared/Forms/Checkbox.tsx
@@ -11,7 +11,7 @@ export default function Checkbox({
     <input
       type="checkbox"
       className={classNames(
-        "h-4 w-4 rounded border-checkboxBorder bg-checkbox text-primaryAccent focus:ring-primaryAccent",
+        "h-4 w-4 cursor-pointer rounded border-checkboxBorder bg-checkbox text-primaryAccent focus:ring-primaryAccent",
         className
       )}
       {...{ id, checked, onChange }}

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -50,6 +50,11 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     key: "multipleControllerUseSnapshots",
     secret: true,
   },
+  {
+    label: "Code Heatmaps ",
+    description: "Calculate hit counts for editor files all at once",
+    key: "codeHeatMaps",
+  },
 ];
 
 function Experiment({
@@ -126,6 +131,7 @@ export default function ExperimentalSettings({}) {
     value: enableMultipleControllerUseSnapshots,
     update: updateEnableMultipleControllerUseSnapshots,
   } = useFeature("multipleControllerUseSnapshots");
+  const { value: codeHeatMaps, update: updateLiveCodeAnalysis } = useFeature("codeHeatMaps");
 
   const onChange = (key: ExperimentalKey, value: any) => {
     if (key === "enableEventLink") {
@@ -142,6 +148,8 @@ export default function ExperimentalSettings({}) {
       updateEnableUseMultipleControllers(!enableUseMultipleControllers);
     } else if (key == "multipleControllerUseSnapshots") {
       updateEnableMultipleControllerUseSnapshots(!enableMultipleControllerUseSnapshots);
+    } else if (key == "codeHeatMaps") {
+      updateLiveCodeAnalysis(!codeHeatMaps);
     }
   };
 
@@ -151,6 +159,7 @@ export default function ExperimentalSettings({}) {
     enableNetworkRequestComments,
     useMultipleControllers: enableUseMultipleControllers,
     multipleControllerUseSnapshots: enableMultipleControllerUseSnapshots,
+    codeHeatMaps,
   };
 
   const settings = { ...userSettings, ...localSettings };

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -46,6 +46,7 @@ const testSettings: ExperimentalUserSettings = {
   enableEventLink: false,
   enableTeams: true,
   showReact: true,
+  codeHeatMaps: false,
 };
 
 export async function getUserSettings(): Promise<ExperimentalUserSettings> {
@@ -116,6 +117,7 @@ function convertUserSettings(data: any): ExperimentalUserSettings {
     enableEventLink: settings.enableEventLink,
     enableTeams: settings.enableTeams,
     showReact: settings.showReact,
+    codeHeatMaps: settings.codeHeatMaps,
   };
 }
 

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -228,6 +228,7 @@ export const getTrialExpired = (state: UIState) => state.app.trialExpired;
 export const getModal = (state: UIState) => state.app.modal;
 export const getModalOptions = (state: UIState) => state.app.modalOptions;
 export const getAnalysisPoints = (state: UIState) => state.app.analysisPoints;
+
 export const getAnalysisPointsForLocation = (
   state: UIState,
   location: Location | null,
@@ -246,6 +247,7 @@ export const getAnalysisPointsForLocation = (
 
   return points;
 };
+
 export const getHoveredLineNumberLocation = (state: UIState) => state.app.hoveredLineNumberLocation;
 export const getPointsForHoveredLineNumber = (state: UIState) => {
   const location = getHoveredLineNumberLocation(state);

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -11,6 +11,7 @@ export type ExperimentalUserSettings = {
   disableLogRocket: boolean;
   enableEventLink: boolean;
   enableTeams: boolean;
+  codeHeatMaps: boolean;
   showReact: boolean;
 };
 

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -27,6 +27,7 @@ pref("devtools.features.networkRequestComments", true);
 pref("devtools.features.useMultipleControllers", false);
 pref("devtools.features.multipleControllerUseSnapshots", false);
 pref("devtools.features.breakpointPanelAutocomplete", true);
+pref("devtools.features.codeHeatMaps", false);
 
 export const prefs = new PrefsHelper("devtools", {
   eventListenersBreakpoints: ["Bool", "event-listeners-breakpoints"],
@@ -53,6 +54,7 @@ export const features = new PrefsHelper("devtools.features", {
   commentAttachments: ["Bool", "commentAttachments"],
   networkRequestComments: ["Bool", "networkRequestComments"],
   breakpointPanelAutocomplete: ["Bool", "breakpointPanelAutocomplete"],
+  codeHeatMaps: ["Bool", "codeHeatMaps"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {


### PR DESCRIPTION
This pairs with https://github.com/RecordReplay/backend/pull/4899 to fetch all hit counts for a source in one go, and without fetching actual Point data, just a straight hit-count. This makes it possible to do things like https://github.com/RecordReplay/backend/issues/4750. In addition to adding the ability to call the new protocol endpoint, we have a few supporting changes:

- adds an experimental flag for turning this feature on. This feature only works on new recordings that support fetching hit counts for locations in batches
- this caches based on the sourceID, and on the current trim begin and end, so that we will refetch whenever the user changes focus
- in order to make that work I've made the action that fetches the hitcounts for the whole file run on every line hover. We use a memoizable action to short circuit most of the time, so we only fetch the hitpoint counts once for each combination of source and focus window, but anytime any of those change a line hover will fetch the latest hit count


https://user-images.githubusercontent.com/5903784/159845411-e270be48-1416-4801-8f60-e96593fd2b1b.mp4

