### PR TITLE
Remove unneeded comment selectors

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -21,7 +21,6 @@ import {
   getFocusRegion,
   getZoomRegion,
 } from "ui/reducers/timeline";
-import { getPendingComment } from "ui/reducers/comments";
 import { UIStore, UIThunkAction } from ".";
 import { Action } from "redux";
 import { PauseEventArgs } from "protocol/thread/thread";
@@ -476,7 +475,7 @@ export function goToNextPaint(): UIThunkAction {
 }
 
 export function setHoveredItem(hoveredItem: HoveredItem): UIThunkAction {
-  return (dispatch, getState) => {
+  return dispatch => {
     const { target } = hoveredItem;
 
     const hoverEnabledForTarget = (features as any)[`${target}Hover`];
@@ -486,9 +485,7 @@ export function setHoveredItem(hoveredItem: HoveredItem): UIThunkAction {
 
     dispatch({ type: "set_hovered_item", hoveredItem });
 
-    // Don't update the video if user is adding a new comment.
-    const updateGraphics = !getPendingComment(getState());
-    dispatch(setTimelineToTime(hoveredItem?.time || null, updateGraphics));
+    dispatch(setTimelineToTime(hoveredItem?.time || null));
   };
 }
 

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -85,11 +85,6 @@ function CommentEditor({
   );
 }
 
-const connector = connect(
-  (state: UIState) => ({
-    pendingComment: selectors.getPendingComment(state),
-  }),
-  { clearPendingComment: actions.clearPendingComment }
-);
+const connector = connect(null, { clearPendingComment: actions.clearPendingComment });
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(CommentEditor);

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { connect, ConnectedProps } from "react-redux";
+import { connect } from "react-redux";
 import { actions } from "ui/actions";
 import CommentEditor, { PERSIST_COMM_DEBOUNCE_DELAY } from "./CommentEditor";
 import { useGetUserId } from "ui/hooks/users";
@@ -21,7 +21,7 @@ const LoomComment = connect(null, { setModal: actions.setModal })(
   }
 );
 
-type ExistingCommentEditorProps = PropsFromRedux & {
+type ExistingCommentEditorProps = {
   data: CommentData;
   isEditing: boolean;
   setIsEditing: (isEditing: boolean) => void;
@@ -80,10 +80,4 @@ function ExistingCommentEditor({
   );
 }
 
-const connector = connect(null, {
-  clearPendingComment: actions.clearPendingComment,
-});
-
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export default connector(ExistingCommentEditor);
+export default ExistingCommentEditor;

--- a/src/ui/components/Timeline/Focuser.tsx
+++ b/src/ui/components/Timeline/Focuser.tsx
@@ -39,7 +39,7 @@ function ResizeMask({
       (draggingTarget === FocusOperation.resizeEnd && currentTime > focusRegion!.endTime)
     ) {
       dispatch(setTimelineState({ currentTime: hoverTime! }));
-      dispatch(setTimelineToTime(hoverTime, true));
+      dispatch(setTimelineToTime(hoverTime));
     }
   };
 

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -150,7 +150,7 @@ class Timeline extends Component<PropsFromRedux, { isDragging: boolean }> {
         if (!seek(event.point, mouseTime, false)) {
           // if seeking to the new point failed because it is in an unloaded region,
           // we reset the timeline to the current time
-          setTimelineToTime(ThreadFront.currentTime, true);
+          setTimelineToTime(ThreadFront.currentTime);
           setTimelineState({ currentTime: ThreadFront.currentTime });
         }
         clearPendingComment();


### PR DESCRIPTION
We had a couple of unused connections sitting around, so nice to get
those out of there. Also, as far as I can tell, this use of
pendingComment in timeline does not do anything? I could be wrong about
this one, but I pulled it out and couldn't see any difference in
behavior.