### PR TITLE
Deselect the selected request ID when toggling types in the network monitor

### DIFF
--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -45,6 +45,8 @@ export const NetworkMonitor = ({
   const container = useRef<HTMLDivElement>(null);
 
   const toggleType = (type: CanonicalRequestType) => {
+    dispatch(hideRequestDetails());
+
     const newTypes = new Set(types);
     if (newTypes.has(type)) {
       trackEvent("net_monitor.delete_type", { type });


### PR DESCRIPTION
Fix #5876. 