### PR TITLE
Allow users to add comments to a network request

### DIFF
--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -187,15 +187,19 @@ class Message extends Component {
     let handleAddComment = async () => {
       trackEvent("console.add_comment");
       let userId = await getUserId();
+      const opts = {
+        position: null,
+        hasFrames: true,
+        sourceLocation: frame,
+      };
+
       dispatch(
         actions.createComment(
           executionPointTime,
           executionPoint,
-          null,
-          true,
-          frame,
           { ...this.props.auth0.user, id: userId },
-          getRecordingId(this.props.router.query.id)
+          getRecordingId(this.props.router.query.id),
+          opts
         )
       );
     };

--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -1,16 +1,18 @@
 import { Action } from "redux";
 import { selectors } from "ui/reducers";
 import { actions } from "ui/actions";
-import { PendingComment, Comment, Reply, SourceLocation } from "ui/state/comments";
+import { PendingComment, Comment, Reply, SourceLocation, CommentOptions } from "ui/state/comments";
 import { UIThunkAction } from ".";
 import { ThreadFront } from "protocol/thread";
 import escapeHtml from "escape-html";
 import { waitForTime } from "protocol/utils";
 import { PENDING_COMMENT_ID } from "ui/reducers/comments";
-import { RecordingId } from "@recordreplay/protocol";
+import { RecordingId, TimeStampedPoint } from "@recordreplay/protocol";
 import { User } from "ui/types";
 import { setSelectedPrimaryPanel } from "./layout";
-import { getFocusRegion } from "ui/reducers/timeline";
+import { getCurrentTime, getFocusRegion } from "ui/reducers/timeline";
+import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
+import { RequestSummary } from "ui/components/NetworkMonitor/utils";
 const { getFilenameFromURL } = require("devtools/client/debugger/src/utils/sources-tree/getURL");
 const { getTextAtLocation } = require("devtools/client/debugger/src/reducers/sources");
 const { findClosestFunction } = require("devtools/client/debugger/src/utils/ast");
@@ -46,13 +48,12 @@ export function updatePendingCommentContent(content: string): UpdatePendingComme
 export function createComment(
   time: number,
   point: string,
-  position: { x: number; y: number } | null,
-  hasFrames: boolean,
-  sourceLocation: SourceLocation | null,
   user: User,
-  recordingId: RecordingId
+  recordingId: RecordingId,
+  options: CommentOptions
 ): UIThunkAction {
   return async ({ dispatch }) => {
+    const { sourceLocation, hasFrames, position, networkRequestId } = options;
     const labels = sourceLocation ? await dispatch(createLabels(sourceLocation)) : undefined;
     const primaryLabel = labels?.primary;
     const secondaryLabel = labels?.secondary;
@@ -64,6 +65,7 @@ export function createComment(
         createdAt: new Date().toISOString(),
         hasFrames,
         id: PENDING_COMMENT_ID,
+        networkRequestId: networkRequestId || null,
         point,
         position,
         primaryLabel,
@@ -93,7 +95,12 @@ export function createFrameComment(
   return async ({ dispatch }) => {
     const sourceLocation =
       breakpoint?.location || (await getCurrentPauseSourceLocationWithTimeout());
-    dispatch(createComment(time, point, position, true, sourceLocation || null, user, recordingId));
+    const options = {
+      position,
+      hasFrames: true,
+      sourceLocation: sourceLocation || null,
+    };
+    dispatch(createComment(time, point, user, recordingId, options));
   };
 }
 
@@ -110,7 +117,35 @@ export function createFloatingCodeComment(
 ): UIThunkAction {
   return async ({ dispatch }) => {
     const { location: sourceLocation } = breakpoint;
-    dispatch(createComment(time, point, null, false, sourceLocation || null, user, recordingId));
+    const options = {
+      position: null,
+      hasFrames: false,
+      sourceLocation: sourceLocation || null,
+    };
+    dispatch(createComment(time, point, user, recordingId, options));
+  };
+}
+
+export function createNetworkRequestComment(
+  request: RequestSummary,
+  user: User,
+  recordingId: RecordingId
+): UIThunkAction {
+  return async ({ dispatch, getState }) => {
+    const state = getState();
+    const currentTime = getCurrentTime(state);
+    const executionPoint = getExecutionPoint(state);
+
+    const time = request.triggerPoint?.time ?? currentTime;
+    const point = request.triggerPoint?.point || executionPoint!;
+
+    const options = {
+      position: null,
+      hasFrames: false,
+      sourceLocation: null,
+      networkRequestId: request.id,
+    };
+    dispatch(createComment(time, point, user, recordingId, options));
   };
 }
 

--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -17,6 +17,7 @@ import { commentKeys, formatRelativeTime } from "ui/utils/comments";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { features } from "ui/utils/prefs";
 import { getFocusRegion } from "ui/reducers/timeline";
+import NetworkRequestPreview from "./NetworkRequestPreview";
 const { getExecutionPoint } = require("devtools/client/debugger/src/reducers/pause");
 
 function BorderBridge({
@@ -100,6 +101,16 @@ function CommentItem({
   );
 }
 
+function CommentTarget({ comment }: { comment: Comment }) {
+  if (comment.sourceLocation) {
+    return <CommentSource comment={comment} />;
+  } else if (comment.networkRequestId) {
+    return <NetworkRequestPreview networkRequestId={comment.networkRequestId} />;
+  }
+
+  return null;
+}
+
 type PropsFromParent = {
   comment: Comment;
   comments: Comment[];
@@ -150,7 +161,7 @@ function CommentCard({
       >
         <div className={classNames("w-full border-l-2 border-secondaryAccent py-2.5")}>
           <div className={classNames("space-y-2 px-2.5 pl-2")}>
-            {comment.sourceLocation && <CommentSource comment={comment} />}
+            <CommentTarget comment={comment} />
             <FocusContext.Provider
               value={{
                 autofocus: true,
@@ -189,7 +200,7 @@ function CommentCard({
           "border-transparent": !isPaused,
         })}
       >
-        {comment.sourceLocation ? <CommentSource comment={comment} /> : null}
+        <CommentTarget comment={comment} />
         <CommentItem type="comment" comment={comment as Comment} pendingComment={pendingComment} />
         {comment.replies?.map((reply: Reply, i: number) => (
           <div key={replyKeys[i]}>

--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -18,6 +18,7 @@ import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { features } from "ui/utils/prefs";
 import { getFocusRegion } from "ui/reducers/timeline";
 import NetworkRequestPreview from "./NetworkRequestPreview";
+import { useFeature } from "ui/hooks/settings";
 const { getExecutionPoint } = require("devtools/client/debugger/src/reducers/pause");
 
 function BorderBridge({
@@ -102,9 +103,11 @@ function CommentItem({
 }
 
 function CommentTarget({ comment }: { comment: Comment }) {
+  const { value: networkRequestComments } = useFeature("networkRequestComments");
+
   if (comment.sourceLocation) {
     return <CommentSource comment={comment} />;
-  } else if (comment.networkRequestId) {
+  } else if (comment.networkRequestId && networkRequestComments) {
     return <NetworkRequestPreview networkRequestId={comment.networkRequestId} />;
   }
 

--- a/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { setSelectedPanel } from "ui/actions/layout";
+import { showRequestDetails } from "ui/actions/network";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
+import { getSummaryById } from "ui/reducers/network";
+import { UIState } from "ui/state";
+
+import { trackEvent } from "ui/utils/telemetry";
+
+export default function NetworkRequestPreview({ networkRequestId }: { networkRequestId: string }) {
+  const dispatch = useDispatch();
+  const request = useSelector((state: UIState) => getSummaryById(state, networkRequestId));
+
+  const onClick = () => {
+    trackEvent("comments.select_request");
+    dispatch(setSelectedPanel("network"));
+    dispatch(showRequestDetails(networkRequestId));
+  };
+
+  if (!request) {
+    return null;
+  }
+
+  const { method, name, domain } = request;
+
+  return (
+    <div
+      onClick={onClick}
+      className="group cursor-pointer rounded-md border-gray-200 bg-chrome px-2 py-0.5 hover:bg-themeTextFieldBgcolor"
+    >
+      <div className="mono flex flex-col font-medium">
+        <div className="flex w-full flex-row justify-between space-x-1">
+          <div
+            className="cm-s-mozilla overflow-hidden whitespace-pre font-mono text-xs space-x-2"
+            style={{ fontSize: "11px" }}
+          >
+            <span>{`[${method}]`}</span>
+            <span>{name}</span>
+            <span>({`${domain}`})</span>
+          </div>
+          <div
+            className="flex flex-shrink-0 opacity-0 transition group-hover:opacity-100"
+            title="Show in the Network Monitor"
+          >
+            <MaterialIcon iconSize="sm">keyboard_arrow_right</MaterialIcon>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
@@ -22,7 +22,7 @@ export default function NetworkRequestPreview({ networkRequestId }: { networkReq
     return null;
   }
 
-  const { method, name, domain } = request;
+  const { method, name } = request;
 
   return (
     <div
@@ -35,9 +35,8 @@ export default function NetworkRequestPreview({ networkRequestId }: { networkReq
             className="cm-s-mozilla overflow-hidden whitespace-pre font-mono text-xs space-x-2"
             style={{ fontSize: "11px" }}
           >
-            <span>{`[${method}]`}</span>
+            <span className="font-bold">{`[${method}]`}</span>
             <span>{name}</span>
-            <span>({`${domain}`})</span>
           </div>
           <div
             className="flex flex-shrink-0 opacity-0 transition group-hover:opacity-100"

--- a/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
+++ b/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
@@ -1,0 +1,27 @@
+import { useDispatch } from "react-redux";
+import { createNetworkRequestComment } from "ui/actions/comments";
+import { useGetRecordingId } from "ui/hooks/recordings";
+import { useGetUserId } from "ui/hooks/users";
+import useAuth0 from "ui/utils/useAuth0";
+import { RequestSummary } from "./utils";
+
+export default function AddNetworkRequestCommentButton({ request }: { request: RequestSummary }) {
+  const dispatch = useDispatch();
+  const { user } = useAuth0();
+  const { userId } = useGetUserId();
+  const recordingId = useGetRecordingId();
+
+  const addRequestComment = () => {
+    dispatch(createNetworkRequestComment(request, { ...user, id: userId }, recordingId));
+  };
+
+  return (
+    <button
+      className="bg-primaryAccent space-x-2 inline-flex items-center rounded-md border border-transparent px-1 text-xs font-medium leading-4 text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2"
+      onClick={addRequestComment}
+    >
+      <div className="material-icons add-comment-icon text-base text-white">add_comment</div>
+      <div>Add a comment</div>
+    </button>
+  );
+}

--- a/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
+++ b/src/ui/components/NetworkMonitor/AddNetworkRequestCommentButton.tsx
@@ -1,11 +1,13 @@
 import { useDispatch } from "react-redux";
 import { createNetworkRequestComment } from "ui/actions/comments";
 import { useGetRecordingId } from "ui/hooks/recordings";
+import { useFeature } from "ui/hooks/settings";
 import { useGetUserId } from "ui/hooks/users";
 import useAuth0 from "ui/utils/useAuth0";
 import { RequestSummary } from "./utils";
 
 export default function AddNetworkRequestCommentButton({ request }: { request: RequestSummary }) {
+  const { value: networkRequestComments } = useFeature("networkRequestComments");
   const dispatch = useDispatch();
   const { user } = useAuth0();
   const { userId } = useGetUserId();
@@ -14,6 +16,10 @@ export default function AddNetworkRequestCommentButton({ request }: { request: R
   const addRequestComment = () => {
     dispatch(createNetworkRequestComment(request, { ...user, id: userId }, recordingId));
   };
+
+  if (!networkRequestComments) {
+    return null;
+  }
 
   return (
     <button

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -304,9 +304,6 @@ const RequestDetails = ({ cx, request }: { cx: any; request: RequestSummary }) =
         <CloseButton buttonClass="mr-2" handleClick={closePanel} tooltip={"Close tab"} />
       </RequestDetailsTabs>
       <div className={classNames("requestDetails", styles.requestDetails)}>
-        {/* <div className="flex border-b p-2">
-          <AddNetworkRequestCommentButton request={request} />
-        </div> */}
         <div>
           {activeTab === "headers" && <HeadersPanel request={request} />}
           {activeTab === "cookies" && <Cookies request={request} />}

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -298,6 +298,7 @@ const RequestDetails = ({ cx, request }: { cx: any; request: RequestSummary }) =
         <CloseButton buttonClass="mr-2" handleClick={closePanel} tooltip={"Close tab"} />
       </RequestDetailsTabs>
       <div className={classNames("requestDetails", styles.requestDetails)}>
+        <div className="flex border-b p-2"><AddCommentButton /></div>
         <div>
           {activeTab === "headers" && <HeadersPanel request={request} />}
           {activeTab === "cookies" && <Cookies request={request} />}
@@ -310,5 +311,14 @@ const RequestDetails = ({ cx, request }: { cx: any; request: RequestSummary }) =
     </div>
   );
 };
+
+const AddCommentButton: FC = () => {
+  return (
+    <button className="bg-primaryAccent space-x-2 inline-flex items-center rounded-md border border-transparent px-1 text-xs font-medium leading-4 text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2">
+      <div className="material-icons add-comment-icon text-base text-white">add_comment</div>
+      <div>Add a comment</div>
+    </button>
+  );
+}
 
 export default RequestDetails;

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -16,6 +16,7 @@ import { getPointIsInLoadedRegion } from "ui/utils/timeline";
 import { hideRequestDetails } from "ui/actions/network";
 import { getFormattedFrames } from "ui/reducers/network";
 import { actions } from "ui/actions";
+import AddNetworkRequestCommentButton from "./AddNetworkRequestCommentButton";
 
 interface Detail {
   name: string;
@@ -191,11 +192,16 @@ const HeadersPanel = ({ request }: { request: RequestSummary }) => {
   return (
     <>
       <div
-        className={classNames("flex cursor-pointer items-center py-1 font-bold")}
+        className={classNames(
+          "flex cursor-pointer items-center py-1 font-bold justify-between pr-2"
+        )}
         onClick={() => setRequestExpanded(!requestExpanded)}
       >
-        <TriangleToggle open={requestExpanded} />
-        General
+        <div>
+          <TriangleToggle open={requestExpanded} />
+          General
+        </div>
+        <AddNetworkRequestCommentButton request={request} />
       </div>
       {requestExpanded && <DetailTable className={styles.request} details={details} />}
       <div
@@ -298,7 +304,9 @@ const RequestDetails = ({ cx, request }: { cx: any; request: RequestSummary }) =
         <CloseButton buttonClass="mr-2" handleClick={closePanel} tooltip={"Close tab"} />
       </RequestDetailsTabs>
       <div className={classNames("requestDetails", styles.requestDetails)}>
-        <div className="flex border-b p-2"><AddCommentButton /></div>
+        {/* <div className="flex border-b p-2">
+          <AddNetworkRequestCommentButton request={request} />
+        </div> */}
         <div>
           {activeTab === "headers" && <HeadersPanel request={request} />}
           {activeTab === "cookies" && <Cookies request={request} />}
@@ -311,14 +319,5 @@ const RequestDetails = ({ cx, request }: { cx: any; request: RequestSummary }) =
     </div>
   );
 };
-
-const AddCommentButton: FC = () => {
-  return (
-    <button className="bg-primaryAccent space-x-2 inline-flex items-center rounded-md border border-transparent px-1 text-xs font-medium leading-4 text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-primaryAccent focus:ring-offset-2">
-      <div className="material-icons add-comment-icon text-base text-white">add_comment</div>
-      <div>Add a comment</div>
-    </button>
-  );
-}
 
 export default RequestDetails;

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -27,6 +27,11 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     description: "Add breakpoints within a line",
     key: "enableColumnBreakpoints",
   },
+  {
+    label: "Network Request Comments",
+    description: "Leave comments on a network request",
+    key: "enableNetworkRequestComments",
+  },
 ];
 
 function Experiment({
@@ -59,6 +64,8 @@ export default function ExperimentalSettings({}) {
 
   const { value: enableColumnBreakpoints, update: updateEnableColumnBreakpoints } =
     useFeature("columnBreakpoints");
+  const { value: enableNetworkRequestComments, update: updateEnableNetworkRequestComments } =
+    useFeature("networkRequestComments");
 
   const onChange = (key: ExperimentalKey, value: any) => {
     if (key === "enableEventLink") {
@@ -67,11 +74,14 @@ export default function ExperimentalSettings({}) {
       updateReact({ variables: { newValue: value } });
     } else if (key == "enableColumnBreakpoints") {
       updateEnableColumnBreakpoints(!enableColumnBreakpoints);
+    } else if (key == "enableNetworkRequestComments") {
+      updateEnableNetworkRequestComments(!enableNetworkRequestComments);
     }
   };
 
   const localSettings = {
     enableColumnBreakpoints,
+    enableNetworkRequestComments,
   };
   const settings = { ...userSettings, ...localSettings };
 

--- a/src/ui/graphql/comments.ts
+++ b/src/ui/graphql/comments.ts
@@ -16,6 +16,7 @@ export const GET_COMMENTS = gql`
         time
         point
         position
+        networkRequestId
         user {
           id
           name

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -14,6 +14,7 @@ import { formatCallStackFrames } from "devtools/client/debugger/src/selectors/ge
 import sortBy from "lodash/sortBy";
 import sortedUniqBy from "lodash/sortedUniqBy";
 import { getFocusRegion } from "./timeline";
+import { partialRequestsToCompleteSummaries } from "ui/components/NetworkMonitor/utils";
 
 export type NetworkState = {
   events: RequestEventInfo[];
@@ -128,6 +129,14 @@ export const getFormattedFrames = createSelector(getFrames, getSources, (frames,
 export const getResponseBodies = (state: UIState) => state.network.responseBodies;
 export const getRequestBodies = (state: UIState) => state.network.requestBodies;
 export const getSelectedRequestId = (state: UIState) => state.network.selectedRequestId;
+export const getSummaryById = (state: UIState, id: string) => {
+  const summaries = partialRequestsToCompleteSummaries(
+    getRequests(state),
+    getEvents(state),
+    new Set()
+  );
+  return summaries.find(s => s.id === id);
+};
 
 export const getSelectedResponseBody = (state: UIState) => {
   const requestId = getSelectedRequestId(state);

--- a/src/ui/state/comments.ts
+++ b/src/ui/state/comments.ts
@@ -18,6 +18,13 @@ export interface CommentPosition {
   y: number;
 }
 
+export type CommentOptions = {
+  position: CommentPosition | null;
+  hasFrames: boolean;
+  sourceLocation: SourceLocation | null;
+  networkRequestId?: string;
+};
+
 export interface Remark {
   content: string;
   createdAt: string;
@@ -33,6 +40,7 @@ export interface Remark {
 
 export interface Comment extends Remark {
   position: CommentPosition | null;
+  networkRequestId: string | null;
   primaryLabel?: string;
   replies: Reply[];
   secondaryLabel?: string;

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -16,6 +16,7 @@ export type ExperimentalUserSettings = {
 
 export type LocalExperimentalUserSettings = {
   enableColumnBreakpoints: boolean;
+  enableNetworkRequestComments: boolean;
 };
 
 export type LocalUserSettings = LocalExperimentalUserSettings & {

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -27,6 +27,7 @@ type MixpanelEvent =
   | ["comments.delete"]
   | ["comments.focus"]
   | ["comments.select_location"]
+  | ["comments.select_request"]
   | ["comments.start_edit"]
   | ["console.clear_messages"]
   | ["console.overflow"]

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -40,6 +40,7 @@ pref("devtools.features.videoComments", false);
 pref("devtools.features.videoPlayback", false);
 pref("devtools.features.widgetHover", false);
 pref("devtools.features.commentAttachments", false);
+pref("devtools.features.networkRequestComments", false);
 
 export const prefs = new PrefsHelper("devtools", {
   user: ["Json", "user"],
@@ -79,6 +80,7 @@ export const features = new PrefsHelper("devtools.features", {
   videoPlayback: ["Bool", "videoPlayback"],
   widgetHover: ["Bool", "widgetHover"],
   commentAttachments: ["Bool", "commentAttachments"],
+  networkRequestComments: ["Bool", "networkRequestComments"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {


### PR DESCRIPTION
~~Blocked by https://github.com/RecordReplay/devtools/pull/5776 and https://github.com/RecordReplay/backend/pull/4928.~~ Fixes #5160.

This adds basic network request commenting:
- [x] Users should be able to add comments to a network request from the network monitor.
- [x] For network request comments, there should be some preview of the request in the comment sidebar.
- [x] Clicking on a network request comment with a trigger point should bring you to that trigger point. 
- [x] When there's no trigger point, clicking on the comment should bring you to the point/time that the user was paused on at the time that the comment was saved.
- [x] Clicking on the network call preview should open up the network monitor, bring the call to view, and show the request details.
- [x] Feature flag it!

Description | Screenshot
--- | ---
Adds an Add Comment (to a network call) button when the user has selected a network call | <img width="1029" alt="image" src="https://user-images.githubusercontent.com/15959269/158475630-2ffac26b-47b5-443a-bb7c-ea530940daff.png">
Shows a preview of the network call that had been commented on in the comment sidebar | <img width="980" alt="image" src="https://user-images.githubusercontent.com/15959269/158475855-6d5cc01a-fefd-412e-ba46-9c2ff52bfbe5.png">

Follow-ups:
1. The position for the add comment button is not meant to be permanent. This should let us play with this and get a better idea of where the best position for it should be.
2. The current request preview in the comment displays the method, the name, and the url (e.g. `[GET] image.jpg (mywebsite.com)`). It's butt ugly for now and can be prettied up later.
3. QA Wolf tests 