### PR TITLE
Unified hooks for comments

### DIFF
--- a/src/ui/graphql/comments.ts
+++ b/src/ui/graphql/comments.ts
@@ -1,4 +1,6 @@
 import { gql } from "@apollo/client";
+import { Comment, Reply } from "ui/state/comments";
+import { Recording, User } from "ui/types";
 
 export const GET_COMMENTS = gql`
   query GetComments($recordingId: UUID!) {
@@ -51,3 +53,31 @@ export const GET_COMMENTS_TIME = gql`
     }
   }
 `;
+
+type UndefinedToNull<T> = T extends infer NonUndefined | undefined ? NonUndefined | null : T;
+
+export type U2N<T extends Record<any, any>> = {
+  [K in keyof T]-?: UndefinedToNull<T[K]>;
+};
+
+export type GqlUser = {
+  __typename: "User";
+} & Omit<User, "internal">;
+
+export type GqlCommentReply = {
+  __typename: "CommentReply";
+} & U2N<Reply>;
+
+export type GqlComment = {
+  __typename: "Comment";
+} & U2N<Omit<Comment, "user">> & {
+    user: GqlUser;
+  };
+
+export type GqlGetComments = {
+  recording: {
+    __typename: "Recording";
+    uuid: Recording["id"];
+    comments: GqlComment[];
+  };
+};

--- a/src/ui/hooks/comments/comments.ts
+++ b/src/ui/hooks/comments/comments.ts
@@ -16,6 +16,8 @@ export function useGetComments(recordingId: RecordingId): {
     pollInterval: 5000,
   });
 
+  console.log(data);
+
   if (error) {
     console.error("Apollo error while fetching comments:", error);
   }

--- a/src/ui/hooks/useComments.ts
+++ b/src/ui/hooks/useComments.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { Comment } from "ui/state/comments";
+
+type UseCommentsHookReturnType = {
+  comments: Comment[];
+  create: (content: Comment["content"], parentId: Comment["id"]) => void;
+  update: (content: Comment["content"], commentId: Comment["id"]) => void;
+  delete: (commentId: Comment["id"]) => void;
+};
+
+export const useComments = (): UseCommentsHookReturnType => {
+  const [comments, setComments] = useState<Comment[]>([]);
+
+  const createComment: UseCommentsHookReturnType["create"] = () => {};
+  const updateComment: UseCommentsHookReturnType["update"] = () => {};
+  const deleteComment: UseCommentsHookReturnType["delete"] = () => {};
+
+  return {
+    comments,
+    create: createComment,
+    update: updateComment,
+    delete: deleteComment,
+  };
+};


### PR DESCRIPTION
A unified `useComments` hook. 
- [ ] use GQL subscriptions (fixes https://github.com/RecordReplay/devtools/issues/5572)
- [ ] ops:
  - [ ] add a comment, add a reply
  - [ ] get all comments
  - [ ] update a comment, update a reply
  - [ ] delete a comment
  - [ ] set pending comments

Part of https://github.com/RecordReplay/devtools/issues/5573#issuecomment-1072578195.
Fixes #5174.
Fixes #5572.