### PR TITLE
Ready when you are fix

### DIFF
--- a/src/ui/components/shared/Dialog.css
+++ b/src/ui/components/shared/Dialog.css
@@ -1,9 +1,9 @@
 .dialog {
   border-radius: 8px;
-  background: var(--theme-toolbar-background);
+  background: var(--modal-bgcolor);
+  color: var(--modal-color);
   border-radius: 8px;
   box-shadow: 0px 20px 25px -5px rgba(0, 0, 0, 0.1), 0px 10px 10px -5px rgba(0, 0, 0, 0.04);
-  color: var(--theme-toolbar-color);
   height: max-content;
   padding: 24px;
   width: max-content;


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/devtools/issues/5971#issuecomment-1078673041

These images don't look super different, but the colors are now aligned correctly with our other modals and colors.

Was:
![image](https://user-images.githubusercontent.com/9154902/160075996-17654545-8124-4b62-9d9a-426e33c270fa.png)

Now:
![image](https://user-images.githubusercontent.com/9154902/160075944-2f9fbecb-6a20-4f56-b70e-8eb32a921f70.png)
