### PR TITLE
Stabilize comment editing

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -53,7 +53,7 @@ function CommentItemHeader({
 
   useEffect(() => {
     setRelativeDate(formatRelativeTime(new Date(comment.createdAt)));
-  }, []);
+  }, [comment.createdAt]);
 
   if (!comment.user) {
     return null;

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -44,7 +44,7 @@ function CommentEditor({
       collaborators && recording
         ? ([...collaborators.map(c => c.user), recording.user].filter(Boolean) as User[])
         : undefined,
-    [loading]
+    [collaborators, recording]
   );
 
   return (

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
@@ -43,11 +43,11 @@ function ExistingCommentEditor({
     commentId: comment.id,
   });
 
-  const handleSubmit = (inputValue: string) => {
+  const handleSubmit = async (inputValue: string) => {
     if (type === "comment") {
-      updateComment(comment.id, inputValue, (comment as Comment).position);
+      await updateComment(comment.id, inputValue, (comment as Comment).position);
     } else if (type === "reply") {
-      updateCommentReply(comment.id, inputValue);
+      await updateCommentReply(comment.id, inputValue);
     }
     commentsLocalStorage.clear();
     clearPendingComment();

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
@@ -33,20 +33,19 @@ function NewCommentEditor({ clearPendingComment, data, setModal }: NewCommentEdi
       : "video"
   );
 
-  const handleSubmit = (inputValue: string) => {
+  const handleSubmit = async (inputValue: string) => {
     if (!isAuthenticated) {
       setModal("login");
       return;
     }
 
     if (data.type == "new_reply") {
-      handleReplySave(data.comment, inputValue);
+      await handleReplySave(data.comment, inputValue);
     } else {
-      handleNewSave(data.comment, inputValue);
+      await handleNewSave(data.comment, inputValue);
     }
 
     commentsLocalStorage.clear();
-
     clearPendingComment();
   };
 

--- a/src/ui/utils/comments.ts
+++ b/src/ui/utils/comments.ts
@@ -37,12 +37,11 @@ export function formatRelativeTime(date: Date) {
 }
 
 export function commentKeys(comments: (Comment | Reply)[]): string[] {
-  const createdAt = orderedByApproximatelyCreatedAt(comments);
-  return comments.map((c, i) => commentKey(c, createdAt[i]));
+  return comments.map((c, i) => commentKey(c));
 }
 
-function commentKey(comment: Comment | Reply, createdAtOrder: number): string {
-  return compact([createdAtOrder + 1, commentIdentifiers(comment)]).join("-");
+export function commentKey(comment: Comment | Reply): string {
+  return compact([comment.createdAt, commentIdentifiers(comment)]).join("-");
 }
 
 function orderedByApproximatelyCreatedAt(comments: (Comment | Reply)[]): number[] {


### PR DESCRIPTION
This is a proof of concept PR that does a reasonably good job at fixing the comment flickering with a couple of strategies. 

1. Stabilize the comment keys. The keys now use createdAt directly.
2. Use Josh's trick for stabilizing the list of comments in the transcript.
3. Don't render the transcript while we're still loading the user, recording, or comments. 
4. Don't remove the pending comment until we've finished creating or updating the comment

Note, the localStorage cache for pending comments is still pretty broken, but it does not contribute to flickering so i left it in. If you'd like to see how comments work without it you can remove the commit.

---

NOTE: We can discuss tomorrow how we'd like to move forward. This version is not perfect. For instance focus state is sometimes dropped. I have seen some flickering although i think it might also be hot module reloading related. I also think there are some architectural improvements we could make if we would like to. The goal for this PR is to try and find as many sources as flickering as possible and also rule out other sources that seem like they could be causing flickering, but don't.

