### PR TITLE
Keep gutter buttons from scrolling horizontally

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -81,10 +81,10 @@ export default function LineNumberTooltip({
 
   const setHoveredLineNumber = ({
     lineNumber,
-    lineNode,
+    lineNumberNode,
   }: {
     lineNumber: number;
-    lineNode: HTMLElement;
+    lineNumberNode: HTMLElement;
   }) => {
     // The gutter re-renders when we click the line number to add
     // a breakpoint. That triggers a second gutterLineEnter event
@@ -100,7 +100,7 @@ export default function LineNumberTooltip({
     }
 
     dispatch(updateHoveredLineNumber(lineNumber));
-    setTargetNode(lineNode);
+    setTargetNode(lineNumberNode);
   };
   const clearHoveredLineNumber = () => {
     setTargetNode(null);

--- a/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/StaticTooltip.tsx
@@ -7,9 +7,14 @@ type StaticTooltipProps = {
   className?: string;
 };
 
+const GUTTER_HEIGHT = 15;
+const BUTTON_HEIGHT = 18;
+
 export default function StaticTooltip({ targetNode, children, className }: StaticTooltipProps) {
-  const { top, left } = targetNode.getBoundingClientRect();
-  let style = { top: `${top}px`, left: `${left}px` };
+  const { top, right } = targetNode.getBoundingClientRect();
+  let style = { top: `${top + (GUTTER_HEIGHT - BUTTON_HEIGHT) / 2}px`, left: `${right}px` };
+
+  console.log(targetNode)
 
   return ReactDOM.createPortal(
     <div className={`static-tooltip z-10 ml-1 -mt-1 text-sm ${className}`} style={style}>

--- a/src/devtools/client/debugger/src/utils/editor/line-events.js
+++ b/src/devtools/client/debugger/src/utils/editor/line-events.js
@@ -27,6 +27,8 @@ function isValidTarget(target) {
   return isHoveredOnLine(target) && !isNonBreakableLineNode && !isTooltip;
 }
 
+let _LAST_LINE_NUMBER = null;
+
 function emitLineMouseEnter(codeMirror, target) {
   trackEventOnce("editor.mouse_over");
 
@@ -35,17 +37,23 @@ function emitLineMouseEnter(codeMirror, target) {
 
   const lineNumberNode = getLineNumberNode(row);
   const lineNumber = safeJsonParse(lineNumberNode.textContent);
+  _LAST_LINE_NUMBER = lineNumber;
 
-  target.addEventListener(
+  lineNode.addEventListener(
     "mouseleave",
-    event => dispatch(codeMirror, "lineMouseLeave", { lineNumber, lineNode }),
+    event => {
+      console.log({lineNumber, _LAST_LINE_NUMBER});
+      if (lineNumber !== _LAST_LINE_NUMBER || !lineNumberNode.matches(":hover")) {
+        dispatch(codeMirror, "lineMouseLeave", { lineNumber, lineNode, lineNumberNode })
+      }
+    },
     {
       capture: true,
       once: true,
     }
   );
 
-  dispatch(codeMirror, "lineMouseEnter", { lineNumber, lineNode });
+  dispatch(codeMirror, "lineMouseEnter", { lineNumber, lineNode, lineNumberNode });
 }
 
 export function onLineMouseOver(codeMirror) {


### PR DESCRIPTION
Right now, the editor elements that show up on hover (e.g. hits tooltip, +/</> buttons) are anchored to the corresponding line. This makes them scroll away from view when you horizontally-scroll to the right of the editor, since they're anchored to the first column of the line.

This is one of many approaches to keep it from moving around. Another approach I want to try before landing anything is whether we can do a simpler version where we just attach the elements to the gutter element instead of the line, which (hopefully) would have the same effect.

https://user-images.githubusercontent.com/15959269/159467088-82abeafa-6f90-451e-8c01-c2f407c924b0.mov