### PR TITLE
Adding blue to our dark theme color ramp

### DIFF
--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -80,7 +80,9 @@ enum SessionError {
 const SessionErrorMessages: Record<number, string> = {
   [SessionError.BackendDeploy]: "Please wait a few minutes and try again.",
   [SessionError.NodeTerminated]: "Our servers hiccuped but things should be back to normal soon.",
-  [SessionError.KnownFatalError]: "Darn! There was an error. Please try recording again.",
+  [SessionError.UnknownFatalError]: "There was an error. Please try recording again.",
+  [SessionError.KnownFatalError]:
+    "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
   [SessionError.OldBuild]:
     "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
   [SessionError.LongRecording]:

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -80,12 +80,11 @@ enum SessionError {
 const SessionErrorMessages: Record<number, string> = {
   [SessionError.BackendDeploy]: "Please wait a few minutes and try again.",
   [SessionError.NodeTerminated]: "Our servers hiccuped but things should be back to normal soon.",
-  [SessionError.KnownFatalError]:
-    "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
+  [SessionError.KnownFatalError]: "Darn! There was an error. Please try recording again.",
   [SessionError.OldBuild]:
     "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
   [SessionError.LongRecording]:
-    "You’ve hit an error that happens with long recordings. Can you try a shorter recording?",
+    "You’ve hit an error that happens with long recordings. Can you try a shorter one?",
 };
 
 export default async function DevTools(store: AppStore) {


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/devtools/issues/5745

Colour is very subjective, so I'm sure we'll end up tweaking this more. But here's an iteration that starts with our website's dark blue and builds our color ramp off of that. 

Loom: https://www.loom.com/share/b9a4c667126d42b18efe213ba8cec05d

Before:
<img width="544" alt="image" src="https://user-images.githubusercontent.com/9154902/159388760-0691ce0e-4655-40c6-b101-7bc240ea3a06.png">

After:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/9154902/159388808-8c8fa111-ba45-4fd8-8503-bd549a3dbc7f.png">
