### PR TITLE
Add a subtle flash whenever there's activity in the editor and it's not the selected panel

### DIFF
--- a/src/devtools/client/debugger/src/reducers/sources.d.ts
+++ b/src/devtools/client/debugger/src/reducers/sources.d.ts
@@ -21,9 +21,15 @@ export type Source = {
   extensionName?: string | null;
   introductionType?: "scriptElement";
 };
+type SelectedLocation = {
+  sourceId: string;
+  line: number;
+  column?: number;
+  sourceUrl: string;
+}
 
 export function getSelectedSourceWithContent(state: UIState): Source;
 export function getIsSourceMappedSource(state: UIState): boolean;
 export function getSources(state: UIState): Source[];
 export function getSelectedSource(state: UIState): Source;
-export function getSelectedLocation(state: UIState): Source;
+export function getSelectedLocation(state: UIState): SelectedLocation;

--- a/src/ui/components/SecondaryToolbox/TabSpotlight.tsx
+++ b/src/ui/components/SecondaryToolbox/TabSpotlight.tsx
@@ -1,0 +1,39 @@
+import classNames from "classnames";
+import { getSelectedLocation } from "devtools/client/debugger/src/reducers/sources";
+import { useEffect, useRef, useState } from "react";
+import { useSelector } from "react-redux";
+import { getSelectedPanel, getToolboxLayout } from "ui/reducers/layout";
+
+export default function TabSpotlight() {
+  const [isShown, setIsShown] = useState(false);
+  const selectedSource = useSelector(getSelectedLocation);
+  const layout = useSelector(getToolboxLayout);
+  const selectedPanel = useSelector(getSelectedPanel);
+  const timeoutKey = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (!selectedSource?.sourceId || layout === "ide" || selectedPanel === "debugger") {
+      return;
+    }
+
+    if (timeoutKey.current) {
+      clearTimeout(timeoutKey.current);
+    }
+
+    setIsShown(true);
+
+    timeoutKey.current = setTimeout(() => {
+      setIsShown(false);
+      timeoutKey.current = null;
+    }, 2000);
+  }, [selectedSource?.sourceId]);
+
+  return (
+    <div
+      className={classNames(
+        "h-full w-full bg-yellow-500 absolute top-0 left-0 transition-opacity duration-500",
+        isShown ? "opacity-50" : "opacity-0"
+      )}
+    />
+  );
+}


### PR DESCRIPTION
Fix #5804.

@jonbell-lot23 got a version working decently well. For now it just overlays a 50% yellow layer to simulate the flash, but clearly that's the rough version. Let me know what you think v1 should look like!

https://user-images.githubusercontent.com/15959269/158672578-586eae95-e24f-4b7e-8095-742e8ed7d12f.mov


