### PR TITLE
Add option to test runner for long timeouts

### DIFF
--- a/test/src/runTest.js
+++ b/test/src/runTest.js
@@ -95,6 +95,9 @@ async function runTest(state, test, exampleRecordingId, target) {
   if (state.dispatchServer != "wss://dispatch.replay.io") {
     testPath += `&dispatch=${state.dispatchServer}`;
   }
+  if (state.longTimeout) {
+    testPath += "&longTimeout=1";
+  }
 
   let success, why, recordingId;
   if (target == "gecko" || target == "chromium") {

--- a/test/src/state.js
+++ b/test/src/state.js
@@ -28,6 +28,7 @@ const defaultState = {
   onlyTarget: process.env.onlyTarget,
   skippedTests: process.env.SKIPPED_TESTS,
   testTimeout: 240,
+  longTimeout: false,
 
   // Runtime state
   count: 1,
@@ -50,6 +51,7 @@ const usage = `
     --timeout N: Use a timeout of N seconds for tests (default 240).
     --target TARGET: Only run tests using given TARGET
     --server ADDRESS: Set server to connect to (default wss://dispatch.replay.io).
+    --long-timeout: Use longer timeouts when running tests.
 `;
 function processArgs(state, argv) {
   for (let i = 2; i < argv.length; i++) {
@@ -78,6 +80,9 @@ function processArgs(state, argv) {
         break;
       case "--server":
         state.dispatchServer = argv[++i];
+        break;
+      case "--long-timeout":
+        state.longTimeout = true;
         break;
       case "--help":
       case "-h":


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/4946, followup to https://github.com/RecordReplay/devtools/pull/6070, we need to expose the long timeout search param in the test runner in order to use it during backend CI.