### PR TITLE
Don't show the trial notice in the header if the workspace already has a payment method

### DIFF
--- a/src/ui/components/Header/RecordingTrialEnd.tsx
+++ b/src/ui/components/Header/RecordingTrialEnd.tsx
@@ -8,7 +8,7 @@ export function RecordingTrialEnd() {
   const { recording, loading } = hooks.useGetRecording(recordingId);
 
   const workspace = recording?.workspace;
-  if (loading || !workspace || !inUnpaidFreeTrial(workspace)) {
+  if (loading || !workspace || !inUnpaidFreeTrial(workspace) || workspace.hasPaymentMethod) {
     return null;
   }
 

--- a/src/ui/graphql/recordings.ts
+++ b/src/ui/graphql/recordings.ts
@@ -37,6 +37,7 @@ export const GET_RECORDING = gql`
       workspace {
         id
         name
+        hasPaymentMethod
         subscription {
           status
           trialEnds


### PR DESCRIPTION
Fix #6214.