### PR TITLE
Refactor "global keyboard shortcuts" setup

### DIFF
--- a/src/devtools/client/debugger/src/actions/ui.js
+++ b/src/devtools/client/debugger/src/actions/ui.js
@@ -22,6 +22,7 @@ import { getEditor, getLocationsInViewport } from "../utils/editor";
 import { searchContents } from "./file-search";
 import { copyToTheClipboard } from "../utils/clipboard";
 import { isFulfilled } from "../utils/async-value";
+import { closeQuickOpen } from "../reducers/quick-open";
 
 import { getCodeMirror } from "devtools/client/debugger/src/utils/editor";
 import { resizeBreakpointGutter } from "../utils/ui";
@@ -45,7 +46,7 @@ export function setActiveSearch(activeSearch) {
     }
 
     if (getQuickOpenEnabled(getState())) {
-      dispatch({ type: "CLOSE_QUICK_OPEN" });
+      dispatch(closeQuickOpen());
     }
 
     dispatch({

--- a/src/devtools/shared/services.d.ts
+++ b/src/devtools/shared/services.d.ts
@@ -5,3 +5,9 @@ export const prefs: {
   removeObserver: (domain: string, observer: (prefs: any) => void) => void;
 };
 export const pref: (key: string, value: any) => void;
+
+export default {
+  appinfo: {
+    get OS(): "Linux" | "WINNT" | "Darwin" | "Unknown";,
+  },
+};

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import KeyShortcuts from "devtools/client/shared/key-shortcuts";
-import { usesWindow } from "../../ssr";
+
 import { connect, ConnectedProps } from "react-redux";
 import { UIState } from "ui/state";
 import { selectors } from "ui/reducers";
@@ -10,18 +10,7 @@ import { trackEvent } from "ui/utils/telemetry";
 import { deselectSource } from "devtools/client/debugger/src/actions/sources/select";
 import { getCommandPaletteInput } from "./CommandPalette/SearchInput";
 import { getSelectedSource } from "devtools/client/debugger/src/reducers/sources";
-import { isEditableElement } from "ui/utils/key-shortcuts";
-
-function setupShortcuts() {
-  return usesWindow(win => {
-    if (!win) {
-      return null;
-    }
-    return new KeyShortcuts({ window: win, target: win.document });
-  });
-}
-
-const globalShortcuts = setupShortcuts();
+import { isEditableElement, addGlobalShortcut, removeGlobalShortcut } from "ui/utils/key-shortcuts";
 
 function KeyboardShortcuts({
   showCommandPaletteInEditor,
@@ -36,19 +25,6 @@ function KeyboardShortcuts({
   viewMode,
   toggleTheme,
 }: PropsFromRedux) {
-  const addShortcut = (key: string, callback: (e: KeyboardEvent) => void) => {
-    if (!globalShortcuts) {
-      return;
-    }
-    globalShortcuts.on(key, callback);
-  };
-  const removeShortcut = (key: string, callback: (e: KeyboardEvent) => void) => {
-    if (!globalShortcuts) {
-      return;
-    }
-    globalShortcuts.off(key, callback);
-  };
-
   const openFullTextSearch = (e: KeyboardEvent) => {
     e.preventDefault();
     if (viewMode !== "dev") {
@@ -96,18 +72,18 @@ function KeyboardShortcuts({
   // The shortcuts have to be reassigned every time the dependencies change,
   // otherwise we end up with a stale prop.
   useEffect(() => {
-    addShortcut("CmdOrCtrl+Shift+F", openFullTextSearch);
-    addShortcut("CmdOrCtrl+B", toggleLeftSidebar);
-    addShortcut("CmdOrCtrl+K", togglePalette);
-    addShortcut("Shift+T", onToggleTheme);
-    addShortcut("Shift+F", toggleEditFocusMode);
+    addGlobalShortcut("CmdOrCtrl+Shift+F", openFullTextSearch);
+    addGlobalShortcut("CmdOrCtrl+B", toggleLeftSidebar);
+    addGlobalShortcut("CmdOrCtrl+K", togglePalette);
+    addGlobalShortcut("Shift+T", onToggleTheme);
+    addGlobalShortcut("Shift+F", toggleEditFocusMode);
 
     return () => {
-      removeShortcut("CmdOrCtrl+Shift+F", openFullTextSearch);
-      removeShortcut("CmdOrCtrl+B", toggleLeftSidebar);
-      removeShortcut("CmdOrCtrl+K", togglePalette);
-      removeShortcut("Shift+T", onToggleTheme);
-      removeShortcut("Shift+F", toggleEditFocusMode);
+      removeGlobalShortcut("CmdOrCtrl+Shift+F", openFullTextSearch);
+      removeGlobalShortcut("CmdOrCtrl+B", toggleLeftSidebar);
+      removeGlobalShortcut("CmdOrCtrl+K", togglePalette);
+      removeGlobalShortcut("Shift+T", onToggleTheme);
+      removeGlobalShortcut("Shift+F", toggleEditFocusMode);
     };
   }, [viewMode, selectedSource]);
 

--- a/src/ui/utils/key-shortcuts.ts
+++ b/src/ui/utils/key-shortcuts.ts
@@ -1,7 +1,8 @@
-const Services = require("devtools/shared/services");
+import Services from "devtools/shared/services";
+import EventEmitter from "devtools/shared/event-emitter";
+import { KeyCodes } from "devtools/client/shared/keycodes";
+
 const isOSX = Services.appinfo.OS === "Darwin";
-const EventEmitter = require("devtools/shared/event-emitter");
-const { KeyCodes } = require("devtools/client/shared/keycodes");
 
 // List of electron keys mapped to DOM API (DOM_VK_*) key code
 const ElectronKeysMapping: Record<string, string> = {
@@ -214,7 +215,7 @@ export default class KeyShortcuts {
         // When Alt is involved, some platforms (macOS) give different printable characters
         // for the `key` value, like `®` for the key `R`.  In this case, prefer matching by
         // `keyCode` instead.
-        shortcut.keyCode = KeyCodes[`DOM_VK_${key.toUpperCase()}`];
+        shortcut.keyCode = KeyCodes[`DOM_VK_${key.toUpperCase()}` as keyof typeof KeyCodes];
         shortcut.keyCodeString = key;
       } else {
         // Match any single character
@@ -223,7 +224,7 @@ export default class KeyShortcuts {
     } else if (key && key in ElectronKeysMapping) {
       // Maps the others manually to DOM API DOM_VK_*
       key = ElectronKeysMapping[key];
-      shortcut.keyCode = KeyCodes[key];
+      shortcut.keyCode = KeyCodes[key as keyof typeof KeyCodes];
       // Used only to stringify the shortcut
       shortcut.keyCodeString = key;
       shortcut.key = key;

--- a/src/ui/utils/key-shortcuts.ts
+++ b/src/ui/utils/key-shortcuts.ts
@@ -1,6 +1,7 @@
 import Services from "devtools/shared/services";
 import EventEmitter from "devtools/shared/event-emitter";
 import { KeyCodes } from "devtools/client/shared/keycodes";
+import { usesWindow } from "../../ssr";
 
 const isOSX = Services.appinfo.OS === "Darwin";
 
@@ -311,3 +312,30 @@ export default class KeyShortcuts {
     );
   }
 }
+
+function setupGlobalShortcuts() {
+  return usesWindow(win => {
+    if (!win) {
+      return null;
+    }
+    const shortcuts = new KeyShortcuts();
+    shortcuts.attach(window.document);
+    return shortcuts;
+  });
+}
+
+export const globalShortcuts = setupGlobalShortcuts();
+
+export const addGlobalShortcut = (key: string, callback: (e: KeyboardEvent) => void) => {
+  if (!globalShortcuts) {
+    return;
+  }
+  globalShortcuts.on(key, callback);
+};
+
+export const removeGlobalShortcut = (key: string, callback: (e: KeyboardEvent) => void) => {
+  if (!globalShortcuts) {
+    return;
+  }
+  globalShortcuts.off(key, callback);
+};


### PR DESCRIPTION
This PR:

- Updates `ui/utils/key-shortcuts.ts` to use ESM imports, including improving a typedef for a "services" file
- Updates the "global shortcuts" handling in `KeyboardShortcuts.tsx`:
  - Moves the setup for the "global shortcuts" instance of the `KeyShortcuts` class to live in `ui/utils/key-shortcuts.ts` (which also means changing which copy of the `KeyShortcuts` code is being used)
  - Refactors the "add/remove listener" logic to use a lookup table and a couple loops in an effect, to avoid the duplication of keys and callbacks that was previously necessary
- Fixes a broken "close quick open" action dispatch