### PR TITLE
Fixed the tooltip to center with the button #6331

### DIFF
--- a/src/ui/components/shared/IconWithTooltip.tsx
+++ b/src/ui/components/shared/IconWithTooltip.tsx
@@ -42,7 +42,7 @@ function IconTooltip({ targetNode, children }: { targetNode: HTMLElement; childr
   let style = { top: `${top}px`, left: `${left}px` };
 
   return ReactDOM.createPortal(
-    <div className="icon-tooltip absolute z-10 ml-10 mt-1" style={style}>
+    <div className="icon-tooltip absolute z-10 ml-10 mt-0.5" style={style}>
       <div className="rounded-md bg-gray-700 py-1 px-2 text-sm text-white">{children}</div>
     </div>,
     document.body


### PR DESCRIPTION
Setting the margin top to half of the original value seems to have centered it for all of the toolbar buttons. If you would like me to look for an alternative solution, id be glad to try!

Fix #6331.