### PR TITLE
Updating error text

### DIFF
--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -276,7 +276,12 @@ function ReactDevtoolsPanel({
     compareNumericStrings(reactInitPoint, currentPoint) <= 0;
 
   if (!isReady) {
-    return <div className="p-4">React DevTools not yet initialised at this point in time.</div>;
+    return (
+      <div className="flex flex-col gap-4 p-4">
+        <div>React DevTools not yet loaded.</div>
+        <div>Try picking a different point on the timeline.</div>
+      </div>
+    );
   }
 
   const ReactDevTools = createReactDevTools(


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/devtools/issues/5320

When the timeline just hasn't loaded yet, we say:

**React DevTools not yet loaded.**
Try picking a different point on the timeline.



When we hit a bigger issue:

**React DevTools failed to init.**
Try picking a different point on the timeline or reloading the page. If the problem persists, try creating a new recording with the latest version of the Replay browser.
