### PR TITLE
Support multiline expressions in the breakpoint panel editor

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelInput.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelInput.tsx
@@ -20,7 +20,7 @@ export function PanelInput({
 }) {
   const { value: enableBreakpointPanelAutocomplete } = useFeature("breakpointPanelAutocomplete");
   const onKeyPress = (e: KeyboardEvent) => {
-    if (e.key === Keys.ENTER) {
+    if (e.key === Keys.ENTER && !e.shiftKey) {
       e.preventDefault();
       onEnter();
     } else if (e.key === Keys.ESCAPE) {


### PR DESCRIPTION
Fix #4302.

#5242 did most of the work already, all that's left to do here is make sure we're allowing the Shift+Click happen to add a new line.