### PR TITLE
React DevTools skips protocol version check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "react-canvas-confetti": "^1.3.0",
         "react-circular-progressbar": "^2.0.4",
         "react-codemirror2": "^7.2.1",
-        "react-devtools-inline": "^4.24.3",
+        "react-devtools-inline": "^4.24.4",
         "react-devtools-inline_4_17_0": "npm:react-devtools-inline@4.17.0",
         "react-dom": "^0.0.0-experimental-e7d0053e6-20220325",
         "react-dom-factories": "^1.0.2",
@@ -38069,7 +38069,7 @@
       }
     },
     "node_modules/react-devtools-inline": {
-      "version": "4.24.3",
+      "version": "4.24.4",
       "license": "MIT"
     },
     "node_modules/react-devtools-inline_4_17_0": {
@@ -70200,7 +70200,7 @@
       "requires": {}
     },
     "react-devtools-inline": {
-      "version": "4.24.3"
+      "version": "4.24.4"
     },
     "react-devtools-inline_4_17_0": {
       "version": "npm:react-devtools-inline@4.17.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-circular-progressbar": "^2.0.4",
     "react-codemirror2": "^7.2.1",
     "react-devtools-inline_4_17_0": "npm:react-devtools-inline@4.17.0",
-    "react-devtools-inline": "^4.24.3",
+    "react-devtools-inline": "^4.24.4",
     "react-dom": "^0.0.0-experimental-e7d0053e6-20220325",
     "react-dom-factories": "^1.0.2",
     "react-json-view": "^1.21.3",

--- a/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReactDevTools.tsx
@@ -223,7 +223,10 @@ function createReactDevTools(
   const target = { postMessage() {} };
   const wall = new ReplayWall(enablePicker, disablePicker, onShutdown);
   const bridge = createBridge(target, wall);
-  const store = createStore(bridge, { supportsNativeInspection: true });
+  const store = createStore(bridge, {
+    checkBridgeProtocolCompatibility: false,
+    supportsNativeInspection: true,
+  });
   wall.store = store;
   const ReactDevTools = initialize(target, { bridge, store });
 

--- a/src/ui/components/SecondaryToolbox/react-devtools-inline.d.ts
+++ b/src/ui/components/SecondaryToolbox/react-devtools-inline.d.ts
@@ -180,7 +180,7 @@ https: declare module "react-devtools-inline/frontend" {
   export function createBridge(contentWindow: Target, wall?: Wall): FrontendBridge;
   export function createStore(
     bridge: FrontendBridge,
-    config?: { supportsNativeInspection?: boolean }
+    config?: { checkBridgeProtocolCompatibility?: boolean; supportsNativeInspection?: boolean }
   ): Store;
   export function initialize(
     contentWindow: Target,


### PR DESCRIPTION
Resolves #6249

Upgrades `react-devtools-inline` to version [4.24.4.](https://github.com/facebook/react/blob/main/packages/react-devtools/CHANGELOG.md#4244) which allows Replay to disable the bridge protocol version check.