### PR TITLE
Move semgrep ignore to same line

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -37,11 +37,7 @@ function Panel({
   clearHoveredItem,
 }) {
   const [editing, setEditing] = useState(false);
-
-  {
-    /* nosemgrep typescript.react.best-practice.react-props-in-state.react-props-in-state */
-  }
-  const [showCondition, setShowCondition] = useState(!!breakpoint.options.condition);
+  const [showCondition, setShowCondition] = useState(Boolean(breakpoint.options.condition)); // nosemgrep
   const [width, setWidth] = useState(getPanelWidth(editor));
   const [inputToFocus, setInputToFocus] = useState("logValue");
   const dismissNag = hooks.useDismissNag();


### PR DESCRIPTION
I got fooled two ways:

1) Semgrep on a branch runs only on the changed lines, while on `master` it runs on the project I think?
2) It's impossible with the combination of `prettier` and `semgrep` to do what I tried to do in https://github.com/RecordReplay/devtools/pull/6317/files#diff-ce40a81081579d80a585e6e60ea798dcd962b4e7a9cfddf743a9045f0c2bed99R40-R43 because prettier will break the comment up into multiple lines and the `nosemgrep` declaration only works for the *next* line (which `prettier` makes sure is just `}`).

This should take care of both of those issues I think?

Fixes https://github.com/RecordReplay/devtools/issues/6259