### PR TITLE
Use the requestCause if the type is not known

### DIFF
--- a/src/graphql/GetRecording.ts
+++ b/src/graphql/GetRecording.ts
@@ -31,6 +31,7 @@ export interface GetRecording_recording_workspace {
   __typename: "Workspace";
   id: string;
   name: string;
+  hasPaymentMethod: boolean;
   subscription: GetRecording_recording_workspace_subscription | null;
 }
 

--- a/src/stories/NetworkMonitor/RequestDetail.stories.tsx
+++ b/src/stories/NetworkMonitor/RequestDetail.stories.tsx
@@ -20,6 +20,7 @@ export const Basic = Template.bind({});
 
 Basic.args = {
   request: {
+    cause: "fetch",
     documentType: "application/octet-stream",
     domain: "assets.website-files.com",
     end: 984,

--- a/src/stories/NetworkMonitor/utils.ts
+++ b/src/stories/NetworkMonitor/utils.ts
@@ -79,6 +79,7 @@ export const requestSummary = (
   contentType: string = "application/json"
 ): RequestSummary => {
   return {
+    cause: "fetch",
     domain: "replay.io",
     documentType: "html",
     end: 1700,

--- a/src/ui/components/NetworkMonitor/RequestDetails.tsx
+++ b/src/ui/components/NetworkMonitor/RequestDetails.tsx
@@ -171,7 +171,7 @@ const HeadersPanel = ({ request }: { request: RequestSummary }) => {
     { name: "URL", value: <FormattedUrl url={request.url} /> },
     { name: "Request Method", value: request.method },
     { name: "Status Code", value: String(request.status) },
-    { name: "Type", value: request.documentType },
+    { name: "Type", value: request.documentType || request.cause || "unknown" },
     { name: "Start", value: `${request.start}ms` },
   ];
   if (request.firstByte) {
@@ -193,7 +193,7 @@ const HeadersPanel = ({ request }: { request: RequestSummary }) => {
     <>
       <div
         className={classNames(
-          "flex cursor-pointer items-center py-1 font-bold justify-between pr-2"
+          "flex cursor-pointer items-center justify-between py-1 pr-2 font-bold"
         )}
         onClick={() => setRequestExpanded(!requestExpanded)}
       >

--- a/src/ui/components/NetworkMonitor/Table.tsx
+++ b/src/ui/components/NetworkMonitor/Table.tsx
@@ -53,7 +53,7 @@ export default function Table({
       },
       {
         Header: "Type",
-        accessor: "documentType" as const,
+        accessor: (req: RequestSummary) => req.documentType || req.cause,
         className: "",
         width: 125,
       },

--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -27,8 +27,9 @@ export enum CanonicalRequestType {
 }
 
 export type RequestSummary = {
+  cause: string | undefined;
   domain: string;
-  documentType: string;
+  documentType: string | undefined;
   end: number | undefined;
   firstByte: number | undefined;
   hasResponseBody: boolean;
@@ -153,8 +154,9 @@ export const partialRequestsToCompleteSummaries = (
       const request = r.events.request;
       const response = r.events.response;
       const requestDone = r.events["request-done"];
-      const documentType = response ? getDocumentType(response.event.responseHeaders) : "unknown";
+      const documentType = response ? getDocumentType(response.event.responseHeaders) : undefined;
       return {
+        cause: request.event.requestCause,
         documentType,
         domain: host(request.event.requestUrl),
         firstByte: response?.time,


### PR DESCRIPTION
This mimics what Chrome and FF net monitors do. This way, we are always
providing *some* useful information with this column, rather than a
bunch of `unknown`s.

Fixes https://github.com/RecordReplay/devtools/issues/6276

Before

![CleanShot 2022-04-08 at 16 19 03](https://user-images.githubusercontent.com/5903784/162545622-04f1d3ee-a69e-418a-b47f-264d78dde66c.png)


After

![CleanShot 2022-04-08 at 16 16 46](https://user-images.githubusercontent.com/5903784/162545550-bb784801-7023-424c-91a5-199fbda9b109.png)
