### PR TITLE
Don't try to parse content if it is an object

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/CommentEditor.tsx
@@ -12,7 +12,7 @@ import { FocusContext } from "../CommentCard";
 import classNames from "classnames";
 import { Editor } from "@tiptap/react";
 
-export const PERSIST_COMM_DEBOUNCE_DELAY = 500;
+export const PERSIST_COMMENT_DEBOUNCE_DELAY = 500;
 
 export function getCommentEditorDOMId(comment: Comment | Reply) {
   return `comment-editor-${comment.id}`;
@@ -22,8 +22,8 @@ type CommentEditorProps = PropsFromRedux & {
   comment: Comment | Reply;
   editable: boolean;
   handleSubmit: (inputValue: string) => void;
-  onCreate: (editor: { editor: Pick<Editor, "commands"> }) => void;
-  onUpdate: (editor: { editor: Pick<Editor, "getJSON"> }) => void;
+  onCreate?: (editor: { editor: Pick<Editor, "commands"> }) => void;
+  onUpdate?: (editor: { editor: Pick<Editor, "getJSON"> }) => void;
   handleCancel: () => void;
 };
 
@@ -32,8 +32,8 @@ function CommentEditor({
   comment,
   editable,
   handleSubmit,
-  onCreate,
-  onUpdate,
+  onCreate = () => {},
+  onUpdate = () => {},
   handleCancel,
 }: CommentEditorProps) {
   const recordingId = hooks.useGetRecordingId();

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/ExistingCommentEditor.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { actions } from "ui/actions";
-import CommentEditor, { PERSIST_COMM_DEBOUNCE_DELAY } from "./CommentEditor";
+import CommentEditor, { PERSIST_COMMENT_DEBOUNCE_DELAY } from "./CommentEditor";
 import { useGetUserId } from "ui/hooks/users";
 import { useCommentsLocalStorage } from "./useCommentsLocalStorage";
 import debounce from "lodash/debounce";
@@ -70,7 +70,7 @@ function ExistingCommentEditor({
         }}
         onUpdate={debounce(({ editor }) => {
           commentsLocalStorage.set(JSON.stringify(editor.getJSON()));
-        }, PERSIST_COMM_DEBOUNCE_DELAY)}
+        }, PERSIST_COMMENT_DEBOUNCE_DELAY)}
         handleCancel={() => {
           commentsLocalStorage.clear();
           setIsEditing(false);

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/NewCommentEditor.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { connect, ConnectedProps } from "react-redux";
+import { connect, ConnectedProps, useDispatch } from "react-redux";
 
 import { Comment, Reply } from "ui/state/comments";
-import CommentEditor, { PERSIST_COMM_DEBOUNCE_DELAY } from "./CommentEditor";
+import CommentEditor, { PERSIST_COMMENT_DEBOUNCE_DELAY } from "./CommentEditor";
 import { useCommentsLocalStorage } from "./useCommentsLocalStorage";
 import debounce from "lodash/debounce";
 import { CommentData } from "../types";
+import { updatePendingCommentContent } from "ui/actions/comments";
 
 interface NewCommentEditorProps {
   data: CommentData;
@@ -21,22 +22,16 @@ function NewCommentEditor({ onSubmit, data }: NewCommentEditorProps) {
         }
       : "video"
   );
+  const dispatch = useDispatch();
 
   return (
     <CommentEditor
       editable={true}
       comment={data.comment}
-      handleSubmit={inputValue => {
-        onSubmit(data, inputValue);
-        commentsLocalStorage.clear();
-      }}
-      onCreate={({ editor }) => {
-        const storedComment = commentsLocalStorage.get();
-        editor.commands.setContent(storedComment ? JSON.parse(storedComment) : null);
-      }}
+      handleSubmit={inputValue => onSubmit(data, inputValue)}
       onUpdate={debounce(({ editor }) => {
-        commentsLocalStorage.set(JSON.stringify(editor.getJSON()));
-      }, PERSIST_COMM_DEBOUNCE_DELAY)}
+        dispatch(updatePendingCommentContent(editor.getJSON()));
+      }, PERSIST_COMMENT_DEBOUNCE_DELAY)}
       handleCancel={() => commentsLocalStorage.clear()}
     />
   );

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -12,7 +12,7 @@ interface TipTapEditorProps {
   autofocus: boolean;
   blur: () => void;
   close: () => void;
-  content: string;
+  content: string | object;
   editable: boolean;
   handleSubmit: (text: string) => void;
   handleCancel: () => void;
@@ -24,7 +24,10 @@ interface TipTapEditorProps {
   onUpdate: (editor: { editor: Pick<Editor, "getJSON"> }) => void;
 }
 
-const tryToParse = (content: string): any => {
+const tryToParse = (content: string | object): any => {
+  if (typeof content === "object") {
+    return content;
+  }
   try {
     return JSON.parse(content);
   } catch {


### PR DESCRIPTION
We are trying to parse `content` even when it came from Redux, but when it comes from Redux it is already an object, not a string, in which case we can hand it directly to TipTap. With @jasonLaster's change to persist the `pendingComment` slice of redux this means we get comment persistence across switching modes and across tab refreshes, sessions (on the same device), etc.