### PR TITLE
Progressively disclose the mouse target loading spinner

### DIFF
--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -90,7 +90,7 @@ function Video({
       {showCommentTool ? (
         <CommentsOverlay>
           <CommentLoader recordingId={recordingId} />
-          {(mouseTargetsLoading || stalled) && (
+          {((isNodePickerActive && mouseTargetsLoading) || stalled) && (
             <div className="absolute bottom-5 right-5 z-20 flex opacity-50">
               <Spinner className="w-4 animate-spin" />
             </div>


### PR DESCRIPTION
Related to #5851.

The spinner used to be shown right away, even if the user wasn't in node picker mode. This was somewhat confusing since it can be misinterpreted as "the video is loading".