### PR TITLE
Add an assert function that sends an error to sentry

### DIFF
--- a/src/ui/utils/assert.tsx
+++ b/src/ui/utils/assert.tsx
@@ -1,0 +1,9 @@
+import * as Sentry from "@sentry/browser";
+
+export function assert(v: any, why = ""): asserts v {
+  if (!v) {
+    const error = new Error(`Assertion Failed: ${why}`);
+    Sentry.captureException(error);
+    throw error;
+  }
+}


### PR DESCRIPTION
Putting this in primarily so that we can take advantage of sentry for things that would fail silently otherwise.

For example, we depend on the [non-null assertion operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator) quite a bit.
```
const value = valueThatExists!;
…
```
Now it can be:
```
const value = valueThatExists;
assert(valueThatExists, "this value should exist");
…
```

And we'll see in Sentry whenever that's not quite right!