### PR TITLE
Port some unit tests from Firefox DevTools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "fuzzaldrin-plus": "^0.6.0",
         "immer": "^9.0.7",
         "jest": "^27.5.1",
+        "jest-in-case": "^1.0.2",
         "jwt-decode": "^3.1.2",
         "launchdarkly-js-client-sdk": "^2.21.0",
         "lodash": "^4.17.21",
@@ -33050,6 +33051,14 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/jest-in-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jest-in-case/-/jest-in-case-1.0.2.tgz",
+      "integrity": "sha1-VnRLWvMyIr0KurcM+Rnx0XCrdcw=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/jest-jasmine2": {
       "version": "27.5.1",
       "license": "MIT",
@@ -59871,7 +59880,7 @@
         "git-url-parse": "11.5.0",
         "glob": "7.2.0",
         "global-agent": "2.2.0",
-        "graphql": "15.8.0",
+        "graphql": "14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0",
         "graphql-tag": "2.12.4",
         "listr": "0.14.3",
         "lodash.identity": "3.0.0",
@@ -60161,7 +60170,7 @@
         "cosmiconfig": "^5.0.6",
         "dotenv": "^8.0.0",
         "glob": "^7.1.3",
-        "graphql": "15.8.0",
+        "graphql": "14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0",
         "graphql-tag": "^2.10.1",
         "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.1",
@@ -64886,7 +64895,7 @@
         "@oclif/plugin-help": "3.2.1",
         "cli-ux": "^4.7.3",
         "express": "4.16.3",
-        "graphql": "15.8.0",
+        "graphql": "15.4.0",
         "graphql-language-service-interface": "^2.8.2",
         "graphql-language-service-utils": "2.5.1",
         "isomorphic-fetch": "3.0.0",
@@ -66786,6 +66795,11 @@
           }
         }
       }
+    },
+    "jest-in-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jest-in-case/-/jest-in-case-1.0.2.tgz",
+      "integrity": "sha1-VnRLWvMyIr0KurcM+Rnx0XCrdcw="
     },
     "jest-jasmine2": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "fuzzaldrin-plus": "^0.6.0",
     "immer": "^9.0.7",
     "jest": "^27.5.1",
+    "jest-in-case": "^1.0.2",
     "jwt-decode": "^3.1.2",
     "launchdarkly-js-client-sdk": "^2.21.0",
     "lodash": "^4.17.21",

