### PR TITLE
Add security info to share dialog

### DIFF
--- a/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
+++ b/src/ui/components/shared/SharingModal/PrivacyDropdown.tsx
@@ -158,17 +158,19 @@ export default function PrivacyDropdown({ recording }: { recording: Recording })
   }
 
   return (
-    <PortalDropdown
-      buttonContent={<DropdownButton>{summary}</DropdownButton>}
-      buttonStyle={"overflow-hidden"}
-      setExpanded={setExpanded}
-      expanded={expanded}
-      distance={0}
-      position="bottom-right"
-    >
-      <Dropdown menuItemsClassName="z-50 overflow-auto max-h-48" widthClass="w-80">
-        {privacyOptions}
-      </Dropdown>
-    </PortalDropdown>
+    <>
+      <PortalDropdown
+        buttonContent={<DropdownButton>{summary}</DropdownButton>}
+        buttonStyle={"overflow-hidden"}
+        setExpanded={setExpanded}
+        expanded={expanded}
+        distance={0}
+        position="bottom-right"
+      >
+        <Dropdown menuItemsClassName="z-50 overflow-auto max-h-48" widthClass="w-80">
+          {privacyOptions}
+        </Dropdown>
+      </PortalDropdown>
+    </>
   );
 }


### PR DESCRIPTION
Fixes #6064 (Not quite, but it gets a fair amount done)

Addressed:
* Node recordings get a node message
* Normal recordings get a cookies message

Not addressed:
* I dropped the "learn more" link because it was going to cause a modal on top of a modal from a tiny box with three tight links. The overall result was ridiculous; what we really need to do is address the overall design. Perhaps with a pattern similar to our upload screen, where clicking more info shows a little pane to the side.

Node recording before change:
![image](https://user-images.githubusercontent.com/9154902/162112538-a950a2b8-c9d1-4fc8-9a23-af2da7db4d55.png)

Node recording after change:
![image](https://user-images.githubusercontent.com/9154902/162112557-3beeca3a-994f-4cb8-87f1-5136c0c8dd2e.png)

Normal recording before change:
![image](https://user-images.githubusercontent.com/9154902/162112574-384c3237-07bd-423d-a183-c14c0bc8e717.png)

Normal recording after change:
![image](https://user-images.githubusercontent.com/9154902/162112605-6bea15c1-917f-408a-ad23-4ffc095e19da.png)

