### PR TITLE
Refactor the way we looking at indexing progress

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -81,7 +81,7 @@ export default function LineNumberTooltip({
   const isMetaActive = keyModifiers.meta;
   const [codeHeatMaps, setCodeHeatMaps] = useState(features.codeHeatMaps);
 
-  const indexed = useSelector(selectors.getIndexed);
+  const indexed = useSelector(selectors.getIsIndexed);
   const hitCounts = useSelector(getHitCountsForSelectedSource);
   const source = useSelector(getSelectedSource);
   const analysisPoints = useSelector(selectors.getPointsForHoveredLineNumber);

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -207,7 +207,7 @@ function ToggleWidgetButton({ editor, cx, breakpoints }: ToggleWidgetButtonProps
 
 const connector = connect(
   (state: UIState) => ({
-    indexed: selectors.getIndexed(state),
+    indexed: selectors.getIsIndexed(state),
     cx: selectors.getThreadContext(state),
     breakpoints: getBreakpointsForSource(state, getSelectedSource(state)!.id),
   }),

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -153,7 +153,7 @@ const mapStateToProps = (state, { breakpoint }) => ({
     breakpoint.location,
     breakpoint.options.condition
   ),
-  indexed: selectors.getIndexed(state),
+  indexed: selectors.getIsIndexed(state),
   executionPoint: selectors.getExecutionPoint(state),
 });
 

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -172,6 +172,10 @@ export function setupApp(store: UIStore) {
 
 export function onUnprocessedRegions({ level, regions }: unprocessedRegions): UIThunkAction {
   return (dispatch, getState) => {
+    if (level === "executionIndexed") {
+      return;
+    }
+
     let endPoint = Math.max(...regions.map(r => r.end.time), 0);
     if (endPoint == 0) {
       return;
@@ -190,11 +194,7 @@ export function onUnprocessedRegions({ level, regions }: unprocessedRegions): UI
     const processedProgress = endPoint - unprocessedProgress;
     const percentProgress = (processedProgress / endPoint) * 100;
 
-    if (level === "basic") {
-      dispatch(setLoading(percentProgress));
-    } else {
-      dispatch(setIndexing(percentProgress));
-    }
+    dispatch(setLoading(percentProgress));
   };
 }
 

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -23,6 +23,7 @@ import {
   ReplayNavigationEvent,
   AppTheme,
   AppMode,
+  LoadedRegions,
 } from "ui/state/app";
 import { Workspace } from "ui/types";
 import { client, sendMessage } from "protocol/socket";
@@ -98,7 +99,7 @@ export type SetRecordingWorkspaceAction = Action<"set_recording_workspace"> & {
   workspace: Workspace;
 };
 export type SetLoadedRegions = Action<"set_loaded_regions"> & {
-  parameters: loadedRegions;
+  parameters: LoadedRegions;
 };
 export type SetMouseTargetsLoading = Action<"mouse_targets_loading"> & {
   loading: boolean;

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -36,7 +36,6 @@ import { Focuser } from "./Focuser";
 import { trackEvent } from "ui/utils/telemetry";
 import IndexingLoader from "../shared/IndexingLoader";
 import { EditFocusButton } from "./EditFocusButton";
-import { UnloadedRegions } from "./UnloadedRegions";
 import { MouseDownMask } from "./MouseDownMask";
 
 function getIsSecondaryHighlighted(
@@ -377,7 +376,6 @@ class Timeline extends Component<PropsFromRedux, { isDragging: boolean }> {
                 style={{ width: `${clamp(Math.min(hoverPercent, precachedPercent), 0, 100)}%` }}
               />
               <div className="progress-line" style={{ width: `${clamp(percent, 0, 100)}%` }} />
-              <UnloadedRegions />
               {this.renderPreviewMarkers()}
               <Comments />
               {this.renderUnfocusedRegion()}

--- a/src/ui/components/shared/IndexingLoader.tsx
+++ b/src/ui/components/shared/IndexingLoader.tsx
@@ -1,52 +1,44 @@
 import React, { useEffect, useState } from "react";
 import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
-import { connect, ConnectedProps } from "react-redux";
+import { useSelector } from "react-redux";
+import { getIndexingProgress } from "ui/reducers/app";
+import { getViewMode } from "ui/reducers/layout";
 
-import { selectors } from "ui/reducers";
-import { UIState } from "ui/state";
-
-function IndexingLoader({
-  progressPercentage,
-  viewMode,
-}: Pick<PropsFromRedux, "progressPercentage" | "viewMode">) {
+export default function IndexingLoader() {
+  const progress = useSelector(getIndexingProgress);
+  const viewMode = useSelector(getViewMode);
   const [isDone, setDone] = useState(false);
 
   // Set the indexing loader to done immediately, if
   // the loader just mounted and is at 100
   useEffect(() => {
-    if (progressPercentage == 100) {
+    if (progress == 100) {
       setDone(true);
     }
   }, []);
 
   useEffect(() => {
     let timeout: NodeJS.Timeout;
-    if (!isDone && progressPercentage == 100) {
+    if (!isDone && progress == 100) {
       timeout = setTimeout(() => setDone(true), 2000);
     }
 
     return () => clearTimeout(timeout);
-  }, [progressPercentage]);
+  }, [progress]);
 
-  if (isDone || progressPercentage === null || viewMode == "non-dev") {
+  if (progress === null || viewMode == "non-dev") {
     return null;
   }
 
+  console.log({ progress });
+
   return (
-    <div className="absolute h-7 w-7" title={`Indexing (${progressPercentage.toFixed()}%)`}>
+    <div className="absolute h-7 w-7" title={`Indexing (${progress.toFixed()}%)`}>
       <CircularProgressbar
-        value={progressPercentage}
+        value={progress}
         strokeWidth={14}
-        styles={buildStyles({ pathColor: `#0074E8`, trailColor: `transparent` })}
+        styles={buildStyles({ pathColor: `#0074E8`, trailColor: `gray` })}
       />
     </div>
   );
 }
-
-const connector = connect((state: UIState) => ({
-  progressPercentage: selectors.getIndexing(state),
-  viewMode: selectors.getViewMode(state),
-}));
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export default connector(IndexingLoader);

--- a/src/ui/components/shared/IndexingLoader.tsx
+++ b/src/ui/components/shared/IndexingLoader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 import { useSelector } from "react-redux";
 import { getIndexingProgress } from "ui/reducers/app";
@@ -6,31 +6,10 @@ import { getViewMode } from "ui/reducers/layout";
 
 export default function IndexingLoader() {
   const progress = useSelector(getIndexingProgress);
-  const viewMode = useSelector(getViewMode);
-  const [isDone, setDone] = useState(false);
 
-  // Set the indexing loader to done immediately, if
-  // the loader just mounted and is at 100
-  useEffect(() => {
-    if (progress == 100) {
-      setDone(true);
-    }
-  }, []);
-
-  useEffect(() => {
-    let timeout: NodeJS.Timeout;
-    if (!isDone && progress == 100) {
-      timeout = setTimeout(() => setDone(true), 2000);
-    }
-
-    return () => clearTimeout(timeout);
-  }, [progress]);
-
-  if (progress === null || viewMode == "non-dev") {
+  if (progress === 100 || progress === null) {
     return null;
   }
-
-  console.log({ progress });
 
   return (
     <div className="absolute h-7 w-7" title={`Indexing (${progress.toFixed()}%)`}>

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -259,22 +259,30 @@ export const getIndexingProgress = (state: UIState) => {
     return null;
   }
 
-  const indexedProgress = regions.indexed.reduce(
-    (sum, region) => sum + (region.end.time - region.begin.time),
-    0
-  );
-  const loadingProgress = regions.loading.reduce(
+  const { loading, indexed } = regions;
+
+  const indexedProgress = indexed
+    .filter(indexedRegion => {
+      // It's possible for the indexedProgress to not be a subset of
+      // loadingRegions. This acts as a guard if that should happen.
+      // Todo: Investigate this on the backend.
+      return loading.some(
+        loadingRegion =>
+          indexedRegion.begin.time >= loadingRegion.begin.time &&
+          indexedRegion.end.time <= loadingRegion.end.time
+      );
+    })
+    .reduce((sum, region) => sum + (region.end.time - region.begin.time), 0);
+  const loadingProgress = loading.reduce(
     (sum, region) => sum + (region.end.time - region.begin.time),
     0
   );
 
-  console.log({indexedProgress, loadingProgress});
-  
-  return indexedProgress / loadingProgress * 100;
+  return (indexedProgress / loadingProgress) * 100 || 0;
 };
 export const getIsIndexed = (state: UIState) => {
   return getIndexingProgress(state) === 100;
-}
+};
 export const getLoading = (state: UIState) => state.app.loading;
 export const getDisplayedLoadingProgress = (state: UIState) => state.app.displayedLoadingProgress;
 export const getLoadingFinished = (state: UIState) => state.app.loadingFinished;

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -252,8 +252,29 @@ export const isInspectorSelected = (state: UIState) =>
   getViewMode(state) === "dev" && getSelectedPanel(state) == "inspector";
 export const getInitializedPanels = (state: UIState) => state.app.initializedPanels;
 export const getRecordingDuration = (state: UIState) => state.app.recordingDuration;
-export const getIndexing = (state: UIState) => state.app.indexing;
-export const getIndexed = (state: UIState) => state.app.indexing == 100;
+export const getIndexingProgress = (state: UIState) => {
+  const regions = getLoadedRegions(state);
+
+  if (!regions) {
+    return null;
+  }
+
+  const indexedProgress = regions.indexed.reduce(
+    (sum, region) => sum + (region.end.time - region.begin.time),
+    0
+  );
+  const loadingProgress = regions.loading.reduce(
+    (sum, region) => sum + (region.end.time - region.begin.time),
+    0
+  );
+
+  console.log({indexedProgress, loadingProgress});
+  
+  return indexedProgress / loadingProgress * 100;
+};
+export const getIsIndexed = (state: UIState) => {
+  return getIndexingProgress(state) === 100;
+}
 export const getLoading = (state: UIState) => state.app.loading;
 export const getDisplayedLoadingProgress = (state: UIState) => state.app.displayedLoadingProgress;
 export const getLoadingFinished = (state: UIState) => state.app.loadingFinished;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -9,6 +9,7 @@ import {
   KeyboardEventKind,
   MouseEventKind,
   ExecutionPoint,
+  TimeStampedPointRange,
 } from "@recordreplay/protocol";
 import type { RecordingTarget } from "protocol/thread/thread";
 import { Workspace } from "ui/types";
@@ -70,6 +71,12 @@ export interface UploadInfo {
 
 export type AppTheme = "light" | "dark";
 
+interface LoadedRegions {
+  loading: TimeStampedPointRange[];
+  loaded: TimeStampedPointRange[];
+  indexed: TimeStampedPointRange[];
+}
+
 export interface AppState {
   mode: AppMode;
   analysisPoints: AnalysisPoints;
@@ -83,7 +90,7 @@ export interface AppState {
   indexing: number;
   initializedPanels: PanelName[];
   isNodePickerActive: boolean;
-  loadedRegions: loadedRegions | null;
+  loadedRegions: LoadedRegions | null;
   loading: number;
   loadingFinished: boolean;
   loadingPageTipIndex: number;

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -3,7 +3,6 @@ import {
   PointDescription,
   Location,
   MouseEvent,
-  loadedRegions,
   KeyboardEvent,
   NavigationEvent,
   KeyboardEventKind,
@@ -71,7 +70,7 @@ export interface UploadInfo {
 
 export type AppTheme = "light" | "dark";
 
-interface LoadedRegions {
+export interface LoadedRegions {
   loading: TimeStampedPointRange[];
   loaded: TimeStampedPointRange[];
   indexed: TimeStampedPointRange[];


### PR DESCRIPTION
Fix #5851.

- [x] Use the new indexed value from LoadedRegions
- [x] Don't differentiate between loaded/unloaded regions in the timeline

To recap:
- Now that we've landed the [backend patch](https://github.com/RecordReplay/backend/pull/5186), this fixes the way we keep track of the `indexed` value as regions become loaded/unloaded.
- This changes the way we display things in the timeline — within the focused region, we used to expose the parts that were loaded vs unloaded by differentiating them visually. This gets rid of that and just says, in the timeline, the user only cares about what's focused and what's not focused. Unloaded regions don't prohibit clicking on parts of the timeline, so this was deemed okay.
- That said, each region has an indexing state. If your current focused regions has regions are not fully-indexed (and non-indexed region also means that they're not loaded), the information in DevTools (e.g. hit counts, console messages) could be misleading. So while we're indexing, it's nice to be able to signal to the user that the UI is not fully dressed yet.
- The way we'll do this is with the indexing loader that wraps the play button. If that indexing loader/spinner is anything but 100%, then replay's still getting dressed. If it's 100%, then the user can go nuts.
- It used to be that we would hide the indexing loader once it reaches 100%. But because "We've 100% indexed everything!" is an important signal, I thought we should always show that. That's a clearer signal since we'll always display some progress between 0-100%. The current approach displays 0-99.9%, then hides the spinner when it gets to 100%. I wasn't a fan of the idea that the green light would be hidden since having to infer the green light opens up the possibility of user misinterpretation, so this was my preference. It's less subtle, but that gives us space to dial it back if we deem it too noisy and unhelpful. (This could be controversial 🙋‍♂️ @jonbell-lot23)

Follow ups:
- Remove the unloaded regions code from the `BreakpointTimeline`.
- Backend is returning indexed regions that are not strictly a subset of the loading regions. This should be fixed on the backend.
- Haven't deployed the new protocol yet so this relies on its own `LoadedRegions` type instead of importing it from the protocol.