### PR TITLE
Fix parentheses

### DIFF
--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -31,7 +31,7 @@ function isLongTimeout() {
 }
 
 function defaultWaitTimeout() {
-  return 1000 * isLongTimeout() ? 120 : 10;
+  return 1000 * (isLongTimeout() ? 120 : 10);
 }
 
 export async function waitUntil(fn, options) {


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/4946.  We're computing timeouts in tests wrong because of a parenthesis issue.  I think typescript would have caught this?