### PR TITLE
Loading progress bandaid

### DIFF
--- a/src/ui/components/shared/LoadingScreen.tsx
+++ b/src/ui/components/shared/LoadingScreen.tsx
@@ -62,9 +62,17 @@ function LoadingScreen({ uploading, awaitingSourcemaps, progress }: PropsFromRed
     );
   }
 
+  // Right now there's no guarantee that once progress (basic processing progress)
+  // is at 100% that we're ready to close the loading screen and show the replay.
+  // It's possible that we're waiting on other things still (see
+  // jumpToInitialPausePoint). In that scenario, the loading progress bar appears
+  // to stall at 100%. This doesn't do much to fix it since it will still stall,
+  // but at least it will stall at <100%.
+  const adjustedProgress = Math.min(progress || 0, 90);
+
   return (
     <LoadingScreenTemplate showTips={!!progress}>
-      {progress ? <ProgressBar progress={progress} /> : null}
+      {progress ? <ProgressBar progress={adjustedProgress} /> : null}
     </LoadingScreenTemplate>
   );
 }


### PR DESCRIPTION
Fix #6401.

This doesn't fix the stalling behavior. It only makes it so that we stall at 90% instead of 100%. That way the user is not confused why we appear to have finished loading but the we're still stuck in the loading screen.