### PR TITLE
Changing dark theme to be more zypsy blue

### DIFF
--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -356,16 +356,16 @@
   */
 
   /* Color ramp (Dark) */
-  --theme-base-100: #000000; /* background chrome */
-  --theme-base-95: #252525; /* tab bars */
-  --theme-base-90: #303030; /* editor and selected tab */
-  --theme-base-85: #3c3c3c; /* textfields */
-  --theme-base-80: #5c5c5c;
-  --theme-base-70: #828282;
-  --theme-base-60: #a3a3a3;
+  --theme-base-100: #000; /* background chrome */
+  --theme-base-95: #192230; /* tab bars */
+  --theme-base-90: #3d4552; /* editor and selected tab */
+  --theme-base-85: #3e434b; /* textfields */
+  --theme-base-80: #797d81;
+  --theme-base-70: #a2a6a8;
+  --theme-base-60: #c3c6c8;
 
   /* Core classes (Dark) */
-  --chrome: #1c1c1c; /* bg app */
+  --chrome: #081120; /* bg app */
   --theme-body-color: var(--grey-30);
   --checkbox-border: var(--theme-base-90);
   --checkbox: var(--theme-base-80);


### PR DESCRIPTION
[Oops, I first pushed an incorrect PR over here: https://github.com/RecordReplay/devtools/pull/5909 Trying again]

Fixes https://github.com/RecordReplay/devtools/issues/5745

Colour is very subjective, so I'm sure we'll end up tweaking this more. But here's an iteration that starts with our website's dark blue and builds our color ramp off of that. 

Loom: https://www.loom.com/share/b9a4c667126d42b18efe213ba8cec05d

Before:
<img width="544" alt="image" src="https://user-images.githubusercontent.com/9154902/159388760-0691ce0e-4655-40c6-b101-7bc240ea3a06.png">

After:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/9154902/159388808-8c8fa111-ba45-4fd8-8503-bd549a3dbc7f.png">
