### PR TITLE
Add login button for Replay browser-initiated auth flow

### DIFF
--- a/src/ui/utils/browser.ts
+++ b/src/ui/utils/browser.ts
@@ -38,3 +38,14 @@ export function listenForAccessToken(callback: (accessToken: string) => void) {
     })
   );
 }
+
+export function requestBrowserLogin() {
+  window.dispatchEvent(
+    new window.CustomEvent("WebChannelMessageToChrome", {
+      detail: JSON.stringify({
+        id: "record-replay-token",
+        message: { type: "login" },
+      }),
+    })
+  );
+}


### PR DESCRIPTION
Adds a new login button that triggers the external auth flow if you're in the replay browser

https://www.loom.com/share/1e15cd8cb92f4a4ab1a24ba6fe64c310