### PR TITLE
Fix the stack trace in the network monitor

### DIFF
--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -22,6 +22,7 @@ import {
   fetchRequestBody,
   hideRequestDetails,
   showRequestDetails,
+  fetchFrames,
 } from "ui/actions/network";
 import { getThreadContext } from "devtools/client/debugger/src/selectors";
 import LoadingProgressBar from "../shared/LoadingProgressBar";
@@ -103,6 +104,7 @@ export const NetworkMonitor = ({
                 currentTime={currentTime}
                 onRowSelect={row => {
                   trackEvent("net_monitor.select_request_row");
+                  dispatch(fetchFrames(row.point));
 
                   if (row.hasResponseBody) {
                     dispatch(fetchResponseBody(row.id, row.point.point));


### PR DESCRIPTION
I rarely use this feature so I didn't notice (and apparently neither did anyone else so maybe we should take that as info that we should deprioritize https://github.com/RecordReplay/devtools/issues/5108), but the stack trace tab of the network monitor request detail pane has been broken for at least a month. I was undertaking https://github.com/RecordReplay/devtools/issues/5108 when I noticed, but that ticket has a lot more going on, this is a simple fix for just *showing* the stack trace.