### PR TITLE
Fixing error hats in dark theme

### DIFF
--- a/src/ui/components/shared/Warning.tsx
+++ b/src/ui/components/shared/Warning.tsx
@@ -9,8 +9,8 @@ export default function Warning({ children, link }: { children: React.ReactNode;
   }
 
   return (
-    <div className="flex flex-col bg-red-100 py-1 px-2 font-sans leading-tight text-red-700">
-      <div className="flex items-center space-x-1">
+    <div className="flex flex-col message error font-sans leading-tight">
+      <div className="flex items-center space-x-1 py-1">
         <MaterialIcon>error</MaterialIcon>
         <span className="flex-grow overflow-hidden overflow-ellipsis whitespace-pre">
           {children}


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/devtools/issues/5718

Was:
<img width="617" alt="image" src="https://user-images.githubusercontent.com/9154902/158703871-8f20cba8-fee8-4cab-97ff-b59210818f98.png">

Now:
![image](https://user-images.githubusercontent.com/9154902/158703950-8837a7b3-2a71-4bc4-aa94-f8ee86486bb2.png)

![image](https://user-images.githubusercontent.com/9154902/158703987-07466c50-5c1d-4eab-ac87-e8840e027766.png)

The squished icon was fixed by another ticket, and now we're using standard error colours that change based on theme.