### PR TITLE
Replace all uses of `createFactory` with `React.createElement`

### DIFF
--- a/src/devtools/client/debugger/src/components/shared/tree.js
+++ b/src/devtools/client/debugger/src/components/shared/tree.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import React from "react";
-const { Component, createFactory } = React;
+const { Component } = React;
 import dom from "react-dom-factories";
 import PropTypes from "prop-types";
 
@@ -174,7 +174,7 @@ class TreeNode extends Component {
     const { depth, id, item, focused, active, expanded, renderItem, isExpandable } = this.props;
 
     const arrow = isExpandable
-      ? ArrowExpanderFactory({
+      ? React.createElement(ArrowExpander, {
           item,
           expanded,
         })
@@ -213,9 +213,6 @@ class TreeNode extends Component {
     );
   }
 }
-
-const ArrowExpanderFactory = createFactory(ArrowExpander);
-const TreeNodeFactory = createFactory(TreeNode);
 
 /**
  * Create a function that calls the given function `fn` only once per animation
@@ -972,7 +969,7 @@ export class Tree extends Component {
     const nodes = traversal.map((v, i) => {
       const { item, depth } = traversal[i];
       const key = this.props.getKey(item, i);
-      return TreeNodeFactory({
+      return React.createElement(TreeNode, {
         // We make a key unique depending on whether the tree node is in active
         // or inactive state to make sure that it is actually replaced and the
         // tabbable state is reset.

--- a/src/devtools/client/inspector/boxmodel/components/BoxModel.js
+++ b/src/devtools/client/inspector/boxmodel/components/BoxModel.js
@@ -4,23 +4,17 @@
 
 "use strict";
 
-const { createFactory, PureComponent } = require("react");
+const React = require("react");
 const dom = require("react-dom-factories");
 const PropTypes = require("prop-types");
 
-const BoxModelInfo = createFactory(
-  require("devtools/client/inspector/boxmodel/components/BoxModelInfo")
-);
-const BoxModelMain = createFactory(
-  require("devtools/client/inspector/boxmodel/components/BoxModelMain")
-);
-const BoxModelProperties = createFactory(
-  require("devtools/client/inspector/boxmodel/components/BoxModelProperties")
-);
+const BoxModelInfo = require("devtools/client/inspector/boxmodel/components/BoxModelInfo");
+const BoxModelMain = require("devtools/client/inspector/boxmodel/components/BoxModelMain");
+const BoxModelProperties = require("devtools/client/inspector/boxmodel/components/BoxModelProperties");
 
 const Types = require("devtools/client/inspector/boxmodel/types");
 
-class BoxModel extends PureComponent {
+class BoxModel extends React.PureComponent {
   static get propTypes() {
     return {
       boxModel: PropTypes.shape(Types.boxModel).isRequired,
@@ -68,7 +62,7 @@ class BoxModel extends PureComponent {
         },
         onKeyDown: this.onKeyDown,
       },
-      BoxModelMain({
+      React.createElement(BoxModelMain, {
         boxModel,
         boxModelContainer: this.boxModelContainer,
         ref: boxModelMain => {
@@ -79,11 +73,11 @@ class BoxModel extends PureComponent {
         onShowBoxModelHighlighter,
         onShowRulePreviewTooltip,
       }),
-      BoxModelInfo({
+      React.createElement(BoxModelInfo, {
         boxModel,
       }),
       showBoxModelProperties
-        ? BoxModelProperties({
+        ? React.createElement(BoxModelProperties, {
             boxModel,
             setSelectedNode,
             onHideBoxModelHighlighter,

--- a/src/devtools/client/inspector/boxmodel/components/BoxModelMain.js
+++ b/src/devtools/client/inspector/boxmodel/components/BoxModelMain.js
@@ -4,22 +4,20 @@
 
 "use strict";
 
-const { createFactory, PureComponent } = require("react");
+const React = require("react");
 const dom = require("react-dom-factories");
 const PropTypes = require("prop-types");
 const { KeyCodes } = require("devtools/client/shared/keycodes");
 const { LocalizationHelper } = require("devtools/shared/l10n");
 
-const BoxModelEditable = createFactory(
-  require("devtools/client/inspector/boxmodel/components/BoxModelEditable")
-);
+const BoxModelEditable = require("devtools/client/inspector/boxmodel/components/BoxModelEditable");
 
 const Types = require("devtools/client/inspector/boxmodel/types");
 
 const SHARED_STRINGS_URI = "devtools/client/locales/shared.properties";
 const SHARED_L10N = new LocalizationHelper(SHARED_STRINGS_URI);
 
-class BoxModelMain extends PureComponent {
+class BoxModelMain extends React.PureComponent {
   static get propTypes() {
     return {
       boxModel: PropTypes.shape(Types.boxModel).isRequired,
@@ -429,7 +427,7 @@ class BoxModelMain extends PureComponent {
       layout["box-sizing"] == "content-box"
         ? dom.div(
             { className: "boxmodel-size" },
-            BoxModelEditable({
+            React.createElement(BoxModelEditable, {
               box: "content",
               focusable,
               level,
@@ -442,7 +440,7 @@ class BoxModelMain extends PureComponent {
               onShowRulePreviewTooltip,
             }),
             dom.span({}, "\u00D7"),
-            BoxModelEditable({
+            React.createElement(BoxModelEditable, {
               box: "content",
               focusable,
               level,
@@ -545,7 +543,7 @@ class BoxModelMain extends PureComponent {
         )
       ),
       displayPosition
-        ? BoxModelEditable({
+        ? React.createElement(BoxModelEditable, {
             box: "position",
             direction: "top",
             focusable,
@@ -560,7 +558,7 @@ class BoxModelMain extends PureComponent {
           })
         : null,
       displayPosition
-        ? BoxModelEditable({
+        ? React.createElement(BoxModelEditable, {
             box: "position",
             direction: "right",
             focusable,
@@ -572,7 +570,7 @@ class BoxModelMain extends PureComponent {
           })
         : null,
       displayPosition
-        ? BoxModelEditable({
+        ? React.createElement(BoxModelEditable, {
             box: "position",
             direction: "bottom",
             focusable,
@@ -584,7 +582,7 @@ class BoxModelMain extends PureComponent {
           })
         : null,
       displayPosition
-        ? BoxModelEditable({
+        ? React.createElement(BoxModelEditable, {
             box: "position",
             direction: "left",
             focusable,
@@ -595,7 +593,7 @@ class BoxModelMain extends PureComponent {
             onShowRulePreviewTooltip,
           })
         : null,
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "margin",
         direction: "top",
         focusable,
@@ -608,7 +606,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "margin",
         direction: "right",
         focusable,
@@ -618,7 +616,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "margin",
         direction: "bottom",
         focusable,
@@ -628,7 +626,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "margin",
         direction: "left",
         focusable,
@@ -638,7 +636,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "border",
         direction: "top",
         focusable,
@@ -651,7 +649,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "border",
         direction: "right",
         focusable,
@@ -661,7 +659,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "border",
         direction: "bottom",
         focusable,
@@ -671,7 +669,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "border",
         direction: "left",
         focusable,
@@ -681,7 +679,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "padding",
         direction: "top",
         focusable,
@@ -694,7 +692,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "padding",
         direction: "right",
         focusable,
@@ -704,7 +702,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "padding",
         direction: "bottom",
         focusable,
@@ -714,7 +712,7 @@ class BoxModelMain extends PureComponent {
         onShowBoxModelEditor,
         onShowRulePreviewTooltip,
       }),
-      BoxModelEditable({
+      React.createElement(BoxModelEditable, {
         box: "padding",
         direction: "left",
         focusable,

--- a/src/devtools/client/inspector/boxmodel/components/BoxModelProperties.js
+++ b/src/devtools/client/inspector/boxmodel/components/BoxModelProperties.js
@@ -4,21 +4,18 @@
 
 "use strict";
 
-const { createFactory, PureComponent } = require("react");
+const React = require("react");
 const dom = require("react-dom-factories");
 const PropTypes = require("prop-types");
 const { LocalizationHelper } = require("devtools/shared/l10n");
 
-const ComputedProperty = createFactory(
-  require("devtools/client/inspector/boxmodel/components/ComputedProperty")
-);
-
+const ComputedProperty = require("devtools/client/inspector/boxmodel/components/ComputedProperty");
 const Types = require("devtools/client/inspector/boxmodel/types");
 
 const BOXMODEL_STRINGS_URI = "devtools/client/locales/boxmodel.properties";
 const BOXMODEL_L10N = new LocalizationHelper(BOXMODEL_STRINGS_URI);
 
-class BoxModelProperties extends PureComponent {
+class BoxModelProperties extends React.PureComponent {
   static get propTypes() {
     return {
       boxModel: PropTypes.shape(Types.boxModel).isRequired,
@@ -89,7 +86,7 @@ class BoxModelProperties extends PureComponent {
     const properties = layoutInfo.map(info => {
       const { referenceElement, referenceElementType } = this.getReferenceElement(info);
 
-      return ComputedProperty({
+      return React.createElement(ComputedProperty, {
         key: info,
         name: info,
         onHideBoxModelHighlighter,

--- a/src/devtools/client/inspector/changes/ChangesView.js
+++ b/src/devtools/client/inspector/changes/ChangesView.js
@@ -4,12 +4,10 @@
 
 "use strict";
 
-const { createFactory, createElement } = require("react");
+const React = require("react");
 const { Provider } = require("react-redux");
 
-const ChangesApp = createFactory(
-  require("devtools/client/inspector/changes/components/ChangesApp")
-);
+const ChangesApp = require("devtools/client/inspector/changes/components/ChangesApp");
 const { getChangesStylesheet } = require("devtools/client/inspector/changes/selectors/changes");
 const { resetChanges, trackChange } = require("devtools/client/inspector/changes/actions/changes");
 
@@ -56,14 +54,14 @@ class ChangesView {
   }
 
   init() {
-    const changesApp = ChangesApp({
+    const changesApp = React.createElement(ChangesApp, {
       onContextMenu: this.onContextMenu,
       onCopyAllChanges: this.onCopyAllChanges,
       onCopyRule: this.onCopyRule,
     });
 
     // Expose the provider to let inspector.js use it in setupSidebar.
-    this.provider = createElement(
+    this.provider = React.createElement(
       Provider,
       {
         id: "changesview",

--- a/src/devtools/client/inspector/changes/components/ChangesApp.js
+++ b/src/devtools/client/inspector/changes/components/ChangesApp.js
@@ -4,19 +4,17 @@
 
 "use strict";
 
-const { createFactory, PureComponent } = require("react");
+const React = require("react");
 const dom = require("react-dom-factories");
 const PropTypes = require("prop-types");
 const { connect } = require("react-redux");
 
-const CSSDeclaration = createFactory(
-  require("devtools/client/inspector/changes/components/CSSDeclaration")
-);
+const CSSDeclaration = require("devtools/client/inspector/changes/components/CSSDeclaration");
 const { getChangesTree } = require("devtools/client/inspector/changes/selectors/changes");
 const { getSourceForDisplay } = require("devtools/client/inspector/changes/utils/changes-utils");
 const { getStr } = require("devtools/client/inspector/changes/utils/l10n");
 
-class ChangesApp extends PureComponent {
+class ChangesApp extends React.PureComponent {
   static get propTypes() {
     return {
       // Nested CSS rule tree structure of CSS changes grouped by source (stylesheet)
@@ -69,7 +67,7 @@ class ChangesApp extends PureComponent {
       // Sorting changed declarations in the order they appear in the Rules view.
       .sort((a, b) => a.index > b.index)
       .map(({ property, value, index }) => {
-        return CSSDeclaration({
+        return React.createElement(CSSDeclaration, {
           key: "remove-" + property + index,
           className: "level diff-remove",
           property,
@@ -81,7 +79,7 @@ class ChangesApp extends PureComponent {
       // Sorting changed declarations in the order they appear in the Rules view.
       .sort((a, b) => a.index > b.index)
       .map(({ property, value, index }) => {
-        return CSSDeclaration({
+        return React.createElement(CSSDeclaration, {
           key: "add-" + property + index,
           className: "level diff-add",
           property,

--- a/src/devtools/client/inspector/layout/components/LayoutApp.js
+++ b/src/devtools/client/inspector/layout/components/LayoutApp.js
@@ -5,14 +5,14 @@
 "use strict";
 
 const Services = require("devtools/shared/services");
-const { createFactory, createRef, PureComponent } = require("react");
+const React = require("react");
 const dom = require("react-dom-factories");
 const PropTypes = require("prop-types");
 const { connect } = require("react-redux");
 const { LocalizationHelper } = require("devtools/shared/l10n");
 
-const Accordion = createFactory(require("devtools/client/shared/components/Accordion"));
-const BoxModel = createFactory(require("devtools/client/inspector/boxmodel/components/BoxModel"));
+const Accordion = require("devtools/client/shared/components/Accordion");
+const BoxModel = require("devtools/client/inspector/boxmodel/components/BoxModel");
 
 const BoxModelTypes = require("devtools/client/inspector/boxmodel/types");
 
@@ -24,7 +24,7 @@ const LAYOUT_L10N = new LocalizationHelper(LAYOUT_STRINGS_URI);
 
 const BOXMODEL_OPENED_PREF = "devtools.layout.boxmodel.opened";
 
-class LayoutApp extends PureComponent {
+class LayoutApp extends React.PureComponent {
   static get propTypes() {
     return {
       boxModel: PropTypes.shape(BoxModelTypes.boxModel).isRequired,
@@ -39,7 +39,7 @@ class LayoutApp extends PureComponent {
 
   constructor(props) {
     super(props);
-    this.containerRef = createRef();
+    this.containerRef = React.createRef();
 
     this.scrollToTop = this.scrollToTop.bind(this);
   }
@@ -87,7 +87,7 @@ class LayoutApp extends PureComponent {
         {
           className: "h-full overflow-y-auto",
         },
-        Accordion({
+        React.createElement(Accordion, {
           items,
           style: {
             overflow: "auto",

--- a/src/devtools/client/inspector/rules/components/DeclarationValue.js
+++ b/src/devtools/client/inspector/rules/components/DeclarationValue.js
@@ -1,14 +1,12 @@
-const { createFactory, PureComponent } = require("react");
+const React = require("react");
 const PropTypes = require("prop-types");
 const { COLOR, FONT_FAMILY, URI } = require("devtools/client/shared/output-parser");
 
-const Color = createFactory(require("devtools/client/inspector/rules/components/value/Color"));
-const FontFamily = createFactory(
-  require("devtools/client/inspector/rules/components/value/FontFamily")
-);
-const Url = createFactory(require("devtools/client/inspector/rules/components/value/Url"));
+const Color = require("devtools/client/inspector/rules/components/value/Color");
+const FontFamily = require("devtools/client/inspector/rules/components/value/FontFamily");
+const Url = require("devtools/client/inspector/rules/components/value/Url");
 
-class DeclarationValue extends PureComponent {
+class DeclarationValue extends React.PureComponent {
   static get propTypes() {
     return {
       colorSpanClassName: PropTypes.string,
@@ -29,20 +27,20 @@ class DeclarationValue extends PureComponent {
 
       switch (type) {
         case COLOR:
-          return Color({
+          return React.createElement(Color, {
             colorSpanClassName: this.props.colorSpanClassName,
             colorSwatchClassName: this.props.colorSwatchClassName,
             key: value,
             value,
           });
         case FONT_FAMILY:
-          return FontFamily({
+          return React.createElement(FontFamily, {
             fontFamilySpanClassName: this.props.fontFamilySpanClassName,
             key: value,
             value,
           });
         case URI:
-          return Url({
+          return React.createElement(Url, {
             key: value,
             href: v.href,
             value,

--- a/src/devtools/client/inspector/rules/rules.js
+++ b/src/devtools/client/inspector/rules/rules.js
@@ -7,8 +7,6 @@
 const Services = require("devtools/shared/services");
 const ElementStyle = require("devtools/client/inspector/rules/models/element-style").default;
 const { OutputParser } = require("devtools/client/shared/output-parser");
-const { createFactory, createElement } = require("react");
-const { Provider } = require("react-redux");
 const EventEmitter = require("devtools/shared/event-emitter");
 const ClassList = require("devtools/client/inspector/rules/models/class-list").default;
 const { getNodeInfo } = require("devtools/client/inspector/rules/utils/utils");
@@ -26,8 +24,6 @@ const {
   updateRules,
 } = require("devtools/client/inspector/rules/actions/rules");
 const { setComputedProperties } = require("devtools/client/inspector/computed/actions");
-
-const RulesApp = createFactory(require("devtools/client/inspector/rules/components/RulesApp"));
 
 const PREF_UA_STYLES = "devtools.inspector.showUserAgentStyles";
 

--- a/src/devtools/client/shared/components/List.js
+++ b/src/devtools/client/shared/components/List.js
@@ -4,14 +4,14 @@
 
 "use strict";
 
-const { createFactory, createRef, Component, cloneElement } = require("react");
+const React = require("react");
 const PropTypes = require("prop-types");
 const { ul, li, div } = require("react-dom-factories");
 
 const { scrollIntoView } = require("devtools/client/shared/scroll");
 const { preventDefaultAndStopPropagation } = require("devtools/client/shared/events");
 
-class ListItemClass extends Component {
+class ListItemClass extends React.Component {
   static get propTypes() {
     return {
       active: PropTypes.bool,
@@ -29,7 +29,7 @@ class ListItemClass extends Component {
   constructor(props) {
     super(props);
 
-    this.contentRef = createRef();
+    this.contentRef = React.createRef();
 
     this._setTabbableState = this._setTabbableState.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
@@ -102,15 +102,15 @@ class ListItemClass extends Component {
           role: "presentation",
           ref: this.contentRef,
         },
-        cloneElement(component, componentProps || {})
+        React.cloneElement(component, componentProps || {})
       )
     );
   }
 }
 
-const ListItem = createFactory(ListItemClass);
+const ListItem = ListItemClass;
 
-class List extends Component {
+class List extends React.Component {
   static get propTypes() {
     return {
       // A list of all items to be rendered using a List component.
@@ -137,7 +137,7 @@ class List extends Component {
   constructor(props) {
     super(props);
 
-    this.listRef = createRef();
+    this.listRef = React.createRef();
 
     this.state = {
       active: null,
@@ -305,7 +305,7 @@ class List extends Component {
         "aria-activedescendant": current != null ? items[current].key : null,
       },
       items.map((item, index) => {
-        return ListItem({
+        return React.createElement(ListItem, {
           item,
           current: index === current,
           active: index === active,

--- a/src/devtools/client/shared/components/Sidebar.js
+++ b/src/devtools/client/shared/components/Sidebar.js
@@ -4,13 +4,13 @@
 
 "use strict";
 
-const { createFactory, PureComponent } = require("react");
+const React = require("react");
 const PropTypes = require("prop-types");
 
-const SidebarToggle = createFactory(require("devtools/client/shared/components/SidebarToggle"));
-const Tabs = createFactory(require("devtools/client/shared/components/tabs/Tabs").Tabs);
+const SidebarToggle = require("devtools/client/shared/components/SidebarToggle");
+const Tabs = require("devtools/client/shared/components/tabs/Tabs").Tabs;
 
-class Sidebar extends PureComponent {
+class Sidebar extends React.PureComponent {
   static get propTypes() {
     return {
       children: PropTypes.oneOfType([PropTypes.array, PropTypes.element]).isRequired,
@@ -43,7 +43,7 @@ class Sidebar extends PureComponent {
     const { collapsed, collapsePaneTitle, expandPaneTitle, onClick, alignRight, canVerticalSplit } =
       this.props.sidebarToggleButton;
 
-    return SidebarToggle({
+    return React.createElement(SidebarToggle, {
       collapsed,
       collapsePaneTitle,
       expandPaneTitle,
@@ -64,7 +64,8 @@ class Sidebar extends PureComponent {
       activeTab,
     } = this.props;
 
-    return Tabs(
+    return React.createElement(
+      Tabs,
       {
         onAfterChange,
         onAllTabsMenuClick,

--- a/src/devtools/client/shared/components/SmartTrace.js
+++ b/src/devtools/client/shared/components/SmartTrace.js
@@ -4,22 +4,21 @@
 
 "use strict";
 
-const { Component, createFactory } = require("react");
+const React = require("react");
 const PropTypes = require("prop-types");
 const { LocalizationHelper } = require("devtools/shared/l10n");
 
 const l10n = new LocalizationHelper("devtools/client/locales/components.properties");
 const dbgL10n = new LocalizationHelper("devtools/client/locales/debugger.properties");
-const Frames = createFactory(
-  require("devtools/client/debugger/src/components/SecondaryPanes/Frames/index").Frames
-);
+const Frames =
+  require("devtools/client/debugger/src/components/SecondaryPanes/Frames/index").Frames;
 const {
   annotateFrames,
 } = require("devtools/client/debugger/src/utils/pause/frames/annotateFrames");
 
 const { ThreadFront } = require("protocol/thread");
 
-class SmartTrace extends Component {
+class SmartTrace extends React.Component {
   static get propTypes() {
     return {
       stacktrace: PropTypes.array.isRequired,
@@ -117,7 +116,7 @@ class SmartTrace extends Component {
       }))
     );
 
-    return Frames({
+    return React.createElement(Frames, {
       frames,
       selectFrame: (cx, { location }) => {
         const viewSource = onViewSourceInDebugger || onViewSource;

--- a/src/devtools/client/shared/components/StackTrace.js
+++ b/src/devtools/client/shared/components/StackTrace.js
@@ -4,15 +4,15 @@
 
 "use strict";
 
-const { Component, createFactory } = require("react");
+const React = require("react");
 const PropTypes = require("prop-types");
 const dom = require("react-dom-factories");
 const { LocalizationHelper } = require("devtools/shared/l10n");
-const Frame = createFactory(require("devtools/client/shared/components/Frame"));
+const Frame = require("devtools/client/shared/components/Frame");
 
 const l10n = new LocalizationHelper("devtools/client/locales/webconsole.properties");
 
-class AsyncFrameClass extends Component {
+class AsyncFrameClass extends React.Component {
   static get propTypes() {
     return {
       asyncCause: PropTypes.string.isRequired,
@@ -29,7 +29,7 @@ class AsyncFrameClass extends Component {
   }
 }
 
-class StackTrace extends Component {
+class StackTrace extends React.Component {
   static get propTypes() {
     return {
       stacktrace: PropTypes.array.isRequired,
@@ -49,7 +49,7 @@ class StackTrace extends Component {
       if (s.asyncCause) {
         frames.push(
           "\t",
-          AsyncFrame({
+          React.createElement(AsyncFrameClass, {
             key: `${i}-asyncframe`,
             asyncCause: s.asyncCause,
           }),
@@ -60,7 +60,7 @@ class StackTrace extends Component {
       const source = s.filename;
       frames.push(
         "\t",
-        Frame({
+        React.createElement(Frame, {
           key: `${i}-frame`,
           frame: {
             functionDisplayName: s.functionName,
@@ -80,7 +80,5 @@ class StackTrace extends Component {
     return dom.div({ className: "stack-trace" }, frames);
   }
 }
-
-const AsyncFrame = createFactory(AsyncFrameClass);
 
 module.exports = StackTrace;

--- a/src/devtools/client/shared/components/VirtualizedTree.js
+++ b/src/devtools/client/shared/components/VirtualizedTree.js
@@ -4,7 +4,7 @@
 /* eslint-env browser */
 "use strict";
 
-const { Component, createFactory } = require("react");
+const React = require("react");
 const PropTypes = require("prop-types");
 const dom = require("react-dom-factories");
 const { scrollIntoView } = require("devtools/client/shared/scroll");
@@ -56,7 +56,7 @@ const NUMBER_OF_OFFSCREEN_ITEMS = 1;
  *
  * Here is how we could render that data with this component:
  *
- *     class MyTree extends Component {
+ *     class MyTree extends {
  *       static get propTypes() {
  *         // The root item of the tree, with the form described above.
  *         return {
@@ -100,7 +100,7 @@ const NUMBER_OF_OFFSCREEN_ITEMS = 1;
  *       }
  *     }
  */
-class Tree extends Component {
+class Tree extends React.Component {
   static get propTypes() {
     return {
       // Required props
@@ -756,7 +756,7 @@ class Tree extends Component {
       const { item, depth } = toRender[i];
       const key = this.props.getKey(item);
       nodes.push(
-        TreeNode({
+        React.createElement(TreeNodeClass, {
           // We make a key unique depending on whether the tree node is in active or
           // inactive state to make sure that it is actually replaced and the tabbable
           // state is reset.
@@ -844,7 +844,7 @@ class Tree extends Component {
  * An arrow that displays whether its node is expanded (▼) or collapsed
  * (▶). When its node has no children, it is hidden.
  */
-class ArrowExpanderClass extends Component {
+class ArrowExpanderClass extends React.Component {
   static get propTypes() {
     return {
       item: PropTypes.any.isRequired,
@@ -888,7 +888,7 @@ class ArrowExpanderClass extends Component {
   }
 }
 
-class TreeNodeClass extends Component {
+class TreeNodeClass extends React.Component {
   static get propTypes() {
     return {
       id: PropTypes.any.isRequired,
@@ -951,7 +951,7 @@ class TreeNodeClass extends Component {
   }
 
   render() {
-    const arrow = ArrowExpander({
+    const arrow = React.createElement(ArrowExpanderClass, {
       item: this.props.item,
       expanded: this.props.expanded,
       visible: this.props.hasChildren,
@@ -1009,9 +1009,6 @@ class TreeNodeClass extends Component {
     );
   }
 }
-
-const ArrowExpander = createFactory(ArrowExpanderClass);
-const TreeNode = createFactory(TreeNodeClass);
 
 /**
  * Create a function that calls the given function `fn` only once per animation

--- a/src/devtools/client/shared/components/splitter/GridElementWidthResizer.js
+++ b/src/devtools/client/shared/components/splitter/GridElementWidthResizer.js
@@ -4,11 +4,11 @@
 
 "use strict";
 
-const { Component, createFactory } = require("react");
+const React = require("react");
 const PropTypes = require("prop-types");
-const Draggable = createFactory(require("devtools/client/shared/components/splitter/Draggable"));
+const Draggable = require("devtools/client/shared/components/splitter/Draggable");
 
-class GridElementWidthResizer extends Component {
+class GridElementWidthResizer extends React.Component {
   static get propTypes() {
     return {
       getControlledElementNode: PropTypes.func.isRequired,
@@ -119,7 +119,7 @@ class GridElementWidthResizer extends Component {
       classNames.push(this.props.className);
     }
 
-    return Draggable({
+    return React.createElement(Draggable, {
       className: classNames.join(" "),
       onStart: this.onStartMove,
       onStop: this.onStopMove,

--- a/src/devtools/client/shared/components/tabs/TabBar.js
+++ b/src/devtools/client/shared/components/tabs/TabBar.js
@@ -6,11 +6,11 @@
 
 "use strict";
 
-const { Component, createFactory } = require("react");
+const React = require("react");
 const PropTypes = require("prop-types");
 const dom = require("react-dom-factories");
 
-const Sidebar = createFactory(require("devtools/client/shared/components/Sidebar"));
+const Sidebar = require("devtools/client/shared/components/Sidebar");
 
 // Shortcuts
 const { div } = dom;
@@ -18,7 +18,7 @@ const { div } = dom;
 /**
  * Renders Tabbar component.
  */
-class Tabbar extends Component {
+class Tabbar extends React.Component {
   static get propTypes() {
     return {
       children: PropTypes.array,
@@ -325,7 +325,8 @@ class Tabbar extends Component {
 
     return div(
       { className: "devtools-sidebar-tabs" },
-      Sidebar(
+      React.createElement(
+        Sidebar,
         {
           onAllTabsMenuClick: this.onAllTabsMenuClick,
           renderOnlySelected: this.props.renderOnlySelected,

--- a/src/devtools/client/shared/components/tree/TreeRow.js
+++ b/src/devtools/client/shared/components/tree/TreeRow.js
@@ -5,15 +5,15 @@
 
 // Make this available to both AMD and CJS environments
 define(function (require, exports, module) {
-  const { Component, createFactory, createRef } = require("react");
+  const React = require("react");
   const PropTypes = require("prop-types");
   const dom = require("react-dom-factories");
   const { findDOMNode } = require("react-dom");
   const { tr } = dom;
 
   // Tree
-  const TreeCell = createFactory(require("devtools/client/shared/components/tree/TreeCell"));
-  const LabelCell = createFactory(require("devtools/client/shared/components/tree/LabelCell"));
+  const TreeCell = require("devtools/client/shared/components/tree/TreeCell");
+  const LabelCell = require("devtools/client/shared/components/tree/LabelCell");
 
   const { wrapMoveFocus, getFocusableElements } = require("devtools/client/shared/focus");
 
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
    * This template represents a node in TreeView component. It's rendered
    * using <tr> element (the entire tree is one big <table>).
    */
-  class TreeRow extends Component {
+  class TreeRow extends React.Component {
     // See TreeView component for more details about the props and
     // the 'member' object.
     static get propTypes() {
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
     constructor(props) {
       super(props);
 
-      this.treeRowRef = createRef();
+      this.treeRowRef = React.createRef();
 
       this.getRowClass = this.getRowClass.bind(this);
       this._onKeyDown = this._onKeyDown.bind(this);
@@ -274,11 +274,11 @@ define(function (require, exports, module) {
   // Helpers
 
   const RenderCell = props => {
-    return TreeCell(props);
+    return React.createElement(TreeCell, props);
   };
 
   const RenderLabelCell = props => {
-    return LabelCell(props);
+    return React.createElement(LabelCell, props);
   };
 
   // Exports from this module

--- a/src/devtools/client/shared/components/tree/TreeView.js
+++ b/src/devtools/client/shared/components/tree/TreeView.js
@@ -5,15 +5,15 @@
 
 // Make this available to both AMD and CJS environments
 define(function (require, exports, module) {
-  const { cloneElement, Component, createFactory, createRef } = require("react");
+  const React = require("react");
   const { findDOMNode } = require("react-dom");
   const PropTypes = require("prop-types");
   const dom = require("react-dom-factories");
 
   // Reps
   const { ObjectProvider } = require("devtools/client/shared/components/tree/ObjectProvider");
-  const TreeRow = createFactory(require("devtools/client/shared/components/tree/TreeRow"));
-  const TreeHeader = createFactory(require("devtools/client/shared/components/tree/TreeHeader"));
+  const TreeRow = require("devtools/client/shared/components/tree/TreeRow");
+  const TreeHeader = require("devtools/client/shared/components/tree/TreeHeader");
 
   const { scrollIntoView } = require("devtools/client/shared/scroll");
 
@@ -75,7 +75,7 @@ define(function (require, exports, module) {
    *   renderLabelCell: function(object);
    * }
    */
-  class TreeView extends Component {
+  class TreeView extends React.Component {
     // The only required property (not set by default) is the input data
     // object that is used to populate the tree.
     static get propTypes() {
@@ -207,7 +207,7 @@ define(function (require, exports, module) {
         lastSelectedIndex: 0,
       };
 
-      this.treeRef = createRef();
+      this.treeRef = React.createRef();
 
       this.toggle = this.toggle.bind(this);
       this.isExpanded = this.isExpanded.bind(this);
@@ -571,7 +571,7 @@ define(function (require, exports, module) {
     renderRows(parent, level = 0, path = "") {
       let rows = [];
       const decorator = this.props.decorator;
-      let renderRow = this.props.renderRow || TreeRow;
+      let renderRow = this.props.renderRow || (props => React.createElement(TreeRow, props));
 
       // Get children for given parent node, iterate over them and render
       // a row for every one. Use row template (a component) from properties.
@@ -610,7 +610,7 @@ define(function (require, exports, module) {
           if (!Array.isArray(childRows)) {
             const lastIndex = rows.length - 1;
             props.member.loading = true;
-            rows[lastIndex] = cloneElement(rows[lastIndex], props);
+            rows[lastIndex] = React.cloneElement(rows[lastIndex], props);
           } else {
             rows = rows.concat(childRows);
           }
@@ -670,7 +670,7 @@ define(function (require, exports, module) {
           cellPadding: 0,
           cellSpacing: 0,
         },
-        TreeHeader(props),
+        React.createElement(TreeHeader, props),
         dom.tbody(
           {
             role: "presentation",

--- a/src/devtools/client/webconsole/components/Output/ConsoleTable.js
+++ b/src/devtools/client/webconsole/components/Output/ConsoleTable.js
@@ -13,10 +13,8 @@ const {
 
 const { MODE } = require("devtools/packages/devtools-reps");
 
-const GripMessageBody = React.createFactory(
-  require("devtools/client/webconsole/components/Output/GripMessageBody").default
-);
-
+const GripMessageBody =
+  require("devtools/client/webconsole/components/Output/GripMessageBody").default;
 const PropTypes = require("prop-types");
 
 const TABLE_ROW_MAX_ITEMS = 1000;
@@ -68,7 +66,7 @@ class ConsoleTable extends React.Component {
         const cellContent =
           typeof cellValue === "undefined"
             ? ""
-            : GripMessageBody({
+            : React.createElement(GripMessageBody, {
                 grip: cellValue,
                 mode: MODE.SHORT,
                 useQuotes: false,

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -14,7 +14,7 @@ const { actions } = require("ui/actions/index");
 const { MESSAGE_TYPE } = require("devtools/client/webconsole/constants");
 const { MessageIndent } = require("devtools/client/webconsole/components/Output/MessageIndent");
 const MessageIcon = require("devtools/client/webconsole/components/Output/MessageIcon");
-const FrameView = React.createFactory(require("devtools/client/shared/components/Frame"));
+const FrameView = require("devtools/client/shared/components/Frame");
 
 const CollapseButton = require("devtools/client/webconsole/components/Output/CollapseButton");
 const MessageRepeat = require("devtools/client/webconsole/components/Output/MessageRepeat");
@@ -391,7 +391,7 @@ class Message extends React.Component {
           dom.span(
             { className: "message-location devtools-monospace" },
             note.frame
-              ? FrameView({
+              ? React.createElement(FrameView, {
                   frame: note.frame,
                   onClick: this.onViewSourceInDebugger,
                   showEmptyPathAsHost: true,
@@ -413,7 +413,7 @@ class Message extends React.Component {
     const location = dom.span(
       { className: "message-location devtools-monospace" },
       frame
-        ? FrameView({
+        ? React.createElement(FrameView, {
             frame,
             onClick: frame ? this.onViewSourceInDebugger : undefined,
             showEmptyPathAsHost: true,

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
@@ -10,15 +10,10 @@ const PropTypes = require("prop-types");
 const dom = require("react-dom-factories");
 const GripMessageBody =
   require("devtools/client/webconsole/components/Output/GripMessageBody").default;
-const ConsoleTable = React.createFactory(
-  require("devtools/client/webconsole/components/Output/ConsoleTable")
-);
+const ConsoleTable = require("devtools/client/webconsole/components/Output/ConsoleTable");
 const { isGroupType, l10n } = require("devtools/client/webconsole/utils/messages");
 
-const Message = React.createFactory(
-  require("devtools/client/webconsole/components/Output/Message")
-);
-
+const Message = require("devtools/client/webconsole/components/Output/Message");
 ConsoleApiCall.displayName = "ConsoleApiCall";
 
 ConsoleApiCall.propTypes = {
@@ -109,7 +104,7 @@ function ConsoleApiCall(props) {
   } else if (typeof messageText === "string") {
     messageBody = messageText;
   } else if (messageText) {
-    messageBody = GripMessageBody({
+    messageBody = React.createElement(GripMessageBody, {
       dispatch,
       messageId,
       grip: messageText,
@@ -121,7 +116,7 @@ function ConsoleApiCall(props) {
 
   let attachment = null;
   if (type === "table") {
-    attachment = ConsoleTable({
+    attachment = React.createElement(ConsoleTable, {
       dispatch,
       id: message.id,
       parameters: message.parameters,
@@ -136,7 +131,7 @@ function ConsoleApiCall(props) {
 
   const collapsible = isGroupType(type) || (level === "error" && Array.isArray(stacktrace));
   const topLevelClasses = ["cm-s-mozilla"];
-  return Message({
+  return React.createElement(Message, {
     messageId,
     executionPoint,
     executionPointTime,
@@ -184,7 +179,7 @@ function formatReps(options = {}) {
     parameters
       // Get all the grips.
       .map((grip, key) =>
-        GripMessageBody({
+        React.createElement(GripMessageBody, {
           dispatch,
           messageId,
           grip,

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleCommand.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleCommand.js
@@ -7,10 +7,7 @@
 // React & Redux
 const React = require("react");
 const PropTypes = require("prop-types");
-const Message = React.createFactory(
-  require("devtools/client/webconsole/components/Output/Message")
-);
-
+const Message = require("devtools/client/webconsole/components/Output/Message");
 ConsoleCommand.displayName = "ConsoleCommand";
 
 ConsoleCommand.propTypes = {
@@ -31,7 +28,7 @@ function ConsoleCommand(props) {
   // (no CodeMirror editor), then it will just render text.
   const messageBody = React.createElement("syntax-highlighted", null, messageText);
 
-  return Message({
+  return React.createElement(Message, {
     source,
     type,
     level,

--- a/src/devtools/client/webconsole/components/Output/message-types/EvaluationResult.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/EvaluationResult.js
@@ -7,9 +7,7 @@
 // React & Redux
 const React = require("react");
 const PropTypes = require("prop-types");
-const Message = React.createFactory(
-  require("devtools/client/webconsole/components/Output/Message")
-);
+const Message = require("devtools/client/webconsole/components/Output/Message");
 const GripMessageBody =
   require("devtools/client/webconsole/components/Output/GripMessageBody").default;
 
@@ -70,7 +68,7 @@ function EvaluationResult(props) {
 
   const topLevelClasses = ["cm-s-mozilla"];
 
-  return Message({
+  return React.createElement(Message, {
     dispatch,
     source,
     type,

--- a/src/devtools/client/webconsole/components/Output/message-types/PageError.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/PageError.js
@@ -7,10 +7,7 @@
 // React & Redux
 const React = require("react");
 const PropTypes = require("prop-types");
-const Message = React.createFactory(
-  require("devtools/client/webconsole/components/Output/Message")
-);
-
+const Message = require("devtools/client/webconsole/components/Output/Message");
 const { createPrimitiveValueFront } = require("protocol/thread");
 
 const { REPS, MODE } = require("devtools/packages/devtools-reps");
@@ -64,7 +61,7 @@ function PageError(props) {
     urlCropLimit: 120,
   });
 
-  return Message({
+  return React.createElement(Message, {
     dispatch,
     messageId,
     executionPoint,

--- a/src/devtools/client/webconsole/components/Output/message-types/PaywallMessage.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/PaywallMessage.js
@@ -7,10 +7,7 @@
 // React & Redux
 const React = require("react");
 const PropTypes = require("prop-types");
-const Message = React.createFactory(
-  require("devtools/client/webconsole/components/Output/Message")
-);
-
+const Message = require("devtools/client/webconsole/components/Output/Message");
 PaywallMessage.displayName = "PaywallMessage";
 
 PaywallMessage.propTypes = {
@@ -26,7 +23,7 @@ function PaywallMessage(props) {
   const { message, timestampsVisible, maybeScrollToBottom, isPaused, dispatch } = props;
   const { indent, source, level, timeStamp, executionPointTime } = message;
 
-  return Message({
+  return React.createElement(Message, {
     source,
     type: "paywall",
     level,


### PR DESCRIPTION
This PR:

- **NUKES ALL THE USES OF `React.createFactory` THAT WERE SPITTING OUT WARNINGS! YAYYYY!** 🎉 

Straightforward conversion from `React.createFactory(SomeComponent)` and `SomeComponent(props)`, to `React.createElement(SomeComponent, props)`.

And now I see no more "`createFactory` is deprecated please stop using it" warnings in either local dev or the unit tests!