### PR TITLE
Remove dead "NAVIGATE" and "BATCH" reducer cases

### DIFF
--- a/src/devtools/client/debugger/src/reducers/ast.js
+++ b/src/devtools/client/debugger/src/reducers/ast.js
@@ -48,14 +48,6 @@ function update(state = initialASTState(), action) {
       return { ...state };
     }
 
-    case "NAVIGATE": {
-      return initialASTState();
-    }
-
-    case "BATCH":
-      action.updates.forEach(u => (state = update(state, u)));
-      return state;
-
     default: {
       return state;
     }

--- a/src/devtools/client/debugger/src/reducers/async-requests.js
+++ b/src/devtools/client/debugger/src/reducers/async-requests.js
@@ -14,9 +14,7 @@ const initialAsyncRequestState = [];
 function update(state = initialAsyncRequestState, action) {
   const { seqId } = action;
 
-  if (action.type === "NAVIGATE") {
-    return initialAsyncRequestState;
-  } else if (seqId) {
+  if (seqId) {
     let newState;
     if (action.status === "start") {
       newState = [...state, seqId];

--- a/src/devtools/client/debugger/src/reducers/breakpoints.js
+++ b/src/devtools/client/debugger/src/reducers/breakpoints.js
@@ -46,10 +46,6 @@ function update(state = initialBreakpointsState(), action) {
       return { ...state, breakpoints: {}, requestedBreakpoints: {} };
     }
 
-    case "NAVIGATE": {
-      return initialBreakpointsState();
-    }
-
     case "SET_XHR_BREAKPOINT": {
       return addXHRBreakpoint(state, action);
     }

--- a/src/devtools/client/debugger/src/reducers/file-search.js
+++ b/src/devtools/client/debugger/src/reducers/file-search.js
@@ -59,10 +59,6 @@ function update(state = createFileSearchState(), action) {
       };
     }
 
-    case "NAVIGATE": {
-      return { ...state, query: "", searchResults: emptySearchResults };
-    }
-
     default: {
       return state;
     }

--- a/src/devtools/client/debugger/src/reducers/pause.js
+++ b/src/devtools/client/debugger/src/reducers/pause.js
@@ -187,22 +187,6 @@ function update(state = createPauseState(), action) {
     case "EVALUATE_EXPRESSION":
       return { ...state, command: action.status === "start" ? "expression" : null };
 
-    case "NAVIGATE": {
-      const navigateCounter = state.cx.navigateCounter + 1;
-      return {
-        ...state,
-        cx: {
-          navigateCounter,
-        },
-        threadcx: {
-          navigateCounter,
-          pauseCounter: 0,
-          isPaused: false,
-        },
-        ...resumedPauseState,
-      };
-    }
-
     case "SET_EXPANDED_SCOPE": {
       const { path, expanded } = action;
       const expandedScopes = new Set(state.expandedScopes);
@@ -213,10 +197,6 @@ function update(state = createPauseState(), action) {
       }
       return { ...state, expandedScopes };
     }
-
-    case "BATCH":
-      action.updates.forEach(u => (state = update(state, u)));
-      return state;
   }
 
   return state;

--- a/src/devtools/client/debugger/src/reducers/source-actors.js
+++ b/src/devtools/client/debugger/src/reducers/source-actors.js
@@ -42,11 +42,6 @@ export default function update(state = initial, action) {
       break;
     }
 
-    case "NAVIGATE": {
-      state = initial;
-      break;
-    }
-
     case "SET_SOURCE_ACTOR_BREAKPOINT_COLUMNS":
       state = updateBreakpointColumns(state, action);
       break;

--- a/src/devtools/client/debugger/src/reducers/sources.ts
+++ b/src/devtools/client/debugger/src/reducers/sources.ts
@@ -260,12 +260,6 @@ function update(state = initialSourcesState(), action: AnyAction) {
         },
       };
     }
-    case "NAVIGATE":
-      return {
-        ...initialSourcesState(),
-        epoch: state.epoch + 1,
-      };
-
     case "SET_FOCUSED_SOURCE_ITEM":
       return { ...state, focusedItem: action.item };
 

--- a/src/devtools/client/debugger/src/reducers/tabs.js
+++ b/src/devtools/client/debugger/src/reducers/tabs.js
@@ -62,14 +62,6 @@ function update(state = initialTabState(), action) {
       return addSelectedSource(state, action.source);
     }
 
-    case "NAVIGATE": {
-      return resetTabState(state);
-    }
-
-    case "BATCH":
-      action.updates.forEach(u => (state = update(state, u)));
-      return state;
-
     default:
       return state;
   }

--- a/src/devtools/client/debugger/src/reducers/threads.js
+++ b/src/devtools/client/debugger/src/reducers/threads.js
@@ -36,12 +36,6 @@ export default function update(state = initialThreadsState(), action) {
         traits: action.traits,
         isWebExtension: action.isWebExtension,
       };
-
-    case "NAVIGATE":
-      return {
-        ...initialThreadsState(),
-        mainThread: action.mainThread,
-      };
     default:
       return state;
   }

--- a/src/devtools/client/debugger/src/reducers/ui.js
+++ b/src/devtools/client/debugger/src/reducers/ui.js
@@ -96,10 +96,6 @@ function update(state = createUIState(), action) {
       return { ...state, cursorPosition: action.cursorPosition };
     }
 
-    case "NAVIGATE": {
-      return { ...state, activeSearch: null, highlightedLineRange: {} };
-    }
-
     default: {
       return state;
     }

--- a/src/ui/setup/redux/middleware/context.js
+++ b/src/ui/setup/redux/middleware/context.js
@@ -47,13 +47,9 @@ function actionLogData(action) {
 }
 
 function logAction(action) {
-  if (action.type == "BATCH") {
-    action.updates.forEach(logAction);
-  } else {
-    const data = actionLogData(action);
-    const status = action.status ? ` [${action.status}]` : "";
-    log(`Debugger ${action.type}${data}${status}`);
-  }
+  const data = actionLogData(action);
+  const status = action.status ? ` [${action.status}]` : "";
+  log(`Debugger ${action.type}${data}${status}`);
 }
 
 // Middleware which looks for actions that have a cx property and ignores


### PR DESCRIPTION
This PR:

- Removes the dead reducer cases for `"BATCH"` and `"NAVIGATE"`

Could not find any references to those actions still being dispatched in the codebase, and Jason confirmed they're dead:

> acemarke: I see a "NAVIGATE" action that is being handled in many reducers to reset state, but I can't see anywhere that it's dispatched.  Is this dead?
> jlast: NAVIGATE would be great to kill.
> acemarke: also "BATCH" appears to be dead as well
> jlast: yep - pretty sure