### PR TITLE
Fix breakpoint status width

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -134,7 +134,7 @@ function BreakpointNavigationStatus({ executionPoint, analysisPoints, indexed })
       : [];
 
     status = `${points.length}/${analysisPoints.data.length}`;
-    maxStatusLength = `${analysisPoints.length}/${analysisPoints.data.length}`.length;
+    maxStatusLength = `${analysisPoints.data.length}/${analysisPoints.data.length}`.length;
   }
 
   return (


### PR DESCRIPTION
Fix #6112.

<img width="2554" alt="image" src="https://user-images.githubusercontent.com/15959269/161614656-f205ee70-d18e-4c3b-919f-ab255e2b74d7.png">
