### PR TITLE
Fix React DevTool left/right arrow toggle keys

### DIFF
--- a/src/ui/utils/key-shortcuts.ts
+++ b/src/ui/utils/key-shortcuts.ts
@@ -145,6 +145,11 @@ export default class KeyShortcuts {
   }
 
   handleEvent(event: KeyboardEvent) {
+    if (event.defaultPrevented) {
+      // Something else (e.g. React DevTools) has already claimed this event.
+      return;
+    }
+
     for (const [key, shortcut] of this.keys) {
       if (this.doesEventMatchShortcut(event, shortcut)) {
         this.eventEmitter.emit(key, event);


### PR DESCRIPTION
Fixes #6273.

Noticed a bug with the embedded React DevTools left/right arrow keys not working. These keys are supposed to collapse/toggle the React component subtree that's selected (similar to how the Elements panel works). Turns out this wasn't working because of how Replay _recreates_ the React DevTools anytime the `currentPoint` changes. (IMO we should "fix" this but that's a bigger discussion.)

Anyway the cause turned out to be that both React DevTools _and_ Replay were both handling the left/right key event. The fix is for Replay to respect `event.defaultPrevented`.

https://app.replay.io/recording/react-devtools-leftright-arrow-functionality-fixed--71debddd-7141-47f5-891d-2c2a94d53306