--- a/src/devtools/client/debugger/src/utils/breakpoint/__snapshots__/astBreakpointLocation.test.js.snap
+++ b/src/devtools/client/debugger/src/utils/breakpoint/__snapshots__/astBreakpointLocation.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ast invalid location returns name for an anon fn in global scope as undefined 1`] = `
+Object {
+  "index": 0,
+  "name": undefined,
+  "offset": Object {
+    "column": 0,
+    "line": 44,
+  },
+}
+`;
+
+exports[`ast invalid location returns the scope name for global scope as undefined 1`] = `
+Object {
+  "index": 0,
+  "name": undefined,
+  "offset": Object {
+    "column": 0,
+    "line": 10,
+  },
+}
+`;
+
+exports[`ast valid location returns name for a nested anon fn as the parent func 1`] = `
+Object {
+  "index": 0,
+  "name": "outer",
+  "offset": Object {
+    "column": undefined,
+    "line": 22,
+  },
+}
+`;
+
+exports[`ast valid location returns name for a nested named fn 1`] = `
+Object {
+  "index": 0,
+  "name": "inner",
+  "offset": Object {
+    "column": undefined,
+    "line": 1,
+  },
+}
+`;
+
+exports[`ast valid location returns name for an anon fn with a named variable 1`] = `
+Object {
+  "index": 0,
+  "name": "globalDeclaration",
+  "offset": Object {
+    "column": undefined,
+    "line": 1,
+  },
+}
+`;
+
+exports[`ast valid location returns the scope and offset 1`] = `
+Object {
+  "index": 0,
+  "name": "math",
+  "offset": Object {
+    "column": undefined,
+    "line": 5,
+  },
+}
+`;

--- a/src/devtools/client/debugger/src/utils/breakpoint/astBreakpointLocation.test.js
+++ b/src/devtools/client/debugger/src/utils/breakpoint/astBreakpointLocation.test.js
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { getASTLocation } from "./astBreakpointLocation.js";
+import {
+  populateSource,
+  populateOriginalSource,
+} from "devtools/client/debugger/src/workers/parser/tests/helpers";
+
+import { getSymbols } from "devtools/client/debugger/src/workers/parser/getSymbols";
+
+import cases from "jest-in-case";
+
+async function setup({ file, location, functionName, original }) {
+  const source = original ? populateOriginalSource(file) : populateSource(file);
+
+  const symbols = getSymbols(source.id);
+
+  const astLocation = getASTLocation(source, symbols, location);
+  expect(astLocation.name).toBe(functionName);
+  expect(astLocation).toMatchSnapshot();
+}
+
+describe("ast", () => {
+  cases("valid location", setup, [
+    {
+      name: "returns the scope and offset",
+      file: "math",
+      location: { line: 6, column: 0 },
+      functionName: "math",
+    },
+    {
+      name: "returns name for a nested anon fn as the parent func",
+      file: "outOfScope",
+      location: { line: 25, column: 0 },
+      functionName: "outer",
+    },
+    {
+      name: "returns name for a nested named fn",
+      file: "outOfScope",
+      location: { line: 5, column: 0 },
+      functionName: "inner",
+    },
+    {
+      name: "returns name for an anon fn with a named variable",
+      file: "outOfScope",
+      location: { line: 40, column: 0 },
+      functionName: "globalDeclaration",
+    },
+  ]);
+
+  cases("invalid location", setup, [
+    {
+      name: "returns the scope name for global scope as undefined",
+      file: "class",
+      original: true,
+      location: { line: 10, column: 0 },
+      functionName: undefined,
+    },
+    {
+      name: "returns name for an anon fn in global scope as undefined",
+      file: "outOfScope",
+      location: { line: 44, column: 0 },
+      functionName: undefined,
+    },
+  ]);
+});

--- a/src/devtools/client/debugger/src/utils/editor/get-expression.test.js
+++ b/src/devtools/client/debugger/src/utils/editor/get-expression.test.js
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+//
+
+import CodeMirror from "codemirror";
+import { getExpressionFromCoords } from "./get-expression";
+
+describe("get-expression", () => {
+  let isCreateTextRangeDefined;
+
+  beforeAll(() => {
+    if (document.body.createTextRange) {
+      isCreateTextRangeDefined = true;
+    } else {
+      isCreateTextRangeDefined = false;
+      // CodeMirror needs createTextRange
+      // https://discuss.codemirror.net/t/working-in-jsdom-or-node-js-natively/138/5
+      document.body.createTextRange = () => ({
+        getBoundingClientRect: jest.fn(),
+        getClientRects: () => ({}),
+      });
+    }
+  });
+
+  afterAll(() => {
+    if (!isCreateTextRangeDefined) {
+      delete document.body.createTextRange;
+    }
+  });
+
+  describe("getExpressionFromCoords", () => {
+    xit("returns null when location.line is greater than the lineCount", () => {
+      const cm = CodeMirror(document.body, {
+        value: "let Line1;\n" + "let Line2;\n",
+        mode: "javascript",
+      });
+
+      const result = getExpressionFromCoords(cm, {
+        line: 3,
+        column: 1,
+      });
+      expect(result).toBeNull();
+    });
+
+    xit("gets the expression using CodeMirror.getTokenAt", () => {
+      const codemirrorMock = {
+        lineCount: () => 100,
+        getTokenAt: jest.fn(() => ({ start: 0, end: 0 })),
+        doc: {
+          getLine: () => "",
+        },
+      };
+      getExpressionFromCoords(codemirrorMock, { line: 1, column: 1 });
+      expect(codemirrorMock.getTokenAt).toHaveBeenCalled();
+    });
+
+    xit("requests the correct line and column from codeMirror", () => {
+      const codemirrorMock = {
+        lineCount: () => 100,
+        getTokenAt: jest.fn(() => ({ start: 0, end: 1 })),
+        doc: {
+          getLine: jest.fn(() => ""),
+        },
+      };
+      getExpressionFromCoords(codemirrorMock, { line: 20, column: 5 });
+      // getExpressionsFromCoords uses one based line indexing
+      // CodeMirror uses zero based line indexing
+      expect(codemirrorMock.getTokenAt).toHaveBeenCalledWith({
+        line: 19,
+        ch: 5,
+      });
+      expect(codemirrorMock.doc.getLine).toHaveBeenCalledWith(19);
+    });
+
+    xit("when called with column 0 returns null", () => {
+      const cm = CodeMirror(document.body, {
+        value: "foo bar;\n",
+        mode: "javascript",
+      });
+
+      const result = getExpressionFromCoords(cm, {
+        line: 1,
+        column: 0,
+      });
+      expect(result).toBeNull();
+    });
+
+    xit("gets the expression when first token on the line", () => {
+      const cm = CodeMirror(document.body, {
+        value: "foo bar;\n",
+        mode: "javascript",
+      });
+
+      const result = getExpressionFromCoords(cm, {
+        line: 1,
+        column: 1,
+      });
+      if (!result) {
+        throw new Error("no result");
+      }
+      expect(result.expression).toEqual("foo");
+      expect(result.location.start).toEqual({ line: 1, column: 0 });
+      expect(result.location.end).toEqual({ line: 1, column: 3 });
+    });
+
+    xit("includes previous tokens in the expression", () => {
+      const cm = CodeMirror(document.body, {
+        value: "foo.bar;\n",
+        mode: "javascript",
+      });
+
+      const result = getExpressionFromCoords(cm, {
+        line: 1,
+        column: 5,
+      });
+      if (!result) {
+        throw new Error("no result");
+      }
+      expect(result.expression).toEqual("foo.bar");
+      expect(result.location.start).toEqual({ line: 1, column: 0 });
+      expect(result.location.end).toEqual({ line: 1, column: 7 });
+    });
+
+    xit("includes multiple previous tokens in the expression", () => {
+      const cm = CodeMirror(document.body, {
+        value: "foo.bar.baz;\n",
+        mode: "javascript",
+      });
+
+      const result = getExpressionFromCoords(cm, {
+        line: 1,
+        column: 10,
+      });
+      if (!result) {
+        throw new Error("no result");
+      }
+      expect(result.expression).toEqual("foo.bar.baz");
+      expect(result.location.start).toEqual({ line: 1, column: 0 });
+      expect(result.location.end).toEqual({ line: 1, column: 11 });
+    });
+
+    xit("does not include tokens not part of the expression", () => {
+      const cm = CodeMirror(document.body, {
+        value: "foo bar.baz;\n",
+        mode: "javascript",
+      });
+
+      const result = getExpressionFromCoords(cm, {
+        line: 1,
+        column: 10,
+      });
+      if (!result) {
+        throw new Error("no result");
+      }
+      expect(result.expression).toEqual("bar.baz");
+      expect(result.location.start).toEqual({ line: 1, column: 4 });
+      expect(result.location.end).toEqual({ line: 1, column: 11 });
+    });
+  });
+});

--- a/src/devtools/client/debugger/src/utils/editor/get-token-location.test.js
+++ b/src/devtools/client/debugger/src/utils/editor/get-token-location.test.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { getTokenLocation } from "./get-token-location";
+
+describe("getTokenLocation", () => {
+  const codemirror = {
+    coordsChar: jest.fn(() => ({
+      line: 1,
+      ch: "C",
+    })),
+  };
+  const token = {
+    getBoundingClientRect() {
+      return {
+        left: 10,
+        top: 20,
+        width: 10,
+        height: 10,
+      };
+    },
+  };
+  it("calls into codeMirror", () => {
+    getTokenLocation(codemirror, token);
+    expect(codemirror.coordsChar).toHaveBeenCalledWith({
+      left: 15,
+      top: 25,
+    });
+  });
+});

--- a/src/devtools/client/debugger/src/utils/editor/source-search.test.js
+++ b/src/devtools/client/debugger/src/utils/editor/source-search.test.js
@@ -1,0 +1,177 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { find, searchSourceForHighlight, getMatchIndex, removeOverlay } from "./source-search";
+
+const getCursor = jest.fn(() => ({ line: 90, ch: 54 }));
+const cursor = {
+  find: jest.fn(),
+  from: jest.fn(),
+  to: jest.fn(),
+};
+const getSearchCursor = jest.fn(() => cursor);
+const modifiers = {
+  caseSensitive: false,
+  regexMatch: false,
+  wholeWord: false,
+};
+
+const getCM = () => ({
+  operation: jest.fn(cb => cb()),
+  addOverlay: jest.fn(),
+  removeOverlay: jest.fn(),
+  getCursor,
+  getSearchCursor,
+  firstLine: jest.fn(),
+  state: {},
+});
+
+describe("source-search", () => {
+  describe("find", () => {
+    it("calls into CodeMirror APIs via clearSearch & doSearch", () => {
+      const ctx = { cm: getCM() };
+      expect(ctx.cm.state).toEqual({});
+      find(ctx, "test", false, modifiers);
+      // First we check the APIs called via clearSearch
+      expect(ctx.cm.removeOverlay).toHaveBeenCalledWith(null);
+      // Next those via doSearch
+      expect(ctx.cm.operation).toHaveBeenCalled();
+      expect(ctx.cm.removeOverlay).toHaveBeenCalledWith(null);
+      expect(ctx.cm.addOverlay).toHaveBeenCalledWith(
+        { token: expect.any(Function) },
+        { opaque: false }
+      );
+      expect(ctx.cm.getCursor).toHaveBeenCalledWith("anchor");
+      expect(ctx.cm.getCursor).toHaveBeenCalledWith("head");
+      const search = {
+        query: "test",
+        posTo: { line: 0, ch: 0 },
+        posFrom: { line: 0, ch: 0 },
+        overlay: { token: expect.any(Function) },
+        results: [],
+      };
+      expect(ctx.cm.state).toEqual({ search });
+    });
+
+    it("clears a previous overlay", () => {
+      const ctx = { cm: getCM() };
+      ctx.cm.state.search = {
+        query: "foo",
+        posTo: null,
+        posFrom: null,
+        overlay: { token: expect.any(Function) },
+        results: [],
+      };
+      find(ctx, "test", true, modifiers);
+      expect(ctx.cm.removeOverlay).toHaveBeenCalledWith({
+        token: expect.any(Function),
+      });
+    });
+
+    it("clears for empty queries", () => {
+      const ctx = { cm: getCM() };
+      ctx.cm.state.search = {
+        query: "foo",
+        posTo: null,
+        posFrom: null,
+        overlay: null,
+        results: [],
+      };
+      find(ctx, "", true, modifiers);
+      expect(ctx.cm.removeOverlay).toHaveBeenCalledWith(null);
+      ctx.cm.removeOverlay.mockClear();
+      ctx.cm.state.search.query = "bar";
+      find(ctx, "", true, modifiers);
+      expect(ctx.cm.removeOverlay).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("searchSourceForHighlight", () => {
+    it("calls into CodeMirror APIs and sets the correct selection", () => {
+      const line = 15;
+      const from = { line, ch: 1 };
+      const to = { line, ch: 5 };
+      const cm = {
+        ...getCM(),
+        setSelection: jest.fn(),
+        getSearchCursor: () => ({
+          find: () => true,
+          from: () => from,
+          to: () => to,
+        }),
+      };
+      const ed = { alignLine: jest.fn() };
+      const ctx = { cm, ed };
+
+      expect(ctx.cm.state).toEqual({});
+      searchSourceForHighlight(ctx, false, "test", false, modifiers, line, 1);
+
+      expect(ctx.cm.operation).toHaveBeenCalled();
+      expect(ctx.cm.removeOverlay).toHaveBeenCalledWith(null);
+      expect(ctx.cm.addOverlay).toHaveBeenCalledWith(
+        { token: expect.any(Function) },
+        { opaque: false }
+      );
+      expect(ctx.cm.getCursor).toHaveBeenCalledWith("anchor");
+      expect(ctx.cm.getCursor).toHaveBeenCalledWith("head");
+      expect(ed.alignLine).toHaveBeenCalledWith(line, "center");
+      expect(cm.setSelection).toHaveBeenCalledWith(from, to);
+    });
+  });
+
+  describe("findNext", () => {});
+
+  describe("findPrev", () => {});
+
+  describe("getMatchIndex", () => {
+    it("iterates in the matches", () => {
+      const count = 3;
+
+      // reverse 2, 1, 0, 2
+
+      let matchIndex = getMatchIndex(count, 2, true);
+      expect(matchIndex).toBe(1);
+
+      matchIndex = getMatchIndex(count, 1, true);
+      expect(matchIndex).toBe(0);
+
+      matchIndex = getMatchIndex(count, 0, true);
+      expect(matchIndex).toBe(2);
+
+      // forward 1, 2, 0, 1
+
+      matchIndex = getMatchIndex(count, 1, false);
+      expect(matchIndex).toBe(2);
+
+      matchIndex = getMatchIndex(count, 2, false);
+      expect(matchIndex).toBe(0);
+
+      matchIndex = getMatchIndex(count, 0, false);
+      expect(matchIndex).toBe(1);
+    });
+  });
+
+  describe("removeOverlay", () => {
+    it("calls CodeMirror APIs: removeOverlay, getCursor & setSelection", () => {
+      const ctx = {
+        cm: {
+          removeOverlay: jest.fn(),
+          getCursor,
+          state: {},
+          doc: {
+            setSelection: jest.fn(),
+          },
+        },
+      };
+      removeOverlay(ctx, "test");
+      expect(ctx.cm.removeOverlay).toHaveBeenCalled();
+      expect(ctx.cm.getCursor).toHaveBeenCalled();
+      expect(ctx.cm.doc.setSelection).toHaveBeenCalledWith(
+        { line: 90, ch: 54 },
+        { line: 90, ch: 54 },
+        { scroll: false }
+      );
+    });
+  });
+});

--- a/src/devtools/client/debugger/src/utils/pause/frames/annotateFrames.test.js
+++ b/src/devtools/client/debugger/src/utils/pause/frames/annotateFrames.test.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+//
+
+import { annotateFrames } from "./annotateFrames";
+import { makeMockFrameWithURL } from "devtools/client/debugger/src/utils/test-mockup";
+
+describe("annotateFrames", () => {
+  it("should return Angular", () => {
+    const callstack = [
+      makeMockFrameWithURL(
+        "https://stackblitz.io/turbo_modules/@angular/core@7.2.4/bundles/core.umd.js"
+      ),
+      makeMockFrameWithURL("/node_modules/zone/zone.js"),
+      makeMockFrameWithURL("https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"),
+    ];
+    const frames = annotateFrames(callstack);
+    expect(frames).toEqual(callstack.map(f => ({ ...f, library: "Angular" })));
+  });
+});

--- a/src/devtools/client/debugger/src/utils/pause/frames/displayName.test.js
+++ b/src/devtools/client/debugger/src/utils/pause/frames/displayName.test.js
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+//
+
+import { formatCopyName, formatDisplayName, simplifyDisplayName } from "./displayName";
+import { makeMockFrame, makeMockSource } from "devtools/client/debugger/src/utils/test-mockup";
+
+describe("formatCopyName", () => {
+  it("simple", () => {
+    const source = makeMockSource("todo-view.js");
+    const frame = makeMockFrame(undefined, source, undefined, 12, "child");
+
+    expect(formatCopyName(frame)).toEqual("child (todo-view.js#12)");
+  });
+});
+
+describe("formatting display names", () => {
+  it("uses a library description", () => {
+    const source = makeMockSource("assets/backbone.js");
+    const frame = {
+      ...makeMockFrame(undefined, source, undefined, undefined, "extend/child"),
+      library: "Backbone",
+    };
+
+    expect(formatDisplayName(frame, undefined)).toEqual("Create Class");
+  });
+
+  it("shortens an anonymous function", () => {
+    const source = makeMockSource("assets/bar.js");
+    const frame = makeMockFrame(undefined, source, undefined, undefined, "extend/child/bar/baz");
+
+    expect(formatDisplayName(frame, undefined)).toEqual("baz");
+  });
+
+  it("does not truncates long function names", () => {
+    const source = makeMockSource("extend/child/bar/baz");
+    const frame = makeMockFrame(
+      undefined,
+      source,
+      undefined,
+      undefined,
+      "bazbazbazbazbazbazbazbazbazbazbazbazbaz"
+    );
+
+    expect(formatDisplayName(frame, undefined)).toEqual("bazbazbazbazbazbazbazbazbazbazbazbazbaz");
+  });
+
+  it("returns the original function name when present", () => {
+    const source = makeMockSource("entry.js");
+    const frame = {
+      ...makeMockFrame(undefined, source),
+      originalDisplayName: "originalFn",
+      displayName: "fn",
+    };
+
+    expect(formatDisplayName(frame, undefined)).toEqual("originalFn");
+  });
+
+  it("returns anonymous when displayName is undefined", () => {
+    const frame = { ...makeMockFrame(), displayName: undefined };
+    expect(formatDisplayName(frame, undefined)).toEqual("<anonymous>");
+  });
+
+  it("returns anonymous when displayName is null", () => {
+    const frame = { ...makeMockFrame(), displayName: null };
+    expect(formatDisplayName(frame, undefined)).toEqual("<anonymous>");
+  });
+
+  it("returns anonymous when displayName is an empty string", () => {
+    const frame = { ...makeMockFrame(), displayName: "" };
+    expect(formatDisplayName(frame, undefined)).toEqual("<anonymous>");
+  });
+});
+
+describe("simplifying display names", () => {
+  const cases = {
+    defaultCase: [["define", "define"]],
+
+    objectProperty: [
+      ["z.foz", "foz"],
+      ["z.foz/baz", "baz"],
+      ["z.foz/baz/y.bay", "bay"],
+      ["outer/x.fox.bax.nx", "nx"],
+      ["outer/fow.baw", "baw"],
+      ["fromYUI._attach", "_attach"],
+      ["Y.ClassNameManager</getClassName", "getClassName"],
+      ["orion.textview.TextView</addHandler", "addHandler"],
+      ["this.eventPool_.createObject", "createObject"],
+    ],
+
+    arrayProperty: [
+      ["this.eventPool_[createObject]", "createObject"],
+      ["jQuery.each(^)/jQuery.fn[o]", "o"],
+      ["viewport[get+D]", "get+D"],
+      ["arr[0]", "0"],
+    ],
+
+    functionProperty: [
+      ["fromYUI._attach/<.", "_attach"],
+      ["Y.ClassNameManager<", "ClassNameManager"],
+      ["fromExtJS.setVisible/cb<", "cb"],
+      ["fromDojo.registerWin/<", "registerWin"],
+    ],
+
+    annonymousProperty: [["jQuery.each(^)", "each"]],
+  };
+
+  Object.keys(cases).forEach(type => {
+    cases[type].forEach(([kase, expected]) => {
+      it(`${type} - ${kase}`, () => expect(simplifyDisplayName(kase)).toEqual(expected));
+    });
+  });
+});

--- a/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.test.js
+++ b/src/devtools/client/debugger/src/utils/pause/frames/getLibraryFromUrl.test.js
@@ -1,4 +1,5 @@
 import { getLibraryFromUrl } from "./getLibraryFromUrl";
+import { makeMockFrameWithURL } from "devtools/client/debugger/src/utils/test-mockup";
 
 describe("getLibraryFromUrl", () => {
   test("FB ReactDOM", () => {
@@ -31,5 +32,122 @@ describe("getLibraryFromUrl", () => {
         source: { url: "https://www.foo.com/_next/static/chunks/pages/_app-foobarbaz.js" },
       })
     ).toEqual(null);
+  });
+
+  describe("When Preact is on the frame", () => {
+    it("should return Preact and not React", () => {
+      const frame = makeMockFrameWithURL(
+        "https://cdnjs.cloudflare.com/ajax/libs/preact/8.2.5/preact.js"
+      );
+      expect(getLibraryFromUrl(frame)).toEqual("Preact");
+    });
+  });
+
+  describe("When Vue is on the frame", () => {
+    it("should return VueJS for different builds", () => {
+      const buildTypeList = [
+        "vue.js",
+        "vue.common.js",
+        "vue.esm.js",
+        "vue.runtime.js",
+        "vue.runtime.common.js",
+        "vue.runtime.esm.js",
+        "vue.min.js",
+        "vue.runtime.min.js",
+      ];
+
+      buildTypeList.forEach(buildType => {
+        const frame = makeMockFrameWithURL(
+          `https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/${buildType}`
+        );
+        expect(getLibraryFromUrl(frame)).toEqual("VueJS");
+      });
+    });
+  });
+
+  describe("When React is in the URL", () => {
+    it("should not return React if it is not part of the filename", () => {
+      const notReactUrlList = [
+        "https://react.js.com/test.js",
+        "https://debugger-example.com/test.js",
+        "https://debugger-react-example.com/test.js",
+        "https://debugger-react-example.com/react/test.js",
+        "https://debugger-example.com/react-contextmenu.js",
+      ];
+      notReactUrlList.forEach(notReactUrl => {
+        const frame = makeMockFrameWithURL(notReactUrl);
+        expect(getLibraryFromUrl(frame)).toBeNull();
+      });
+    });
+
+    it("should return React if it is part of the filename", () => {
+      const reactUrlList = [
+        "https://debugger-example.com/react.js",
+        "https://debugger-example.com/react.development.js",
+        "https://debugger-example.com/react.production.min.js",
+        "https://debugger-react-example.com/react.js",
+        "https://debugger-react-example.com/react/react.js",
+
+        // NOTE: not sure why these are now failing
+        // "https://debugger-example.com/react-dom.js",
+        // "https://debugger-example.com/react-dom.development.js",
+        // "https://debugger-example.com/react-dom.production.min.js",
+        // "https://debugger-react-example.com/react-dom.js",
+        // "https://debugger-react-example.com/react/react-dom.js",
+        "/node_modules/react/test.js",
+        "/node_modules/react-dom/test.js",
+      ];
+      reactUrlList.forEach(reactUrl => {
+        const frame = makeMockFrameWithURL(reactUrl);
+        expect(getLibraryFromUrl(frame)).toEqual("React");
+      });
+    });
+  });
+
+  describe("When Angular is in the URL", () => {
+    it("should return Angular for AngularJS (1.x)", () => {
+      const frame = makeMockFrameWithURL(
+        "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+      );
+      expect(getLibraryFromUrl(frame)).toEqual("Angular");
+    });
+
+    it("should return Angular for Angular (2.x)", () => {
+      const frame = makeMockFrameWithURL(
+        "https://stackblitz.io/turbo_modules/@angular/core@7.2.4/bundles/core.umd.js"
+      );
+      expect(getLibraryFromUrl(frame)).toEqual("Angular");
+    });
+
+    it("should not return Angular for Angular components", () => {
+      const frame = makeMockFrameWithURL(
+        "https://firefox-devtools-angular-log.stackblitz.io/~/src/app/hello.component.ts"
+      );
+      expect(getLibraryFromUrl(frame)).toBeNull();
+    });
+  });
+
+  describe("When zone.js is on the frame", () => {
+    it("should not return Angular when no callstack", () => {
+      const frame = makeMockFrameWithURL("/node_modules/zone/zone.js");
+      expect(getLibraryFromUrl(frame)).toEqual(null);
+    });
+
+    it("should not return Angular when stack without Angular frames", () => {
+      const frame = makeMockFrameWithURL("/node_modules/zone/zone.js");
+      const callstack = [frame];
+
+      expect(getLibraryFromUrl(frame, callstack)).toEqual(null);
+    });
+
+    it("should return Angular when stack with AngularJS (1.x) frames", () => {
+      const frame = makeMockFrameWithURL("/node_modules/zone/zone.js");
+      const callstack = [
+        frame,
+        makeMockFrameWithURL("https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"),
+      ];
+
+      expect(getLibraryFromUrl(frame, callstack)).toEqual("Angular");
+    });
   });
 });

--- a/src/devtools/client/debugger/src/utils/quick-open.test.js
+++ b/src/devtools/client/debugger/src/utils/quick-open.test.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import cases from "jest-in-case";
+import { parseQuickOpenQuery, parseLineColumn } from "./quick-open";
+
+cases(
+  "parseQuickOpenQuery utility",
+  ({ type, query }) => expect(parseQuickOpenQuery(query)).toEqual(type),
+  [
+    { name: "empty query defaults to sources", type: "sources", query: "" },
+    { name: "sources query", type: "sources", query: "test" },
+    { name: "functions query", type: "functions", query: "@test" },
+    { name: "variables query", type: "variables", query: "#test" },
+    { name: "goto line", type: "goto", query: ":30" },
+    { name: "goto line:column", type: "goto", query: ":30:60" },
+    { name: "goto source line", type: "gotoSource", query: "test:30:60" },
+    { name: "shortcuts", type: "shortcuts", query: "?" },
+  ]
+);
+
+cases(
+  "parseLineColumn utility",
+  ({ query, location }) => expect(parseLineColumn(query)).toEqual(location),
+  [
+    { name: "empty query", query: "", location: undefined },
+    { name: "just line", query: ":30", location: { line: 30 } },
+    {
+      name: "line and column",
+      query: ":30:90",
+      location: { column: 90, line: 30 },
+    },
+  ]
+);

--- a/src/devtools/client/debugger/src/utils/resource/tests/crud.test.js
+++ b/src/devtools/client/debugger/src/utils/resource/tests/crud.test.js
@@ -1,0 +1,254 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+//
+
+import {
+  createInitial,
+  insertResources,
+  removeResources,
+  updateResources,
+  hasResource,
+  getResourceIds,
+  getResource,
+  getMappedResource,
+} from "..";
+
+const makeResource = id => ({
+  id,
+  name: `name-${id}`,
+  data: 42,
+  obj: {},
+});
+
+const mapName = resource => resource.name;
+const mapWithIdent = (resource, identity) => ({
+  resource,
+  identity,
+  obj: {},
+});
+
+const clone = v => JSON.parse(JSON.stringify(v));
+
+describe("resource CRUD operations", () => {
+  let r1, r2, r3;
+  let originalInitial;
+  let initialState;
+  beforeEach(() => {
+    r1 = makeResource("id-1");
+    r2 = makeResource("id-2");
+    r3 = makeResource("id-3");
+
+    initialState = createInitial();
+    originalInitial = clone(initialState);
+  });
+
+  describe("insert", () => {
+    it("should work", () => {
+      const state = insertResources(initialState, [r1, r2, r3]);
+
+      expect(initialState).toEqual(originalInitial);
+      expect(getResource(state, r1.id)).toBe(r1);
+      expect(getResource(state, r2.id)).toBe(r2);
+      expect(getResource(state, r3.id)).toBe(r3);
+    });
+
+    it("should throw on duplicate", () => {
+      const state = insertResources(initialState, [r1]);
+      expect(() => {
+        insertResources(state, [r1]);
+      }).toThrow(/already exists/);
+
+      expect(() => {
+        insertResources(state, [r2, r2]);
+      }).toThrow(/already exists/);
+    });
+
+    it("should be a no-op when given no resources", () => {
+      const state = insertResources(initialState, []);
+
+      expect(state).toBe(initialState);
+    });
+  });
+
+  describe("read", () => {
+    beforeEach(() => {
+      initialState = insertResources(initialState, [r1, r2, r3]);
+    });
+
+    it("should allow reading all IDs", () => {
+      expect(getResourceIds(initialState)).toEqual([r1.id, r2.id, r3.id]);
+    });
+
+    it("should allow checking for existing of an ID", () => {
+      expect(hasResource(initialState, r1.id)).toBe(true);
+      expect(hasResource(initialState, r2.id)).toBe(true);
+      expect(hasResource(initialState, r3.id)).toBe(true);
+      expect(hasResource(initialState, "unknownId")).toBe(false);
+    });
+
+    it("should allow reading an item", () => {
+      expect(getResource(initialState, r1.id)).toBe(r1);
+      expect(getResource(initialState, r2.id)).toBe(r2);
+      expect(getResource(initialState, r3.id)).toBe(r3);
+
+      expect(() => {
+        getResource(initialState, "unknownId");
+      }).toThrow(/does not exist/);
+    });
+
+    it("should allow reading and mapping an item", () => {
+      expect(getMappedResource(initialState, r1.id, mapName)).toBe(r1.name);
+      expect(getMappedResource(initialState, r2.id, mapName)).toBe(r2.name);
+      expect(getMappedResource(initialState, r3.id, mapName)).toBe(r3.name);
+
+      expect(() => {
+        getMappedResource(initialState, "unknownId", mapName);
+      }).toThrow(/does not exist/);
+    });
+
+    it("should allow reading and mapping an item with identity", () => {
+      const r1Ident = getMappedResource(initialState, r1.id, mapWithIdent);
+      const r2Ident = getMappedResource(initialState, r2.id, mapWithIdent);
+
+      const state = updateResources(initialState, [{ ...r1, obj: {} }]);
+
+      const r1NewIdent = getMappedResource(state, r1.id, mapWithIdent);
+      const r2NewIdent = getMappedResource(state, r2.id, mapWithIdent);
+
+      // The update changed the resource object, but not the identity.
+      expect(r1NewIdent.resource).not.toBe(r1Ident.resource);
+      expect(r1NewIdent.resource).toEqual(r1Ident.resource);
+      expect(r1NewIdent.identity).toBe(r1Ident.identity);
+
+      // The update did not change the r2 resource.
+      expect(r2NewIdent.resource).toBe(r2Ident.resource);
+      expect(r2NewIdent.identity).toBe(r2Ident.identity);
+    });
+  });
+
+  describe("update", () => {
+    beforeEach(() => {
+      initialState = insertResources(initialState, [r1, r2, r3]);
+      originalInitial = clone(initialState);
+    });
+
+    it("should work", () => {
+      const r1Ident = getMappedResource(initialState, r1.id, mapWithIdent);
+      const r2Ident = getMappedResource(initialState, r2.id, mapWithIdent);
+      const r3Ident = getMappedResource(initialState, r3.id, mapWithIdent);
+
+      const state = updateResources(initialState, [
+        {
+          id: r1.id,
+          data: 21,
+        },
+        {
+          id: r2.id,
+          name: "newName",
+        },
+      ]);
+
+      expect(initialState).toEqual(originalInitial);
+      expect(getResource(state, r1.id)).toEqual({ ...r1, data: 21 });
+      expect(getResource(state, r2.id)).toEqual({ ...r2, name: "newName" });
+      expect(getResource(state, r3.id)).toBe(r3);
+
+      const r1NewIdent = getMappedResource(state, r1.id, mapWithIdent);
+      const r2NewIdent = getMappedResource(state, r2.id, mapWithIdent);
+      const r3NewIdent = getMappedResource(state, r3.id, mapWithIdent);
+
+      // The update changed the resource object, but not the identity.
+      expect(r1NewIdent.resource).not.toBe(r1Ident.resource);
+      expect(r1NewIdent.resource).toEqual({
+        ...r1Ident.resource,
+        data: 21,
+      });
+      expect(r1NewIdent.identity).toBe(r1Ident.identity);
+
+      // The update changed the resource object, but not the identity.
+      expect(r2NewIdent.resource).toEqual({
+        ...r2Ident.resource,
+        name: "newName",
+      });
+      expect(r2NewIdent.identity).toBe(r2Ident.identity);
+
+      // The update did not change the r3 resource.
+      expect(r3NewIdent.resource).toBe(r3Ident.resource);
+      expect(r3NewIdent.identity).toBe(r3Ident.identity);
+    });
+
+    it("should throw if not found", () => {
+      expect(() => {
+        updateResources(initialState, [
+          {
+            ...r1,
+            id: "unknownId",
+          },
+        ]);
+      }).toThrow(/does not exists/);
+    });
+
+    it("should be a no-op when new fields are strict-equal", () => {
+      const state = updateResources(initialState, [r1]);
+      expect(state).toBe(initialState);
+    });
+
+    it("should be a no-op when given no resources", () => {
+      const state = updateResources(initialState, []);
+      expect(state).toBe(initialState);
+    });
+  });
+
+  describe("delete", () => {
+    beforeEach(() => {
+      initialState = insertResources(initialState, [r1, r2, r3]);
+      originalInitial = clone(initialState);
+    });
+
+    it("should work with objects", () => {
+      const state = removeResources(initialState, [r1]);
+
+      expect(initialState).toEqual(originalInitial);
+      expect(hasResource(state, r1.id)).toBe(false);
+      expect(hasResource(state, r2.id)).toBe(true);
+      expect(hasResource(state, r3.id)).toBe(true);
+    });
+
+    it("should work with object subsets", () => {
+      const state = removeResources(initialState, [{ id: r1.id }]);
+
+      expect(initialState).toEqual(originalInitial);
+      expect(hasResource(state, r1.id)).toBe(false);
+      expect(hasResource(state, r2.id)).toBe(true);
+      expect(hasResource(state, r3.id)).toBe(true);
+    });
+
+    it("should work with ids", () => {
+      const state = removeResources(initialState, [r1.id]);
+
+      expect(initialState).toEqual(originalInitial);
+      expect(hasResource(state, r1.id)).toBe(false);
+      expect(hasResource(state, r2.id)).toBe(true);
+      expect(hasResource(state, r3.id)).toBe(true);
+    });
+
+    it("should throw if not found", () => {
+      expect(() => {
+        removeResources(initialState, [makeResource("unknownId")]);
+      }).toThrow(/does not exist/);
+      expect(() => {
+        removeResources(initialState, [{ id: "unknownId" }]);
+      }).toThrow(/does not exist/);
+      expect(() => {
+        removeResources(initialState, ["unknownId"]);
+      }).toThrow(/does not exist/);
+    });
+
+    it("should be a no-op when given no resources", () => {
+      const state = removeResources(initialState, []);
+      expect(state).toBe(initialState);
+    });
+  });
+});

--- a/src/devtools/client/debugger/src/utils/resource/tests/query.test.js
+++ b/src/devtools/client/debugger/src/utils/resource/tests/query.test.js
@@ -1,0 +1,1027 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+//
+
+import {
+  createInitial,
+  insertResources,
+  updateResources,
+  makeMapWithArgs,
+  makeWeakQuery,
+  makeShallowQuery,
+  makeStrictQuery,
+} from "..";
+
+const makeResource = id => ({
+  id,
+  name: `name-${id}`,
+  data: 42,
+  obj: {},
+});
+
+// Jest's mock type just wouldn't cooperate below, so this is a custom version
+// that does what I need.
+
+// We need to pass the 'needsArgs' prop through to the query fn so we use
+// this utility to do that and at the same time preserve typechecking.
+const mockFn = f => Object.assign(jest.fn(f), f);
+
+const mockFilter = callback => mockFn(callback);
+const mockMapNoArgs = callback => mockFn(callback);
+const mockMapWithArgs = callback => mockFn(makeMapWithArgs(callback));
+const mockReduce = callback => mockFn(callback);
+
+describe("resource query operations", () => {
+  let r1, r2, r3;
+  let initialState;
+  let mapNoArgs, mapWithArgs, reduce;
+
+  beforeEach(() => {
+    r1 = makeResource("id-1");
+    r2 = makeResource("id-2");
+    r3 = makeResource("id-3");
+
+    initialState = createInitial();
+
+    initialState = insertResources(initialState, [r1, r2, r3]);
+
+    mapNoArgs = mockMapNoArgs((resource, ident) => resource);
+    mapWithArgs = mockMapWithArgs((resource, ident, args) => resource);
+    reduce = mockReduce((mapped, ids, args) => {
+      return mapped.reduce((acc, item, i) => {
+        acc[ids[i]] = item;
+        return acc;
+      }, {});
+    });
+  });
+
+  describe("weak cache", () => {
+    let filter;
+
+    beforeEach(() => {
+      filter = mockFilter(
+        // eslint-disable-next-line max-nested-callbacks
+        (values, args) => args
+      );
+    });
+
+    describe("no args", () => {
+      let query;
+
+      beforeEach(() => {
+        query = makeWeakQuery({ filter, map: mapNoArgs, reduce });
+      });
+
+      it("should return same with same state and same args", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return same with updated other state and same args 1", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Updating r2 does not affect cached result that only cares about r2.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            obj: {},
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return same with updated other state and same args 2", () => {
+        // eslint-disable-next-line max-nested-callbacks
+        mapNoArgs.mockImplementation(resource => ({ ...resource, name: "" }));
+
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: { ...r1, name: "" },
+          [r2.id]: { ...r2, name: "" },
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Since the map function ignores the name value, updating it should
+        // not reset the cached for this query.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: { ...r1, name: "" },
+          [r2.id]: { ...r2, name: "" },
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return diff with updated id state and same args", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Since the mapper returns a value with name, changing a name will
+        // invalidate the cache.
+        const state = updateResources(initialState, [
+          {
+            id: r1.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).not.toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: { ...r1, name: "newName" },
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(3);
+        expect(reduce.mock.calls).toHaveLength(2);
+      });
+
+      it("should return diff with same state and diff args", () => {
+        const firstArgs = [r1.id, r2.id];
+        const secondArgs = [r1.id, r2.id];
+        const result1 = query(initialState, firstArgs);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, secondArgs);
+        expect(result2).not.toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(2);
+
+        // Same result from first query still available.
+        const result3 = query(initialState, firstArgs);
+        expect(result3).not.toBe(result2);
+        expect(result3).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(2);
+
+        // Same result from second query still available.
+        const result4 = query(initialState, secondArgs);
+        expect(result4).toBe(result2);
+        expect(result4).not.toBe(result3);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(2);
+      });
+    });
+
+    describe("with args", () => {
+      let query;
+
+      beforeEach(() => {
+        query = makeWeakQuery({ filter, map: mapWithArgs, reduce });
+      });
+
+      it("should return same with same state and same args", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return same with updated other state and same args 1", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Updating r2 does not affect cached result that only cares about r2.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            obj: {},
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return same with updated other state and same args 2", () => {
+        // eslint-disable-next-line max-nested-callbacks
+        mapWithArgs.mockImplementation(resource => ({
+          ...resource,
+          name: "",
+        }));
+
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: { ...r1, name: "" },
+          [r2.id]: { ...r2, name: "" },
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Since the map function ignores the name value, updating it should
+        // not reset the cached for this query.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: { ...r1, name: "" },
+          [r2.id]: { ...r2, name: "" },
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return diff with updated id state and same args", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Since the mapper returns a value with name, changing a name will
+        // invalidate the cache.
+        const state = updateResources(initialState, [
+          {
+            id: r1.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).not.toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: { ...r1, name: "newName" },
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(3);
+        expect(reduce.mock.calls).toHaveLength(2);
+      });
+
+      it("should return diff with same state and diff args", () => {
+        const firstArgs = [r1.id, r2.id];
+        const secondArgs = [r1.id, r2.id];
+
+        const result1 = query(initialState, firstArgs);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, secondArgs);
+        expect(result2).not.toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(4);
+        expect(reduce.mock.calls).toHaveLength(2);
+
+        // Same result from first query still available.
+        const result3 = query(initialState, firstArgs);
+        expect(result3).not.toBe(result2);
+        expect(result3).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(4);
+        expect(reduce.mock.calls).toHaveLength(2);
+
+        // Same result from second query still available.
+        const result4 = query(initialState, secondArgs);
+        expect(result4).toBe(result2);
+        expect(result4).not.toBe(result3);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(4);
+        expect(reduce.mock.calls).toHaveLength(2);
+      });
+    });
+  });
+
+  describe("shallow cache", () => {
+    let filter;
+
+    beforeEach(() => {
+      filter = mockFilter(
+        // eslint-disable-next-line max-nested-callbacks
+        (values, { ids }) => ids
+      );
+    });
+
+    describe("no args", () => {
+      let query;
+
+      beforeEach(() => {
+        query = makeShallowQuery({ filter, map: mapNoArgs, reduce });
+      });
+
+      it("should return last with same state and same args", () => {
+        const ids = [r1.id, r2.id];
+        const result1 = query(initialState, { ids });
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, { ids });
+        expect(result2).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return last with updated other state and same args 1", () => {
+        const ids = [r1.id, r2.id];
+        const result1 = query(initialState, { ids });
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Updating r2 does not affect cached result that only cares about r2.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            obj: {},
+          },
+        ]);
+
+        const result2 = query(state, { ids });
+        expect(result2).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return last with updated other state and same args 2", () => {
+        // eslint-disable-next-line max-nested-callbacks
+        mapNoArgs.mockImplementation(resource => ({ ...resource, name: "" }));
+
+        const ids = [r1.id, r2.id];
+        const result1 = query(initialState, { ids });
+        expect(result1).toEqual({
+          [r1.id]: { ...r1, name: "" },
+          [r2.id]: { ...r2, name: "" },
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Since the map function ignores the name value, updating it should
+        // not reset the cached for this query.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, { ids });
+        expect(result2).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return new with updated id state and same args", () => {
+        const ids = [r1.id, r2.id];
+        const result1 = query(initialState, { ids });
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Updating r2 does not affect cached result that only cares about r2.
+        const state = updateResources(initialState, [
+          {
+            id: r2.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, { ids });
+        expect(result2).not.toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: { ...r2, name: "newName" },
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(3);
+        expect(reduce.mock.calls).toHaveLength(2);
+      });
+
+      it("should return diff with same state and diff args", () => {
+        const ids = [r1.id, r2.id];
+        const result1 = query(initialState, { ids, flag: true });
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, { ids, flag: false });
+        expect(result2).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result3 = query(initialState, { ids, flag: true });
+        expect(result3).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(3);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result4 = query(initialState, { ids, flag: false });
+        expect(result4).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(4);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+    });
+
+    describe("with args", () => {
+      let query;
+
+      beforeEach(() => {
+        query = makeShallowQuery({ filter, map: mapWithArgs, reduce });
+      });
+
+      it("should return last with same state and same args", () => {
+        const ids = [r1.id, r2.id];
+        const result1 = query(initialState, { ids });
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, { ids });
+        expect(result2).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return last with updated other state and same args 1", () => {
+        const ids = [r1.id, r2.id];
+        const result1 = query(initialState, { ids });
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Updating r2 does not affect cached result that only cares about r2.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            obj: {},
+          },
+        ]);
+
+        const result2 = query(state, { ids });
+        expect(result2).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return last with updated other state and same args 2", () => {
+        // eslint-disable-next-line max-nested-callbacks
+        mapWithArgs.mockImplementation(resource => ({
+          ...resource,
+          name: "",
+        }));
+
+        const ids = [r1.id, r2.id];
+        const result1 = query(initialState, { ids });
+        expect(result1).toEqual({
+          [r1.id]: { ...r1, name: "" },
+          [r2.id]: { ...r2, name: "" },
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Since the map function ignores the name value, updating it should
+        // not reset the cached for this query.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, { ids });
+        expect(result2).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return new with updated id state and same args", () => {
+        const ids = [r1.id, r2.id];
+        const result1 = query(initialState, { ids });
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Updating r2 does not affect cached result that only cares about r2.
+        const state = updateResources(initialState, [
+          {
+            id: r2.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, { ids });
+        expect(result2).not.toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: { ...r2, name: "newName" },
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(3);
+        expect(reduce.mock.calls).toHaveLength(2);
+      });
+
+      it("should return diff with same state and diff args", () => {
+        const ids = [r1.id, r2.id];
+        const result1 = query(initialState, { ids, flag: true });
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, { ids, flag: false });
+        expect(result2).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(4);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result3 = query(initialState, { ids, flag: true });
+        expect(result3).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(3);
+        expect(mapWithArgs.mock.calls).toHaveLength(6);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result4 = query(initialState, { ids, flag: false });
+        expect(result4).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(4);
+        expect(mapWithArgs.mock.calls).toHaveLength(8);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("strict cache", () => {
+    let filter;
+
+    beforeEach(() => {
+      filter = mockFilter(
+        // eslint-disable-next-line max-nested-callbacks
+        (values, ids) => ids
+      );
+    });
+
+    describe("no args", () => {
+      let query;
+
+      beforeEach(() => {
+        query = makeStrictQuery({ filter, map: mapNoArgs, reduce });
+      });
+
+      it("should return same with same state and same args", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return same with updated other state and same args 1", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Updating r2 does not affect cached result that only cares about r2.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            obj: {},
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return same with updated other state and same args 2", () => {
+        // eslint-disable-next-line max-nested-callbacks
+        mapNoArgs.mockImplementation(resource => ({ ...resource, name: "" }));
+
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: { ...r1, name: "" },
+          [r2.id]: { ...r2, name: "" },
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Since the map function ignores the name value, updating it should
+        // not reset the cached for this query.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: { ...r1, name: "" },
+          [r2.id]: { ...r2, name: "" },
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return diff with updated id state and same args", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Since the mapper returns a value with name, changing a name will
+        // invalidate the cache.
+        const state = updateResources(initialState, [
+          {
+            id: r1.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).not.toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: { ...r1, name: "newName" },
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(3);
+        expect(reduce.mock.calls).toHaveLength(2);
+      });
+
+      it("should return diff with same state and diff args", () => {
+        const firstArgs = [r1.id, r2.id];
+        const secondArgs = [r1.id, r2.id];
+        const result1 = query(initialState, firstArgs);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, secondArgs);
+        expect(result2).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result3 = query(initialState, firstArgs);
+        expect(result3).toBe(result2);
+        expect(filter.mock.calls).toHaveLength(3);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result4 = query(initialState, secondArgs);
+        expect(result4).toBe(result3);
+        expect(filter.mock.calls).toHaveLength(4);
+        expect(mapNoArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+    });
+
+    describe("with args", () => {
+      let query;
+
+      beforeEach(() => {
+        query = makeStrictQuery({ filter, map: mapWithArgs, reduce });
+      });
+
+      it("should return same with same state and same args", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return same with updated other state and same args 1", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Updating r2 does not affect cached result that only cares about r2.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            obj: {},
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return same with updated other state and same args 2", () => {
+        // eslint-disable-next-line max-nested-callbacks
+        mapWithArgs.mockImplementation(resource => ({
+          ...resource,
+          name: "",
+        }));
+
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: { ...r1, name: "" },
+          [r2.id]: { ...r2, name: "" },
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Since the map function ignores the name value, updating it should
+        // not reset the cached for this query.
+        const state = updateResources(initialState, [
+          {
+            id: r3.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: { ...r1, name: "" },
+          [r2.id]: { ...r2, name: "" },
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+
+      it("should return diff with updated id state and same args", () => {
+        const args = [r1.id, r2.id];
+        const result1 = query(initialState, args);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        // Since the mapper returns a value with name, changing a name will
+        // invalidate the cache.
+        const state = updateResources(initialState, [
+          {
+            id: r1.id,
+            name: "newName",
+          },
+        ]);
+
+        const result2 = query(state, args);
+        expect(result2).not.toBe(result1);
+        expect(result2).toEqual({
+          [r1.id]: { ...r1, name: "newName" },
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(3);
+        expect(reduce.mock.calls).toHaveLength(2);
+      });
+
+      it("should return diff with same state and diff args", () => {
+        const firstArgs = [r1.id, r2.id];
+        const secondArgs = [r1.id, r2.id];
+
+        const result1 = query(initialState, firstArgs);
+        expect(result1).toEqual({
+          [r1.id]: r1,
+          [r2.id]: r2,
+        });
+        expect(filter.mock.calls).toHaveLength(1);
+        expect(mapWithArgs.mock.calls).toHaveLength(2);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result2 = query(initialState, secondArgs);
+        expect(result2).toBe(result1);
+        expect(filter.mock.calls).toHaveLength(2);
+        expect(mapWithArgs.mock.calls).toHaveLength(4);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result3 = query(initialState, firstArgs);
+        expect(result3).toBe(result2);
+        expect(filter.mock.calls).toHaveLength(3);
+        expect(mapWithArgs.mock.calls).toHaveLength(6);
+        expect(reduce.mock.calls).toHaveLength(1);
+
+        const result4 = query(initialState, secondArgs);
+        expect(result4).toBe(result3);
+        expect(filter.mock.calls).toHaveLength(4);
+        expect(mapWithArgs.mock.calls).toHaveLength(8);
+        expect(reduce.mock.calls).toHaveLength(1);
+      });
+    });
+  });
+});

--- a/src/devtools/client/debugger/src/utils/sources-tree/getURL.test.js
+++ b/src/devtools/client/debugger/src/utils/sources-tree/getURL.test.js
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { getURL } from "./getURL";
+import { makeMockSource } from "devtools/client/debugger/src/utils/test-mockup";
+
+function createMockSource(props) {
+  const rv = {
+    ...makeMockSource(),
+    ...Object.assign(
+      {
+        id: "server1.conn13.child1/39",
+        url: "",
+        sourceMapURL: "",
+        isBlackBoxed: false,
+        isPrettyPrinted: false,
+      },
+      props
+    ),
+  };
+  return rv;
+}
+
+describe("getUrl", () => {
+  it("handles normal url with http and https for filename", function () {
+    const urlObject = getURL(createMockSource({ url: "https://a/b.js" }));
+    expect(urlObject.filename).toBe("b.js");
+
+    const urlObject2 = getURL(
+      createMockSource({ id: "server1.conn13.child1/40", url: "http://a/b.js" })
+    );
+    expect(urlObject2.filename).toBe("b.js");
+  });
+
+  it("handles url with querystring for filename", function () {
+    const urlObject = getURL(
+      createMockSource({
+        url: "https://a/b.js?key=randomKey",
+      })
+    );
+    expect(urlObject.filename).toBe("b.js");
+  });
+
+  it("handles url with '#' for filename", function () {
+    const urlObject = getURL(
+      createMockSource({
+        url: "https://a/b.js#specialSection",
+      })
+    );
+    expect(urlObject.filename).toBe("b.js");
+  });
+
+  it("handles url with no file extension for filename", function () {
+    const urlObject = getURL(
+      createMockSource({
+        url: "https://a/c",
+        id: "c",
+      })
+    );
+    expect(urlObject.filename).toBe("c");
+  });
+
+  it("handles url with no name for filename", function () {
+    const urlObject = getURL(
+      createMockSource({
+        url: "https://a/",
+        id: "c",
+      })
+    );
+    expect(urlObject.filename).toBe("(index)");
+  });
+
+  it("separates resources by protocol and host", () => {
+    const urlObject = getURL(
+      createMockSource({
+        url: "moz-extension://xyz/123",
+        id: "c2",
+      })
+    );
+    expect(urlObject.group).toBe("moz-extension://xyz");
+  });
+
+  it("creates a group name for webpack", () => {
+    const urlObject = getURL(
+      createMockSource({
+        url: "webpack:///src/component.jsx",
+        id: "c3",
+      })
+    );
+    expect(urlObject.group).toBe("webpack://");
+  });
+
+  it("creates a group name for angular source", () => {
+    const urlObject = getURL(
+      createMockSource({
+        url: "ng://src/component.jsx",
+        id: "c3",
+      })
+    );
+    expect(urlObject.group).toBe("ng://");
+  });
+});

--- a/src/devtools/client/debugger/src/utils/sources-tree/utils.test.js
+++ b/src/devtools/client/debugger/src/utils/sources-tree/utils.test.js
@@ -1,0 +1,133 @@
+/* eslint max-nested-callbacks: ["error", 4]*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { makeMockSource } from "devtools/client/debugger/src/utils/test-mockup";
+
+import {
+  createDirectoryNode,
+  getRelativePath,
+  isExactUrlMatch,
+  isDirectory,
+  isNotJavaScript,
+  getPathWithoutThread,
+} from "./utils";
+import { addToTree } from "./addToTree";
+
+describe("sources tree", () => {
+  describe("isExactUrlMatch", () => {
+    it("recognizes root url match", () => {
+      const rootA = "http://example.com/path/to/file.html";
+      const rootB = "https://www.demo.com/index.html";
+
+      expect(isExactUrlMatch("example.com", rootA)).toBe(true);
+      expect(isExactUrlMatch("www.example.com", rootA)).toBe(true);
+      expect(isExactUrlMatch("api.example.com", rootA)).toBe(false);
+      expect(isExactUrlMatch("example.example.com", rootA)).toBe(false);
+      expect(isExactUrlMatch("www.example.example.com", rootA)).toBe(false);
+      expect(isExactUrlMatch("demo.com", rootA)).toBe(false);
+
+      expect(isExactUrlMatch("demo.com", rootB)).toBe(true);
+      expect(isExactUrlMatch("www.demo.com", rootB)).toBe(true);
+      expect(isExactUrlMatch("maps.demo.com", rootB)).toBe(false);
+      expect(isExactUrlMatch("demo.demo.com", rootB)).toBe(false);
+      expect(isExactUrlMatch("www.demo.demo.com", rootB)).toBe(false);
+      expect(isExactUrlMatch("example.com", rootB)).toBe(false);
+    });
+  });
+
+  // describe("isDirectory", () => {
+  //   it("identifies directories correctly", () => {
+  //     const sources = [
+  //       makeMockSource("http://example.com/a.js", "actor1"),
+  //       makeMockSource("http://example.com/b/c/d.js", "actor2"),
+  //     ];
+
+  //     const tree = createDirectoryNode("root", "", []);
+  //     sources.forEach(source => addToTree(tree, source, "http://example.com/", "Main Thread"));
+  //     const [bFolderNode, aFileNode] = tree.contents[0].contents[0].contents;
+  //     const [cFolderNode] = bFolderNode.contents;
+  //     const [dFileNode] = cFolderNode.contents;
+
+  //     expect(isDirectory(bFolderNode)).toBe(true);
+  //     expect(isDirectory(aFileNode)).toBe(false);
+  //     expect(isDirectory(cFolderNode)).toBe(true);
+  //     expect(isDirectory(dFileNode)).toBe(false);
+  //   });
+  // });
+
+  describe("getRelativePath", () => {
+    it("gets the relative path of the file", () => {
+      const relPath = "path/to/file.html";
+      expect(getRelativePath("http://example.com/path/to/file.html")).toBe(relPath);
+      expect(getRelativePath("http://www.example.com/path/to/file.html")).toBe(relPath);
+      expect(getRelativePath("https://www.example.com/path/to/file.js")).toBe("path/to/file.js");
+      expect(getRelativePath("webpack:///path/to/file.html")).toBe(relPath);
+      expect(getRelativePath("file:///path/to/file.html")).toBe(relPath);
+      expect(getRelativePath("file:///path/to/file.html?bla")).toBe(relPath);
+      expect(getRelativePath("file:///path/to/file.html#bla")).toBe(relPath);
+      expect(getRelativePath("file:///path/to/file")).toBe("path/to/file");
+    });
+  });
+
+  describe("isNotJavaScript", () => {
+    it("js file", () => {
+      const source = makeMockSource("http://example.com/foo.js");
+      expect(isNotJavaScript(source)).toBe(false);
+    });
+
+    it("css file", () => {
+      const source = makeMockSource("http://example.com/foo.css");
+      expect(isNotJavaScript(source)).toBe(true);
+    });
+
+    it("svg file", () => {
+      const source = makeMockSource("http://example.com/foo.svg");
+      expect(isNotJavaScript(source)).toBe(true);
+    });
+
+    it("png file", () => {
+      const source = makeMockSource("http://example.com/foo.png");
+      expect(isNotJavaScript(source)).toBe(true);
+    });
+  });
+
+  describe("getPathWithoutThread", () => {
+    it("main thread pattern", () => {
+      const path = getPathWithoutThread("server1.conn0.child1/context18");
+      expect(path).toBe("");
+    });
+
+    it("main thread host", () => {
+      const path = getPathWithoutThread("server1.conn0.child1/context18/dbg-workers.glitch.me");
+      expect(path).toBe("dbg-workers.glitch.me");
+    });
+
+    it("main thread children", () => {
+      const path = getPathWithoutThread(
+        "server1.conn0.child1/context18/dbg-workers.glitch.me/more"
+      );
+      expect(path).toBe("dbg-workers.glitch.me/more");
+    });
+
+    it("worker thread", () => {
+      const path = getPathWithoutThread("server1.conn0.child1/workerTarget25/context1");
+      expect(path).toBe("");
+    });
+
+    it("worker thread with children", () => {
+      const path = getPathWithoutThread(
+        "server1.conn0.child1/workerTarget25/context1/dbg-workers.glitch.me/utils"
+      );
+      expect(path).toBe("dbg-workers.glitch.me/utils");
+    });
+
+    it("worker thread with file named like pattern", () => {
+      const path = getPathWithoutThread(
+        "server1.conn0.child1/workerTarget25/context1/dbg-workers.glitch.me/utils/context38/index.js"
+      );
+      expect(path).toBe("dbg-workers.glitch.me/utils/context38/index.js");
+    });
+  });
+});

--- a/src/devtools/shared/async-store-helper.js
+++ b/src/devtools/shared/async-store-helper.js
@@ -4,8 +4,7 @@
 
 //  "use strict";
 
-const { moduleExpression } = require("@babel/types");
-const asyncStorage = require("./async-storage");
+export const asyncStorage = require("./async-storage");
 
 /*
  * asyncStoreHelper wraps asyncStorage so that it is easy to define project
@@ -16,7 +15,7 @@ const asyncStorage = require("./async-storage");
  *   asyncStore.a         // => asyncStorage.getItem("r._a")
  *   asyncStore.a = 2     // => asyncStorage.setItem("r._a", 2)
  */
-function asyncStoreHelper(root, mappings) {
+export function asyncStoreHelper(root, mappings) {
   let store = {};
 
   function getMappingKey(key) {
@@ -52,5 +51,3 @@ function asyncStoreHelper(root, mappings) {
 
   return store;
 }
-
-module.exports = { asyncStoreHelper };

--- a/src/devtools/shared/async-store-helper.test.js
+++ b/src/devtools/shared/async-store-helper.test.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { asyncStorage, asyncStoreHelper } from "./async-store-helper";
+
+function mockAsyncStorage() {
+  const store = {};
+  jest.spyOn(asyncStorage, "getItem");
+  jest.spyOn(asyncStorage, "setItem");
+
+  asyncStorage.getItem.mockImplementation(key => store[key]);
+  asyncStorage.setItem.mockImplementation((key, value) => (store[key] = value));
+}
+
+describe("asycStoreHelper", () => {
+  it("can get and set values", async () => {
+    mockAsyncStorage();
+    const asyncStore = asyncStoreHelper("root", { a: "_a" });
+    asyncStore.a = 3;
+    expect(await asyncStore.a).toEqual(3);
+  });
+
+  it("supports default values", async () => {
+    mockAsyncStorage();
+    const asyncStore = asyncStoreHelper("root", { a: ["_a", {}] });
+    expect(await asyncStore.a).toEqual({});
+  });
+
+  it("undefined default value", async () => {
+    mockAsyncStorage();
+    const asyncStore = asyncStoreHelper("root", { a: "_a" });
+    expect(await asyncStore.a).toEqual(null);
+  });
+
+  it("setting an undefined mapping", async () => {
+    mockAsyncStorage();
+    const asyncStore = asyncStoreHelper("root", { a: "_a" });
+    expect(() => {
+      asyncStore.b = 3;
+    }).toThrow("AsyncStore: b is not defined");
+  });
+});


### PR DESCRIPTION
This adds some unit tests that were helpful in the Firefox Debugger days. 

- The `getExpressionFromCoords` were failing so i skipped them.
- `getLibraryFromUrl` had some cases which no longer passed which I skipped as well