### PR TITLE
fix: apply dark mode styles to PendingTeam screen & prompt

### DIFF
--- a/src/ui/components/Library/PendingTeamPrompt.tsx
+++ b/src/ui/components/Library/PendingTeamPrompt.tsx
@@ -8,6 +8,7 @@ import * as selectors from "ui/reducers/app";
 import * as actions from "ui/actions/app";
 import { UIState } from "ui/state";
 import { useConfirm } from "../shared/Confirm";
+import styles from "./Library.module.css";
 
 type PendingTeamPromptProps = PropsFromRedux & { workspace: PendingWorkspaceInvitation };
 
@@ -47,7 +48,9 @@ function PendingTeamPrompt({ workspace, setWorkspaceId }: PendingTeamPromptProps
 
   return (
     <div className="absolute top-0 left-0 grid h-full w-full items-center">
-      <div className="mx-auto flex max-w-lg flex-col space-y-4 rounded-md bg-white py-8 px-12 shadow-lg">
+      <div
+        className={`mx-auto flex max-w-lg flex-col space-y-4 rounded-md bg-white py-8 px-12 shadow-lg ${styles.libraryWrapper}`}
+      >
         <div className="flex flex-col space-y-1">
           <div className="text-lg">
             You were invited to <strong>{name}</strong>

--- a/src/ui/components/Library/PendingTeamPrompt.tsx
+++ b/src/ui/components/Library/PendingTeamPrompt.tsx
@@ -8,7 +8,6 @@ import * as selectors from "ui/reducers/app";
 import * as actions from "ui/actions/app";
 import { UIState } from "ui/state";
 import { useConfirm } from "../shared/Confirm";
-import styles from "./Library.module.css";
 
 type PendingTeamPromptProps = PropsFromRedux & { workspace: PendingWorkspaceInvitation };
 

--- a/src/ui/components/Library/PendingTeamPrompt.tsx
+++ b/src/ui/components/Library/PendingTeamPrompt.tsx
@@ -48,9 +48,7 @@ function PendingTeamPrompt({ workspace, setWorkspaceId }: PendingTeamPromptProps
 
   return (
     <div className="absolute top-0 left-0 grid h-full w-full items-center">
-      <div
-        className={`mx-auto flex max-w-lg flex-col space-y-4 rounded-md bg-white py-8 px-12 shadow-lg ${styles.libraryWrapper}`}
-      >
+      <div className="mx-auto flex max-w-lg flex-col space-y-4 rounded-md bg-modalBgcolor py-8 px-12 shadow-lg">
         <div className="flex flex-col space-y-1">
           <div className="text-lg">
             You were invited to <strong>{name}</strong>

--- a/src/ui/components/Library/PendingTeamScreen.tsx
+++ b/src/ui/components/Library/PendingTeamScreen.tsx
@@ -3,7 +3,6 @@ import { PendingWorkspaceInvitation } from "ui/types";
 import { getDisplayedUrl } from "ui/utils/environment";
 import PendingTeamPrompt from "./PendingTeamPrompt";
 import { getDurationString, getRelativeDate } from "./RecordingRow";
-import styles from "./Library.module.css";
 
 const MOCK_DATA = [
   { date: "2021-12-01T18:37:44.077Z", user: { name: "Jaril" } },

--- a/src/ui/components/Library/PendingTeamScreen.tsx
+++ b/src/ui/components/Library/PendingTeamScreen.tsx
@@ -3,6 +3,7 @@ import { PendingWorkspaceInvitation } from "ui/types";
 import { getDisplayedUrl } from "ui/utils/environment";
 import PendingTeamPrompt from "./PendingTeamPrompt";
 import { getDurationString, getRelativeDate } from "./RecordingRow";
+import styles from "./Library.module.css";
 
 const MOCK_DATA = [
   { date: "2021-12-01T18:37:44.077Z", user: { name: "Jaril" } },
@@ -85,7 +86,9 @@ export function PendingTeamScreen({ workspace }: { workspace: PendingWorkspaceIn
   const { name } = workspace;
 
   return (
-    <div className="-5 flex flex-col space-y-5 overflow-auto bg-gray-100 px-8 py-6">
+    <div
+      className={`-5 flex flex-col space-y-5 overflow-auto bg-gray-100 px-8 py-6 ${styles.libraryWrapper}`}
+    >
       <div className="flex flex-row items-center justify-between">
         <div className="flex flex-row items-center space-x-2 text-2xl font-semibold">
           <span>{name}</span>

--- a/src/ui/components/Library/PendingTeamScreen.tsx
+++ b/src/ui/components/Library/PendingTeamScreen.tsx
@@ -86,9 +86,7 @@ export function PendingTeamScreen({ workspace }: { workspace: PendingWorkspaceIn
   const { name } = workspace;
 
   return (
-    <div
-      className={`-5 flex flex-col space-y-5 overflow-auto bg-gray-100 px-8 py-6 ${styles.libraryWrapper}`}
-    >
+    <div className="-5 flex flex-col space-y-5 overflow-auto px-8 py-6">
       <div className="flex flex-row items-center justify-between">
         <div className="flex flex-row items-center space-x-2 text-2xl font-semibold">
           <span>{name}</span>


### PR DESCRIPTION
This PR fixes the styles for `PendingTeamScreen.tsx` & `PendingTeamPrompt.tsx` when in dark mode. (Fixes #6254 )

cc: @jaril 

UPDATED SCREENSHOTS
---
![image](https://user-images.githubusercontent.com/53361996/163049425-0991052f-b571-40bb-b635-512888fce133.png)
![image](https://user-images.githubusercontent.com/53361996/163049460-77bf1e53-9237-4063-8e78-1f2ddb3ad5f4.png)

