### PR TITLE
Correct env for e2e on master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,16 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 500
           check_interval: 30
-          environment: ${{ github.ref == 'refs/heads/master' && "production" || "staging" }}
+        if: github.ref != 'refs/heads/master'
+      - name: Waiting for 200 from the Vercel Prod
+        uses: patrickedqvist/wait-for-vercel-preview@v1.1.1
+        id: waitFor200
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 500
+          check_interval: 30
+          environment: "production"
+        if: github.ref == 'refs/heads/master'
       - run: echo ${{steps.waitFor200.outputs.url}}
     outputs:
       url: ${{ steps.waitFor200.outputs.url }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 500
           check_interval: 30
-          environment: ${{ fromJSON('["staging", "production"]')[github.ref == 'refs/heads/master'] }}
+          environment: ${{ fromJSON('["", "production"]')[github.ref == 'refs/heads/master'] }}
     outputs:
       url: ${{ steps.waitFor200.outputs.url }}
   test0:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Run test suites
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   download-browser:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,17 +54,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 500
           check_interval: 30
-        if: github.ref != 'refs/heads/master'
-      - name: Waiting for 200 from the Vercel Prod
-        uses: patrickedqvist/wait-for-vercel-preview@v1.1.1
-        id: waitFor200
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 500
-          check_interval: 30
-          environment: "production"
-        if: github.ref == 'refs/heads/master'
-      - run: echo ${{steps.waitFor200.outputs.url}}
+          environment: ${{ fromJSON('["staging", "production"]')[github.ref == 'refs/heads/master'] }}
     outputs:
       url: ${{ steps.waitFor200.outputs.url }}
   test0:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 500
           check_interval: 30
+          environment: ${{ github.ref == 'refs/heads/master' && "production" || "staging" }}
       - run: echo ${{steps.waitFor200.outputs.url}}
     outputs:
       url: ${{ steps.waitFor200.outputs.url }}


### PR DESCRIPTION
Sets an additional `environment` var for the job if the branch is `master`.
Otherwise, it tries to ping preview branches on Vercel.

Config per https://github.com/patrickedqvist/wait-for-vercel-preview#environment