### PR TITLE
Format Response bodies based on theme

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -21,6 +21,7 @@ import {
   EventKind,
   ReplayEvent,
   ReplayNavigationEvent,
+  AppTheme,
 } from "ui/state/app";
 import { Workspace } from "ui/types";
 import { client, sendMessage } from "protocol/socket";
@@ -43,9 +44,8 @@ import { getRecordingId } from "ui/utils/recording";
 import { prefs } from "devtools/client/debugger/src/utils/prefs";
 import { shallowEqual } from "devtools/client/debugger/src/utils/resource/compare";
 import { getShowVideoPanel } from "ui/reducers/layout";
-import { getIsInFocusMode } from "ui/reducers/timeline";
 import { toggleFocusMode } from "./timeline";
-import { features } from "ui/utils/prefs";
+import { getTheme } from "ui/reducers/app";
 
 export type SetRecordingDurationAction = Action<"set_recording_duration"> & { duration: number };
 export type LoadingAction = Action<"loading"> & { loading: number };
@@ -55,7 +55,7 @@ export type SetDisplayedLoadingProgressAction = Action<"set_displayed_loading_pr
 export type SetLoadingFinishedAction = Action<"set_loading_finished"> & { finished: boolean };
 export type IndexingAction = Action<"indexing"> & { indexing: number };
 export type SetSessionIdAction = Action<"set_session_id"> & { sessionId: SessionId };
