### PR TITLE
Keep presses on editor buttons from propagating to codemirror

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -82,6 +82,7 @@ const AddLogpoint: FC<{ showNag: boolean; onClick: () => void; breakpoint?: Brea
 
 function QuickActions({
   hoveredLineNumber,
+  onMouseDown,
   keyModifiers,
   targetNode,
   breakpoint,
@@ -140,6 +141,8 @@ function QuickActions({
   return (
     <div
       className="absolute z-50 flex flex-row space-x-px transform -translate-y-1/2"
+      // This is necessary so that we don't move the CodeMirror cursor while clicking.
+      onMouseDown={onMouseDown}
       style={{ top: `${(1 / 2) * height}px` }}
     >
       {button}


### PR DESCRIPTION
Fix #5839.

We used to have this "trick" for keeping CodeMirror from reacting to clicks to its children. It's only necessary in this case since we have clickable items (e.g. the + button) that, when clicked, ends up moving CodeMirror's cursor.

This puts it back.