### PR TITLE
Tweaking error messages

### DIFF
--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -80,7 +80,9 @@ enum SessionError {
 const SessionErrorMessages: Record<number, string> = {
   [SessionError.BackendDeploy]: "Please wait a few minutes and try again.",
   [SessionError.NodeTerminated]: "Our servers hiccuped but things should be back to normal soon.",
-  [SessionError.KnownFatalError]: "Darn! There was an error. Please try recording again.",
+  [SessionError.UnknownFatalError]: "There was an error. Please try recording again.",
+  [SessionError.KnownFatalError]:
+    "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
   [SessionError.OldBuild]:
     "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
   [SessionError.LongRecording]:


### PR DESCRIPTION
I misunderstood the previous ask. Here's where we are now:

* SessionError.OldBuild and SessionError.KnownFatalError have the same message: upgrade and try again
* SessionError.UnknownFatalError talks about trying again (no upgrade message)