### PR TITLE
Applying GraphQL types

### DIFF
--- a/pages/team/invitation/[id].tsx
+++ b/pages/team/invitation/[id].tsx
@@ -37,7 +37,7 @@ export default function Share() {
         return;
       }
 
-      if (auth0.isAuthenticated) {
+      if (auth0.isAuthenticated && invitationCode) {
         claimTeamInvitationCode({ variables: { code: invitationCode } });
       } else {
         // If the user is not logged in, show them the login screen

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -93,7 +93,7 @@ function _DevTools({
     }
 
     trackEventOnce("session.devtools_start", {
-      userIsAuthor,
+      userIsAuthor: !!userIsAuthor,
       workspaceUuid: recording?.workspace?.id || null,
     });
   }, [loading]);

--- a/src/ui/components/shared/SharingModal/CollaboratorsList.tsx
+++ b/src/ui/components/shared/SharingModal/CollaboratorsList.tsx
@@ -20,7 +20,9 @@ function Collaborator({
 }) {
   const { deleteCollaborator } = hooks.useDeleteCollaborator();
   const handleDeleteClick = () => {
-    deleteCollaborator({ variables: { collaborationId } });
+    if (collaborationId) {
+      deleteCollaborator({ variables: { collaborationId } });
+    }
   };
   let iconAndName;
 

--- a/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
+++ b/src/ui/components/shared/UserSettingsModal/UserSettingsModal.tsx
@@ -112,8 +112,9 @@ function UserAPIKeys() {
       loading={addLoading}
       error={addError}
       addKey={(label, scopes) =>
+        // @ts-ignore
         addUserApiKey({ variables: { label: label, scopes } }).then(
-          resp => resp.data.createUserAPIKey
+          resp => resp.data?.createUserAPIKey
         )
       }
       deleteKey={id => deleteUserApiKey({ variables: { id } })}

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceAPIKeys.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceAPIKeys.tsx
@@ -23,9 +23,10 @@ export default function WorkspaceAPIKeys({ workspaceId }: { workspaceId: string 
       loading={addLoading}
       error={addError}
       addKey={(label, scopes) =>
+        // @ts-ignore
         addWorkspaceApiKey({
-          variables: { label, scopes, workspaceId },
-        }).then(resp => resp.data.createWorkspaceAPIKey)
+          variables: { label, scopes: scopes ?? [], workspaceId },
+        }).then(resp => resp.data?.createWorkspaceAPIKey)
       }
       scopes={["admin:all", "write:sourcemap"]}
       deleteKey={id => deleteWorkspaceApiKey({ variables: { id } })}

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -87,7 +87,7 @@ function WorkspaceForm({ workspaceId, members }: WorkspaceFormProps) {
     setErrorMessage(null);
     setIsLoading(true);
     const resp = await inviteNewWorkspaceMember({
-      variables: { workspaceId, email: inputValue, roles: ["viewer", "debugger"] },
+      variables: { workspaceId: workspaceId!, email: inputValue, roles: ["viewer", "debugger"] },
     });
 
     if (resp.errors) {

--- a/src/ui/hooks/collaborators.ts
+++ b/src/ui/hooks/collaborators.ts
@@ -1,5 +1,7 @@
 import { gql, useMutation } from "@apollo/client";
 import { RecordingId } from "@recordreplay/protocol";
+import { AddCollaborator, AddCollaboratorVariables } from "graphql/AddCollaborator";
+import { DeleteCollaborator, DeleteCollaboratorVariables } from "graphql/DeleteCollaborator";
 import { useGetRecording } from "./recordings";
 import { useGetUserId } from "./users";
 
@@ -15,7 +17,10 @@ export function useIsCollaborator(recordingId: RecordingId) {
 }
 
 export function useDeleteCollaborator() {
-  const [deleteCollaborator, { error }] = useMutation(
+  const [deleteCollaborator, { error }] = useMutation<
+    DeleteCollaborator,
+    DeleteCollaboratorVariables
+  >(
     gql`
       mutation DeleteCollaborator($collaborationId: ID!) {
         removeRecordingCollaborator(input: { id: $collaborationId }) {
@@ -36,7 +41,10 @@ export function useDeleteCollaborator() {
 }
 
 export function useAddNewCollaborator(onCompleted: () => void, onError: () => void) {
-  const [addNewCollaborator, { loading, error }] = useMutation(
+  const [addNewCollaborator, { loading, error }] = useMutation<
+    AddCollaborator,
+    AddCollaboratorVariables
+  >(
     gql`
       mutation AddCollaborator($email: String!, $recordingId: ID!) {
         addRecordingCollaborator(input: { email: $email, recordingId: $recordingId }) {

--- a/src/ui/hooks/comments/comments.ts
+++ b/src/ui/hooks/comments/comments.ts
@@ -8,6 +8,7 @@ import {
   UpdateCommentReplyContent,
   UpdateCommentReplyContentVariables,
 } from "graphql/UpdateCommentReplyContent";
+import { GetComments, GetCommentsVariables } from "graphql/GetComments";
 
 const NO_COMMENTS: Comment[] = [];
 
@@ -16,7 +17,7 @@ export function useGetComments(recordingId: RecordingId): {
   loading: boolean;
   error?: ApolloError;
 } {
-  const { data, loading, error } = useQuery(GET_COMMENTS, {
+  const { data, loading, error } = useQuery<GetComments, GetCommentsVariables>(GET_COMMENTS, {
     variables: { recordingId },
     pollInterval: 5000,
   });

--- a/src/ui/hooks/comments/comments.ts
+++ b/src/ui/hooks/comments/comments.ts
@@ -3,6 +3,11 @@ import { gql, useQuery, useMutation, ApolloError } from "@apollo/client";
 import { query } from "ui/utils/apolloClient";
 import { Comment, CommentPosition } from "ui/state/comments";
 import { GET_COMMENTS_TIME, GET_COMMENTS } from "ui/graphql/comments";
+import { UpdateCommentContent, UpdateCommentContentVariables } from "graphql/UpdateCommentContent";
+import {
+  UpdateCommentReplyContent,
+  UpdateCommentReplyContentVariables,
+} from "graphql/UpdateCommentReplyContent";
 
 const NO_COMMENTS: Comment[] = [];
 
@@ -36,7 +41,10 @@ export function useGetComments(recordingId: RecordingId): {
 }
 
 export function useUpdateComment() {
-  const [updateCommentContent, { error }] = useMutation(
+  const [updateCommentContent, { error }] = useMutation<
+    UpdateCommentContent,
+    UpdateCommentContentVariables
+  >(
     gql`
       mutation UpdateCommentContent($newContent: String!, $commentId: ID!, $position: JSONObject) {
         updateComment(input: { id: $commentId, content: $newContent, position: $position }) {
@@ -73,7 +81,10 @@ export function useUpdateComment() {
 }
 
 export function useUpdateCommentReply() {
-  const [updateCommentReplyContent, { error }] = useMutation(
+  const [updateCommentReplyContent, { error }] = useMutation<
+    UpdateCommentReplyContent,
+    UpdateCommentReplyContentVariables
+  >(
     gql`
       mutation UpdateCommentReplyContent($newContent: String!, $commentId: ID!) {
         updateCommentReply(input: { id: $commentId, content: $newContent }) {

--- a/src/ui/hooks/comments/comments.ts
+++ b/src/ui/hooks/comments/comments.ts
@@ -1,7 +1,7 @@
 import { RecordingId } from "@recordreplay/protocol";
 import { gql, useQuery, useMutation, ApolloError } from "@apollo/client";
 import { query } from "ui/utils/apolloClient";
-import { Comment, CommentPosition } from "ui/state/comments";
+import { Comment, CommentPosition, Reply } from "ui/state/comments";
 import { GET_COMMENTS_TIME, GET_COMMENTS } from "ui/graphql/comments";
 import { UpdateCommentContent, UpdateCommentContentVariables } from "graphql/UpdateCommentContent";
 import {
@@ -9,8 +9,6 @@ import {
   UpdateCommentReplyContentVariables,
 } from "graphql/UpdateCommentReplyContent";
 import { GetComments, GetCommentsVariables } from "graphql/GetComments";
-
-const NO_COMMENTS: Comment[] = [];
 
 export function useGetComments(recordingId: RecordingId): {
   comments: Comment[];
@@ -26,8 +24,7 @@ export function useGetComments(recordingId: RecordingId): {
     console.error("Apollo error while fetching comments:", error);
   }
 
-  let comments = data?.recording?.comments || NO_COMMENTS;
-  comments = comments.map((comment: any) => ({
+  let comments = (data?.recording?.comments ?? []).map((comment: any) => ({
     ...comment,
     replies: comment.replies.map((reply: any) => ({
       ...reply,
@@ -103,7 +100,7 @@ export function useUpdateCommentReply() {
     updateCommentReplyContent({
       variables: { commentId, newContent },
       optimisticResponse: {
-        updateComment: {
+        updateCommentReply: {
           success: true,
           __typename: "UpdateCommentReply",
         },

--- a/src/ui/hooks/comments/useAddComment.tsx
+++ b/src/ui/hooks/comments/useAddComment.tsx
@@ -6,6 +6,7 @@ import { trackEvent } from "ui/utils/telemetry";
 import omit from "lodash/omit";
 import { GET_USER_ID } from "ui/graphql/users";
 import { AddComment, AddCommentVariables } from "graphql/AddComment";
+import { GetComments } from "graphql/GetComments";
 
 export default function useAddComment() {
   const [addComment, { error }] = useMutation<AddComment, AddCommentVariables>(
@@ -45,14 +46,12 @@ export default function useAddComment() {
           __typename: "AddComment",
         },
       },
-      update: (cache, { data: { addComment } }) => {
-        const {
-          comment: { id: commentId },
-        } = addComment;
-        const data: any = cache.readQuery({
+      update: (cache, { data }) => {
+        const commentId = data?.addComment?.comment?.id;
+        const cacheData = cache.readQuery<GetComments>({
           query: GET_COMMENTS,
           variables: { recordingId: comment.recordingId },
-        });
+        })!;
         const {
           viewer: {
             user: { id: userId },
@@ -75,11 +74,11 @@ export default function useAddComment() {
           __typename: "Comment",
         };
         const newData = {
-          ...data,
+          ...cacheData,
           recording: {
-            ...data.recording,
+            ...cacheData.recording,
             comments: [
-              ...data.recording.comments.filter((c: Remark) => c.id !== commentId),
+              ...(cacheData.recording?.comments ?? []).filter(c => c.id !== commentId),
               newComment,
             ],
           },

--- a/src/ui/hooks/comments/useAddComment.tsx
+++ b/src/ui/hooks/comments/useAddComment.tsx
@@ -5,9 +5,10 @@ import { GET_COMMENTS } from "ui/graphql/comments";
 import { trackEvent } from "ui/utils/telemetry";
 import omit from "lodash/omit";
 import { GET_USER_ID } from "ui/graphql/users";
+import { AddComment, AddCommentVariables } from "graphql/AddComment";
 
 export default function useAddComment() {
-  const [addComment, { error }] = useMutation(
+  const [addComment, { error }] = useMutation<AddComment, AddCommentVariables>(
     gql`
       mutation AddComment($input: AddCommentInput!) {
         addComment(input: $input) {

--- a/src/ui/hooks/comments/useAddCommentReply.tsx
+++ b/src/ui/hooks/comments/useAddCommentReply.tsx
@@ -5,12 +5,13 @@ import { GET_COMMENTS } from "ui/graphql/comments";
 import { Reply } from "ui/state/comments";
 import { PENDING_COMMENT_ID } from "ui/reducers/comments";
 import { useGetRecordingId } from "../recordings";
+import { AddCommentReply, AddCommentReplyVariables } from "graphql/AddCommentReply";
 
 export default function useAddCommentReply() {
   const { user } = useAuth0();
   const recordingId = useGetRecordingId();
 
-  const [addCommentReply, { error }] = useMutation(
+  const [addCommentReply, { error }] = useMutation<AddCommentReply, AddCommentReplyVariables>(
     gql`
       mutation AddCommentReply($input: AddCommentReplyInput!) {
         addCommentReply(input: $input) {

--- a/src/ui/hooks/comments/useAddCommentReply.tsx
+++ b/src/ui/hooks/comments/useAddCommentReply.tsx
@@ -6,6 +6,7 @@ import { Reply } from "ui/state/comments";
 import { PENDING_COMMENT_ID } from "ui/reducers/comments";
 import { useGetRecordingId } from "../recordings";
 import { AddCommentReply, AddCommentReplyVariables } from "graphql/AddCommentReply";
+import { GetComments } from "graphql/GetComments";
 
 export default function useAddCommentReply() {
   const { user } = useAuth0();
@@ -47,15 +48,11 @@ export default function useAddCommentReply() {
         },
       },
       update: (cache, payload) => {
-        const {
-          data: {
-            addCommentReply: { commentReply },
-          },
-        } = payload;
-        const data: any = cache.readQuery({
+        const commentReply = payload?.data?.addCommentReply?.commentReply;
+        const cachedata = cache.readQuery<GetComments>({
           query: GET_COMMENTS,
           variables: { recordingId },
-        });
+        })!;
         const {
           viewer: {
             user: { id: userId },
@@ -64,12 +61,14 @@ export default function useAddCommentReply() {
           query: GET_USER_ID,
         });
 
-        const parentComment = data.recording.comments.find((r: any) => r.id === reply.parentId);
+        const parentComment = (cachedata?.recording?.comments ?? []).find(
+          (r: any) => r.id === reply.parentId
+        );
         if (!parentComment) {
           return;
         }
         const newReply = {
-          id: commentReply.id,
+          id: commentReply!.id,
           content: reply.content,
           createdAt: reply.createdAt,
           updatedAt: reply.updatedAt,
@@ -86,17 +85,17 @@ export default function useAddCommentReply() {
           ...parentComment,
           replies: [
             ...parentComment.replies.filter(
-              (r: any) => r.id !== PENDING_COMMENT_ID && r.id !== commentReply.id
+              (r: any) => r.id !== PENDING_COMMENT_ID && r.id !== commentReply!.id
             ),
             newReply,
           ],
         };
         const newData = {
-          ...data,
+          ...cachedata,
           recording: {
-            ...data.recording,
+            ...cachedata.recording,
             comments: [
-              ...data.recording.comments.filter((r: any) => r.id !== reply.parentId),
+              ...(cachedata.recording?.comments ?? []).filter((r: any) => r.id !== reply.parentId),
               newParentComment,
             ],
           },

--- a/src/ui/hooks/comments/useDeleteComment.tsx
+++ b/src/ui/hooks/comments/useDeleteComment.tsx
@@ -21,7 +21,7 @@ export default function useDeleteComment() {
   return (commentId: string, recordingId: RecordingId) => {
     deleteComment({
       variables: { commentId },
-      optimisticResponse: { deleteComment: { success: true } },
+      optimisticResponse: { deleteComment: { success: true, __typename: "DeleteComment" } },
       update: cache => {
         const data: any = cache.readQuery({
           query: GET_COMMENTS,

--- a/src/ui/hooks/comments/useDeleteComment.tsx
+++ b/src/ui/hooks/comments/useDeleteComment.tsx
@@ -1,9 +1,10 @@
 import { RecordingId } from "@recordreplay/protocol";
 import { gql, useMutation } from "@apollo/client";
 import { GET_COMMENTS } from "ui/graphql/comments";
+import { DeleteComment, DeleteCommentVariables } from "graphql/DeleteComment";
 
 export default function useDeleteComment() {
-  const [deleteComment, { error }] = useMutation(
+  const [deleteComment, { error }] = useMutation<DeleteComment, DeleteCommentVariables>(
     gql`
       mutation DeleteComment($commentId: ID!) {
         deleteComment(input: { id: $commentId }) {

--- a/src/ui/hooks/comments/useDeleteCommentReply.tsx
+++ b/src/ui/hooks/comments/useDeleteCommentReply.tsx
@@ -24,7 +24,9 @@ export default function useDeleteCommentReply() {
   return (commentReplyId: string, recordingId: RecordingId) => {
     deleteCommentReply({
       variables: { commentReplyId },
-      optimisticResponse: { deleteCommentReply: { success: true } },
+      optimisticResponse: {
+        deleteCommentReply: { success: true, __typename: "DeleteCommentReply" },
+      },
       update: cache => {
         const data: any = cache.readQuery({
           query: GET_COMMENTS,

--- a/src/ui/hooks/comments/useDeleteCommentReply.tsx
+++ b/src/ui/hooks/comments/useDeleteCommentReply.tsx
@@ -1,9 +1,13 @@
 import { RecordingId } from "@recordreplay/protocol";
 import { gql, useMutation } from "@apollo/client";
 import { GET_COMMENTS } from "ui/graphql/comments";
+import { DeleteCommentReply, DeleteCommentReplyVariables } from "graphql/DeleteCommentReply";
 
 export default function useDeleteCommentReply() {
-  const [deleteCommentReply, { error }] = useMutation(
+  const [deleteCommentReply, { error }] = useMutation<
+    DeleteCommentReply,
+    DeleteCommentReplyVariables
+  >(
     gql`
       mutation DeleteCommentReply($commentReplyId: ID!) {
         deleteCommentReply(input: { id: $commentReplyId }) {

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -187,7 +187,7 @@ export function useIsTeamDeveloper() {
     console.error("Apollo error while getting the user's role", error);
   }
 
-  return { isTeamDeveloper: data?.recording.userRole !== "team-user", loading };
+  return { isTeamDeveloper: data?.recording?.userRole !== "team-user", loading };
 }
 
 // If the user has no role, then they're either viewing a non-team recording they
@@ -202,7 +202,7 @@ export function useHasNoRole() {
     console.error("Apollo error while getting the user's role", error);
   }
 
-  return { hasNoRole: data?.recording.userRole === "none", loading };
+  return { hasNoRole: data?.recording?.userRole === "none", loading };
 }
 
 function convertRecording(rec: any): Recording | undefined {
@@ -262,7 +262,7 @@ export function useGetRecordingPhoto(recordingId: RecordingId): {
   }
 
   const screenData = data.recording?.thumbnail;
-  return { error, loading, screenData };
+  return { error, loading, screenData: screenData ?? undefined };
 }
 
 export function useGetOwnersAndCollaborators(recordingId: RecordingId): {
@@ -343,7 +343,7 @@ export function useGetOwnersAndCollaborators(recordingId: RecordingId): {
           new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
       );
   }
-  const recording = convertRecording(data.recording);
+  const recording = convertRecording(data?.recording);
   return { collaborators, recording, loading, error };
 }
 
@@ -370,7 +370,7 @@ export function useGetIsPrivate(recordingId: RecordingId) {
     console.error("Apollo error while getting isPrivate", error);
   }
 
-  const isPrivate = data.recording?.private;
+  const isPrivate = data?.recording?.private;
 
   return { isPrivate, loading, error };
 }
@@ -410,7 +410,7 @@ export function useIsOwner() {
     return false;
   }
 
-  const recording = data.recording;
+  const recording = data?.recording;
   if (!recording?.owner) {
     return false;
   }
@@ -460,8 +460,11 @@ export function useGetWorkspaceRecordings(
   }
 
   let recordings: Recording[] = [];
-  if (data?.node?.recordings) {
-    recordings = data.node.recordings.edges.map(({ node }: any) => convertRecording(node));
+
+  // @ts-ignore
+  const recordingsData = data?.node?.recordings;
+  if (recordingsData) {
+    recordings = recordingsData.edges.map(({ node }: any) => convertRecording(node));
   }
   return { recordings, loading };
 }
@@ -630,7 +633,7 @@ export function useUpdateRecordingWorkspace(isOptimistic: boolean = true) {
           recording: {
             uuid: recordingId,
             __typename: "Recording",
-            workspace: { __typename: "Workspace", id: targetWorkspaceId },
+            workspace: { __typename: "Workspace", id: targetWorkspaceId! },
           },
           success: true,
           __typename: "UpdateRecordingWorkspace",

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -29,6 +29,19 @@ import {
   AcceptRecordingCollaboratorRequest,
   AcceptRecordingCollaboratorRequestVariables,
 } from "graphql/AcceptRecordingCollaboratorRequest";
+import { GetRecording, GetRecordingVariables } from "graphql/GetRecording";
+import { GetRecordingUserId, GetRecordingUserIdVariables } from "graphql/GetRecordingUserId";
+import { GetMyRecordings } from "graphql/GetMyRecordings";
+import { getRecordingPhoto, getRecordingPhotoVariables } from "graphql/getRecordingPhoto";
+import {
+  GetOwnerAndCollaborators,
+  GetOwnerAndCollaboratorsVariables,
+} from "graphql/GetOwnerAndCollaborators";
+import { GetRecordingPrivacy, GetRecordingPrivacyVariables } from "graphql/GetRecordingPrivacy";
+import {
+  GetWorkspaceRecordings,
+  GetWorkspaceRecordingsVariables,
+} from "graphql/GetWorkspaceRecordings";
 
 function isTest() {
   return new URL(window.location.href).searchParams.get("test");
@@ -148,7 +161,7 @@ export function useGetRecording(recordingId: RecordingId | null | undefined): {
   isAuthorized: boolean;
   loading: boolean;
 } {
-  const { data, error, loading } = useQuery(GET_RECORDING, {
+  const { data, error, loading } = useQuery<GetRecording, GetRecordingVariables>(GET_RECORDING, {
     variables: { recordingId },
     skip: !recordingId,
   });
@@ -166,7 +179,7 @@ export function useGetRecording(recordingId: RecordingId | null | undefined): {
 
 export function useIsTeamDeveloper() {
   const recordingId = getRecordingId();
-  const { data, error, loading } = useQuery(GET_RECORDING, {
+  const { data, error, loading } = useQuery<GetRecording, GetRecordingVariables>(GET_RECORDING, {
     variables: { recordingId },
   });
 
@@ -181,7 +194,7 @@ export function useIsTeamDeveloper() {
 // don't own, or a team recording for a team that they don't belong to.
 export function useHasNoRole() {
   const recordingId = getRecordingId();
-  const { data, error, loading } = useQuery(GET_RECORDING, {
+  const { data, error, loading } = useQuery<GetRecording, GetRecordingVariables>(GET_RECORDING, {
     variables: { recordingId },
   });
 
@@ -228,7 +241,7 @@ export function useGetRecordingPhoto(recordingId: RecordingId): {
   loading: boolean;
   screenData?: string;
 } {
-  const { data, loading, error } = useQuery(
+  const { data, loading, error } = useQuery<getRecordingPhoto, getRecordingPhotoVariables>(
     gql`
       query getRecordingPhoto($recordingId: UUID!) {
         recording(uuid: $recordingId) {
@@ -258,7 +271,10 @@ export function useGetOwnersAndCollaborators(recordingId: RecordingId): {
   recording: Recording | undefined;
   collaborators: CollaboratorDbData[] | null;
 } {
-  const { data, loading, error } = useQuery(
+  const { data, loading, error } = useQuery<
+    GetOwnerAndCollaborators,
+    GetOwnerAndCollaboratorsVariables
+  >(
     gql`
       query GetOwnerAndCollaborators($recordingId: UUID!) {
         recording(uuid: $recordingId) {
@@ -332,7 +348,7 @@ export function useGetOwnersAndCollaborators(recordingId: RecordingId): {
 }
 
 export function useGetIsPrivate(recordingId: RecordingId) {
-  const { data, loading, error } = useQuery(
+  const { data, loading, error } = useQuery<GetRecordingPrivacy, GetRecordingPrivacyVariables>(
     gql`
       query GetRecordingPrivacy($recordingId: UUID!) {
         recording(uuid: $recordingId) {
@@ -378,9 +394,12 @@ export function useUpdateIsPrivate() {
 export function useIsOwner() {
   const recordingId = useGetRecordingId();
   const { userId } = useGetUserId();
-  const { data, loading, error } = useQuery(GET_RECORDING_USER_ID, {
-    variables: { recordingId },
-  });
+  const { data, loading, error } = useQuery<GetRecordingUserId, GetRecordingUserIdVariables>(
+    GET_RECORDING_USER_ID,
+    {
+      variables: { recordingId },
+    }
+  );
 
   if (loading) {
     return false;
@@ -402,7 +421,7 @@ export function useIsOwner() {
 export function useGetPersonalRecordings():
   | { recordings: null; loading: true }
   | { recordings: Recording[]; loading: false } {
-  const { data, error, loading } = useQuery(GET_MY_RECORDINGS, {
+  const { data, error, loading } = useQuery<GetMyRecordings>(GET_MY_RECORDINGS, {
     pollInterval: 5000,
   });
 
@@ -424,7 +443,10 @@ export function useGetPersonalRecordings():
 export function useGetWorkspaceRecordings(
   currentWorkspaceId: WorkspaceId
 ): { recordings: null; loading: true } | { recordings: Recording[]; loading: false } {
-  const { data, error, loading } = useQuery(GET_WORKSPACE_RECORDINGS, {
+  const { data, error, loading } = useQuery<
+    GetWorkspaceRecordings,
+    GetWorkspaceRecordingsVariables
+  >(GET_WORKSPACE_RECORDINGS, {
     variables: { workspaceId: currentWorkspaceId },
     pollInterval: 5000,
   });

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -10,6 +10,25 @@ import { useRouter } from "next/router";
 import { extractIdAndSlug } from "ui/utils/helpers";
 import { getRecordingId } from "ui/utils/recording";
 import { ColorSwatchIcon } from "@heroicons/react/solid";
+import {
+  SetRecordingIsPrivate,
+  SetRecordingIsPrivateVariables,
+} from "graphql/SetRecordingIsPrivate";
+import {
+  UpdateRecordingWorkspace,
+  UpdateRecordingWorkspaceVariables,
+} from "graphql/UpdateRecordingWorkspace";
+import { DeleteRecording, DeleteRecordingVariables } from "graphql/DeleteRecording";
+import { InitializeRecording, InitializeRecordingVariables } from "graphql/InitializeRecording";
+import { UpdateRecordingTitle, UpdateRecordingTitleVariables } from "graphql/UpdateRecordingTitle";
+import {
+  RequestRecordingAccess,
+  RequestRecordingAccessVariables,
+} from "graphql/RequestRecordingAccess";
+import {
+  AcceptRecordingCollaboratorRequest,
+  AcceptRecordingCollaboratorRequestVariables,
+} from "graphql/AcceptRecordingCollaboratorRequest";
 
 function isTest() {
   return new URL(window.location.href).searchParams.get("test");
@@ -341,7 +360,7 @@ export function useGetIsPrivate(recordingId: RecordingId) {
 }
 
 export function useUpdateIsPrivate() {
-  const [updateIsPrivate] = useMutation(
+  const [updateIsPrivate] = useMutation<SetRecordingIsPrivate, SetRecordingIsPrivateVariables>(
     gql`
       mutation SetRecordingIsPrivate($recordingId: ID!, $isPrivate: Boolean!) {
         updateRecordingPrivacy(input: { id: $recordingId, private: $isPrivate }) {
@@ -426,7 +445,10 @@ export function useGetWorkspaceRecordings(
 }
 
 export function useUpdateRecordingWorkspace(isOptimistic: boolean = true) {
-  const [updateRecordingWorkspace] = useMutation(
+  const [updateRecordingWorkspace] = useMutation<
+    UpdateRecordingWorkspace,
+    UpdateRecordingWorkspaceVariables
+  >(
     gql`
       mutation UpdateRecordingWorkspace($recordingId: ID!, $workspaceId: ID) {
         updateRecordingWorkspace(input: { id: $recordingId, workspaceId: $workspaceId }) {
@@ -609,15 +631,20 @@ const DELETE_RECORDING = gql`
 `;
 
 export function useDeleteRecording(onCompleted: () => void) {
-  const [deleteRecording] = useMutation(DELETE_RECORDING, {
-    onCompleted,
-  });
+  const [deleteRecording] = useMutation<DeleteRecording, DeleteRecordingVariables>(
+    DELETE_RECORDING,
+    {
+      onCompleted,
+    }
+  );
 
   return deleteRecording;
 }
 
 export function useDeleteRecordingFromLibrary() {
-  const [deleteRecording] = useMutation(DELETE_RECORDING);
+  const [deleteRecording] = useMutation<DeleteRecording, DeleteRecordingVariables>(
+    DELETE_RECORDING
+  );
 
   return (recordingId: RecordingId, workspaceId: WorkspaceId | null) => {
     deleteRecording({
@@ -685,7 +712,7 @@ export function useDeleteRecordingFromLibrary() {
 }
 
 export function useInitializeRecording() {
-  const [initializeRecording] = useMutation(
+  const [initializeRecording] = useMutation<InitializeRecording, InitializeRecordingVariables>(
     gql`
       mutation InitializeRecording($recordingId: ID!, $title: String!, $workspaceId: ID) {
         initializeRecording(input: { id: $recordingId, title: $title, workspaceId: $workspaceId }) {
@@ -708,7 +735,7 @@ export function useInitializeRecording() {
 }
 
 export function useUpdateRecordingTitle() {
-  const [updateRecordingTitle] = useMutation(
+  const [updateRecordingTitle] = useMutation<UpdateRecordingTitle, UpdateRecordingTitleVariables>(
     gql`
       mutation UpdateRecordingTitle($recordingId: ID!, $title: String!) {
         updateRecordingTitle(input: { id: $recordingId, title: $title }) {
@@ -780,7 +807,10 @@ export async function getRecordingMetadata(id: string) {
 export function useRequestRecordingAccess() {
   const recordingId = useGetRecordingId();
 
-  const [requestRecordingAccess] = useMutation(
+  const [requestRecordingAccess] = useMutation<
+    RequestRecordingAccess,
+    RequestRecordingAccessVariables
+  >(
     gql`
       mutation RequestRecordingAccess($recordingId: ID!) {
         requestRecordingAccess(input: { recordingId: $recordingId }) {
@@ -794,7 +824,10 @@ export function useRequestRecordingAccess() {
 }
 
 export function useAcceptRecordingRequest() {
-  const [acceptRecordingRequest] = useMutation(
+  const [acceptRecordingRequest] = useMutation<
+    AcceptRecordingCollaboratorRequest,
+    AcceptRecordingCollaboratorRequestVariables
+  >(
     gql`
       mutation AcceptRecordingCollaboratorRequest($requestId: ID!) {
         acceptRecordingCollaboratorRequest(input: { id: $requestId }) {

--- a/src/ui/hooks/sessions.ts
+++ b/src/ui/hooks/sessions.ts
@@ -3,6 +3,7 @@ import { gql, useQuery, useMutation } from "@apollo/client";
 import { User } from "ui/state/session";
 import { useGetUserId } from "./users";
 import { GET_ACTIVE_SESSIONS } from "ui/graphql/sessions";
+import { GetActiveSessions, GetActiveSessionsVariables } from "graphql/GetActiveSessions";
 
 interface SessionUser extends User {
   sessionId?: string;
@@ -14,10 +15,13 @@ interface Session {
 
 export function useGetActiveSessions(recordingId: RecordingId) {
   const { userId, loading: userLoading } = useGetUserId();
-  const { data, error, loading } = useQuery(GET_ACTIVE_SESSIONS, {
-    variables: { recordingId },
-    pollInterval: 5000,
-  });
+  const { data, error, loading } = useQuery<GetActiveSessions, GetActiveSessionsVariables>(
+    GET_ACTIVE_SESSIONS,
+    {
+      variables: { recordingId },
+      pollInterval: 5000,
+    }
+  );
 
   if (error) {
     console.error("Apollo error while getting active sessions", error);

--- a/src/ui/hooks/sessions.ts
+++ b/src/ui/hooks/sessions.ts
@@ -4,6 +4,7 @@ import { User } from "ui/state/session";
 import { useGetUserId } from "./users";
 import { GET_ACTIVE_SESSIONS } from "ui/graphql/sessions";
 import { GetActiveSessions, GetActiveSessionsVariables } from "graphql/GetActiveSessions";
+import { filter } from "lodash";
 
 interface SessionUser extends User {
   sessionId?: string;
@@ -37,16 +38,18 @@ export function useGetActiveSessions(recordingId: RecordingId) {
 
   // Don't show the user's own sessions.
   const activeSessions = data.recording?.activeSessions || [];
-  const filteredSessions = activeSessions.filter((session: Session) => session.user?.id !== userId);
+  const filteredSessions = activeSessions.filter(session => session.user?.id !== userId);
 
   // This includes the sessionId with the user. Otherwise, all anonymous users
   // look the same (null) and we can't maintain some order.
-  const users: SessionUser[] = filteredSessions
-    .map((session: Session) => ({
-      ...session.user,
-      sessionId: session.id,
-    }))
-    .sort();
+  const users: SessionUser[] = (
+    filteredSessions
+      .map(session => ({
+        ...session.user,
+        sessionId: session.id,
+      }))
+      .filter(i => i.name !== null) as SessionUser[]
+  ).sort();
 
   return { users, loading };
 }

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -28,6 +28,7 @@ import {
   UpdateUserSettingsReact,
   UpdateUserSettingsReactVariables,
 } from "graphql/UpdateUserSettingsReact";
+import { GetUserSettings } from "graphql/GetUserSettings";
 
 const emptySettings: ExperimentalUserSettings = {
   apiKeys: [],
@@ -59,7 +60,7 @@ export async function getUserSettings(): Promise<ExperimentalUserSettings> {
 
 export function useGetUserSettings() {
   const { isAuthenticated } = useAuth0();
-  const { data, error, loading } = useQuery(GET_USER_SETTINGS);
+  const { data, error, loading } = useQuery<GetUserSettings>(GET_USER_SETTINGS);
 
   if (isTest()) {
     return { userSettings: testSettings, loading: false };

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -10,6 +10,24 @@ import { features } from "ui/utils/prefs";
 import { prefs as prefsService } from "devtools/shared/services";
 import { useEffect, useState } from "react";
 import { maybeTrackTeamChange } from "ui/utils/mixpanel";
+import {
+  UpdateUserDefaultWorkspace,
+  UpdateUserDefaultWorkspaceVariables,
+} from "graphql/UpdateUserDefaultWorkspace";
+import { CreateUserAPIKey, CreateUserAPIKeyVariables } from "graphql/CreateUserAPIKey";
+import { DeleteUserAPIKey, DeleteUserAPIKeyVariables } from "graphql/DeleteUserAPIKey";
+import {
+  UpdateUserSettingsLogRocket,
+  UpdateUserSettingsLogRocketVariables,
+} from "graphql/UpdateUserSettingsLogRocket";
+import {
+  UpdateUserSettingsEventLink,
+  UpdateUserSettingsEventLinkVariables,
+} from "graphql/UpdateUserSettingsEventLink";
+import {
+  UpdateUserSettingsReact,
+  UpdateUserSettingsReactVariables,
+} from "graphql/UpdateUserSettingsReact";
 
 const emptySettings: ExperimentalUserSettings = {
   apiKeys: [],
@@ -105,6 +123,12 @@ type MutableSettings = Extract<
   "disableLogRocket" | "enableEventLink" | "showReact"
 >;
 
+type GqlPair = {
+  disableLogRocket: [UpdateUserSettingsLogRocket, UpdateUserSettingsLogRocketVariables];
+  enableEventLink: [UpdateUserSettingsEventLink, UpdateUserSettingsEventLinkVariables];
+  showReact: [UpdateUserSettingsReact, UpdateUserSettingsReactVariables];
+};
+
 const SETTINGS_MUTATIONS: Record<MutableSettings, DocumentNode> = {
   disableLogRocket: gql`
     mutation UpdateUserSettingsLogRocket($newValue: Boolean) {
@@ -130,7 +154,10 @@ const SETTINGS_MUTATIONS: Record<MutableSettings, DocumentNode> = {
 } as const;
 
 export function useUpdateUserSetting(key: MutableSettings) {
-  const [updateUserSetting, { error }] = useMutation(SETTINGS_MUTATIONS[key], {
+  const [updateUserSetting, { error }] = useMutation<
+    GqlPair[typeof key][0],
+    GqlPair[typeof key][1]
+  >(SETTINGS_MUTATIONS[key], {
     refetchQueries: ["GetUserSettings"],
   });
 
@@ -142,7 +169,10 @@ export function useUpdateUserSetting(key: MutableSettings) {
 }
 
 export function useUpdateDefaultWorkspace() {
-  const [updateUserSetting, { error }] = useMutation(
+  const [updateUserSetting, { error }] = useMutation<
+    UpdateUserDefaultWorkspace,
+    UpdateUserDefaultWorkspaceVariables
+  >(
     gql`
       mutation UpdateUserDefaultWorkspace($workspaceId: ID) {
         updateUserDefaultWorkspace(input: { workspaceId: $workspaceId }) {
@@ -177,7 +207,10 @@ export function useUpdateDefaultWorkspace() {
 }
 
 export function useAddUserApiKey() {
-  const [addUserApiKey, { loading, error }] = useMutation(ADD_USER_API_KEY, {
+  const [addUserApiKey, { loading, error }] = useMutation<
+    CreateUserAPIKey,
+    CreateUserAPIKeyVariables
+  >(ADD_USER_API_KEY, {
     refetchQueries: ["GetUserSettings"],
   });
 
@@ -185,7 +218,10 @@ export function useAddUserApiKey() {
 }
 
 export function useDeleteUserApiKey() {
-  const [deleteUserApiKey, { loading, error }] = useMutation(DELETE_USER_API_KEY, {
+  const [deleteUserApiKey, { loading, error }] = useMutation<
+    DeleteUserAPIKey,
+    DeleteUserAPIKeyVariables
+  >(DELETE_USER_API_KEY, {
     refetchQueries: ["GetUserSettings"],
   });
 

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -6,6 +6,13 @@ import { sendTelemetryEvent } from "ui/utils/telemetry";
 import { useGetRecording } from "./recordings";
 import { Recording, Workspace } from "ui/types";
 import { useGetNonPendingWorkspaces } from "./workspaces";
+import { DismissNag, DismissNagVariables } from "graphql/DismissNag";
+import { subscribeToEmailType, subscribeToEmailTypeVariables } from "graphql/subscribeToEmailType";
+import {
+  unsubscribeToEmailType,
+  unsubscribeToEmailTypeVariables,
+} from "graphql/unsubscribeToEmailType";
+import { AcceptTOS, AcceptTOSVariables } from "graphql/AcceptTOS";
 
 export async function getUserId() {
   const result = await query({
@@ -138,7 +145,7 @@ export function useGetUserInfo(): UserInfo & { loading: boolean } {
 
 export function useDismissNag() {
   const { id, nags } = useGetUserInfo();
-  const [dismissNag, { error }] = useMutation(DISMISS_NAG, {
+  const [dismissNag, { error }] = useMutation<DismissNag, DismissNagVariables>(DISMISS_NAG, {
     refetchQueries: ["GetUser"],
   });
 
@@ -158,7 +165,10 @@ export function useDismissNag() {
 }
 
 export function useSubscribeToEmailType() {
-  const [subscribeToEmailType, { error }] = useMutation(
+  const [subscribeToEmailType, { error }] = useMutation<
+    subscribeToEmailType,
+    subscribeToEmailTypeVariables
+  >(
     gql`
       mutation subscribeToEmailType($emailType: String!) {
         subscribeToEmailType(input: { emailType: $emailType }) {
@@ -176,7 +186,10 @@ export function useSubscribeToEmailType() {
   return (emailType: EmailSubscription) => subscribeToEmailType({ variables: { emailType } });
 }
 export function useUnsubscribeToEmailType() {
-  const [unsubscribeToEmailType, { error }] = useMutation(
+  const [unsubscribeToEmailType, { error }] = useMutation<
+    unsubscribeToEmailType,
+    unsubscribeToEmailTypeVariables
+  >(
     gql`
       mutation unsubscribeToEmailType($emailType: String!) {
         unsubscribeToEmailType(input: { emailType: $emailType }) {
@@ -195,7 +208,7 @@ export function useUnsubscribeToEmailType() {
 }
 
 export function useAcceptTOS() {
-  const [acceptTOS] = useMutation(
+  const [acceptTOS] = useMutation<AcceptTOS, AcceptTOSVariables>(
     gql`
       mutation AcceptTOS($version: Int!) {
         acceptTermsOfService(input: { version: $version }) {

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -13,6 +13,8 @@ import {
   unsubscribeToEmailTypeVariables,
 } from "graphql/unsubscribeToEmailType";
 import { AcceptTOS, AcceptTOSVariables } from "graphql/AcceptTOS";
+import { GetUserId } from "graphql/GetUserId";
+import { GetUser } from "graphql/GetUser";
 
 export async function getUserId() {
   const result = await query({
@@ -31,7 +33,7 @@ export async function dismissNag(nag: Nag) {
 }
 
 export function useGetUserId() {
-  const { data, loading, error } = useQuery(GET_USER_ID);
+  const { data, loading, error } = useQuery<GetUserId>(GET_USER_ID);
   return { userId: data?.viewer?.user.id, loading, error };
 }
 
@@ -111,7 +113,7 @@ export async function getUserInfo(): Promise<UserInfo | undefined> {
 }
 
 export function useGetUserInfo(): UserInfo & { loading: boolean } {
-  const { data, loading, error } = useQuery(GET_USER_INFO);
+  const { data, loading, error } = useQuery<GetUser>(GET_USER_INFO);
 
   if (error) {
     console.error("Apollo error while fetching user:", error);

--- a/src/ui/hooks/users.ts
+++ b/src/ui/hooks/users.ts
@@ -119,16 +119,19 @@ export function useGetUserInfo(): UserInfo & { loading: boolean } {
     console.error("Apollo error while fetching user:", error);
   }
 
-  const id: string = data?.viewer?.user.id;
-  const picture: string = data?.viewer?.user.picture;
-  const name: string = data?.viewer?.user.name;
-  const email: string = data?.viewer?.email;
-  const internal: boolean = data?.viewer?.internal;
-  const nags: Nag[] = data?.viewer?.nags;
-  const unsubscribedEmailTypes: EmailSubscription[] = data?.viewer?.unsubscribedEmailTypes;
-  const acceptedTOSVersion = data?.viewer?.acceptedTOSVersion;
-  const motd: string = data?.viewer?.motd;
-  const features = data?.viewer?.features || {};
+  const id: string = data?.viewer?.user.id!;
+  const picture: string = data?.viewer?.user.picture!;
+  const name: string = data?.viewer?.user.name!;
+  const email: string = data?.viewer?.email!;
+  const internal: boolean = data?.viewer?.internal!;
+  const nags: Nag[] = data?.viewer?.nags as Nag[];
+  const unsubscribedEmailTypes: EmailSubscription[] = data?.viewer
+    ?.unsubscribedEmailTypes as EmailSubscription[];
+  const acceptedTOSVersion = data?.viewer?.acceptedTOSVersion ?? null;
+  const motd: string = data?.viewer?.motd!;
+  const features = data?.viewer?.features || {
+    library: false,
+  };
 
   return {
     loading,
@@ -253,7 +256,7 @@ export function useGetUserPermissions(recording: Recording) {
   }
 
   const isOwner = userId == recording.user?.id;
-  const isPrivileged = isPrivilegedUser(recording, userId, workspaces);
+  const isPrivileged = userId ? isPrivilegedUser(recording, userId, workspaces) : false;
 
   return {
     loading: false,

--- a/src/ui/hooks/workspaces.ts
+++ b/src/ui/hooks/workspaces.ts
@@ -1,5 +1,18 @@
 import { gql, useQuery, useMutation } from "@apollo/client";
 import {
+  CreateWorkspaceAPIKey,
+  CreateWorkspaceAPIKeyVariables,
+} from "graphql/CreateWorkspaceAPIKey";
+import { DeleteWorkspace, DeleteWorkspaceVariables } from "graphql/DeleteWorkspace";
+import {
+  DeleteWorkspaceAPIKey,
+  DeleteWorkspaceAPIKeyVariables,
+} from "graphql/DeleteWorkspaceAPIKey";
+import {
+  UpdateWorkspaceCodeDomainLimitations,
+  UpdateWorkspaceCodeDomainLimitationsVariables,
+} from "graphql/UpdateWorkspaceCodeDomainLimitations";
+import {
   ACTIVATE_WORKSPACE_SUBSCRIPTION,
   ADD_WORKSPACE_API_KEY,
   CANCEL_WORKSPACE_SUBSCRIPTION,
@@ -227,7 +240,10 @@ export function useGetNonPendingWorkspaces(): { workspaces: Workspace[]; loading
 }
 
 export function useUpdateWorkspaceCodeDomainLimitations() {
-  const [updateWorkspaceCodeDomainLimitations] = useMutation(
+  const [updateWorkspaceCodeDomainLimitations] = useMutation<
+    UpdateWorkspaceCodeDomainLimitations,
+    UpdateWorkspaceCodeDomainLimitationsVariables
+  >(
     gql`
       mutation UpdateWorkspaceCodeDomainLimitations($workspaceId: ID!, $isLimited: Boolean!) {
         updateWorkspaceCodeDomainLimitations(
@@ -246,7 +262,7 @@ export function useUpdateWorkspaceCodeDomainLimitations() {
 }
 
 export function useDeleteWorkspace() {
-  const [deleteWorkspace] = useMutation(
+  const [deleteWorkspace] = useMutation<DeleteWorkspace, DeleteWorkspaceVariables>(
     gql`
       mutation DeleteWorkspace($workspaceId: ID!, $shouldDeleteRecordings: Boolean!) {
         deleteWorkspace(
@@ -276,7 +292,10 @@ export function useGetWorkspaceApiKeys(workspaceId: string) {
 }
 
 export function useAddWorkspaceApiKey() {
-  const [addWorkspaceApiKey, { loading, error }] = useMutation(ADD_WORKSPACE_API_KEY, {
+  const [addWorkspaceApiKey, { loading, error }] = useMutation<
+    CreateWorkspaceAPIKey,
+    CreateWorkspaceAPIKeyVariables
+  >(ADD_WORKSPACE_API_KEY, {
     refetchQueries: ["GetWorkspaceApiKeys"],
   });
 
@@ -284,7 +303,10 @@ export function useAddWorkspaceApiKey() {
 }
 
 export function useDeleteWorkspaceApiKey() {
-  const [deleteWorkspaceApiKey, { loading, error }] = useMutation(DELETE_WORKSPACE_API_KEY, {
+  const [deleteWorkspaceApiKey, { loading, error }] = useMutation<
+    DeleteWorkspaceAPIKey,
+    DeleteWorkspaceAPIKeyVariables
+  >(DELETE_WORKSPACE_API_KEY, {
     refetchQueries: ["GetWorkspaceApiKeys"],
   });
 

--- a/src/ui/hooks/workspaces.ts
+++ b/src/ui/hooks/workspaces.ts
@@ -8,6 +8,8 @@ import {
   DeleteWorkspaceAPIKey,
   DeleteWorkspaceAPIKeyVariables,
 } from "graphql/DeleteWorkspaceAPIKey";
+import { GetNonPendingWorkspaces } from "graphql/GetNonPendingWorkspaces";
+import { GetPendingWorkspaces } from "graphql/GetPendingWorkspaces";
 import {
   UpdateWorkspaceCodeDomainLimitations,
   UpdateWorkspaceCodeDomainLimitationsVariables,
@@ -65,7 +67,7 @@ export function useCreateNewWorkspace(onCompleted: (data: any) => void) {
 }
 
 export function useGetPendingWorkspaces() {
-  const { data, loading, error } = useQuery(
+  const { data, loading, error } = useQuery<GetPendingWorkspaces>(
     gql`
       query GetPendingWorkspaces {
         viewer {
@@ -173,7 +175,7 @@ export function useUpdateWorkspaceSettings() {
 }
 
 export function useGetNonPendingWorkspaces(): { workspaces: Workspace[]; loading: boolean } {
-  const { data, loading, error } = useQuery(
+  const { data, loading, error } = useQuery<GetNonPendingWorkspaces>(
     gql`
       query GetNonPendingWorkspaces {
         viewer {

--- a/src/ui/hooks/workspaces_user.ts
+++ b/src/ui/hooks/workspaces_user.ts
@@ -11,6 +11,7 @@ import {
   DeleteUserFromWorkspace,
   DeleteUserFromWorkspaceVariables,
 } from "graphql/DeleteUserFromWorkspace";
+import { GetWorkspaceMembers, GetWorkspaceMembersVariables } from "graphql/GetWorkspaceMembers";
 import {
   InviteNewWorkspaceMember,
   InviteNewWorkspaceMemberVariables,
@@ -22,7 +23,7 @@ import {
 import { WorkspaceUser } from "ui/types";
 
 export function useGetWorkspaceMembers(workspaceId: string) {
-  const { data, loading, error } = useQuery(
+  const { data, loading, error } = useQuery<GetWorkspaceMembers, GetWorkspaceMembersVariables>(
     gql`
       query GetWorkspaceMembers($workspaceId: ID!) {
         node(id: $workspaceId) {

--- a/src/ui/hooks/workspaces_user.ts
+++ b/src/ui/hooks/workspaces_user.ts
@@ -1,4 +1,24 @@
 import { gql, useQuery, useMutation } from "@apollo/client";
+import {
+  AcceptPendingInvitation,
+  AcceptPendingInvitationVariables,
+} from "graphql/AcceptPendingInvitation";
+import {
+  ClaimTeamInvitationCode,
+  ClaimTeamInvitationCodeVariables,
+} from "graphql/ClaimTeamInvitationCode";
+import {
+  DeleteUserFromWorkspace,
+  DeleteUserFromWorkspaceVariables,
+} from "graphql/DeleteUserFromWorkspace";
+import {
+  InviteNewWorkspaceMember,
+  InviteNewWorkspaceMemberVariables,
+} from "graphql/InviteNewWorkspaceMember";
+import {
+  RejectPendingInvitation,
+  RejectPendingInvitationVariables,
+} from "graphql/RejectPendingInvitation";
 import { WorkspaceUser } from "ui/types";
 
 export function useGetWorkspaceMembers(workspaceId: string) {
@@ -89,7 +109,10 @@ export function useInviteNewWorkspaceMember(onCompleted: () => void) {
   // user to a team.
   const onError = onCompleted;
 
-  const [inviteNewWorkspaceMember] = useMutation(
+  const [inviteNewWorkspaceMember] = useMutation<
+    InviteNewWorkspaceMember,
+    InviteNewWorkspaceMemberVariables
+  >(
     gql`
       mutation InviteNewWorkspaceMember($email: String!, $workspaceId: ID!, $roles: [String!]) {
         addWorkspaceMember(input: { email: $email, workspaceId: $workspaceId, roles: $roles }) {
@@ -104,7 +127,10 @@ export function useInviteNewWorkspaceMember(onCompleted: () => void) {
 }
 
 export function useClaimTeamInvitationCode(onCompleted: () => void, onError: () => void) {
-  const [inviteNewWorkspaceMember] = useMutation(
+  const [inviteNewWorkspaceMember] = useMutation<
+    ClaimTeamInvitationCode,
+    ClaimTeamInvitationCodeVariables
+  >(
     gql`
       mutation ClaimTeamInvitationCode($code: ID!) {
         claimTeamInvitationCode(input: { code: $code }) {
@@ -119,7 +145,10 @@ export function useClaimTeamInvitationCode(onCompleted: () => void, onError: () 
 }
 
 export function useDeleteUserFromWorkspace() {
-  const [deleteUserFromWorkspace] = useMutation(
+  const [deleteUserFromWorkspace] = useMutation<
+    DeleteUserFromWorkspace,
+    DeleteUserFromWorkspaceVariables
+  >(
     gql`
       mutation DeleteUserFromWorkspace($membershipId: ID!) {
         removeWorkspaceMember(input: { id: $membershipId }) {
@@ -134,7 +163,10 @@ export function useDeleteUserFromWorkspace() {
 }
 
 export function useAcceptPendingInvitation(onCompleted: () => void) {
-  const [acceptPendingInvitation] = useMutation(
+  const [acceptPendingInvitation] = useMutation<
+    AcceptPendingInvitation,
+    AcceptPendingInvitationVariables
+  >(
     gql`
       mutation AcceptPendingInvitation($workspaceId: ID!) {
         acceptWorkspaceMembership(input: { id: $workspaceId }) {
@@ -152,7 +184,10 @@ export function useAcceptPendingInvitation(onCompleted: () => void) {
 }
 
 export function useRejectPendingInvitation(onCompleted: () => void) {
-  const [rejectPendingInvitation] = useMutation(
+  const [rejectPendingInvitation] = useMutation<
+    RejectPendingInvitation,
+    RejectPendingInvitationVariables
+  >(
     gql`
       mutation RejectPendingInvitation($workspaceId: ID!) {
         rejectWorkspaceMembership(input: { id: $workspaceId }) {

--- a/src/ui/hooks/workspaces_user.ts
+++ b/src/ui/hooks/workspaces_user.ts
@@ -80,8 +80,10 @@ export function useGetWorkspaceMembers(workspaceId: string) {
   }
 
   let workspaceUsers: WorkspaceUser[] | undefined = undefined;
-  if (data?.node?.members) {
-    workspaceUsers = data.node.members.edges.map(({ node }: any) => {
+  // @ts-ignore
+  const members = data?.node?.members;
+  if (members) {
+    workspaceUsers = members.edges.map(({ node }: any) => {
       if (node.__typename === "WorkspacePendingEmailMember") {
         return {
           membershipId: node.id,


### PR DESCRIPTION
Using autogenerated GraphQL types as generic params for various Apollo hooks.

- fixed a number of type errors that ensued.
- fixed a few places that actually seemed like potentials for a bug (not sure if graphql fails if certain things are missing) 
- I've `@ts-ignore`d some things as it seemed that codegen wasn't that smart to generate full types for some involved queries.

Even with ignores and forced types, we're still in better shape (and definitely not worse!) than previously and will be helpful moving forward to have types to rely on.