### PR TITLE
Collapse the editor tabs when in a single column layout and there's no tabs open

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Tabs.js
+++ b/src/devtools/client/debugger/src/components/Editor/Tabs.js
@@ -156,6 +156,13 @@ class Tabs extends PureComponent {
   }
 
   render() {
+    const { toolboxLayout, tabSources } = this.props;
+    const isSingleColumnLayout = ["left", "bottom"].includes(toolboxLayout);
+
+    if (isSingleColumnLayout && !tabSources.length) {
+      return null;
+    }
+
     return <div className="source-header">{this.renderTabs()}</div>;
   }
 }


### PR DESCRIPTION
Fix #5832.

<img width="1800" alt="image" src="https://user-images.githubusercontent.com/15959269/160023455-f472de5c-168a-4053-87aa-52a4efc298e6.png">
