### PR TITLE
Switch from pushState to replaceState

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -246,7 +246,7 @@ function updateUrl({
   url.searchParams.set("point", point);
   url.searchParams.set("time", `${time}`);
   url.searchParams.set("hasFrames", `${hasFrames}`);
-  window.history.pushState({}, "", url.toString());
+  window.history.replaceState({}, "", url.toString());
 }
 
 export function seek(


### PR DESCRIPTION
Fix #6050.

This keeps the browser back/forward buttons working [as I expect it should](https://github.com/RecordReplay/devtools/issues/6050#issuecomment-1087932342), i.e. pressing back brings you to the previous page you were on, instead of moving back to a previous pause position in the same replay.