### PR TITLE
Remove the video DOM node ref from the Redux store

### DIFF
--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -12,6 +12,7 @@ import { Canvas } from "ui/state/app";
 import { setCanvas, setEventsForType, setVideoUrl } from "ui/actions/app";
 import { setPlaybackPrecachedTime, setPlaybackStalled } from "ui/actions/timeline";
 import { getPlaybackPrecachedTime, getRecordingDuration } from "ui/reducers/timeline";
+import { getVideoNode } from "./videoNode";
 
 const MINIMUM_VIDEO_CONTENT = 5000;
 
@@ -203,7 +204,7 @@ class VideoPlayer {
     this.commands =
       this.commands &&
       this.commands.then(async () => {
-        const video = this.store?.getState().app.videoNode;
+        const video = getVideoNode();
         if (features.videoPlayback && video) {
           video.pause();
           video.currentTime = timeMs / 1000;
@@ -215,7 +216,7 @@ class VideoPlayer {
     this.commands =
       this.commands &&
       this.commands.then(() => {
-        const video = this.store?.getState().app.videoNode;
+        const video = getVideoNode();
         const currentTime = this.store?.getState().timeline.currentTime;
         if (features.videoPlayback && video) {
           video.currentTime = (currentTime || 0) / 1000;

--- a/src/protocol/videoNode.ts
+++ b/src/protocol/videoNode.ts
@@ -1,0 +1,14 @@
+// This is the DOM node used to display a video in the UI.
+// We store it as a separate variable here, so that `<Video>` can
+// use a React ref to save the DOM node as it renders, and then
+// `graphics.ts` can access that DOM node to call `stop()/start()`,
+// without having the two files directly interact with each other.
+let videoNode: HTMLVideoElement | null;
+
+export const setVideoNode = (node: HTMLVideoElement | null) => {
+  videoNode = node;
+};
+
+export const getVideoNode = () => {
+  return videoNode;
+};

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -85,7 +85,6 @@ export type SetHoveredLineNumberLocation = Action<"set_hovered_line_number_locat
 export type SetIsNodePickerActive = Action<"set_is_node_picker_active"> & { active: boolean };
 export type SetCanvas = Action<"set_canvas"> & { canvas: Canvas };
 export type SetVideoUrl = Action<"set_video_url"> & { videoUrl: string };
-export type SetVideoNode = Action<"set_video_node"> & { videoNode: HTMLVideoElement | null };
 export type SetWorkspaceId = Action<"set_workspace_id"> & { workspaceId: WorkspaceId | null };
 export type SetDefaultSettingsTab = Action<"set_default_settings_tab"> & {
   tabTitle: SettingsTabTitle;
@@ -122,7 +121,6 @@ export type AppActions =
   | SetCanvas
   | SetMouseTargetsLoading
   | SetVideoUrl
-  | SetVideoNode
   | SetWorkspaceId
   | SetDefaultSettingsTab
   | SetRecordingTargetAction
@@ -318,10 +316,6 @@ export function setIsNodePickerActive(active: boolean): SetIsNodePickerActive {
 
 export function setVideoUrl(videoUrl: string): SetVideoUrl {
   return { type: "set_video_url", videoUrl };
-}
-
-export function setVideoNode(videoNode: HTMLVideoElement | null): SetVideoNode {
-  return { type: "set_video_node", videoNode };
 }
 
 export function setCanvasAction(canvas: Canvas): SetCanvas {

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect } from "react";
 import { connect, ConnectedProps, useDispatch, useSelector } from "react-redux";
-import { actions } from "ui/actions";
 import { installObserver, refreshGraphics, Video as VideoPlayer } from "../../protocol/graphics";
+import { setVideoNode } from "../../protocol/videoNode";
 import { selectors } from "../reducers";
 import CommentsOverlay from "ui/components/Comments/VideoComments/index";
 import CommentTool from "ui/components/shared/CommentTool";
@@ -22,7 +22,7 @@ const HideVideoButton: FC = () => {
 
   return (
     <button
-      className="absolute top-0 right-0 flex bg-themeTabBgcolor rounded-full p-1"
+      className="absolute top-0 right-0 flex rounded-full bg-themeTabBgcolor p-1"
       title="Hide Video"
       onClick={onClick}
     >
@@ -47,7 +47,6 @@ function Video({
   isNodePickerActive,
   pendingComment,
   recordingTarget,
-  setVideoNode,
   stalled,
   mouseTargetsLoading,
   videoUrl,
@@ -104,21 +103,16 @@ function Video({
   );
 }
 
-const connector = connect(
-  (state: UIState) => ({
-    pendingComment: selectors.getPendingComment(state),
-    isNodePickerActive: selectors.getIsNodePickerActive(state),
-    currentTime: selectors.getCurrentTime(state),
-    playback: selectors.getPlayback(state),
-    recordingTarget: selectors.getRecordingTarget(state),
-    videoUrl: selectors.getVideoUrl(state),
-    stalled: selectors.isPlaybackStalled(state),
-    mouseTargetsLoading: selectors.areMouseTargetsLoading(state),
-  }),
-  {
-    setVideoNode: actions.setVideoNode,
-  }
-);
+const connector = connect((state: UIState) => ({
+  pendingComment: selectors.getPendingComment(state),
+  isNodePickerActive: selectors.getIsNodePickerActive(state),
+  currentTime: selectors.getCurrentTime(state),
+  playback: selectors.getPlayback(state),
+  recordingTarget: selectors.getRecordingTarget(state),
+  videoUrl: selectors.getVideoUrl(state),
+  stalled: selectors.isPlaybackStalled(state),
+  mouseTargetsLoading: selectors.areMouseTargetsLoading(state),
+}));
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 export default connector(Video);

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -36,7 +36,6 @@ export const initialAppState: AppState = {
   trialExpired: false,
   unexpectedError: null,
   uploading: null,
-  videoNode: null,
   videoUrl: null,
   workspaceId: null,
   currentPoint: null,
@@ -173,13 +172,6 @@ export default function update(
       };
     }
 
-    case "set_video_node": {
-      return {
-        ...state,
-        videoNode: action.videoNode,
-      };
-    }
-
     case "set_video_url": {
       return {
         ...state,
@@ -292,7 +284,6 @@ export const getFlatEvents = (state: UIState) => {
 export const getIsNodePickerActive = (state: UIState) => state.app.isNodePickerActive;
 export const getCanvas = (state: UIState) => state.app.canvas;
 export const getVideoUrl = (state: UIState) => state.app.videoUrl;
-export const getVideoNode = (state: UIState) => state.app.videoNode;
 export const getWorkspaceId = (state: UIState) => state.app.workspaceId;
 export const getDefaultSettingsTab = (state: UIState) => state.app.defaultSettingsTab;
 export const getRecordingTarget = (state: UIState) => state.app.recordingTarget;

--- a/src/ui/setup/store.ts
+++ b/src/ui/setup/store.ts
@@ -71,11 +71,6 @@ const sanitizeStateForDevtools = <S>(state: S) => {
 
   // Use Immer to simplify nested immutable updates when making a copy of the state
   const sanitizedState = customImmer.produce(state, (draft: any) => {
-    if (draft.app) {
-      // TODO This is a DOM node in the Redux state and shouldn't even be here anyway
-      draft.app.videoNode = OMITTED;
-    }
-
     sanitizeContents(draft.sources?.focusedItem?.contents);
     sanitizeContents(draft.sourceTree?.focusedItem?.contents);
 
@@ -106,12 +101,6 @@ const sanitizeActionForDevTools = <A extends AnyAction>(action: A) => {
     return sanitize(draft, "", `sanitizedAction[${action.type}]`, false);
   });
 
-  // @ts-ignore
-  if (sanitizedAction.videoNode) {
-    // @ts-ignore
-    delete sanitizedAction.videoNode;
-  }
-
   return sanitizedAction;
 };
 
@@ -126,8 +115,7 @@ export function bootstrapStore(initialState: Partial<UIState>) {
     // NOTE: This is only the _initial_ setup! Other reducers are code-split for now.
     // See devtools.ts and devtools-toolbox.ts for other reducers
     reducer: reducers,
-    // TODO This works around a TS error from `app.videoNode`. Move that out of Redux.
-    preloadedState: initialState as any,
+    preloadedState: initialState,
     // @ts-ignore
     middleware: gDM => {
       const originalMiddlewareArray = gDM({

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -94,7 +94,6 @@ export interface AppState {
   trialExpired: boolean;
   unexpectedError: UnexpectedError | null;
   uploading: UploadInfo | null;
-  videoNode: HTMLVideoElement | null;
   videoUrl: string | null;
   workspaceId: WorkspaceId | null;
   mouseTargetsLoading: boolean;


### PR DESCRIPTION
DOM nodes are not "state", and not serializable, so they shouldn't
go in the Redux store.

Here, the Redux store was being used to pass around the DOM node for
the playing video, so that `<Video>` could save the node ref, and
`graphics.ts` could later call methods on it.  Understandable as a
hack, but not a good idea.

We can accomplish the same thing by just having a tiny module with
a getter/setter pair, and store the DOM node ref there.

For previous background on why this DOM node was in the Redux store in the first place, see:

- #2921
- #2907
- #2908

Did some manual testing before PR to confirm that I can start playing a video in one mode, toggle to the other, and it keeps on playing.