### PR TITLE
Fixing error message

### DIFF
--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -80,12 +80,11 @@ enum SessionError {
 const SessionErrorMessages: Record<number, string> = {
   [SessionError.BackendDeploy]: "Please wait a few minutes and try again.",
   [SessionError.NodeTerminated]: "Our servers hiccuped but things should be back to normal soon.",
-  [SessionError.KnownFatalError]:
-    "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
+  [SessionError.KnownFatalError]: "Darn! There was an error. Please try recording again.",
   [SessionError.OldBuild]:
     "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
   [SessionError.LongRecording]:
-    "You’ve hit an error that happens with long recordings. Can you try a shorter recording?",
+    "You’ve hit an error that happens with long recordings. Can you try a shorter one?",
 };
 
 export default async function DevTools(store: AppStore) {


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/devtools/issues/5856

We wrote this copy correctly [in February](https://www.notion.so/replayio/Back-end-error-messages-47afdf09b20f419cb8610138bd053d26) but it looks like we decided to collapse the Fatal and OldBuild errors. This puts it back to the original intent, which is giving a descriptive error when there's a fatal. Also used Brian's recommendation to talk about recording a second time, rather than a general "oops" dead-end.