### PR TITLE
Ignore version bumps for react-devtools-inline and react-dom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     open-pull-requests-limit: 15
     pull-request-branch-name:
       separator: "-"
+    ignore:
+    - dependency-name: "react-devtools-inline"
+    - dependency-name: "react-dom"


### PR DESCRIPTION
Fix #6158.