### PR TITLE
Fix persistence of webconsole prefs

### DIFF
--- a/src/devtools/client/webconsole/actions/filters.ts
+++ b/src/devtools/client/webconsole/actions/filters.ts
@@ -4,32 +4,12 @@
 
 import type { UIThunkAction } from "ui/actions";
 
-import { prefs } from "../utils/prefs";
-
 import {
   filterTextUpdated,
   filterToggled,
   getAllFilters,
   FilterBooleanFields,
 } from "../reducers/filters";
-
-type PrefsKeys = keyof typeof prefs;
-
-type MessageFilters = "error" | "warn" | "info" | "debug" | "log";
-
-const FILTER_PREF_MAP: Record<MessageFilters, PrefsKeys> = {
-  error: "filterError",
-  warn: "filterWarn",
-  info: "filterInfo",
-  debug: "filterDebug",
-  log: "filterLog",
-};
-
-const updatePrefs = (filter: MessageFilters, active: boolean) => {
-  const prefKey = FILTER_PREF_MAP[filter];
-  // TODO Centralize prefs updates instead of doing in a thunk
-  prefs[prefKey] = active;
-};
 
 const filterStateUpdated = (): UIThunkAction => (dispatch, getState) => {
   const newFiltersState = getAllFilters(getState());
@@ -51,19 +31,10 @@ export const filterTextSet = (text: string): UIThunkAction => {
 
 export function filterToggle(filter: FilterBooleanFields): UIThunkAction {
   return (dispatch, getState) => {
-    const filtersState = getAllFilters(getState());
     // Actually toggle the state
     dispatch(filterToggled(filter));
 
     // Force a recalculation of updated messages
     dispatch(filterStateUpdated());
-
-    // Now update prefs
-    const newFiltersState = getAllFilters(getState());
-    const newValue = newFiltersState[filter];
-
-    // Technically mismatching keys here - the UI does toggle `"nodemodules"`,
-    // but we don't have that set up to persist right now
-    updatePrefs(filter as MessageFilters, newValue);
   };
 }

--- a/src/devtools/client/webconsole/actions/index.js
+++ b/src/devtools/client/webconsole/actions/index.js
@@ -5,11 +5,15 @@
 "use strict";
 
 const actionModules = [
+  // These are now RTK "slices" exporting their action creators
+  require("devtools/client/webconsole/reducers/ui"),
+  require("devtools/client/webconsole/reducers/filters"),
+
+  // Still need some thunks from here
   require("devtools/client/webconsole/actions/filters"),
+
   require("devtools/client/webconsole/actions/input"),
   require("devtools/client/webconsole/actions/messages"),
-  // This is now an RTK "slice" exporting its action creators
-  require("devtools/client/webconsole/reducers/ui"),
   require("devtools/client/webconsole/actions/toolbox"),
 ];
 

--- a/src/devtools/client/webconsole/components/FilterBar/FilterBar.js
+++ b/src/devtools/client/webconsole/components/FilterBar/FilterBar.js
@@ -4,72 +4,23 @@
 "use strict";
 
 // React & Redux
-const React = require("react");
-const { Component } = React;
-const { connect } = require("react-redux");
-
-// Actions
-const actions = require("devtools/client/webconsole/actions/index");
-
-// Selectors
-const { getFilteredMessagesCount } = require("devtools/client/webconsole/selectors/messages");
-const { getAllMessagesById } = require("devtools/client/webconsole/selectors/messages");
+import React from "react";
 
 // Constants
-const FilterSearchBox = require("./FilterSearchBox").default;
-const ClearButton = require("./ClearButton").default;
-const { FilterDrawerToggle } = require("./FilterDrawerToggle");
+import FilterSearchBox from "./FilterSearchBox";
+import ClearButton from "./ClearButton";
+import { FilterDrawerToggle } from "./FilterDrawerToggle";
 
-const PropTypes = require("prop-types");
-
-class FilterBar extends Component {
-  static get propTypes() {
-    return {
-      filteredMessagesCount: PropTypes.object.isRequired,
-      allMessagesById: PropTypes.object,
-    };
-  }
-
-  shouldComponentUpdate(nextProps) {
-    const { filteredMessagesCount, allMessagesById } = this.props;
-
-    if (JSON.stringify(nextProps.filteredMessagesCount) !== JSON.stringify(filteredMessagesCount)) {
-      return true;
-    }
-
-    if (nextProps.allMessagesById !== allMessagesById) {
-      return true;
-    }
-
-    return false;
-  }
-
-  render() {
-    return (
-      <div
-        className={`webconsole-filteringbar-wrapper text-xs`}
-        aria-live="off"
-        ref={node => (this.wrapperNode = node)}
-      >
-        <div className="devtools-toolbar devtools-input-toolbar webconsole-filterbar-primary space-x-2 px-2 py-1">
-          <FilterDrawerToggle />
-          <FilterSearchBox />
-          <ClearButton />
-        </div>
+function FilterBar() {
+  return (
+    <div className={`webconsole-filteringbar-wrapper text-xs`} aria-live="off">
+      <div className="devtools-toolbar devtools-input-toolbar webconsole-filterbar-primary space-x-2 px-2 py-1">
+        <FilterDrawerToggle />
+        <FilterSearchBox />
+        <ClearButton />
       </div>
-    );
-  }
+    </div>
+  );
 }
 
-function mapStateToProps(state) {
-  return {
-    filteredMessagesCount: getFilteredMessagesCount(state),
-    allMessagesById: getAllMessagesById(state),
-  };
-}
-
-export default connect(mapStateToProps, {
-  messagesClearEvaluations: actions.messagesClearEvaluations,
-  filterTextSet: actions.filterTextSet,
-  filterToggle: actions.filterToggle,
-})(FilterBar);
+export default FilterBar;

--- a/src/devtools/client/webconsole/components/FilterBar/FilterSearchBox.tsx
+++ b/src/devtools/client/webconsole/components/FilterBar/FilterSearchBox.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, KeyboardEvent, useState } from "react";
-import { connect } from "react-redux";
+import { useDispatch } from "react-redux";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 const actions = require("devtools/client/webconsole/actions/index");
 
@@ -14,11 +14,13 @@ function TextInput(props: React.HTMLProps<HTMLInputElement>) {
   );
 }
 
-export function FilterSearchBox({ filterTextSet }: { filterTextSet: any }) {
+export function FilterSearchBox() {
+  const dispatch = useDispatch();
+
   const [searchString, _setSearchString] = useState("");
   const setSearchString = (value: string) => {
     _setSearchString(value);
-    filterTextSet(value);
+    dispatch(actions.filterTextSet(value));
   };
   const onChange = (e: ChangeEvent<HTMLInputElement>) => setSearchString(e.target.value);
   const clearInput = () => setSearchString("");
@@ -51,6 +53,4 @@ export function FilterSearchBox({ filterTextSet }: { filterTextSet: any }) {
   );
 }
 
-export default connect(state => ({}), {
-  filterTextSet: actions.filterTextSet,
-})(FilterSearchBox);
+export default FilterSearchBox;

--- a/src/devtools/client/webconsole/reducers/ui.ts
+++ b/src/devtools/client/webconsole/reducers/ui.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { createSlice, createNextState } from "@reduxjs/toolkit";
 
-interface WebconsoleUIState {
+export interface WebconsoleUIState {
   timestampsVisible: boolean;
 }
 

--- a/src/devtools/client/webconsole/store.ts
+++ b/src/devtools/client/webconsole/store.ts
@@ -16,6 +16,8 @@ export function getConsoleInitialState() {
       debug: prefs.filterDebug,
       log: prefs.filterLog,
     }),
-    consoleUI: UiState(),
+    consoleUI: UiState({
+      timestampsVisible: prefs.timestampsVisible,
+    }),
   };
 }

