### PR TITLE
Add a hitCount line limit

### DIFF
--- a/src/devtools/client/debugger/src/actions/sources/breakableLines.js
+++ b/src/devtools/client/debugger/src/actions/sources/breakableLines.js
@@ -20,12 +20,14 @@ export function setBreakableLines(cx, sourceId) {
   };
 }
 
-export function setBreakpointHitCounts(sourceId, onFailure) {
+export function setBreakpointHitCounts(sourceId, lineNumber, onFailure) {
   return async (dispatch, getState) => {
     const actors = getSourceActorsForSource(getState(), sourceId);
 
     return Promise.all(
-      actors.map(actor => dispatch(loadSourceActorBreakpointHitCounts({ id: actor.id, onFailure })))
+      actors.map(actor =>
+        dispatch(loadSourceActorBreakpointHitCounts({ id: actor.id, lineNumber, onFailure }))
+      )
     );
   };
 }

--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -117,7 +117,7 @@ export default function LineNumberTooltip({
       if (lineNumber === lastHoveredLineNumber.current) {
         if (codeHeatMaps) {
           dispatch(
-            setBreakpointHitCounts(source!.id, () => {
+            setBreakpointHitCounts(source!.id, lineNumber, () => {
               setCodeHeatMaps(false);
               dispatch(runAnalysisOnLine(lineNumber));
             })

--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -47,7 +47,8 @@ export function SourceOutline({
 
   useEffect(() => {
     if (selectedSource) {
-      dispatch(setBreakpointHitCounts(selectedSource.id));
+      // We start by loading the first N lines of hits, where N is the line limit.
+      dispatch(setBreakpointHitCounts(selectedSource.id, 1));
     }
   }, [selectedSource?.id]);
 

--- a/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
@@ -19,7 +19,7 @@ function addHitCountsToFunctions(functions: FunctionSymbol[], hitCounts: HitCoun
       return hitCount.location.line === end.line && hitCount.location.column! >= start.column;
     });
 
-    return { ...functionSymbol, hits: features.codeHeatMaps ? hitCount?.hits || 0 : undefined };
+    return { ...functionSymbol, hits: features.codeHeatMaps ? hitCount?.hits : undefined };
   });
 }
 


### PR DESCRIPTION
Right now we have a very naive algorithm: fetch hitCounts for all lines when a source file gets hovered for the first time. This can swamp a controller if a file is tens of thousands of lines long, but it's *very* useful in the case that a file is of a reasonable length. In my experience, 1000 line fetches at once still feels pretty instantaneous, and I think many files that people are interested in having analyzed completely will be under 1000 lines. The hardest part of this change was just understanding how `memoizableAction` works for the third time 🙃 

In case the above did not make sense, here's an example:

- The user loads a file
- SourceOutline sees that a new file is loaded and asks for the hitCount on line 1
- memoizableAction will see that the line requests was 1, and actually ask for the hits for lines 1-1000.
- If the user scrolls to line 1005 (for example) and hovers, memoizableAction will fetch the hits for lines 1000-2000, etc.

This does not totally resolve https://github.com/RecordReplay/backend/issues/5132 and https://github.com/RecordReplay/backend/issues/5108, but it helps a *lot*.