### PR TITLE
Clean up the network monitor splitbox layout

### DIFF
--- a/src/ui/components/NetworkMonitor/HeaderGroups.tsx
+++ b/src/ui/components/NetworkMonitor/HeaderGroups.tsx
@@ -41,19 +41,22 @@ export function HeaderGroups({
             className="flex items-center divide-x divide-themeTextFieldBgcolor font-normal"
             {...headerProps}
           >
-            {headerGroup.headers.map(column => {
+            {headerGroup.headers.map((column, index) => {
               const { key, ...columnProps } = column.getHeaderProps();
+              const isLastColumn = index === headerGroup.headers.length - 1;
               return (
                 <div className={classNames("p-1", styles[column.id])} {...columnProps} key={key}>
                   {column.render("Header")}
-                  <div
-                    //@ts-ignore
-                    {...column.getResizerProps()}
-                    className={classNames("select-none", styles.resizer, {
-                      //@ts-ignore typescript freaking *hates* react-table
-                      isResizing: column.isResizing,
-                    })}
-                  />
+                  {!isLastColumn ? (
+                    <div
+                      //@ts-ignore
+                      {...column.getResizerProps()}
+                      className={classNames("select-none", styles.resizer, {
+                        //@ts-ignore typescript freaking *hates* react-table
+                        isResizing: column.isResizing,
+                      })}
+                    />
+                  ) : null}
                 </div>
               );
             })}

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -126,7 +126,7 @@ export const NetworkMonitor = ({
                 />
               ) : null
             }
-            splitterSize={1}
+            splitterSize={2}
             vert={vert}
           />
         </div>


### PR DESCRIPTION
1. Make the splitter handlebar 2px so it's easier to resize the net monitor.
2. Don't allow the user to resize the last column in the table