### PR TITLE
Fix the breakpoint panel layout when there are two inputs

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.css
@@ -93,12 +93,10 @@
 
 .breakpoint-panel .panel-editor.conditional form .CodeMirror {
   border: 1px solid #e5e7eb;
-  height: 21px;
 }
 
 .breakpoint-panel form .form-row {
   align-items: center;
-  height: 28px;
   display: flex;
 }
 

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelForm.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelForm.tsx
@@ -70,9 +70,9 @@ export default function PanelForm({
   };
 
   return (
-    <form className="flex flex-grow flex-col pl-2 relative">
+    <form className="flex flex-grow flex-col pl-2 relative py-0.5 space-y-0.5">
       {showCondition ? (
-        <div className={"form-row"}>
+        <div className="form-row">
           <div className="mr-1 w-6 flex-shrink-0">if</div>
           <PanelInput
             autofocus={inputToFocus == "condition"}
@@ -83,7 +83,7 @@ export default function PanelForm({
           />
         </div>
       ) : null}
-      <div className={classnames("form-row")}>
+      <div className="form-row">
         {showCondition ? <div className="mr-1 w-6 flex-shrink-0">log</div> : null}
         <PanelInput
           autofocus={inputToFocus == "logValue"}


### PR DESCRIPTION
https://www.loom.com/share/18f0c155aec646b982758852a62ae188

This fixes:
- rounded corners on the autocomplete hovered state for the breakpoint panel menus
- panel layout issues when there's a condition attached to the brekapoint.