### PR TITLE
Pull the user to the sources tab if they're opening a source location from the console

### DIFF
--- a/src/devtools/client/debugger/panel.d.ts
+++ b/src/devtools/client/debugger/panel.d.ts
@@ -11,6 +11,6 @@ export class DebuggerPanel {
   destroy(): void;
   getSourceByActorId(id?: string): any;
   getSourceByURL(url?: string): any;
-  selectSource(sourceId: string, line?: number, column?: number): any;
+  selectSource(sourceId: string, line?: number, column?: number, openSourcesTab: boolean): any;
   getFrameId(): { asyncIndex: number; frameId?: string };
 }

--- a/src/devtools/client/debugger/panel.js
+++ b/src/devtools/client/debugger/panel.js
@@ -114,12 +114,12 @@ export class DebuggerPanel {
     return this._selectors.getIsPaused(this._getState());
   }
 
-  async selectSource(sourceId, line, column) {
+  async selectSource(sourceId, line, column, openSourcesTab) {
     const cx = this._selectors.getContext(this._getState());
     const location = { sourceId, line, column };
 
-    this._actions.showSource(cx, sourceId, /* openSourcesTab */ false);
-    await this._actions.selectSource(cx, sourceId, location, /* openSourcesTab */ false);
+    this._actions.showSource(cx, sourceId, openSourcesTab);
+    await this._actions.selectSource(cx, sourceId, location, openSourcesTab);
   }
 
   getSourceByActorId(sourceId) {

--- a/src/devtools/client/inspector/event-listeners/EventListenersApp.tsx
+++ b/src/devtools/client/inspector/event-listeners/EventListenersApp.tsx
@@ -105,7 +105,8 @@ export const EventListenersApp: FC = () => {
                                   locationUrl,
                                   location.line,
                                   location.column,
-                                  location.sourceId
+                                  location.sourceId,
+                                  true
                                 );
                               }}
                             >

--- a/src/devtools/client/webconsole/actions/toolbox.js
+++ b/src/devtools/client/webconsole/actions/toolbox.js
@@ -67,8 +67,14 @@ export function onMessageHover(type, message) {
   };
 }
 
-export function onViewSourceInDebugger(frame) {
+export function onViewSourceInDebugger(frame, openSourcesTab) {
   return () => {
-    window.gToolbox.viewSourceInDebugger(frame.url, frame.line, frame.column, frame.sourceId);
+    window.gToolbox.viewSourceInDebugger(
+      frame.url,
+      frame.line,
+      frame.column,
+      frame.sourceId,
+      openSourcesTab
+    );
   };
 }

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -120,10 +120,10 @@ class Message extends React.Component {
     e.preventDefault();
   }
 
-  onViewSourceInDebugger = frame => {
+  onViewSourceInDebugger = (frame, openSourcesTab = true) => {
     const { dispatch } = this.props;
     trackEvent("console.select_source ");
-    dispatch(actions.onViewSourceInDebugger(frame));
+    dispatch(actions.onViewSourceInDebugger(frame, openSourcesTab));
   };
 
   toggleMessage(e) {
@@ -181,7 +181,7 @@ class Message extends React.Component {
         actions.seek(executionPoint, executionPointTime, executionPointHasFrames, message.pauseId)
       );
 
-      this.onViewSourceInDebugger({ ...frame, url: frame.source });
+      this.onViewSourceInDebugger({ ...frame, url: frame.source }, false);
       dismissNag(Nag.FIRST_CONSOLE_NAVIGATE);
     };
     let handleAddComment = async () => {

--- a/src/ui/utils/devtools-toolbox.ts
+++ b/src/ui/utils/devtools-toolbox.ts
@@ -131,7 +131,8 @@ export class DevToolsToolbox {
     url: string | undefined,
     line: number | undefined,
     column: number | undefined,
-    id: string | undefined
+    id: string | undefined,
+    openSourcesTab: boolean
   ) {
     const dbg = this.getPanel("debugger");
     if (!dbg) {
@@ -139,7 +140,7 @@ export class DevToolsToolbox {
     }
     const source = id ? dbg.getSourceByActorId(id) : dbg.getSourceByURL(url);
     if (source) {
-      dbg.selectSource(source.id, line, column);
+      dbg.selectSource(source.id, line, column, openSourcesTab);
     }
   }
 }


### PR DESCRIPTION
Fix #5825.

Right now, if you're in a one column mode (e.g. dock to left, dock to bottom), where it's possible for the editor to be unselected, clicking on a location (e.g. `script.js:8`) from a console message won't yank you into the editor. This makes it so that happens. 

Clicking on a rewind/fast forward action on a console message still won't yank you, however, which is the desired behavior.

(We really should refactor the way we use "debugger" actions in the console, but I held off on that for this PR).

https://user-images.githubusercontent.com/15959269/160426084-09ea9451-e107-46c8-9c91-391d45aea67a.mov


