### PR TITLE
Fix imports to unblock CI

### DIFF
--- a/src/devtools/client/webconsole/store.ts
+++ b/src/devtools/client/webconsole/store.ts
@@ -4,17 +4,11 @@
 "use strict";
 
 import { FilterState } from "devtools/client/webconsole/reducers/filters";
-import { PrefState } from "devtools/client/webconsole/reducers/prefs";
 import { UiState } from "devtools/client/webconsole/reducers/ui";
 import { prefs } from "devtools/client/webconsole/utils/prefs";
 
 export function getConsoleInitialState() {
-  const groupWarnings = prefs.groupWarningMessages;
-
   return {
-    prefs: PrefState({
-      groupWarnings,
-    }),
     filters: FilterState({
       error: prefs.filterError,
       warn: prefs.filterWarn,


### PR DESCRIPTION
I saw from yesterday's conversations that webconsole prefs are deprecated, so this felt safe to remove then as well.

Related: https://github.com/RecordReplay/devtools/pull/5800