### PR TITLE
Handle unauthenticated errors from the graphql API

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -151,7 +151,8 @@ function AppUtilities({ children }: { children: ReactNode }) {
       await getAccessTokenSilently({ ignoreCache: true });
     } catch {
       pingTelemetry("devtools-auth-error-refresh-fail");
-      router.push("/login");
+      const returnToPath = window.location.pathname + window.location.search;
+      router.push({ pathname: "/login", query: { returnTo: returnToPath } });
     }
   };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,23 +1,28 @@
 import "../src/test-prep";
 
+import { useAuth0 } from "@auth0/auth0-react";
 import Head from "next/head";
 import type { AppContext, AppProps } from "next/app";
+import { useRouter } from "next/router";
 import NextApp from "next/app";
 import React, { ReactNode, useEffect, useState } from "react";
-import { Provider } from "react-redux";
 import { IntercomProvider } from "react-use-intercom";
-import tokenManager from "ui/utils/tokenManager";
-import { ApolloWrapper } from "ui/utils/apolloClient";
+import { Provider } from "react-redux";
+import { Store } from "redux";
 import LoadingScreen from "ui/components/shared/LoadingScreen";
 import ErrorBoundary from "ui/components/ErrorBoundary";
 import _App from "ui/components/App";
 import { bootstrapApp } from "ui/setup";
-import "image/image.css";
-import "image/icon.css";
-import { Store } from "redux";
 import { ConfirmProvider } from "ui/components/shared/Confirm";
 import MaintenanceModeScreen from "ui/components/MaintenanceMode";
+import { InstallRouteListener } from "ui/utils/routeListener";
+import { useLaunchDarkly } from "ui/utils/launchdarkly";
+import { pingTelemetry } from "ui/utils/replay-telemetry";
+import tokenManager from "ui/utils/tokenManager";
+import { ApolloWrapper } from "ui/utils/apolloClient";
 
+import "image/image.css";
+import "image/icon.css";
 import "tailwindcss/tailwind.css";
 import "../src/base.css";
 import "devtools/client/debugger/src/components/variables.css";
@@ -124,11 +129,6 @@ import "ui/components/Toolbox.css";
 import "ui/components/Transcript/Transcript.css";
 import "ui/components/Views/NonDevView.css";
 import "ui/utils/sourcemapVisualizer.css";
-import { InstallRouteListener } from "ui/utils/routeListener";
-import { useRouter } from "next/router";
-import { useLaunchDarkly } from "ui/utils/launchdarkly";
-import { useAuth0 } from "@auth0/auth0-react";
-import { pingTelemetry } from "ui/utils/replay-telemetry";
 
 interface AuthProps {
   apiKey?: string;


### PR DESCRIPTION
## Issue

Sometimes the frontend thinks it has a valid auth session but the backend thinks the JWT has expired. In this case, devtools will try to render the correct view but the backend can't provide the data.

In the case of #5707, this manifests as an error to the user that there is "No Active Team" when in fact the user needs to re-authenticate.

## Resolution

* Adds an `onAuthError` callback which is invoked when our backend throws an `UNAUTHENTICATED` error
* Calls Auth0 to get a new access token when `onAuthError` is called falling back to show the login screen if an error occurs