-export type UpdateThemeAction = Action<"update_theme"> & { theme: string };
+export type UpdateThemeAction = Action<"update_theme"> & { theme: AppTheme };
 export type SetInitializedPanelsAction = Action<"set_initialized_panels"> & { panel: PanelName };
 export type SetUploadingAction = Action<"set_uploading"> & { uploading: UploadInfo | null };
 export type SetAwaitingSourcemapsAction = Action<"set_awaiting_sourcemaps"> & {
@@ -244,8 +244,16 @@ function setIndexing(indexing: number): IndexingAction {
   return { type: "indexing", indexing };
 }
 
-export function updateTheme(theme: string): UpdateThemeAction {
+export function updateTheme(theme: AppTheme): UpdateThemeAction {
   return { type: "update_theme", theme };
+}
+
+export function toggleTheme(): UIThunkAction {
+  return (dispatch, getState) => {
+    const theme = getTheme(getState());
+    const newTheme = theme == "dark" ? "light" : "dark";
+    dispatch(updateTheme(newTheme));
+  };
 }
 
 export function setInitializedPanels(panel: PanelName): SetInitializedPanelsAction {
@@ -432,7 +440,7 @@ export function executeCommand(key: CommandKey): UIThunkAction {
       const showVideoPanel = getShowVideoPanel(getState());
       dispatch(setShowVideoPanel(!showVideoPanel));
     } else if (key === "toggle_dark_mode") {
-      features.darkMode = !features.darkMode;
+      dispatch(toggleTheme());
     } else if (key === "pin_to_bottom") {
       dispatch(setToolboxLayout("bottom"));
     } else if (key === "pin_to_left") {
@@ -441,8 +449,6 @@ export function executeCommand(key: CommandKey): UIThunkAction {
       dispatch(setToolboxLayout("ide"));
     }
 
-    {
-      dispatch(hideCommandPalette());
-    }
+    dispatch(hideCommandPalette());
   };
 }

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useEffect, createContext } from "react";
-import { connect, ConnectedProps } from "react-redux";
+import { connect, ConnectedProps, useSelector } from "react-redux";
 import useAuth0 from "ui/utils/useAuth0";
 
 import AppErrors from "./shared/Error";
@@ -21,7 +21,6 @@ import FirstReplayModal from "./shared/FirstReplayModal";
 import TOSScreen, { LATEST_TOS_VERSION } from "./TOSScreen";
 import SingleInviteModal from "./shared/OnboardingModal/SingleInviteModal";
 import FocusModal from "./shared/FocusModal/FocusModal";
-import { useFeature } from "ui/hooks/settings";
 import { ConfirmRenderer } from "./shared/Confirm";
 import PrivacyModal from "./shared/PrivacyModal";
 import LoomModal from "./shared/LoomModal";
@@ -93,7 +92,7 @@ function App({ children, modal }: AppProps) {
   const auth = useAuth0();
   const dismissNag = hooks.useDismissNag();
   const userInfo = useGetUserInfo();
-  const { value: enableDarkMode } = useFeature("darkMode");
+  const theme = useSelector(selectors.getTheme);
 
   useEffect(() => {
     if (userInfo.nags && shouldShowNag(userInfo.nags, Nag.FIRST_LOG_IN)) {
@@ -126,8 +125,8 @@ function App({ children, modal }: AppProps) {
   }, []);
 
   useEffect(() => {
-    document.body.parentElement!.className = enableDarkMode ? "theme-dark" : "theme-light";
-  }, [enableDarkMode]);
+    document.body.parentElement!.className = `theme-${theme}`;
+  }, [theme]);
 
   if (auth.isLoading || userInfo.loading) {
     return <LoadingScreen />;

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -78,6 +78,7 @@ const TipTapEditor = ({
                 onSubmit(JSON.stringify(editor.getJSON()));
                 return true;
               },
+
               Enter: ({ editor }) => {
                 onSubmit(JSON.stringify(editor.getJSON()));
                 return true;

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -10,7 +10,6 @@ import { trackEvent } from "ui/utils/telemetry";
 import { deselectSource } from "devtools/client/debugger/src/actions/sources/select";
 import { getCommandPaletteInput } from "./CommandPalette/SearchInput";
 import { getSelectedSource } from "devtools/client/debugger/src/reducers/sources";
-import { features } from "ui/utils/prefs";
 import { isEditableElement } from "ui/utils/key-shortcuts";
 
 function setupShortcuts() {
@@ -35,6 +34,7 @@ function KeyboardShortcuts({
   toggleFocusMode,
   togglePaneCollapse,
   viewMode,
+  toggleTheme,
 }: PropsFromRedux) {
   const addShortcut = (key: string, callback: (e: KeyboardEvent) => void) => {
     if (!globalShortcuts) {
@@ -80,10 +80,10 @@ function KeyboardShortcuts({
       paletteInput.focus();
     }
   };
-  const toggleTheme = (e: KeyboardEvent) => {
+  const onToggleTheme = (e: KeyboardEvent) => {
     if (!e.target || !isEditableElement(e.target)) {
       e.preventDefault();
-      features.darkMode = !features.darkMode;
+      toggleTheme();
     }
   };
   const toggleEditFocusMode = (e: KeyboardEvent) => {
@@ -99,14 +99,14 @@ function KeyboardShortcuts({
     addShortcut("CmdOrCtrl+Shift+F", openFullTextSearch);
     addShortcut("CmdOrCtrl+B", toggleLeftSidebar);
     addShortcut("CmdOrCtrl+K", togglePalette);
-    addShortcut("Shift+T", toggleTheme);
+    addShortcut("Shift+T", onToggleTheme);
     addShortcut("Shift+F", toggleEditFocusMode);
 
     return () => {
       removeShortcut("CmdOrCtrl+Shift+F", openFullTextSearch);
       removeShortcut("CmdOrCtrl+B", toggleLeftSidebar);
       removeShortcut("CmdOrCtrl+K", togglePalette);
-      removeShortcut("Shift+T", toggleTheme);
+      removeShortcut("Shift+T", onToggleTheme);
       removeShortcut("Shift+F", toggleEditFocusMode);
     };
   }, [viewMode, selectedSource]);
@@ -129,6 +129,7 @@ const connector = connect(
     toggleCommandPalette: actions.toggleCommandPalette,
     toggleFocusMode: actions.toggleFocusMode,
     showCommandPaletteInEditor: deselectSource,
+    toggleTheme: actions.toggleTheme,
   }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/NetworkMonitor/HttpBody.tsx
+++ b/src/ui/components/NetworkMonitor/HttpBody.tsx
@@ -14,6 +14,8 @@ import {
   URLEncodedToPlaintext,
 } from "./content";
 import classNames from "classnames";
+import { useSelector } from "react-redux";
+import { getTheme } from "ui/reducers/app";
 
 const TextBodyComponent = ({ raw, text }: { raw: RawBody; text: string }) => {
   const [copied, setCopied] = useState(false);
@@ -55,6 +57,7 @@ const HttpBody = ({
   contentType: string;
   filename: string;
 }) => {
+  const theme = useSelector(getTheme);
   const raw = useMemo(() => {
     return BodyPartsToArrayBuffer(bodyParts, contentType);
   }, [bodyParts]);
@@ -64,7 +67,16 @@ const HttpBody = ({
   }, [raw]);
 
   if (displayable.as === Displayable.JSON) {
-    return <ReactJson src={displayable.content} shouldCollapse={() => true} />;
+    return (
+      <ReactJson
+        style={{ backgroundColor: "none" }}
+        theme={theme == "light" ? "rjv-default" : "tube"}
+        src={displayable.content}
+        shouldCollapse={false}
+        displayDataTypes={false}
+        displayObjectSize={false}
+      />
+    );
   }
   if (displayable.as === Displayable.Text) {
     return (

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { connect, ConnectedProps } from "react-redux";
+import { connect, ConnectedProps, useSelector } from "react-redux";
 import { createBridge, createStore, initialize, Store, Wall } from "react-devtools-inline/frontend";
 import { ExecutionPoint, ObjectId } from "@recordreplay/protocol";
 import { ThreadFront } from "protocol/thread";
 import { compareNumericStrings } from "protocol/utils";
 import { UIState } from "ui/state";
 import { Annotation } from "ui/state/reactDevTools";
-import { getCurrentPoint } from "ui/reducers/app";
+import { getCurrentPoint, getTheme } from "ui/reducers/app";
 import {
   getAnnotations,
   getProtocolCheckFailed,
@@ -17,7 +17,6 @@ import { setHasReactComponents, setProtocolCheckFailed } from "ui/actions/reactD
 import Highlighter from "highlighter/highlighter";
 import NodePicker, { NodePickerOpts } from "ui/utils/nodePicker";
 import { sendTelemetryEvent, trackEvent } from "ui/utils/telemetry";
-import { useFeature } from "ui/hooks/settings";
 
 const getDOMNodes = `((rendererID, id) => __REACT_DEVTOOLS_GLOBAL_HOOK__.rendererInterfaces.get(rendererID).findNativeNodesForFiberID(id))`;
 
@@ -238,7 +237,7 @@ function ReactDevtoolsPanel({
   protocolCheckFailed,
   reactInitPoint,
 }: PropsFromRedux) {
-  const { value: enableDarkMode } = useFeature("darkMode");
+  const theme = useSelector(getTheme);
 
   if (currentPoint === null) {
     return null;
@@ -294,7 +293,7 @@ function ReactDevtoolsPanel({
 
   return (
     <ReactDevTools
-      browserTheme={enableDarkMode ? "dark" : "light"}
+      browserTheme={theme}
       enabledInspectedElementContextMenu={false}
       overrideTab="components"
       showTabBar={false}

--- a/src/ui/components/shared/ReplayLogo.tsx
+++ b/src/ui/components/shared/ReplayLogo.tsx
@@ -1,6 +1,9 @@
 import { selector } from "devtools/client/inspector/rules/types";
 import React from "react";
+import { useSelector } from "react-redux";
 import { useFeature } from "ui/hooks/settings";
+import { getTheme } from "ui/reducers/app";
+import { AppTheme } from "ui/state/app";
 
 const logoSizes = {
   xs: "h-4",
@@ -40,11 +43,12 @@ export default function ReplayLogo({
   wide?: boolean;
   size?: keyof typeof logoSizes;
 }) {
+  const theme = useSelector(getTheme);
   const height = logoSizes[size];
-  const { value: isDarkMode } = useFeature("darkMode");
+  const isDark = theme === "dark";
 
   if (wide) {
-    const src = isDarkMode ? "/images/logo-wide-dark.svg" : "/images/logo-wide.svg";
+    const src = isDark ? "/images/logo-wide-dark.svg" : "/images/logo-wide.svg";
     return <img className={`${height} w-auto`} src={src} />;
   }
 

--- a/src/ui/components/shared/UserSettingsModal/PreferencesSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/PreferencesSettings.tsx
@@ -1,10 +1,12 @@
-import React, { FormEvent, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import hooks from "ui/hooks";
 import Checkbox from "../Forms/Checkbox";
 import { EmailSubscription } from "ui/hooks/users";
 import { CheckboxRow } from "./CheckboxRow";
-import { useFeature } from "ui/hooks/settings";
 import { trackEvent } from "ui/utils/telemetry";
+import { toggleTheme } from "ui/actions/app";
+import { getTheme } from "ui/reducers/app";
 
 const EMAIL_NOTIFICATIONS = {
   [EmailSubscription.COLLABORATOR_REQUEST]: "When somebody invites you to collaborate on a replay",
@@ -103,11 +105,12 @@ function PrivacyPreferences() {
 }
 
 function UiPreferences() {
-  const { value: enableDarkMode, update: updateEnableDarkMode } = useFeature("darkMode");
+  const theme = useSelector(getTheme);
+  const dispatch = useDispatch();
 
   const handleDarkModeToggle = () => {
-    trackEvent("feature.dark_mode", { enabled: !enableDarkMode });
-    updateEnableDarkMode(!enableDarkMode);
+    trackEvent("feature.dark_mode", { enabled: theme !== "dark" });
+    dispatch(toggleTheme());
   };
 
   return (
@@ -119,7 +122,11 @@ function UiPreferences() {
           data-private
           htmlFor="enableDarkMode"
         >
-          <Checkbox id="enableDarkMode" checked={enableDarkMode} onChange={handleDarkModeToggle} />
+          <Checkbox
+            id="enableDarkMode"
+            checked={theme === "dark"}
+            onChange={handleDarkModeToggle}
+          />
           <div>Enable Dark Mode</div>
         </label>
       </div>

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -2,6 +2,7 @@ import {
   AnalysisError,
   AnalysisPayload,
   AppState,
+  AppTheme,
   EventKind,
   ProtocolError,
   ReplayEvent,
@@ -15,6 +16,7 @@ import { isInTrimSpan } from "ui/utils/timeline";
 import { compareBigInt } from "ui/utils/helpers";
 import { getFocusRegion } from "ui/reducers/timeline";
 import { getSelectedPanel, getViewMode } from "./layout";
+import { prefs } from "ui/utils/prefs";
 
 export const initialAppState: AppState = {
   analysisPoints: {},
@@ -39,7 +41,7 @@ export const initialAppState: AppState = {
   recordingTarget: null,
   recordingWorkspace: null,
   sessionId: null,
-  theme: "theme-light",
+  theme: prefs.theme as AppTheme,
   trialExpired: false,
   unexpectedError: null,
   uploading: null,

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -1,6 +1,6 @@
 import { UIStore } from "ui/actions";
 import { UIState } from "ui/state";
-import { prefs, asyncStore } from "ui/utils/prefs";
+import { prefs, asyncStore, features } from "ui/utils/prefs";
 import { prefs as webconsolePrefs } from "devtools/client/webconsole/utils/prefs";
 import { getRecordingId } from "ui/utils/recording";
 import {
@@ -17,6 +17,7 @@ import { persistTabs } from "devtools/client/debugger/src/utils/tabs";
 import { getTabs } from "devtools/client/debugger/src/reducers/tabs";
 import { getPendingComment } from "ui/reducers/comments";
 import { RecordingId } from "@recordreplay/protocol";
+import { getTheme } from "ui/reducers/app";
 
 export interface ReplaySessions {
   [id: string]: ReplaySession;
@@ -62,6 +63,7 @@ export function updatePrefs(state: UIState, oldState: UIState) {
   }
 
   updatePref("viewMode", getViewMode);
+  updatePref("theme", getTheme);
 
   updateAsyncPref("eventListenerBreakpoints", (state: UIState) => state.eventListenerBreakpoints);
   updateAsyncPref("commandHistory", (state: UIState) => state.messages?.commandHistory);

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -68,6 +68,8 @@ export interface UploadInfo {
   total?: string;
 }
 
+export type AppTheme = "light" | "dark";
+
 export interface AppState {
   analysisPoints: AnalysisPoints;
   awaitingSourcemaps: boolean;
@@ -90,7 +92,7 @@ export interface AppState {
   recordingTarget: RecordingTarget | null;
   recordingWorkspace: Workspace | null;
   sessionId: SessionId | null;
-  theme: string;
+  theme: AppTheme;
   trialExpired: boolean;
   unexpectedError: UnexpectedError | null;
   uploading: UploadInfo | null;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -16,10 +16,10 @@ pref("devtools.disableLogRocket", false);
 pref("devtools.listenForMetrics", false);
 pref("devtools.disableCache", false);
 pref("devtools.sidePanelSize", "240px");
+pref("devtools.theme", "light");
 
 // app features
 pref("devtools.features.columnBreakpoints", false);
-pref("devtools.features.darkMode", false);
 pref("devtools.features.httpBodies", true);
 pref("devtools.features.videoPlayback", false);
 pref("devtools.features.commentAttachments", false);
@@ -43,13 +43,13 @@ export const prefs = new PrefsHelper("devtools", {
   sidePanelSize: ["String", "sidePanelSize"],
   listenForMetrics: ["Bool", "listenForMetrics"],
   disableCache: ["Bool", "disableCache"],
+  theme: ["String", "theme"],
 });
 
 export const features = new PrefsHelper("devtools.features", {
   useMultipleControllers: ["Bool", "useMultipleControllers"],
   multipleControllerUseSnapshots: ["Bool", "multipleControllerUseSnapshots"],
   columnBreakpoints: ["Bool", "columnBreakpoints"],
-  darkMode: ["Bool", "darkMode"],
   httpBodies: ["Bool", "httpBodies"],
   videoPlayback: ["Bool", "videoPlayback"],
   commentAttachments: ["Bool", "commentAttachments"],


### PR DESCRIPTION
- Fixes issue where the net monitor response bodies are not formatted based on theme
- Starts refactoring themes so that they are managed in redux
- I'd like to replace the `darkMode` boolean with a `theme` enum which can be `light`, `dark`, or `system`. 