### PR TITLE
Clean up logging

### DIFF
--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -293,8 +293,9 @@ class _ThreadFront {
     const sessionId = await this.waitForSession();
 
     client.Session.addLoadedRegionsListener((parameters: loadedRegions) => {
+      // TODO Remove this once we have a better region loading indicator
       // Log loaded regions to help with diagnostics.
-      // console.log("LoadedRegions", parameters);
+      console.log("LoadedRegions", parameters);
       listenerCallback(parameters);
     });
 

--- a/src/ui/utils/sanitize.ts
+++ b/src/ui/utils/sanitize.ts
@@ -60,6 +60,6 @@ export function sanitizeAction(action: any, logSanitized: boolean) {
 
 export const sanityCheckMiddleware: Middleware<{}, UIState, Dispatch<UIAction>> =
   store => next => action => {
-    sanitizeAction(action, true);
+    sanitizeAction(action, false);
     return next(action);
   };

--- a/test/mock/src/handlers/basic.ts
+++ b/test/mock/src/handlers/basic.ts
@@ -39,7 +39,6 @@ export function basicMessageHandlers(): MockHandlerRecord {
       endpoint: h.bindings.endpoint,
     }),
     "Session.loadedRegions": (params: any, h: MockHandlerHelpers) => {
-      // console.log("Loaded regions args: ", ...args);
       h.emitEvent("Session.loadedRegions", params);
       return new Promise(resolve => {});
     },


### PR DESCRIPTION
- Re-enable "loaded regions" message, as Brian H says it's useful
- Silence "of type ValueFront" warning