### PR TITLE
Fixing breakpoints dead-end with better text

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -93,17 +93,19 @@ function PanelSummary({
     const hits = analysisPoints === "error" ? "10k" : prefs.maxHitsDisplayed;
 
     return (
-      <div className="summary flex items-center bg-red-100 text-red-700">
+      <div className="summary flex items-center bg-errorBgcolor text-errorColor rounded-t">
         <Popup
           trigger={
             <div className="flex items-center space-x-2 overflow-hidden pl-2">
               <MaterialIcon className="text-xl">error</MaterialIcon>
-              <span className="overflow-hidden overflow-ellipsis whitespace-pre hover:underline">
+              <span className="overflow-hidden overflow-ellipsis whitespace-pre">
+                Use {""}                
                 <a
                   href="https://www.notion.so/replayio/Debugger-Limitations-5b33bb0e5bd1459cbd7daf3234219c27#1e6ed519f3f849458a7aa88b7be497b6"
                   rel="noreferrer noopener"
+                  className="underline "
                   target="_blank"
-                >{`Disabled because it was hit ${hits}+ times`}</a>
+                >{`Focus Mode`}</a> to reduce the number of hits.
               </span>
             </div>
           }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,8 @@ module.exports = {
         checkbox: "var(--checkbox)",
         checkboxBorder: "var(--checkbox-border)",
         chrome: "var(--chrome)",
+        errorBgcolor: "var(--console-error-background)",
+        errorColor: "var(--console-error-color)",
         iconColor: "var(--icon-color)",
         iconColorDisabled: "var(--theme-text-field-bgcolor)",
         jellyfishBgcolor: "var(--jellyfish-bgcolor)",
@@ -46,7 +48,7 @@ module.exports = {
         themeToolbarPanelIconColor: "var(--theme-toolbar-panel-icon-color)",
         toolbarBackground: "var(--theme-toolbar-background)",
         toolbarBackgroundAlt: "var(--theme-toolbar-background-alt)",
-        lightGrey: "var(--light-grey)",
+        lightGrey: "var(--light-grey)",      
       },
       lineHeight: {
         "comment-text": "1.125rem",


### PR DESCRIPTION
Fixes: https://github.com/RecordReplay/devtools/issues/5830

Was:
![image](https://user-images.githubusercontent.com/9154902/158729587-ffb71f9e-4d43-469d-b4cd-13c5d972f248.png)

![image](https://user-images.githubusercontent.com/9154902/158729617-cda818d2-ea6f-4a2f-9390-4a6eda0e5fa0.png)

Now:
![image](https://user-images.githubusercontent.com/9154902/158729669-da23ac58-e2a6-4b05-8106-eaa13670f757.png)

![image](https://user-images.githubusercontent.com/9154902/158729638-b1f4cbb3-a7c4-42a6-8984-3292d6ef35b2.png)

Features include:

* An indication of how to fix the issue
* A link to Focus Mode in our docs
* Alignment with our other error colours
* Fixed a rounded edge bug -- was looking squared off and wrong in dark theme
