### PR TITLE
Don't reset the global filter when data changes

### DIFF
--- a/src/ui/components/NetworkMonitor/Table.tsx
+++ b/src/ui/components/NetworkMonitor/Table.tsx
@@ -79,6 +79,8 @@ export default function Table({
   );
   const tableInstance = useTable<RequestSummary>(
     {
+      //@ts-ignore
+      autoResetGlobalFilter: false,
       columns: columns as any,
       data,
       defaultColumn,

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -34,11 +34,8 @@ export const NetworkMonitor = ({
   cx,
   events,
   loading,
-  requestBodies,
   requests,
-  responseBodies,
   seek,
-  selectFrame,
 }: PropsFromRedux) => {
   const selectedRequestId = useSelector(getSelectedRequestId);
   const [types, setTypes] = useState<Set<CanonicalRequestType>>(new Set([]));
@@ -68,7 +65,7 @@ export const NetworkMonitor = ({
       resizeObserver.current.observe(container.current);
     }
   });
-  //
+
   useEffect(() => {
     // If the selected request has been filtered out by the focus region, unselect it.
     if (selectedRequestId && !requests.find(r => r.id === selectedRequestId)) {


### PR DESCRIPTION
I'm not sure why react table thinks that data is changing, because this
seems to happen even at random times when not clicking on a row. Maybe
it also happens when we receive network events from the server? Anyways,
this fixes the issue.

For a little more context:

https://react-table.tanstack.com/docs/api/useGlobalFilter

> autoResetGlobalFilter: Boolean
Defaults to true
When true, the globalFilter state will automatically reset if any of the following conditions are met:
data is changed
To disable, set to false
For more information see the FAQ ["How do I stop my table state from automatically resetting when my data changes?"](https://react-table.tanstack.com/docs/faq#how-do-i-stop-my-table-state-from-automatically-resetting-when-my-data-changes)