### PR TITLE
Show pretty-printed original sources as original (#5792)

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/SourcemapToggle.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/SourcemapToggle.tsx
@@ -87,7 +87,7 @@ export function SourcemapToggle({
   return (
     <div className="mapped-source flex items-center space-x-1 pl-3">
       <Toggle
-        enabled={selectedSource.isOriginal}
+        enabled={ThreadFront.isSourceMappedSource(selectedSource.id)}
         setEnabled={setEnabled}
         disabled={!alternateSourceId}
       />

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -1168,7 +1168,7 @@ class _ThreadFront {
         return false;
       }
       kind = minifiedInfo.kind;
-      assert(kind != "prettyPrinted", "source kind must be prettyPrinted");
+      assert(kind != "prettyPrinted", "source kind must not be prettyPrinted");
     }
     return kind == "sourceMapped";
   }


### PR DESCRIPTION
`ThreadFront.isSourceMappedSource()` also takes into account that original sources may also be pretty-printed (though that's rare).