--- a/src/ui/state/index.ts
+++ b/src/ui/state/index.ts
@@ -11,6 +11,7 @@ import { ComputedState } from "devtools/client/inspector/computed/state";
 import { MessageState } from "devtools/client/webconsole/reducers/messages";
 import { NetworkState } from "ui/reducers/network";
 import { QuickOpenState } from "devtools/client/debugger/src/reducers/quick-open";
+import type { WebconsoleUIState } from "devtools/client/webconsole/reducers/ui";
 import { WebconsoleFiltersState } from "devtools/client/webconsole/reducers/filters";
 import { LayoutState } from "./layout";
 
@@ -20,6 +21,7 @@ export interface UIState {
   classList: ClassListState;
   comments: CommentsState;
   computed: ComputedState;
+  consoleUI: WebconsoleUIState;
   contextMenus: ContextMenusState;
   eventListenerBreakpoints: any;
   filters: WebconsoleFiltersState;


### PR DESCRIPTION
This PR:

- Adds `consoleUI` to the `UIState` definition
- Restores use of `prefs.timestampsVisible` in defining `consoleUI` initial state
- Restructures webconsole prefs persistence to centralize the persistence logic and actually set persistence values reactively

Previously, the "log level" prefs were being persisted in a thunk,
in `actions/filters`.  Jason wants pref persistence to be reactive
and in a single location, in `ui/setup/prefs`.

Also, the `timestampsVisible` flag wasn't being persisted properly,
and the `node_modules` pref looks like it was never persisted.  Both
of those are now persisted correctly.

Fixes #5845 