### PR TITLE
Handle unauthenticated errors from the graphql API

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -151,7 +151,8 @@ function AppUtilities({ children }: { children: ReactNode }) {
       await getAccessTokenSilently({ ignoreCache: true });
     } catch {
       pingTelemetry("devtools-auth-error-refresh-fail");
-      router.push("/login");
+      const returnToPath = window.location.pathname + window.location.search;
+      router.push({ pathname: "/login", query: { returnTo: returnToPath } });
     }
   };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -139,10 +139,14 @@ const maintenanceMode = false;
 
 function AppUtilities({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const { getAccessTokenSilently } = useAuth0();
+  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
 
   const handleAuthError = async () => {
-    if (router.pathname.startsWith("/login")) {
+    // This handler attempts to handle the scenario in which the frontend and
+    // our auth client think the user has a valid auth session but the backend
+    // disagrees. In this case, we should refresh the token so we can continue
+    // or, if that fails, return to the login page so the user can resume.
+    if (!isAuthenticated || router.pathname.startsWith("/login")) {
       return;
     }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,23 +1,28 @@
 import "../src/test-prep";
 
+import { useAuth0 } from "@auth0/auth0-react";
 import Head from "next/head";
 import type { AppContext, AppProps } from "next/app";
+import { useRouter } from "next/router";
 import NextApp from "next/app";
 import React, { ReactNode, useEffect, useState } from "react";
-import { Provider } from "react-redux";
 import { IntercomProvider } from "react-use-intercom";
-import tokenManager from "ui/utils/tokenManager";
-import { ApolloWrapper } from "ui/utils/apolloClient";
+import { Provider } from "react-redux";
+import { Store } from "redux";
 import LoadingScreen from "ui/components/shared/LoadingScreen";
 import ErrorBoundary from "ui/components/ErrorBoundary";
 import _App from "ui/components/App";
 import { bootstrapApp } from "ui/setup";
-import "image/image.css";
-import "image/icon.css";
-import { Store } from "redux";
 import { ConfirmProvider } from "ui/components/shared/Confirm";
 import MaintenanceModeScreen from "ui/components/MaintenanceMode";
+import { InstallRouteListener } from "ui/utils/routeListener";
+import { useLaunchDarkly } from "ui/utils/launchdarkly";
+import { pingTelemetry } from "ui/utils/replay-telemetry";
+import tokenManager from "ui/utils/tokenManager";
+import { ApolloWrapper } from "ui/utils/apolloClient";
 
+import "image/image.css";
+import "image/icon.css";
 import "tailwindcss/tailwind.css";
 import "../src/base.css";
 import "devtools/client/debugger/src/components/variables.css";
@@ -124,11 +129,6 @@ import "ui/components/Toolbox.css";
 import "ui/components/Transcript/Transcript.css";
 import "ui/components/Views/NonDevView.css";
 import "ui/utils/sourcemapVisualizer.css";
-import { InstallRouteListener } from "ui/utils/routeListener";
-import { useRouter } from "next/router";
-import { useLaunchDarkly } from "ui/utils/launchdarkly";
-import { useAuth0 } from "@auth0/auth0-react";
-import { pingTelemetry } from "ui/utils/replay-telemetry";
 
 interface AuthProps {
   apiKey?: string;


### PR DESCRIPTION
V2 of #6125 

This adds an `!isAuthenticated` check to prevent try to refresh the token when there was no token to begin with.

The error condition (there are probably others) was opening a public replay anonymously and using the rewind button in the console to navigate backwards. This triggered `dismissNag` which fails because the user isn't authenticated.