### PR TITLE
Fix QA Wolf test related to navigating while editing focus

### DIFF
--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -95,10 +95,6 @@ class Timeline extends Component<PropsFromRedux, { isDragging: boolean }> {
     }
   };
 
-  onMouseDown = () => {
-    this.setState({ isDragging: true });
-  };
-
   onPlayerMouseMove = (e: MouseEvent | React.MouseEvent) => {
     const { hoverTime, setTimelineToTime, setTimelineState, isFocusing, focusRegion } = this.props;
     const mouseTime = this.getMouseTime(e);
@@ -154,7 +150,6 @@ class Timeline extends Component<PropsFromRedux, { isDragging: boolean }> {
     }
 
     trackEvent("timeline.progress_select");
-    this.setState({ isDragging: false });
     if (!(hoverTime === null || clickedOnCommentMarker || clickedOnUnfocusedRegion)) {
       const event = mostRecentPaintOrMouseEvent(mouseTime);
       if (event && event.point) {
@@ -376,7 +371,6 @@ class Timeline extends Component<PropsFromRedux, { isDragging: boolean }> {
               onMouseMove={e => this.onPlayerMouseMove(e)}
               onMouseUp={e => this.onPlayerMouseUp(e)}
               onMouseEnter={this.onPlayerMouseEnter}
-              onMouseDown={this.onMouseDown}
             >
               <div className="progress-line full" />
               <div


### PR DESCRIPTION
Fix #6392

https://user-images.githubusercontent.com/15959269/163447934-0480df36-47c2-433d-bffb-8fae4fd9fd42.mov

`isDragging` was flipped to `true` whenever there was a mousedown in the timeline. This was unintended — isDragging is only supposed to be toggled when the user is dragging the focus handlebars. 