### PR TITLE
Pass in the appropriate env vars during e2e tests

### DIFF
--- a/test/src/getExample.js
+++ b/test/src/getExample.js
@@ -49,6 +49,9 @@ async function recordToFile(state, browserName, example) {
   const browser = await playwright[browserName].launch({
     executablePath: state.browserPath,
     headless: state.headless,
+    RECORD_REPLAY_API_KEY: state.replayApiKey,
+    RECORD_REPLAY_DISPATCH: state.dispatchServer,
+    RECORD_REPLAY_DRIVER: state.driverPath,
   });
 
   const context = await browser.newContext();


### PR DESCRIPTION
I think this might be what was causing
https://github.com/RecordReplay/backend/issues/4946