### PR TITLE
Disable comments local storage

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/useCommentsLocalStorage.ts
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/useCommentsLocalStorage.ts
@@ -27,7 +27,8 @@ export const useCommentsLocalStorage = (mode: Mode) => {
   };
 
   const getComment = (): string | null => {
-    return localStorage.getItem(storeKey);
+    return "";
+    // return localStorage.getItem(storeKey);
   };
 
   const clearComment = (): void => {


### PR DESCRIPTION
We're currently re-using the same comment for most replies which makes it difficult to debug editing.