### PR TITLE
Fix showing expired badge for teams with a payment method

### DIFF
--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -83,7 +83,7 @@ export interface Subscription {
   createdAt: string;
   seatCount: number;
   effectiveFrom?: string;
-  effectiveUntil?: string;
+  effectiveUntil: string;
   createdBy: User;
   status: WorkspaceSubscriptionStatus;
   trialEnds: string | null;

--- a/src/ui/utils/workspace.ts
+++ b/src/ui/utils/workspace.ts
@@ -16,22 +16,20 @@ export function subscriptionEndsIn(workspace: Workspace, date?: Date | number) {
   const subscription = workspace.subscription;
 
   if (!subscription) {
-    return 0;
+    return Infinity;
   }
 
   if (
     subscription.status === WorkspaceSubscriptionStatus.Canceled ||
     subscription.status === WorkspaceSubscriptionStatus.Incomplete
   ) {
-    return subscription.effectiveUntil
-      ? differenceInCalendarDays(new Date(subscription.effectiveUntil), date)
-      : 0;
+    return differenceInCalendarDays(new Date(subscription.effectiveUntil), date);
   }
 
   if (subscription.status === WorkspaceSubscriptionStatus.Active) {
-    // TODO: Use the following when effective_until is always populated
-    // return !workspace.hasPaymentMethod ? subscription.effectiveUntil : Infinity;
-    return Infinity;
+    return !workspace.hasPaymentMethod
+      ? differenceInCalendarDays(new Date(subscription.effectiveUntil), date)
+      : Infinity;
   }
 
   return differenceInCalendarDays(new Date(subscription.trialEnds!), date);
@@ -40,7 +38,7 @@ export function subscriptionEndsIn(workspace: Workspace, date?: Date | number) {
 export function subscriptionExpired(workspace: Workspace, date?: Date) {
   const expiresIn = subscriptionEndsIn(workspace, date);
 
-  return expiresIn <= 0;
+  return expiresIn < 0;
 }
 
 export function decodeWorkspaceId(workspaceId: string | null) {


### PR DESCRIPTION
The logic for determining that a sub was expiring was failing because the "date in calendar days" was 0 but since the customer has a payment method, that's okay!

https://app.replay.io/recording/replay-with-expired-fixed--b15d847e-c096-43a2-827a-5609ee38e6ae