### PR TITLE
Added types for `fuzzaldrin-plus`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "@types/codemirror": "^5.60.5",
         "@types/cookie": "^0.4.1",
         "@types/escape-html": "^1.0.1",
+        "@types/fuzzaldrin-plus": "^0.6.2",
         "@types/lodash": "^4.14.179",
         "@types/logrocket-react": "^3.0.0",
         "@types/mixpanel-browser": "^2.35.6",
@@ -11927,6 +11928,12 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "dev": true
+    },
+    "node_modules/@types/fuzzaldrin-plus": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@types/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.2.tgz",
+      "integrity": "sha512-f9QkOre3T9YI1+Pd6CVgt0rY/KiPFlYHhbKXmjDYZVbIgOLDls1k22nuIq7skIGz/tS4f5gRRWW6wR2B2dWEqQ==",
       "dev": true
     },
     "node_modules/@types/glob": {
@@ -39532,6 +39539,12 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "dev": true
+    },
+    "@types/fuzzaldrin-plus": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@types/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.2.tgz",
+      "integrity": "sha512-f9QkOre3T9YI1+Pd6CVgt0rY/KiPFlYHhbKXmjDYZVbIgOLDls1k22nuIq7skIGz/tS4f5gRRWW6wR2B2dWEqQ==",
       "dev": true
     },
     "@types/glob": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@types/codemirror": "^5.60.5",
     "@types/cookie": "^0.4.1",
     "@types/escape-html": "^1.0.1",
+    "@types/fuzzaldrin-plus": "^0.6.2",
     "@types/lodash": "^4.14.179",
     "@types/logrocket-react": "^3.0.0",
     "@types/mixpanel-browser": "^2.35.6",

--- a/src/devtools/client/webconsole/utils/autocomplete.ts
+++ b/src/devtools/client/webconsole/utils/autocomplete.ts
@@ -10,7 +10,7 @@ import generate from "@babel/generator";
 import { ValueFront } from "protocol/thread";
 import { WiredObject } from "protocol/thread/pause";
 import { GETTERS_FROM_PROTOTYPES } from "devtools/packages/devtools-reps/object-inspector/utils";
-const { filter } = require("fuzzaldrin-plus");
+import { filter } from "fuzzaldrin-plus";
 
 type PropertyExpression = {
   left: string;

--- a/src/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/ui/components/CommandPalette/CommandPalette.tsx
@@ -8,7 +8,7 @@ import { UIState } from "ui/state";
 import { ExperimentalUserSettings } from "ui/types";
 import CommandButton from "./CommandButton";
 import SearchInput from "./SearchInput";
-const { filter } = require("fuzzaldrin-plus");
+import { filter } from "fuzzaldrin-plus";
 import styles from "./CommandPalette.module.css";
 
 export type Command = {
@@ -74,8 +74,8 @@ const ITEMS_TO_SHOW = 4;
 function getShownCommands(searchString: string, hasReactComponents: boolean) {
   const { userSettings } = hooks.useGetUserSettings();
 
-  const commands: Command[] = searchString
-    ? filter(COMMANDS, searchString, { key: "label" })
+  const commands: readonly Command[] = searchString
+    ? filter(COMMANDS as Command[], searchString, { key: "label" })
     : COMMANDS;
 
   const enabledCommands = commands.filter(command => {
@@ -102,7 +102,7 @@ function getShownCommands(searchString: string, hasReactComponents: boolean) {
 
 function PaletteShortcut() {
   return (
-    <div className="flex absolute right-4 select-none text-primaryAccent">
+    <div className="absolute right-4 flex select-none text-primaryAccent">
       <div className="img cmd-icon" style={{ background: "var(--primary-accent)" }} />
       <div className="img k-icon" style={{ background: "var(--primary-accent)" }} />
     </div>


### PR DESCRIPTION
While reviewing https://github.com/RecordReplay/devtools/pull/5823, I've noticed the lack of types for fuzzaldrin, so I've added them.