### PR TITLE
Progress bar and timeline colour tweaks

### DIFF
--- a/src/ui/components/Timeline/Timeline.css
+++ b/src/ui/components/Timeline/Timeline.css
@@ -155,7 +155,7 @@
 }
 
 .timeline .progress-line.preview-max {
-  border-top-color: #89ceee; /* primary accent color at 40% opacity */
+  border-top-color: #a6d4fa; /* primary accent color at 40% opacity */
 }
 
 .timeline .unloaded-regions,

--- a/src/ui/components/shared/IndexingLoader.tsx
+++ b/src/ui/components/shared/IndexingLoader.tsx
@@ -16,7 +16,7 @@ export default function IndexingLoader() {
       <CircularProgressbar
         value={progress}
         strokeWidth={14}
-        styles={buildStyles({ pathColor: `#0074E8`, trailColor: `gray` })}
+        styles={buildStyles({ pathColor: `#0074E8`, trailColor: `var(--theme-base-100)` })}
       />
     </div>
   );


### PR DESCRIPTION
The progress bar was using gray before, but I dialled it back to be more subtle. (and work in both themes)

Fixes #6269