### PR TITLE
Allow an initialHeight to be set in accordion items

### DIFF
--- a/packages/accordion/index.tsx
+++ b/packages/accordion/index.tsx
@@ -30,17 +30,18 @@ import {
 
 // When I wrote this code God and I knew what I was doing. Now only God knows.
 
+export type SectionHeight = string | number;
+export type CollapsedState = boolean[];
+export type CreasesState = number[];
 export interface AccordionItem {
   component: React.ReactNode;
   header: string;
   expanded: boolean;
   className?: string;
+  initialHeight?: SectionHeight;
   onToggle?: () => void;
   button?: React.ReactNode;
 }
-export type SectionHeight = string | number;
-export type CollapsedState = boolean[];
-export type CreasesState = number[];
 
 function ResizeHandle({
   onResizeStart,
@@ -66,42 +67,42 @@ function ResizeHandle({
 }
 
 export function AccordionPane({
-  children,
-  header,
+  _expanded = false,
   button,
-  index,
-  expanded,
+  children,
   className,
   dispatch = () => ({}),
-  isBeingResized = false,
-  _expanded = false,
-  isResizable = false,
+  expanded,
+  header,
   height = 0,
-  onToggle = () => ({}),
+  index,
+  initialHeight,
+  isBeingResized = false,
+  isResizable = false,
   onResizeStart = () => ({}),
+  onToggle = () => ({}),
 }: {
-  children: React.ReactNode;
-  header: string;
+  _expanded?: boolean;
   button?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
   dispatch?: Dispatch<AccordionAction>;
   expanded?: boolean;
-  index?: number;
-  className?: string;
-  isBeingResized?: boolean;
-  _expanded?: boolean;
-  isResizable?: boolean;
+  header: string;
   height?: SectionHeight;
-  onToggle: () => void;
+  index?: number;
+  initialHeight?: SectionHeight;
+  isBeingResized?: boolean;
+  isResizable?: boolean;
   onResizeStart?: (e: React.MouseEvent) => void;
+  onToggle: () => void;
 }) {
   // Whenever the real `expanded` state changes, make sure we update the Accordion's
   // internal `_expanded` state to reflect the change. There's probably a simpler way to
   // do this by intercepting the expanded state in the Accordion so we only have one
   // expanded prop (the one from the Accordion) being considered by the AccordionPane.
   // https://gist.github.com/jaril/dfad5343f141c175d767d21cd6fdaab2
-  useEffect(() => {
-    dispatch(expanded ? expandSection(index!) : collapseSection(index!));
-  }, [expanded]);
+  useEffect(() => dispatch(expanded ? expandSection(index!) : collapseSection(index!)), [expanded]);
 
   return (
     <div
@@ -133,11 +134,20 @@ export function AccordionPane({
 export const Accordion: FC<{
   children: ReactElement<typeof AccordionPane>[];
 }> = ({ children }) => {
-  const initialExpandedState = Children.map(
-    children,
-    c => (c as unknown as AccordionItem).expanded ?? false
-  );
-  const [state, dispatch] = useReducer(reducer, getInitialState(initialExpandedState as boolean[]));
+  const initialState = Children.map(children, c => {
+    if (!c?.hasOwnProperty("props")) {
+      return {
+        expanded: false,
+        initialHeight: undefined,
+      };
+    }
+
+    return {
+      expanded: !!(c as ReactElement).props.expanded ?? false,
+      initialHeight: (c as ReactElement).props.initialHeight,
+    };
+  });
+  const [state, dispatch] = useReducer(reducer, getInitialState(initialState!));
   const isResizing = getIsResizing(state);
   const resizingParams = getResizingParams(state);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -158,12 +168,8 @@ export const Accordion: FC<{
 
     dispatch(startResizing(index, e.screenY));
   };
-  const onResize = (e: React.MouseEvent) => {
-    dispatch(resize(e.screenY));
-  };
-  const onResizeEnd = (e: React.MouseEvent) => {
-    dispatch(endResizing());
-  };
+  const onResize = (e: React.MouseEvent) => dispatch(resize(e.screenY));
+  const onResizeEnd = (e: React.MouseEvent) => dispatch(endResizing());
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(entries => {

--- a/packages/accordion/reducer.ts
+++ b/packages/accordion/reducer.ts
@@ -41,10 +41,16 @@ export type AccordionAction =
   | ResizeAction
   | ContainerResizeAction;
 
-const createDefaultSection = (expanded: boolean) => {
+const createDefaultSection = ({
+  expanded,
+  initialHeight,
+}: {
+  expanded: boolean;
+  initialHeight: number | undefined;
+}) => {
   return {
     expanded,
-    displayedHeight: 0,
+    displayedHeight: initialHeight || 0,
   };
 };
 
@@ -123,7 +129,9 @@ export const getResizingParams = (state: AccordionState) => {
 
 // Reducer
 
-export function getInitialState(expandedState: boolean[]): AccordionState {
+export function getInitialState(
+  expandedState: { initialHeight: number | undefined; expanded: boolean }[]
+): AccordionState {
   const sections: Section[] = [];
 
   for (let i = 0; i < expandedState.length; i++) {

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
@@ -34,6 +34,7 @@ function PrimaryPanes(props: PropsFromRedux) {
         className="sources-pane"
         expanded={!sourcesCollapsed}
         onToggle={() => props.toggleSourcesCollapse()}
+        initialHeight={"50%"}
         button={<QuickOpenButton />}
       >
         <SourcesTree />

--- a/src/devtools/client/webconsole/actions/messages.js
+++ b/src/devtools/client/webconsole/actions/messages.js
@@ -25,7 +25,6 @@ const {
   MESSAGES_CLEAR_EVALUATIONS,
   MESSAGES_CLEAR_EVALUATION,
 } = require("devtools/client/webconsole/constants");
-import { trackEvent } from "ui/utils/telemetry";
 
 const defaultIdGenerator = new IdGenerator();
 let queuedMessages = [];


### PR DESCRIPTION
This was really bothering me, because our `sources` item sits at the top of our default accordion, and often its content is large, but its initial size is tiny, while the bottom panel is huge and has very little content. I have added an optional `initialHeight` prop that can be provided to start the sections off at certain heights.  I thought about trying to do something fancy like defaulting the sizes of panels to `100/n` percent, where `n` is the number of accordion items, but that seemed like sometimes it would not be what the user wanted (and if they *do* want it, they can make that happen with just an `initialHeight` prop anyways).

Before:

![CleanShot 2022-03-25 at 14 01 30](https://user-images.githubusercontent.com/5903784/160200268-8f4090b1-1cd6-4db9-be6a-1174dddbb431.png)

After:

![CleanShot 2022-03-25 at 14 02 27](https://user-images.githubusercontent.com/5903784/160200347-ccb93ec4-e280-4f24-8d9a-be01fbd02f57.png)


Also, we were trying to set an initial `expanded` state, but I don't think it was working, because we were not looking at `props`, which should be where that was set.