### PR TITLE
Allow login texts to be customizable based on what flow sent them to the login screen

### DIFF
--- a/pages/browser/import-settings.tsx
+++ b/pages/browser/import-settings.tsx
@@ -9,6 +9,7 @@ import {
   OnboardingHeader,
   OnboardingModalContainer,
 } from "ui/components/shared/Onboarding";
+import { LoginLink } from "ui/components/shared/Login/Login";
 
 function launchMigrationWizard(e: React.MouseEvent<HTMLAnchorElement>) {
   e.preventDefault();
@@ -28,7 +29,7 @@ export default function ImportSettings() {
           <OnboardingBody>{`If you'd like, I can carry your settings over from your main browser so you can get started quickly.`}</OnboardingBody>
         </OnboardingContent>
         <OnboardingActions>
-          <Link href="/">
+          <LoginLink>
             <a
               type="button"
               className={getButtonClasses("blue", "primary", "2xl")}
@@ -36,12 +37,12 @@ export default function ImportSettings() {
             >
               {`Sounds helpful, let's do it`}
             </a>
-          </Link>
-          <Link href="/">
+          </LoginLink>
+          <LoginLink>
             <a type="button" className={getButtonClasses("gray", "primary", "2xl")}>
               Skip
             </a>
-          </Link>
+          </LoginLink>
         </OnboardingActions>
         <iframe id="migrationFrame" className="h-0 w-0" />
       </OnboardingContentWrapper>

--- a/src/ui/components/shared/Login/Login.tsx
+++ b/src/ui/components/shared/Login/Login.tsx
@@ -1,13 +1,22 @@
 import { gql } from "@apollo/client";
-import React, { useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
+import Link from "next/link";
 
 import { query } from "ui/utils/apolloClient";
 import { setUserInBrowserPrefs } from "ui/utils/browser";
+import { getLoginReferrerParam } from "ui/utils/environment";
 import { isTeamMemberInvite } from "ui/utils/onboarding";
 import useAuth0 from "ui/utils/useAuth0";
 
 import { PrimaryLgButton } from "../Button";
 import { OnboardingContentWrapper, OnboardingModalContainer } from "../Onboarding";
+
+const LOGIN_TEXT = {
+  default: "Replay captures everything you need for the perfect bug report, all in one link",
+  "first-browser-open":
+    "Replay captures everything you need for the perfect bug report, all in one link",
+} as const;
+type LoginReferrer = keyof typeof LOGIN_TEXT;
 
 const GET_CONNECTION = gql`
   query GetConnection($email: String!) {
@@ -83,6 +92,8 @@ function SocialLogin({
   onShowSSOLogin: () => void;
   onLogin: () => void;
 }) {
+  const msg = LOGIN_TEXT[getLoginReferrerParam()];
+
   return (
     <div className="space-y-6">
       {isTeamMemberInvite() ? <h1 className="text-2xl font-extrabold">Almost there!</h1> : null}
@@ -91,13 +102,12 @@ function SocialLogin({
           <p>In order to join your team, we first need you to sign in.</p>
         ) : (
           <>
-            <p className="text-center">
-              Replay captures everything you need for the perfect bug report, all in one link.{" "}
+            <div className="text-center">
+              <p>{msg}</p>
               <a href="https://replay.io" className="pointer-hand underline">
                 Learn more
               </a>
-            </p>
-            <p></p>
+            </div>
           </>
         )}
       </div>
@@ -112,6 +122,17 @@ function SocialLogin({
       </button>
     </div>
   );
+}
+
+export function LoginLink({
+  children,
+  referrer,
+}: {
+  children: ReactNode;
+  referrer?: LoginReferrer;
+}) {
+  const href = `/${referrer ? `?login-referrer=${referrer}` : ""}`;
+  return <Link href={href}>{children}</Link>;
 }
 
 export default function Login({ returnToPath = "" }: { returnToPath?: string }) {

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -109,6 +109,11 @@ export function getPausePointParams() {
   return null;
 }
 
+export function getLoginReferrerParam() {
+  const referrerParam = url.searchParams.get("login-referrer");
+  return referrerParam === "first-browser-open" ? referrerParam : "default";
+}
+
 export function removeUrlParameters() {
   window.history.pushState({}, document.title, window.location.pathname);
 }


### PR DESCRIPTION
This helps us add custom login messages based on how the user landed on the login screen. Copy should follow so while it's related to #5785, it doesn't directly close it. @jonbell-lot23 