### PR TITLE
Changed comments to sort by 'point' rather than 'time'

### DIFF
--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -27,7 +27,7 @@ export default function Transcript() {
       displayedComments.push(pendingComment.comment);
     }
 
-    const sortedComments = sortBy(displayedComments, ["time", "createdAt"]);
+    const sortedComments = sortBy(displayedComments, ["point", "createdAt"]);
     return sortedComments;
   }, [comments, pendingComment]);
 


### PR DESCRIPTION
Resolves https://github.com/RecordReplay/customer-support/issues/48

I don't have a great corpus of testing data for this, but I verified that this change fixed the incorrectly-ordered comments in the parent issue.