### PR TITLE
Add descriptions in our assert calls

### DIFF
--- a/src/protocol/analysisManager.ts
+++ b/src/protocol/analysisManager.ts
@@ -131,8 +131,8 @@ class AnalysisManager {
     handler: AnalysisHandler<T>,
     maxPoints: number
   ) {
-    assert(!handler.onAnalysisPoints);
-    assert(handler.onAnalysisResult);
+    assert(!handler.onAnalysisPoints, "There should be no onAnalysisPoints handler.");
+    assert(handler.onAnalysisResult, "There should be an onAnalysisResults handler");
 
     const pointsHandler: AnalysisHandler<void> = {};
     const allPoints: PointDescription[] = [];

--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -40,9 +40,12 @@ function mostRecentIndex<T extends Timed>(array: T[], time: number): number | un
   const index = binarySearch(0, array.length, (index: number) => {
     return time - array[index].time;
   });
-  assert(array[index].time <= time);
+  assert(
+    array[index].time <= time,
+    "The most recent item should be at or preceding the given time"
+  );
   if (index + 1 < array.length) {
-    assert(array[index + 1].time >= time);
+    assert(array[index + 1].time >= time, "the most recent item's index should be in the array");
   }
   return index;
 }

--- a/src/protocol/utils.ts
+++ b/src/protocol/utils.ts
@@ -41,7 +41,7 @@ export function throttle(callback: () => void, time: number) {
 }
 
 export function clamp(value: number, min: number, max: number) {
-  assert(min < max);
+  assert(min < max, "min should be less than max");
   return Math.max(min, Math.min(max, value));
 }
 


### PR DESCRIPTION
This adds some descriptions so we know what assert errors map out to in Sentry.