### PR TITLE
Dark mode tweaks

### DIFF
--- a/src/devtools/client/debugger/src/components/shared/SearchInput.css
+++ b/src/devtools/client/debugger/src/components/shared/SearchInput.css
@@ -11,7 +11,7 @@
   min-height: 28px;
   width: 100%;
   background-color: var(--theme-text-field-bgcolor);
-  color: var(--theme-text-field-bgcolor-color);
+  color: var(--theme-text-field-color);
 }
 
 .search-field .img.search {
@@ -55,7 +55,7 @@
   line-height: 16px;
   font-family: inherit;
   font-size: inherit;
-  color: var(--theme-text-field-bgcolor-color);
+  color: var(--theme-text-field-color);
   background-color: transparent;
 }
 

--- a/src/devtools/client/themes/variables.css
+++ b/src/devtools/client/themes/variables.css
@@ -141,7 +141,7 @@
   --icon-color: var(--theme-body-color);
   --theme-focuser-bgcolor: var(--primary-accent);
   --theme-sidebar-background: var(--theme-base-100);
-  --theme-text-field-bgcolor-color: var(--theme-body-color);
+  --theme-text-field-color: var(--theme-body-color);
   --theme-text-field-bgcolor: var(--theme-base-95);
   --text-field-border: var(--cool-gray-300);
   --tab-selected-bgcolor: var(--theme-base-100); /* current tab */
@@ -374,7 +374,7 @@
   --icon-color: var(--theme-body-color);
   --theme-focuser-bgcolor: var(--primary-accent);
   --theme-sidebar-background: var(--theme-body-bgcolor);
-  --theme-text-field-bgcolor-color: #fff;
+  --theme-text-field-color: #fff;
   --theme-text-field-bgcolor: var(--theme-base-85);
   --text-field-border: var(--theme-base-85);
 

--- a/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -370,7 +370,7 @@ function OnboardingModal(props: PropsFromRedux) {
     <>
       <Modal options={{ maskTransparency: "translucent" }} onMaskClick={props.hideModal}>
         <div
-          className="relative flex flex-col justify-between space-y-6 rounded-lg bg-white p-4 text-sm shadow-xl"
+          className="text-modalColor relative flex flex-col justify-between space-y-2 rounded-lg bg-modalBgcolor p-4 text-sm shadow-xl backdrop-blur-sm"
           style={{ width: "480px" }}
         >
           {slide}

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -52,7 +52,7 @@ function CollaboratorRequests({ recording }: { recording: Recording }) {
       <div className="space-y-1.5 overflow-auto" style={{ maxHeight: "160px" }}>
         {displayedRequests.map((c, i) => (
           <div
-            className="flex items-center justify-between space-x-2 rounded-lg p-2 hover:bg-gray-100"
+            className="hover:bg-theme-base-90 flex items-center justify-between space-x-2 rounded-lg p-2"
             key={i}
           >
             <div className="flex items-center space-x-2">


### PR DESCRIPTION
Fixes #5978 

Was:
<img width="502" alt="image" src="https://user-images.githubusercontent.com/9154902/160213665-a012800f-04ef-442d-abfc-14ca0fcde050.png">

Now:
<img width="528" alt="image" src="https://user-images.githubusercontent.com/9154902/160213627-47d58856-fc47-4fc7-bd7f-e94eb9549705.png">

I also fixed our textfield color. It was too dark because of a bug. Also found a hover state and fixed it.