### PR TITLE
Disable commenting, editing, etc. when updating

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
-import { selectors } from "ui/reducers";
 import CommentEditor, { PERSIST_COMM_DEBOUNCE_DELAY } from "./CommentEditor";
 import { useGetUserId } from "ui/hooks/users";
 import { useCommentsLocalStorage } from "./useCommentsLocalStorage";
@@ -23,7 +22,6 @@ const LoomComment = connect(null, { setModal: actions.setModal })(
 );
 
 type ExistingCommentEditorProps = PropsFromRedux & {
-  editable: boolean;
   data: CommentData;
   isEditing: boolean;
   setIsEditing: (isEditing: boolean) => void;
@@ -31,7 +29,6 @@ type ExistingCommentEditorProps = PropsFromRedux & {
 };
 
 function ExistingCommentEditor({
-  editable,
   isEditing,
   setIsEditing,
   data,
@@ -58,7 +55,7 @@ function ExistingCommentEditor({
       }}
     >
       <CommentEditor
-        editable={editable && isEditing}
+        editable={isEditing}
         comment={comment}
         handleSubmit={inputValue => {
           commentsLocalStorage.clear();

--- a/src/ui/hooks/comments/comments.ts
+++ b/src/ui/hooks/comments/comments.ts
@@ -56,7 +56,7 @@ export function useUpdateComment() {
     console.error("Apollo error while updating a comment:", error);
   }
 
-  return (commentId: string, newContent: string, position: CommentPosition | null) => {
+  return (commentId: string, newContent: string, position: CommentPosition | null) =>
     updateCommentContent({
       variables: { commentId, newContent, position },
       optimisticResponse: {
@@ -75,7 +75,6 @@ export function useUpdateComment() {
         });
       },
     });
-  };
 }
 
 export function useUpdateCommentReply() {
@@ -96,7 +95,7 @@ export function useUpdateCommentReply() {
     console.error("Apollo error while updating a comment:", error);
   }
 
-  return (commentId: string, newContent: string) => {
+  return (commentId: string, newContent: string) =>
     updateCommentReplyContent({
       variables: { commentId, newContent },
       optimisticResponse: {
@@ -112,7 +111,6 @@ export function useUpdateCommentReply() {
         });
       },
     });
-  };
 }
 
 export async function getFirstComment(

--- a/src/ui/hooks/comments/useAddComment.tsx
+++ b/src/ui/hooks/comments/useAddComment.tsx
@@ -29,7 +29,7 @@ export default function useAddComment() {
   return (comment: Comment) => {
     trackEvent("comments.create");
 
-    addComment({
+    return addComment({
       variables: {
         input: {
           ...omit(comment, ["id", "createdAt", "updatedAt", "replies", "user"]),

--- a/src/ui/hooks/comments/useAddCommentReply.tsx
+++ b/src/ui/hooks/comments/useAddCommentReply.tsx
@@ -29,7 +29,7 @@ export default function useAddCommentReply() {
     console.error("Apollo error while adding a comment:", error);
   }
 
-  return (reply: Reply) => {
+  return (reply: Reply) =>
     addCommentReply({
       variables: {
         input: {
@@ -108,5 +108,4 @@ export default function useAddCommentReply() {
         });
       },
     });
-  };
 }


### PR DESCRIPTION
This will mark a comment as updating, which will disable all of the
various paths to editing it and its replies. It will also make it
translucent, to let the user know that stuff is still in progress.

Follow-up: This GraphQL operation to insert a comment record should not
take 5.5 seconds.