### PR TITLE
Fixed `next` warning for style link tags

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -175,8 +175,6 @@ function Routing({ Component, pageProps }: AppProps) {
         <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
         <title>Replay</title>
-        <link rel="stylesheet" href="/fonts/inter/inter.css" />
-        <link rel="stylesheet" href="/fonts/material_icons/material_icons.css" />
       </Head>
       <_App>
         <InstallRouteListener />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -49,6 +49,8 @@ export default class MyDocument extends Document {
         <Head>
           {/* nosemgrep typescript.react.security.audit.react-http-leak.react-http-leak */}
           <meta httpEquiv="Content-Security-Policy" content={csp(this.props)} />
+          <link rel="stylesheet" href="/fonts/inter/inter.css" />
+          <link rel="stylesheet" href="/fonts/material_icons/material_icons.css" />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
Fixes #5853.

A fix per https://nextjs.org/docs/messages/no-stylesheets-in-head-component.