### PR TITLE
Fix auth refresh logic

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,7 +5,7 @@ import Head from "next/head";
 import type { AppContext, AppProps } from "next/app";
 import { useRouter } from "next/router";
 import NextApp from "next/app";
-import React, { ReactNode, useEffect, useLayoutEffect, useState } from "react";
+import React, { ReactNode, useEffect, useMemo, useState } from "react";
 import { IntercomProvider } from "react-use-intercom";
 import { Provider } from "react-redux";
 import { Store } from "redux";
@@ -184,7 +184,7 @@ function Routing({ Component, pageProps }: AppProps) {
   const [store, setStore] = useState<Store | null>(null);
   const { getFeatureFlag } = useLaunchDarkly();
 
-  useLayoutEffect(() => {
+  useMemo(() => {
     resetCache();
   }, [token.token]);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,7 +5,7 @@ import Head from "next/head";
 import type { AppContext, AppProps } from "next/app";
 import { useRouter } from "next/router";
 import NextApp from "next/app";
-import React, { ReactNode, useEffect, useMemo, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { IntercomProvider } from "react-use-intercom";
 import { Provider } from "react-redux";
 import { Store } from "redux";
@@ -19,7 +19,7 @@ import { InstallRouteListener } from "ui/utils/routeListener";
 import { useLaunchDarkly } from "ui/utils/launchdarkly";
 import { pingTelemetry } from "ui/utils/replay-telemetry";
 import tokenManager from "ui/utils/tokenManager";
-import { ApolloWrapper, resetCache } from "ui/utils/apolloClient";
+import { ApolloWrapper } from "ui/utils/apolloClient";
 
 import "image/image.css";
 import "image/icon.css";
@@ -128,7 +128,6 @@ import "ui/components/Timeline/Tooltip.css";
 import "ui/components/Toolbox.css";
 import "ui/components/Transcript/Transcript.css";
 import "ui/utils/sourcemapVisualizer.css";
-import useToken from "ui/utils/useToken";
 
 interface AuthProps {
   apiKey?: string;
@@ -180,13 +179,8 @@ function AppUtilities({ children }: { children: ReactNode }) {
   );
 }
 function Routing({ Component, pageProps }: AppProps) {
-  const token = useToken();
   const [store, setStore] = useState<Store | null>(null);
   const { getFeatureFlag } = useLaunchDarkly();
-
-  useMemo(() => {
-    resetCache();
-  }, [token.token]);
 
   useEffect(() => {
     bootstrapApp().then((store: Store) => setStore(store));

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,7 +5,7 @@ import Head from "next/head";
 import type { AppContext, AppProps } from "next/app";
 import { useRouter } from "next/router";
 import NextApp from "next/app";
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useLayoutEffect, useState } from "react";
 import { IntercomProvider } from "react-use-intercom";
 import { Provider } from "react-redux";
 import { Store } from "redux";
@@ -19,7 +19,7 @@ import { InstallRouteListener } from "ui/utils/routeListener";
 import { useLaunchDarkly } from "ui/utils/launchdarkly";
 import { pingTelemetry } from "ui/utils/replay-telemetry";
 import tokenManager from "ui/utils/tokenManager";
-import { ApolloWrapper } from "ui/utils/apolloClient";
+import { ApolloWrapper, resetCache } from "ui/utils/apolloClient";
 
 import "image/image.css";
 import "image/icon.css";
@@ -128,6 +128,7 @@ import "ui/components/Timeline/Tooltip.css";
 import "ui/components/Toolbox.css";
 import "ui/components/Transcript/Transcript.css";
 import "ui/utils/sourcemapVisualizer.css";
+import useToken from "ui/utils/useToken";
 
 interface AuthProps {
   apiKey?: string;
@@ -179,8 +180,13 @@ function AppUtilities({ children }: { children: ReactNode }) {
   );
 }
 function Routing({ Component, pageProps }: AppProps) {
+  const token = useToken();
   const [store, setStore] = useState<Store | null>(null);
   const { getFeatureFlag } = useLaunchDarkly();
+
+  useLayoutEffect(() => {
+    resetCache();
+  }, [token.token]);
 
   useEffect(() => {
     bootstrapApp().then((store: Store) => setStore(store));

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -19,6 +19,7 @@ import setup from "ui/setup/dynamic/devtools";
 import { GetStaticProps } from "next/types";
 import { extractIdAndSlug } from "ui/utils/helpers";
 import { setModal } from "ui/actions/app";
+import useToken from "ui/utils/useToken";
 
 interface MetadataProps {
   metadata?: {
@@ -112,6 +113,7 @@ function RecordingPage({
   setExpectedError,
   head,
 }: PropsFromRedux & { head?: React.ReactNode }) {
+  const token = useToken();
   const store = useStore();
   const { query } = useRouter();
   const dispatch = useDispatch();
@@ -141,7 +143,7 @@ function RecordingPage({
       }
     }
     getRecording();
-  }, [recordingId, rawRecordingId, store, getAccessibleRecording, setExpectedError]);
+  }, [recordingId, rawRecordingId, store, getAccessibleRecording, setExpectedError, token.token]);
 
   if (!recording || typeof window === "undefined") {
     return (

--- a/src/ui/utils/apolloClient.tsx
+++ b/src/ui/utils/apolloClient.tsx
@@ -78,11 +78,6 @@ export function ApolloWrapper({
   );
 }
 
-export async function resetCache() {
-  const apolloClient = await clientWaiter.promise;
-  return await apolloClient.resetStore();
-}
-
 export async function query({ variables = {}, query }: { variables: any; query: DocumentNode }) {
   const apolloClient = await clientWaiter.promise;
   return await apolloClient.query({ variables, query });

--- a/src/ui/utils/apolloClient.tsx
+++ b/src/ui/utils/apolloClient.tsx
@@ -18,7 +18,7 @@ import { isTest, isMock, waitForMockEnvironment } from "ui/utils/environment";
 import useToken from "ui/utils/useToken";
 import { PopupBlockedError } from "ui/components/shared/Error";
 
-const clientWaiter = defer<ApolloClient<NormalizedCacheObject>>();
+let clientWaiter = defer<ApolloClient<NormalizedCacheObject>>();
 
 export function ApolloWrapper({
   children,
@@ -78,6 +78,11 @@ export function ApolloWrapper({
   );
 }
 
+export async function resetCache() {
+  const apolloClient = await clientWaiter.promise;
+  return await apolloClient.resetStore();
+}
+
 export async function query({ variables = {}, query }: { variables: any; query: DocumentNode }) {
   const apolloClient = await clientWaiter.promise;
   return await apolloClient.query({ variables, query });
@@ -100,6 +105,11 @@ export const createApolloClient = memoizeLast(function (
   token: string | undefined,
   onAuthError?: () => void
 ) {
+  let previousWaiter = clientWaiter;
+  clientWaiter = defer<ApolloClient<NormalizedCacheObject>>();
+
+  clientWaiter.promise.then(previousWaiter.resolve);
+
   const retryLink = createRetryLink();
   const errorLink = createErrorLink(onAuthError);
   const httpLink = createHttpLink(token);

--- a/src/ui/utils/browser.ts
+++ b/src/ui/utils/browser.ts
@@ -23,8 +23,8 @@ export function setAccessTokenInBrowserPrefs(token: string | null) {
 
 export function listenForAccessToken(callback: (accessToken: string) => void) {
   window.addEventListener("WebChannelMessageToContent", (ev: any) => {
-    const token = ev.detail?.message?.token;
-    if (token) {
+    const { error, token } = ev.detail?.message || {};
+    if (!error) {
       callback(token);
     }
   });

--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -41,9 +41,7 @@ class TokenManager {
 
     if (typeof window !== "undefined") {
       listenForAccessToken(token => {
-        if (token) {
-          this.setExternalAuth(token);
-        }
+        this.setExternalAuth(token);
       });
     }
   }


### PR DESCRIPTION
## Issue

If you have multiple app.replay.io tabs open in the Replay browser and log out in one, it does not log you out of the others.

## Resolution

* Invalidate the apollo cache on auth change so logging out does not give continued access to previously retrieved data
* Revalidate a recording is accessible on token change

## Additional items

There's still an outstanding item where the "Private Recording" modal still appears after logging back into the app in another tab. Tried to create a replay of this but it's challenging across auth sessions.