### PR TITLE
Update NextJS library regex to avoid false positive  

### DIFF
--- a/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.js
@@ -108,7 +108,7 @@ const libraryMap = [
   },
   {
     label: "NextJS",
-    pattern: /[\._]next/i,
+    pattern: /[\._]next(?!\/static\/chunks\/pages\/)/i,
   },
   // FB's internal ReactDOM filename
   {

--- a/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.test.js
+++ b/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.test.js
@@ -16,4 +16,20 @@ describe("getLibraryFromUrl", () => {
       getLibraryFromUrl({ source: { url: "https://www.foo.com/bar/shared/react.js" } })
     ).toEqual("React");
   });
+
+  test("NextJS library", () => {
+    expect(
+      getLibraryFromUrl({
+        source: { url: "https://www.foo.com/_next/static/chunks/framework-f82aae7a1453fce0.js" },
+      })
+    ).toEqual("NextJS");
+  });
+
+  test("NextJS bundle application", () => {
+    expect(
+      getLibraryFromUrl({
+        source: { url: "https://www.foo.com/_next/static/chunks/pages/_app-foobarbaz.js" },
+      })
+    ).toEqual(null);
+  });
 });


### PR DESCRIPTION
Resolves #5919

Next serves static JavaScript assets at a path that contains the string "_next". Previously, Replay tagged all JavaScript paths containing that string as belonging to NextJS because of this check:
https://github.com/RecordReplay/devtools/blob/f8181e040956da79a589f885645a29cd609e4cea/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.js#L109-L112

Looking at one of my own Next apps, it seems that Next serves both its own code and user code at paths that match this check. (For example, `/_next/static/chunks/<filename>` for "Next code" and `/_next/static/chunks/pages/<filename>` for "user code".)

This commit changes the NextJS regex to ignore user code by ignoring paths that include the "pages" directory:
```js
/[\._]next(?!\/static\/chunks\/pages\/)/i
```