### PR TITLE
Use a number rather than a percentage for `initialHeight`

### DIFF
--- a/packages/accordion/index.tsx
+++ b/packages/accordion/index.tsx
@@ -38,7 +38,7 @@ export interface AccordionItem {
   header: string;
   expanded: boolean;
   className?: string;
-  initialHeight?: SectionHeight;
+  initialHeight?: number;
   onToggle?: () => void;
   button?: React.ReactNode;
 }
@@ -91,7 +91,7 @@ export function AccordionPane({
   header: string;
   height?: SectionHeight;
   index?: number;
-  initialHeight?: SectionHeight;
+  initialHeight?: number;
   isBeingResized?: boolean;
   isResizable?: boolean;
   onResizeStart?: (e: React.MouseEvent) => void;

--- a/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
+++ b/src/devtools/client/debugger/src/components/PrimaryPanes/index.tsx
@@ -34,7 +34,7 @@ function PrimaryPanes(props: PropsFromRedux) {
         className="sources-pane"
         expanded={!sourcesCollapsed}
         onToggle={() => props.toggleSourcesCollapse()}
-        initialHeight={"50%"}
+        initialHeight={400}
         button={<QuickOpenButton />}
       >
         <SourcesTree />


### PR DESCRIPTION
Originally I thought this was clever, but it actually fails when you go
to adjust the heights, because the reducer does not know how to deal
with percentages. The real solution here would be to make the reducer
smart enough to convert back and forth between percenages and pixel
values, but I think that's quite a bit harder than just throwing a
reasonable number in there and calling it a day.