### PR TITLE
Add CMD+F (search) to Console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,7 @@
         "fs-extra": "^10.0.1",
         "graphql": "15.8.0",
         "graphqurl": "^1.0.1",
+        "identity-obj-proxy": "^3.0.0",
         "mini-css-extract-plugin": "^2.6.0",
         "node-polyfill-webpack-plugin": "^1.1.4",
         "postcss": "^8.4.12",
@@ -32218,6 +32219,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "license": "MIT",
@@ -32888,6 +32895,18 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ieee754": {
@@ -67907,6 +67926,12 @@
         }
       }
     },
+    "harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "requires": {
@@ -68360,6 +68385,15 @@
       "version": "5.1.0",
       "dev": true,
       "requires": {}
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
+      }
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "fs-extra": "^10.0.1",
     "graphql": "15.8.0",
     "graphqurl": "^1.0.1",
+    "identity-obj-proxy": "^3.0.0",
     "mini-css-extract-plugin": "^2.6.0",
     "node-polyfill-webpack-plugin": "^1.1.4",
     "postcss": "^8.4.12",

--- a/src/devtools/client/debugger/src/components/shared/SearchInput.js
+++ b/src/devtools/client/debugger/src/components/shared/SearchInput.js
@@ -32,6 +32,7 @@ class SearchInput extends Component {
   $input;
 
   static defaultProps = {
+    className: "",
     expanded: false,
     hasPrefix: false,
     selectedItemId: "",
@@ -183,6 +184,7 @@ class SearchInput extends Component {
 
   render() {
     const {
+      className,
       expanded,
       handleClose,
       onChange,
@@ -214,7 +216,7 @@ class SearchInput extends Component {
     };
 
     return (
-      <div className="search-outline">
+      <div className={`search-outline ${className || ""}`}>
         <div
           className={classnames("search-field rounded-lg", size)}
           role="combobox"

--- a/src/devtools/client/shared/react.d.ts
+++ b/src/devtools/client/shared/react.d.ts
@@ -1,0 +1,8 @@
+import "react";
+
+declare module "react" {
+  type Callback = () => void;
+
+  // useTransition() is only available in the experimental react release.
+  export function useTransition(): [isPending: boolean, startTransition: (Callback) => void];
+}

--- a/src/devtools/client/shared/react.d.ts
+++ b/src/devtools/client/shared/react.d.ts
@@ -3,6 +3,7 @@ import "react";
 declare module "react" {
   type Callback = () => void;
 
-  // useTransition() is only available in the experimental react release.
+  // The following hooks are only available in the experimental react release.
+  export function useDeferredValue(value: T): T;
   export function useTransition(): [isPending: boolean, startTransition: (Callback) => void];
 }

--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -121,7 +121,6 @@
   font-size: var(--theme-code-font-size);
   line-height: var(--console-output-line-height);
   color: var(--console-message-color);
-  background-color: var(--console-message-background);
 }
 
 @media (min-width: 1000px) {

--- a/src/devtools/client/webconsole/components/App.tsx
+++ b/src/devtools/client/webconsole/components/App.tsx
@@ -9,13 +9,13 @@ import Warning from "ui/components/shared/Warning";
 import { MouseEventHandler } from "react";
 import { useSelector } from "react-redux";
 import JSTerm from "./Input/JSTerm";
-import { ConsoleSearch, ActionsContext, StateContext, useSearch } from "./Search/";
+import { ConsoleSearch, ActionsContext, StateContext, useConsoleSearch } from "./Search/";
 
 /**
  * Console root Application component.
  */
 const App = (): JSX.Element => {
-  const [state, actions] = useSearch();
+  const [state, actions] = useConsoleSearch();
 
   // @ts-ignore
   const consoleOverflow = useSelector(state => state.messages.overflow);

--- a/src/devtools/client/webconsole/components/App.tsx
+++ b/src/devtools/client/webconsole/components/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { KeyboardEvent } from "react";
 
 // We directly require Components that we know are going to be used right away
 import ConsoleOutput from "devtools/client/webconsole/components/Output/ConsoleOutput";
@@ -8,12 +8,15 @@ import { FilterDrawer } from "./FilterDrawer";
 import Warning from "ui/components/shared/Warning";
 import { MouseEventHandler } from "react";
 import { useSelector } from "react-redux";
-import JSTerm from "devtools/client/webconsole/components/Input/JSTerm";
+import JSTerm from "./Input/JSTerm";
+import { ConsoleSearch, ActionsContext, StateContext, useSearch } from "./Search/";
 
 /**
  * Console root Application component.
  */
 const App = (): JSX.Element => {
+  const [state, actions] = useSearch();
+
   // @ts-ignore
   const consoleOverflow = useSelector(state => state.messages.overflow);
   // @ts-ignore
@@ -47,25 +50,50 @@ const App = (): JSX.Element => {
     window.jsterm?.editor.focus();
   };
 
+  const onKeyDown = (event: KeyboardEvent) => {
+    switch (event.key) {
+      case "Escape":
+        actions.hide();
+
+        event.preventDefault();
+        event.stopPropagation();
+        break;
+      case "f":
+      case "F":
+        if (event.metaKey) {
+          actions.show();
+
+          event.preventDefault();
+          event.stopPropagation();
+        }
+        break;
+    }
+  };
+
   return (
-    <div className="flex w-full flex-col">
-      <FilterBar key="filterbar" />
-      <div className="flex flex-grow overflow-hidden">
-        <FilterDrawer />
-        <div className="webconsole-app" onClick={onClick}>
-          <ConsoleNag />
-          {consoleOverflow ? (
-            <Warning link="https://www.notion.so/replayio/Debugger-Limitations-5b33bb0e5bd1459cbd7daf3234219c27#8d72d62414a7490586ee5ac3adef09fb">
-              There are too many console messages so not all are being displayed
-            </Warning>
-          ) : null}
-          <div className="flexible-output-input" key="in-out-container">
-            <ConsoleOutput key="console-output" />
-            <JSTerm />
+    <ActionsContext.Provider value={actions}>
+      <StateContext.Provider value={state}>
+        <div className="flex w-full flex-col" onKeyDown={onKeyDown}>
+          <FilterBar key="filterbar" />
+          <div className="flex flex-grow overflow-hidden">
+            <FilterDrawer />
+            <div className="webconsole-app" onClick={onClick}>
+              <ConsoleNag />
+              {consoleOverflow ? (
+                <Warning link="https://www.notion.so/replayio/Debugger-Limitations-5b33bb0e5bd1459cbd7daf3234219c27#8d72d62414a7490586ee5ac3adef09fb">
+                  There are too many console messages so not all are being displayed
+                </Warning>
+              ) : null}
+              <div className="flexible-output-input" key="in-out-container">
+                <ConsoleOutput key="console-output" />
+                <JSTerm />
+                <ConsoleSearch />
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
+      </StateContext.Provider>
+    </ActionsContext.Provider>
   );
 };
 

--- a/src/devtools/client/webconsole/components/Input/JSTerm.tsx
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useContext, useRef, useState } from "react";
 import { Editor } from "codemirror";
 import { useDispatch, useSelector } from "react-redux";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
@@ -79,6 +79,7 @@ export default function JSTerm() {
     setHistoryIndex(0);
   };
 
+  // TODO [bvaughn] Refocus JSTerm <input> when SearchInput is hidden
   return (
     <div>
       <div className="relative">
@@ -88,7 +89,7 @@ export default function JSTerm() {
           aria-live="off"
           tabIndex={-1}
         >
-          <div className="ml-3 console-chevron h-3 w-3 mr-1" />
+          <div className="console-chevron ml-3 mr-1 h-3 w-3" />
           {isInLoadedRegion ? (
             <EditorWithAutocomplete
               onEditorMount={(editor: Editor, showAutocomplete?: (show: boolean) => void) =>
@@ -113,5 +114,5 @@ function InaccessibleEditor() {
   const playback = useSelector(getPlayback);
   const msg = playback ? "Console evaluations are disabled during playback" : "Loading…";
 
-  return <div className="flex items-center h-full italic text-gray-400">{msg}</div>;
+  return <div className="flex h-full items-center italic text-gray-400">{msg}</div>;
 }

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
@@ -16,6 +16,8 @@ import { MessageContainer } from "devtools/client/webconsole/components/Output/M
 import ConsoleLoadingBar from "./ConsoleLoadingBar";
 
 import constants from "devtools/client/webconsole/constants";
+import { StateContext } from "../Search";
+import { Message } from "../../reducers/messages";
 
 function mapStateToProps(state: UIState) {
   return {
@@ -44,10 +46,16 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 class ConsoleOutput extends React.Component<PropsFromRedux> {
   outputNode = React.createRef<HTMLDivElement>();
 
+  _scrollTimeoutID: number | null = null;
+  _prevSearchResultMessage: Message | null = null;
+
+  static contextType = StateContext;
+
   componentDidMount() {
     if (this.props.visibleMessages.length > 0) {
       scrollToBottom(this.outputNode.current!);
     }
+    this.scrollCurrentSearchResultIntoView();
   }
 
   componentDidUpdate(prevProps: PropsFromRedux) {
@@ -59,17 +67,12 @@ class ConsoleOutput extends React.Component<PropsFromRedux> {
     }
 
     this.maybeScrollToResult(prevProps);
+    this.scrollCurrentSearchResultIntoView();
   }
 
-  scrollToClosestMessage() {
-    const { closestMessage } = this.props;
-
-    if (!closestMessage) {
-      return;
-    }
-
+  ensureMessageIsInView(message: Message) {
     const element: HTMLElement = this.outputNode.current!.querySelector(
-      `.message[data-message-id="${closestMessage.id}"]`
+      `.message[data-message-id="${message.id}"]`
     )!;
 
     if (!element) {
@@ -81,9 +84,43 @@ class ConsoleOutput extends React.Component<PropsFromRedux> {
       return;
     }
 
+    if (this._scrollTimeoutID) {
+      clearTimeout(this._scrollTimeoutID);
+    }
+
     // Chrome sometimes ignores element.scrollIntoView() here,
     // calling it with a little delay fixes it
-    setTimeout(() => element.scrollIntoView({ block: "center", behavior: "smooth" }));
+    this._scrollTimeoutID = setTimeout(() =>
+      element.scrollIntoView({ block: "center", behavior: "smooth" })
+    );
+  }
+
+  scrollCurrentSearchResultIntoView() {
+    const { currentIndex, results, visible } = this.context;
+
+    if (!visible) {
+      return;
+    }
+
+    const message =
+      currentIndex >= 0 && currentIndex < results.length ? results[currentIndex] : null;
+
+    // Only programmatically scroll after changes to the selected search result.
+    if (this._prevSearchResultMessage === message || message === null) {
+      return;
+    }
+
+    this._prevSearchResultMessage = message;
+
+    this.ensureMessageIsInView(message);
+  }
+
+  scrollToClosestMessage() {
+    const { closestMessage } = this.props;
+
+    if (closestMessage) {
+      this.ensureMessageIsInView(closestMessage);
+    }
   }
 
   maybeScrollToResult(prevProps: PropsFromRedux) {
@@ -151,36 +188,29 @@ class ConsoleOutput extends React.Component<PropsFromRedux> {
       loadedRegions,
     } = this.props;
 
-    const messageNodes = visibleMessages
-      .filter(messageId => {
-        const time = messages.entities[messageId]!.executionPointTime!;
-        return loadedRegions!.loaded.some(
-          region => time >= region.begin.time && time <= region.end.time
-        );
-      })
-      .map((messageId, i) => {
-        const message = messages.entities[messageId]!;
-        // @ts-ignore ExecutionPoint/string mismatch
-        const isPrimaryHighlighted = hoveredItem?.point === message.executionPoint;
-        const shouldScrollIntoView = isPrimaryHighlighted && hoveredItem?.target !== "console";
+    const messageNodes = visibleMessages.map((messageId, i) => {
+      const message = messages.entities[messageId]!;
+      // @ts-ignore ExecutionPoint/string mismatch
+      const isPrimaryHighlighted = hoveredItem?.point === message.executionPoint;
+      const shouldScrollIntoView = isPrimaryHighlighted && hoveredItem?.target !== "console";
 
-        return React.createElement(MessageContainer, {
-          dispatch,
-          key: messageId,
-          messageId,
-          message,
-          open: messagesUi.includes(messageId),
-          // TODO Reconsider this when we rebuild message grouping
-          payload: undefined,
-          timestampsVisible,
+      return React.createElement(MessageContainer, {
+        dispatch,
+        key: messageId,
+        messageId,
+        message,
+        open: messagesUi.includes(messageId),
+        // TODO Reconsider this when we rebuild message grouping
+        payload: undefined,
+        timestampsVisible,
 
-          pausedExecutionPoint,
-          isPaused: closestMessage?.id == messageId,
-          isFirstMessageForPoint: this.getIsFirstMessageForPoint(i, visibleMessages),
-          isPrimaryHighlighted,
-          shouldScrollIntoView,
-        });
+        pausedExecutionPoint,
+        isPaused: closestMessage?.id == messageId,
+        isFirstMessageForPoint: this.getIsFirstMessageForPoint(i, visibleMessages),
+        isPrimaryHighlighted,
+        shouldScrollIntoView,
       });
+    });
 
     return (
       <div className="webconsole-output" ref={this.outputNode} role="main">

--- a/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
+++ b/src/devtools/client/webconsole/components/Output/ConsoleOutput.tsx
@@ -96,14 +96,13 @@ class ConsoleOutput extends React.Component<PropsFromRedux> {
   }
 
   scrollCurrentSearchResultIntoView() {
-    const { currentIndex, results, visible } = this.context;
+    const { index, results, visible } = this.context;
 
     if (!visible) {
       return;
     }
 
-    const message =
-      currentIndex >= 0 && currentIndex < results.length ? results[currentIndex] : null;
+    const message = index >= 0 && index < results.length ? results[index] : null;
 
     // Only programmatically scroll after changes to the selected search result.
     if (this._prevSearchResultMessage === message || message === null) {

--- a/src/devtools/client/webconsole/components/Output/GripMessageBody.js
+++ b/src/devtools/client/webconsole/components/Output/GripMessageBody.js
@@ -37,9 +37,6 @@ function GripMessageBody(props) {
     maybeScrollToBottom,
   } = props;
 
-  // TODO [bvaughn] Respect search query by wrapping matches in a <mark> tag,
-  // TODO [bvaughn] Highlight the current match specifically.
-
   let styleObject;
   if (userProvidedStyle && userProvidedStyle !== "") {
     styleObject = cleanupStyle(userProvidedStyle, nodename => document.createElement(nodename));

--- a/src/devtools/client/webconsole/components/Output/GripMessageBody.js
+++ b/src/devtools/client/webconsole/components/Output/GripMessageBody.js
@@ -37,6 +37,9 @@ function GripMessageBody(props) {
     maybeScrollToBottom,
   } = props;
 
+  // TODO [bvaughn] Respect search query by wrapping matches in a <mark> tag,
+  // TODO [bvaughn] Highlight the current match specifically.
+
   let styleObject;
   if (userProvidedStyle && userProvidedStyle !== "") {
     styleObject = cleanupStyle(userProvidedStyle, nodename => document.createElement(nodename));

--- a/src/devtools/client/webconsole/components/Output/Message.js
+++ b/src/devtools/client/webconsole/components/Output/Message.js
@@ -106,7 +106,9 @@ class Message extends React.Component {
       this.props.pausedExecutionPoint !== nextProps.pausedExecutionPoint ||
       this.props.isPaused !== nextProps.isPaused ||
       this.props.timestampsVisible !== nextProps.timestampsVisible ||
-      this.props.open !== nextProps.open
+      this.props.open !== nextProps.open ||
+      // This is a hack to work around the memoization limitations of this component.
+      this.props.topLevelClasses.join(",") !== nextProps.topLevelClasses.join(",")
     );
   }
 

--- a/src/devtools/client/webconsole/components/Output/MessageContainer.js
+++ b/src/devtools/client/webconsole/components/Output/MessageContainer.js
@@ -65,13 +65,8 @@ export class MessageContainer extends React.Component {
     const MessageComponent = getMessageComponent(message);
 
     let topLevelClassName = null;
-    const { currentIndex, results, visible } = this.context;
-    if (
-      visible &&
-      currentIndex >= 0 &&
-      currentIndex < results.length &&
-      message === results[currentIndex]
-    ) {
+    const { index, results, visible } = this.context;
+    if (visible && index >= 0 && index < results.length && message === results[index]) {
       topLevelClassName = styles.CurrentSearchResult;
     }
 

--- a/src/devtools/client/webconsole/components/Output/MessageContainer.js
+++ b/src/devtools/client/webconsole/components/Output/MessageContainer.js
@@ -14,6 +14,9 @@ import DefaultRenderer from "./message-types/DefaultRenderer";
 import EvaluationResult from "./message-types/EvaluationResult";
 import PageError from "./message-types/PageError";
 
+import styles from "./MessageContainer.module.css";
+import { StateContext } from "../Search";
+
 const { MESSAGE_SOURCE, MESSAGE_TYPE } = require("devtools/client/webconsole/constants");
 
 export class MessageContainer extends React.Component {
@@ -32,6 +35,8 @@ export class MessageContainer extends React.Component {
       shouldScrollIntoView: PropTypes.bool.isRequired,
     };
   }
+
+  static contextType = StateContext;
 
   static get defaultProps() {
     return {
@@ -58,7 +63,21 @@ export class MessageContainer extends React.Component {
   render() {
     const message = this.props.message;
     const MessageComponent = getMessageComponent(message);
-    return <MessageComponent {...this.props} message={message} />;
+
+    let topLevelClassName = null;
+    const { currentIndex, results, visible } = this.context;
+    if (
+      visible &&
+      currentIndex >= 0 &&
+      currentIndex < results.length &&
+      message === results[currentIndex]
+    ) {
+      topLevelClassName = styles.CurrentSearchResult;
+    }
+
+    return (
+      <MessageComponent {...this.props} message={message} topLevelClassName={topLevelClassName} />
+    );
   }
 }
 

--- a/src/devtools/client/webconsole/components/Output/MessageContainer.js
+++ b/src/devtools/client/webconsole/components/Output/MessageContainer.js
@@ -66,6 +66,8 @@ export class MessageContainer extends React.Component {
 
     let topLevelClassName = null;
     const { index, results, visible } = this.context;
+
+    // Highlight this row if the console search UI is visible/active and it is the currently selected result.
     if (visible && index >= 0 && index < results.length && message === results[index]) {
       topLevelClassName = styles.CurrentSearchResult;
     }

--- a/src/devtools/client/webconsole/components/Output/MessageContainer.module.css
+++ b/src/devtools/client/webconsole/components/Output/MessageContainer.module.css
@@ -1,0 +1,3 @@
+.CurrentSearchResult {
+  background-color: var(--theme-contrast-background);
+}

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
@@ -23,6 +23,7 @@ ConsoleApiCall.propTypes = {
   maybeScrollToBottom: PropTypes.func,
   isPrimaryHighlighted: PropTypes.bool.isRequired,
   shouldScrollIntoView: PropTypes.bool.isRequired,
+  topLevelClassName: PropTypes.string,
 };
 
 ConsoleApiCall.defaultProps = {
@@ -43,6 +44,7 @@ export default function ConsoleApiCall(props) {
     isFirstMessageForPoint,
     isPrimaryHighlighted,
     shouldScrollIntoView,
+    topLevelClassName,
   } = props;
   const {
     id: messageId,
@@ -130,6 +132,9 @@ export default function ConsoleApiCall(props) {
 
   const collapsible = isGroupType(type) || (level === "error" && Array.isArray(stacktrace));
   const topLevelClasses = ["cm-s-mozilla"];
+  if (topLevelClassName) {
+    topLevelClasses.push(topLevelClassName);
+  }
   return React.createElement(Message, {
     messageId,
     executionPoint,

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleCommand.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleCommand.js
@@ -13,13 +13,15 @@ ConsoleCommand.propTypes = {
   message: PropTypes.object.isRequired,
   timestampsVisible: PropTypes.bool.isRequired,
   maybeScrollToBottom: PropTypes.func,
+  topLevelClassName: PropTypes.string,
 };
 
 /**
  * Displays input from the console.
  */
 export default function ConsoleCommand(props) {
-  const { message, timestampsVisible, maybeScrollToBottom, isPaused, dispatch } = props;
+  const { message, timestampsVisible, maybeScrollToBottom, isPaused, dispatch, topLevelClassName } =
+    props;
   const { indent, source, type, level, timeStamp, executionPointTime } = message;
   const messageText = trimCode(message.messageText);
 
@@ -31,7 +33,7 @@ export default function ConsoleCommand(props) {
     source,
     type,
     level,
-    topLevelClasses: [],
+    topLevelClasses: topLevelClassName ? [topLevelClassName] : [],
     messageBody,
     indent,
     timeStamp,

--- a/src/devtools/client/webconsole/components/Output/message-types/EvaluationResult.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/EvaluationResult.js
@@ -17,6 +17,7 @@ EvaluationResult.propTypes = {
   timestampsVisible: PropTypes.bool.isRequired,
   maybeScrollToBottom: PropTypes.func,
   open: PropTypes.bool,
+  topLevelClassName: PropTypes.string,
 };
 
 EvaluationResult.defaultProps = {
@@ -24,7 +25,15 @@ EvaluationResult.defaultProps = {
 };
 
 export default function EvaluationResult(props) {
-  const { dispatch, message, timestampsVisible, maybeScrollToBottom, open, isPaused } = props;
+  const {
+    dispatch,
+    message,
+    timestampsVisible,
+    maybeScrollToBottom,
+    open,
+    isPaused,
+    topLevelClassName,
+  } = props;
 
   const {
     source,
@@ -65,6 +74,9 @@ export default function EvaluationResult(props) {
   }
 
   const topLevelClasses = ["cm-s-mozilla"];
+  if (topLevelClassName) {
+    topLevelClasses.push(topLevelClassName);
+  }
 
   return React.createElement(Message, {
     dispatch,

--- a/src/devtools/client/webconsole/components/Output/message-types/PageError.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/PageError.js
@@ -17,6 +17,7 @@ PageError.propTypes = {
   open: PropTypes.bool,
   timestampsVisible: PropTypes.bool.isRequired,
   maybeScrollToBottom: PropTypes.func,
+  topLevelClassName: PropTypes.string,
 };
 
 PageError.defaultProps = {
@@ -34,6 +35,7 @@ export default function PageError(props) {
     maybeScrollToBottom,
     pausedExecutionPoint,
     isFirstMessageForPoint,
+    topLevelClassName,
   } = props;
   const {
     id: messageId,
@@ -71,7 +73,7 @@ export default function PageError(props) {
     source,
     type,
     level,
-    topLevelClasses: [],
+    topLevelClasses: topLevelClassName ? [topLevelClassName] : [],
     indent: message.indent,
     messageBody,
     repeat,

--- a/src/devtools/client/webconsole/components/Output/message-types/PaywallMessage.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/PaywallMessage.js
@@ -13,20 +13,22 @@ PaywallMessage.propTypes = {
   message: PropTypes.object.isRequired,
   timestampsVisible: PropTypes.bool.isRequired,
   maybeScrollToBottom: PropTypes.func,
+  topLevelClassName: PropTypes.string,
 };
 
 /**
  * Displays input from the console.
  */
 export default function PaywallMessage(props) {
-  const { message, timestampsVisible, maybeScrollToBottom, isPaused, dispatch } = props;
+  const { message, timestampsVisible, maybeScrollToBottom, isPaused, dispatch, topLevelClassName } =
+    props;
   const { indent, source, level, timeStamp, executionPointTime } = message;
 
   return React.createElement(Message, {
     source,
     type: "paywall",
     level,
-    topLevelClasses: [],
+    topLevelClasses: topLevelClassName ? [topLevelClassName] : [],
     messageBody: React.createElement("span", {
       className: "text-gray-500 font-bold",
       children: "Evaluations are only available for Developers in the Team plan.",

--- a/src/devtools/client/webconsole/components/Search/ConsoleSearch.module.css
+++ b/src/devtools/client/webconsole/components/Search/ConsoleSearch.module.css
@@ -1,0 +1,11 @@
+.SearchBar {
+  width: 100%;
+  height: var(--editor-searchbar-height);
+  display: flex;
+  align-items: center;
+  border-top: 1px solid var(--theme-splitter-color);
+}
+
+.SearchInput {
+  flex: 1;
+}

--- a/src/devtools/client/webconsole/components/Search/ConsoleSearch.tsx
+++ b/src/devtools/client/webconsole/components/Search/ConsoleSearch.tsx
@@ -1,0 +1,66 @@
+import React, { ChangeEvent, KeyboardEvent, useContext } from "react";
+import SearchInput from "devtools/client/debugger/src/components/shared/SearchInput";
+import styles from "./ConsoleSearch.module.css";
+import { ActionsContext, StateContext } from "./ConsoleSearchContext";
+
+/******************************************************************
+  Search feature
+
+  Phase 1:
+    * Search logic should be re-run when any of the following change:
+      * Search state changes from inactive to active (and !!query)
+      * Query text changes (and state == active)
+      * Console log text changes (and state == active)
+        * Future optimization: If possible, only evaluate new entries if change is additive?
+    * Search results should be higher in the tree so that...
+      * Search state is shared between console and search input
+      * Search state is persisted if input is closed and reopened
+    * Jumping to next/previous search should auto scroll MessageContainer into view
+
+  Phase 2:
+    * Searching (heavy lifting) should be done in a worker
+      * Could we use a module-level Suspense cache for this?
+        This cache could be cleared when the Console data changed?
+******************************************************************/
+
+type Props = {};
+
+export default function ConsoleSearch({}: Props) {
+  const actions = useContext(ActionsContext);
+  const state = useContext(StateContext);
+
+  if (!state.visible) {
+    return null;
+  }
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter") {
+      if (event.shiftKey) {
+        actions.goToPrevious();
+      } else {
+        actions.goToNext();
+      }
+    }
+  };
+
+  const onChange = (event: ChangeEvent) => {
+    const newQuery = (event.target as HTMLInputElement).value;
+    actions.search(newQuery);
+  };
+
+  return (
+    <div className={styles.SearchBar}>
+      <SearchInput
+        className={styles.SearchInput}
+        count={state.results.length}
+        handleClose={actions.hide}
+        handleNext={actions.goToNext}
+        handlePrev={actions.goToPrevious}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        placeholder="Find string in logs"
+        query={state.query}
+      />
+    </div>
+  );
+}

--- a/src/devtools/client/webconsole/components/Search/ConsoleSearchContext.tsx
+++ b/src/devtools/client/webconsole/components/Search/ConsoleSearchContext.tsx
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+
+import type { Actions, State } from "./useSearch";
+
+// Storing state and dispatch in separate contexts allows parts of the tree to access the (state) dispatch function
+// without re-rendering when the state value changes.
+export const ActionsContext = createContext<Actions>(null as any);
+export const StateContext = createContext<State>(null as any);

--- a/src/devtools/client/webconsole/components/Search/ConsoleSearchContext.tsx
+++ b/src/devtools/client/webconsole/components/Search/ConsoleSearchContext.tsx
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-import type { Actions, State } from "./useSearch";
+import type { Actions, State } from "./useConsoleSearch";
 
 // Storing state and dispatch in separate contexts allows parts of the tree to access the (state) dispatch function
 // without re-rendering when the state value changes.

--- a/src/devtools/client/webconsole/components/Search/index.ts
+++ b/src/devtools/client/webconsole/components/Search/index.ts
@@ -1,5 +1,6 @@
 import ConsoleSearch from "./ConsoleSearch";
 import { ActionsContext, StateContext } from "./ConsoleSearchContext";
+import useConsoleSearch from "./useConsoleSearch";
 import useSearch from "./useSearch";
 
-export { ActionsContext, ConsoleSearch, StateContext, useSearch };
+export { ActionsContext, ConsoleSearch, StateContext, useConsoleSearch, useSearch };

--- a/src/devtools/client/webconsole/components/Search/index.ts
+++ b/src/devtools/client/webconsole/components/Search/index.ts
@@ -1,0 +1,5 @@
+import ConsoleSearch from "./ConsoleSearch";
+import { ActionsContext, StateContext } from "./ConsoleSearchContext";
+import useSearch from "./useSearch";
+
+export { ActionsContext, ConsoleSearch, StateContext, useSearch };

--- a/src/devtools/client/webconsole/components/Search/useConsoleSearch.test.tsx
+++ b/src/devtools/client/webconsole/components/Search/useConsoleSearch.test.tsx
@@ -1,0 +1,166 @@
+import React from "react";
+import { act } from "react-dom/test-utils";
+import {
+  createTestStore,
+  filterCommonTestWarnings,
+  render as testUtilsRender,
+} from "test/testUtils";
+import useConsoleSearch from "./useConsoleSearch";
+import { Message } from "../../reducers/messages";
+
+import type { Actions, State } from "./useConsoleSearch";
+import type { UIStore } from "ui/actions";
+import { ValueFront } from "protocol/thread";
+import { UIState } from "ui/state";
+
+describe("useConsoleSearch", () => {
+  filterCommonTestWarnings();
+
+  let lastCommitedSearchActions: Actions | null = null;
+  let lastCommitedSearchState: State | null = null;
+  let messageIdCounter: number = 0;
+  let TestComponent: any;
+
+  beforeEach(() => {
+    lastCommitedSearchActions = null;
+    lastCommitedSearchState = null;
+    messageIdCounter = 0;
+
+    TestComponent = () => {
+      const [state, actions] = useConsoleSearch();
+      lastCommitedSearchActions = actions;
+      lastCommitedSearchState = state;
+
+      return null;
+    };
+  });
+
+  // TODO [bvaughn] This is pretty gross; can we collocate this (closer to the Redux code if nothing else)?
+  function createMessage(
+    type: string,
+    messageText: string,
+    parameters: ValueFront[] = []
+  ): Message {
+    return {
+      allowRepeating: false,
+      category: null,
+      errorMessageName: null,
+      exceptionDocURL: null,
+      executionPoint: null,
+      executionHasFrames: false,
+      executionPointTime: 1,
+      groupId: null,
+      id: `${messageIdCounter++}`,
+      indent: 0,
+      innerWindowID: null,
+      level: "",
+      messageText,
+      notes: null,
+      parameters,
+      pauseId: "",
+      repeatId: null,
+      source: "",
+      stacktrace: [],
+      type,
+      lastExecutionPoint: {
+        point: "1",
+        time: 1,
+        messageCount: 0,
+      },
+    };
+  }
+
+  function createValueFront(value: any): ValueFront {
+    return new ValueFront(null, { value });
+  }
+
+  async function createStore(messages: Message[] = []): Promise<UIStore> {
+    const messageIDs = messages.map(message => message.id);
+    const idToMessageMap = messages.reduce((map, message) => {
+      return {
+        ...map,
+        [message.id]: message,
+      };
+    }, {});
+
+    const defaultState = (await createTestStore()).getState();
+
+    return createTestStore({
+      ...defaultState,
+      app: {
+        ...defaultState.app,
+        loadedRegions: {
+          indexed: [],
+          loaded: [
+            {
+              begin: {
+                point: "0",
+                time: 0,
+              },
+              end: {
+                point: "1000",
+                time: 1000,
+              },
+            },
+          ],
+          loading: [],
+        },
+      },
+      messages: {
+        ...defaultState.messages,
+        messages: {
+          ids: messageIDs,
+          entities: idToMessageMap,
+        },
+        visibleMessages: messageIDs,
+      },
+    });
+  }
+
+  async function render(store?: UIStore) {
+    if (!store) {
+      store = await createStore([
+        createMessage("logPoint", "Plain string message"),
+        createMessage("logPoint", "", [
+          createValueFront(123),
+          createValueFront("string value"),
+          createValueFront(true),
+        ]),
+        createMessage("logPoint", "Another string message"),
+        createMessage("logPoint", "", [createValueFront("another string value")]),
+      ]);
+    }
+
+    await testUtilsRender(<TestComponent />, { store });
+  }
+
+  it("should search visible Messages", async () => {
+    await render();
+
+    console.log('search => "message"');
+    act(() => {
+      lastCommitedSearchActions?.search("message");
+    });
+
+    expect(lastCommitedSearchState?.index).toBe(0);
+    expect(lastCommitedSearchState?.results.map(result => result.id)).toMatchInlineSnapshot(`
+      Array [
+        "0",
+        "2",
+      ]
+    `);
+
+    console.log('search => "another"');
+    act(() => {
+      lastCommitedSearchActions?.search("another");
+    });
+
+    expect(lastCommitedSearchState?.index).toBe(0);
+    expect(lastCommitedSearchState?.results.map(result => result.id)).toMatchInlineSnapshot(`
+      Array [
+        "2",
+        "3",
+      ]
+    `);
+  });
+});

--- a/src/devtools/client/webconsole/components/Search/useConsoleSearch.ts
+++ b/src/devtools/client/webconsole/components/Search/useConsoleSearch.ts
@@ -11,12 +11,13 @@ function search(query: string, messages: Message[]): Message[] {
 
   const needle = query.toLocaleLowerCase();
   messages.forEach(message => {
-    console.log(message.id, 'messageText:', message.messageText);
-    if (typeof message.messageText === "string" && message.messageText.toLocaleLowerCase().includes(needle)) {
+    if (
+      typeof message.messageText === "string" &&
+      message.messageText.toLocaleLowerCase().includes(needle)
+    ) {
       results.push(message);
     } else {
       message.parameters?.some(parameter => {
-        console.log(message.id, 'parameter:', parameter);
         if (parameter.isPrimitive()) {
           if (String(parameter.primitive()).toLocaleLowerCase().includes(needle)) {
             results.push(message);

--- a/src/devtools/client/webconsole/components/Search/useConsoleSearch.ts
+++ b/src/devtools/client/webconsole/components/Search/useConsoleSearch.ts
@@ -11,10 +11,12 @@ function search(query: string, messages: Message[]): Message[] {
 
   const needle = query.toLocaleLowerCase();
   messages.forEach(message => {
-    if (typeof message.messageText === "string" && message.messageText.includes(needle)) {
+    console.log(message.id, 'messageText:', message.messageText);
+    if (typeof message.messageText === "string" && message.messageText.toLocaleLowerCase().includes(needle)) {
       results.push(message);
     } else {
       message.parameters?.some(parameter => {
+        console.log(message.id, 'parameter:', parameter);
         if (parameter.isPrimitive()) {
           if (String(parameter.primitive()).toLocaleLowerCase().includes(needle)) {
             results.push(message);

--- a/src/devtools/client/webconsole/components/Search/useConsoleSearch.ts
+++ b/src/devtools/client/webconsole/components/Search/useConsoleSearch.ts
@@ -1,0 +1,65 @@
+import { useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { useSearch } from ".";
+import { Message } from "../../reducers/messages";
+import { getMessages } from "../../selectors";
+
+import type { Actions as SearchActions, State as SearchState } from "./useSearch";
+
+function search(query: string, messages: Message[]): Message[] {
+  const results: Message[] = [];
+
+  const needle = query.toLocaleLowerCase();
+  messages.forEach(message => {
+    if (typeof message.messageText === "string" && message.messageText.includes(needle)) {
+      results.push(message);
+    } else {
+      message.parameters?.some(parameter => {
+        if (parameter.isPrimitive()) {
+          if (String(parameter.primitive()).toLocaleLowerCase().includes(needle)) {
+            results.push(message);
+            return true;
+          }
+        }
+        return false;
+      });
+    }
+  });
+
+  return results;
+}
+
+export type Actions = SearchActions<Message> & {
+  hide: () => void;
+  show: () => void;
+};
+
+export type State = SearchState<Message> & {
+  visible: boolean;
+};
+
+export default function useConsoleSearch(): [State, Actions] {
+  const messages = useSelector(getMessages);
+  const [state, dispatch] = useSearch<Message>(messages, search);
+
+  const [visible, setVisible] = useState<boolean>(false);
+
+  const externalActions = useMemo(
+    () => ({
+      ...dispatch,
+      hide: () => setVisible(false),
+      show: () => setVisible(true),
+    }),
+    [dispatch]
+  );
+
+  const externalState = useMemo(
+    () => ({
+      ...state,
+      visible,
+    }),
+    [state, visible]
+  );
+
+  return [externalState, externalActions];
+}

--- a/src/devtools/client/webconsole/components/Search/useSearch.test.tsx
+++ b/src/devtools/client/webconsole/components/Search/useSearch.test.tsx
@@ -1,0 +1,219 @@
+import React, { useState } from "react";
+import { act } from "react-dom/test-utils";
+import { filterCommonTestWarnings, render } from "test/testUtils";
+import useSearch from "./useSearch";
+
+import type { Actions, State } from "./useSearch";
+
+type Item = {
+  text: string;
+};
+
+function itemSearch(query: string, items: Item[]) {
+  query = query.toLowerCase();
+
+  return items.filter(item => item.text.toLowerCase().includes(query));
+}
+
+describe("useSearch", () => {
+  filterCommonTestWarnings();
+
+  let lastCommitedSearchActions: Actions<Item> | null = null;
+  let lastCommitedSearchState: State<Item> | null = null;
+  let updateSearchableItems: React.Dispatch<React.SetStateAction<Item[]>> | null = null;
+  let TestComponent: any;
+
+  beforeEach(() => {
+    lastCommitedSearchActions = null;
+    lastCommitedSearchState = null;
+    updateSearchableItems = null;
+
+    TestComponent = () => {
+      const [items, setItems] = useState<Item[]>([]);
+      updateSearchableItems = setItems;
+
+      const [state, actions] = useSearch<Item>(items, itemSearch);
+      lastCommitedSearchActions = actions;
+      lastCommitedSearchState = state;
+
+      return null;
+    };
+  });
+
+  it("should re-render when searchable items change", async () => {
+    await render(<TestComponent />, {});
+    expect(lastCommitedSearchState?.results).toMatchInlineSnapshot(`Array []`);
+
+    act(() => {
+      lastCommitedSearchActions?.search("ba");
+    });
+    expect(lastCommitedSearchState?.results).toMatchInlineSnapshot(`Array []`);
+
+    act(() => {
+      updateSearchableItems?.([{ text: "foo" }, { text: "bar" }, { text: "baz" }, { text: "qux" }]);
+    });
+    expect(lastCommitedSearchState?.results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "text": "bar",
+        },
+        Object {
+          "text": "baz",
+        },
+      ]
+    `);
+  });
+
+  it("should re-render when search query change", async () => {
+    await render(<TestComponent />, {});
+    expect(lastCommitedSearchState?.results).toMatchInlineSnapshot(`Array []`);
+
+    act(() => {
+      updateSearchableItems?.([{ text: "foo" }, { text: "bar" }, { text: "baz" }, { text: "qux" }]);
+    });
+    expect(lastCommitedSearchState?.results).toMatchInlineSnapshot(`Array []`);
+
+    act(() => {
+      lastCommitedSearchActions?.search("ba");
+    });
+    expect(lastCommitedSearchState?.results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "text": "bar",
+        },
+        Object {
+          "text": "baz",
+        },
+      ]
+    `);
+
+    act(() => {
+      lastCommitedSearchActions?.search("blah");
+    });
+    expect(lastCommitedSearchState?.results).toMatchInlineSnapshot(`Array []`);
+  });
+
+  it("should update the selected index when search actions are called", async () => {
+    await render(<TestComponent />, {});
+    act(() => {
+      updateSearchableItems?.([{ text: "a" }, { text: "aa" }, { text: "bbb" }, { text: "aaa" }]);
+      lastCommitedSearchActions?.search("a");
+    });
+    expect(lastCommitedSearchState?.index).toBe(0);
+
+    act(() => {
+      lastCommitedSearchActions?.goToNext();
+    });
+    expect(lastCommitedSearchState?.index).toBe(1);
+
+    act(() => {
+      lastCommitedSearchActions?.goToNext();
+    });
+    expect(lastCommitedSearchState?.index).toBe(2);
+
+    act(() => {
+      lastCommitedSearchActions?.goToNext();
+    });
+    expect(lastCommitedSearchState?.index).toBe(0);
+
+    act(() => {
+      lastCommitedSearchActions?.goToPrevious();
+    });
+    expect(lastCommitedSearchState?.index).toBe(2);
+
+    act(() => {
+      lastCommitedSearchActions?.goToPrevious();
+    });
+    expect(lastCommitedSearchState?.index).toBe(1);
+
+    act(() => {
+      lastCommitedSearchActions?.goToPrevious();
+    });
+    expect(lastCommitedSearchState?.index).toBe(0);
+  });
+
+  it("should automatically update the selected index as search results change", async () => {
+    await render(<TestComponent />, {});
+    act(() => {
+      updateSearchableItems?.([{ text: "bbb" }, { text: "aa" }, { text: "aab" }, { text: "aaa" }]);
+      lastCommitedSearchActions?.search("a");
+    });
+    expect(lastCommitedSearchState).toMatchInlineSnapshot(`
+      Object {
+        "index": 0,
+        "query": "a",
+        "results": Array [
+          Object {
+            "text": "aa",
+          },
+          Object {
+            "text": "aab",
+          },
+          Object {
+            "text": "aaa",
+          },
+        ],
+      }
+    `);
+
+    // Select the second item in the matching set.
+    act(() => {
+      lastCommitedSearchActions?.goToNext();
+    });
+    expect(lastCommitedSearchState).toMatchInlineSnapshot(`
+      Object {
+        "index": 1,
+        "query": "a",
+        "results": Array [
+          Object {
+            "text": "aa",
+          },
+          Object {
+            "text": "aab",
+          },
+          Object {
+            "text": "aaa",
+          },
+        ],
+      }
+    `);
+
+    // Refine the search, so that the selected item is still in the results.
+    act(() => {
+      lastCommitedSearchActions?.search("aa");
+    });
+    expect(lastCommitedSearchState).toMatchInlineSnapshot(`
+      Object {
+        "index": 1,
+        "query": "aa",
+        "results": Array [
+          Object {
+            "text": "aa",
+          },
+          Object {
+            "text": "aab",
+          },
+          Object {
+            "text": "aaa",
+          },
+        ],
+      }
+    `);
+
+    // Refine the search, so that the selected item is no longer in the results.
+    act(() => {
+      lastCommitedSearchActions?.search("aaa");
+    });
+    expect(lastCommitedSearchState).toMatchInlineSnapshot(`
+      Object {
+        "index": 0,
+        "query": "aaa",
+        "results": Array [
+          Object {
+            "text": "aaa",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/src/devtools/client/webconsole/components/Search/useSearch.ts
+++ b/src/devtools/client/webconsole/components/Search/useSearch.ts
@@ -1,0 +1,216 @@
+import { useEffect, useMemo, useReducer, useRef, useTransition } from "react";
+import { useStore } from "react-redux";
+import { selectors } from "ui/reducers";
+import { Message } from "../../reducers/messages";
+
+export type Actions = {
+  hide: () => void;
+  goToNext: () => void;
+  goToPrevious: () => void;
+  search: (query: string) => void;
+  show: () => void;
+};
+
+export type State = {
+  _messages: Message[];
+  currentIndex: number;
+  query: string;
+  results: Message[];
+  visible: boolean;
+};
+
+type UpdateMessagesAction = { type: "updateMessages"; messages: Message[] };
+type UpdateQueryAction = { type: "updateQuery"; query: string };
+
+type Action =
+  | { type: "hide" }
+  | { type: "goToNext" }
+  | { type: "goToPrevious" }
+  | { type: "updateSearchResults" }
+  | { type: "show" }
+  | UpdateMessagesAction
+  | UpdateQueryAction;
+
+const EMPTY_ARRAY: Message[] = [];
+
+const initialState: State = {
+  _messages: [],
+  currentIndex: -1,
+  query: "",
+  results: EMPTY_ARRAY,
+  visible: false,
+};
+
+let lastSearchQuery: string = "";
+let lastSearchMessages: Message[] = [];
+let lastSearchCurrentIndex: number = -1;
+let lastSearchResults: Message[] = [];
+
+// Low budget memoization since we're searching in a reducer (which may run more than once).
+// TODO [bvaughn] Rethink the approach of searching in a reducer vs in an effect/event handler.
+function memoizedSearch(state: State): [Message[], number] {
+  const { _messages: messages, currentIndex, query, results } = state;
+
+  const prevSelectedMessage =
+    currentIndex >= 0 && results.length > 0 ? results[currentIndex] : null;
+
+  if (lastSearchQuery === query && lastSearchMessages === messages) {
+    return [lastSearchResults, lastSearchCurrentIndex];
+  }
+
+  lastSearchMessages = messages;
+  lastSearchQuery = query;
+
+  if (!query) {
+    lastSearchResults = [];
+    lastSearchCurrentIndex = -1;
+  } else {
+    lastSearchResults = [];
+    lastSearchCurrentIndex = -1;
+
+    const needle = query.toLocaleLowerCase();
+
+    messages.forEach(message => {
+      let matches = false;
+      if (typeof message.messageText === "string" && message.messageText.includes(needle)) {
+        matches = true;
+      } else {
+        matches = message.parameters?.some(parameter => {
+          if (parameter.isPrimitive()) {
+            if (String(parameter.primitive()).toLocaleLowerCase().includes(needle)) {
+              return true;
+            }
+          }
+          return false;
+        });
+      }
+
+      if (matches) {
+        lastSearchResults.push(message);
+
+        if (message === prevSelectedMessage) {
+          // If previously focused result is still in matches, update currentIndex to match.
+          lastSearchCurrentIndex = lastSearchResults.length - 1;
+        }
+      }
+    });
+  }
+
+  // If our new search doesn't contain the previously focused result, reset the index.
+  if (lastSearchCurrentIndex < 0) {
+    lastSearchCurrentIndex = 0;
+  }
+
+  return [lastSearchResults, lastSearchCurrentIndex];
+}
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "hide": {
+      return {
+        ...state,
+        visible: false,
+      };
+    }
+    case "goToNext": {
+      const { currentIndex, results } = state;
+      return {
+        ...state,
+        currentIndex: currentIndex < results.length - 1 ? currentIndex + 1 : 0,
+      };
+    }
+    case "goToPrevious": {
+      const { currentIndex, results } = state;
+      return {
+        ...state,
+        currentIndex: currentIndex > 0 ? currentIndex - 1 : results.length - 1,
+      };
+    }
+    case "updateSearchResults": {
+      const [results, currentIndex] = memoizedSearch(state);
+      return {
+        ...state,
+        currentIndex,
+        results,
+      };
+    }
+    case "updateMessages": {
+      const messages = (action as UpdateMessagesAction).messages;
+      return {
+        ...state,
+        _messages: messages,
+      };
+    }
+    case "updateQuery": {
+      const query = (action as UpdateQueryAction).query;
+      return {
+        ...state,
+        query,
+      };
+    }
+    case "show": {
+      return {
+        ...state,
+        visible: true,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export default function useSearch(): [State, Actions] {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const [_, startTransition] = useTransition();
+
+  // When messages/visibleMessages change, schedule a (low-pri) update to re-run search logic.
+  const prevMessages = useRef<Message[]>(null as any);
+  const store = useStore();
+  useEffect(() => {
+    const updateStateIfMessagesHaveChanged = () => {
+      const state = store.getState();
+      const messages = selectors.getMessages(state);
+      if (messages !== prevMessages.current) {
+        prevMessages.current = messages;
+        startTransition(() => {
+          dispatch({ type: "updateMessages", messages });
+          dispatch({ type: "updateSearchResults" });
+        });
+      }
+    };
+
+    // Check if Messages have changed between render and this effect.
+    updateStateIfMessagesHaveChanged();
+
+    return store.subscribe(updateStateIfMessagesHaveChanged);
+  }, [store]);
+
+  const actions = useMemo(
+    () => ({
+      hide: () => {
+        dispatch({ type: "hide" });
+      },
+      goToNext: () => {
+        dispatch({ type: "goToNext" });
+      },
+      goToPrevious: () => {
+        dispatch({ type: "goToPrevious" });
+      },
+      search: (query: string) => {
+        // Query text updates with high priority so the input feels snappy.
+        dispatch({ type: "updateQuery", query });
+        startTransition(() => {
+          // Search results are updated in a slightly lower priority.
+          dispatch({ type: "updateSearchResults" });
+        });
+      },
+      show: () => {
+        dispatch({ type: "show" });
+      },
+    }),
+    []
+  );
+
+  return [state, actions];
+}

--- a/src/devtools/client/webconsole/selectors/messages.ts
+++ b/src/devtools/client/webconsole/selectors/messages.ts
@@ -5,6 +5,7 @@
 import { createSelector } from "reselect";
 
 import type { UIState } from "ui/state";
+import { isTimeInRegions } from "ui/utils/timeline";
 import type { Message } from "../reducers/messages";
 import { messagesAdapter } from "../reducers/messages";
 
@@ -49,11 +50,7 @@ export const getVisibleMessages = createSelector(
       }
 
       // Filter out messages that haven't yet been loaded.
-      if (
-        !loadedRegions!.loaded.some(
-          region => executionPointTime >= region.begin.time && executionPointTime <= region.end.time
-        )
-      ) {
+      if (!isTimeInRegions(executionPointTime, loadedRegions!.loaded)) {
         return false;
       }
 

--- a/src/devtools/client/webconsole/selectors/messages.ts
+++ b/src/devtools/client/webconsole/selectors/messages.ts
@@ -35,15 +35,30 @@ export const getVisibleMessages = createSelector(
   getAllMessagesById,
   (state: UIState) => state.messages.visibleMessages,
   getFocusRegion,
-  (messages, visibleMessages, focusRegion) => {
-    const msgs = visibleMessages;
+  (state: UIState) => state.app.loadedRegions,
+  (messages, visibleMessages, focusRegion, loadedRegions) => {
+    const msgs = visibleMessages.filter(messageId => {
+      const message = messages.entities[messageId]!;
+      const executionPointTime = message.executionPointTime!;
 
-    if (focusRegion) {
-      return msgs.filter(id => {
-        const msg = messages.entities[id]!;
-        return isInTrimSpan(msg.executionPointTime, focusRegion);
-      });
-    }
+      // Filter out messages that aren't within the focused region.
+      if (focusRegion) {
+        if (!isInTrimSpan(executionPointTime, focusRegion)) {
+          return false;
+        }
+      }
+
+      // Filter out messages that haven't yet been loaded.
+      if (
+        !loadedRegions!.loaded.some(
+          region => executionPointTime >= region.begin.time && executionPointTime <= region.end.time
+        )
+      ) {
+        return false;
+      }
+
+      return true;
+    });
 
     return msgs;
   }

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -12,7 +12,7 @@ import { UIState } from "ui/state";
 import { SessionActions } from "ui/actions/session";
 import { Location } from "@recordreplay/protocol";
 import { getLocationAndConditionKey } from "devtools/client/debugger/src/utils/breakpoint";
-import { isInTrimSpan } from "ui/utils/timeline";
+import { isInTrimSpan, isTimeInRegions } from "ui/utils/timeline";
 import { compareBigInt } from "ui/utils/helpers";
 import { getFocusRegion } from "ui/reducers/timeline";
 import { getSelectedPanel, getViewMode } from "./layout";
@@ -357,10 +357,7 @@ export const getDefaultSettingsTab = (state: UIState) => state.app.defaultSettin
 export const getRecordingTarget = (state: UIState) => state.app.recordingTarget;
 export const getRecordingWorkspace = (state: UIState) => state.app.recordingWorkspace;
 export const isRegionLoaded = (state: UIState, time: number | null | undefined) =>
-  typeof time !== "number" ||
-  !!getLoadedRegions(state)?.loaded.some(
-    region => time >= region.begin.time && time <= region.end.time
-  );
+  typeof time !== "number" || isTimeInRegions(time, getLoadedRegions(state)?.loaded);
 export const getIsFocusing = (state: UIState) => getModal(state) === "focusing";
 export const areMouseTargetsLoading = (state: UIState) => state.app.mouseTargetsLoading;
 export const getCurrentPoint = (state: UIState) => state.app.currentPoint;

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -145,3 +145,7 @@ export function getPointIsInLoadedRegion(loadedRegions: TimeStampedPointRange[],
     r => BigInt(point) >= BigInt(r.begin.point) && BigInt(point) <= BigInt(r.end.point)
   );
 }
+
+export function isTimeInRegions(time: number, regions?: TimeStampedPointRange[]): boolean {
+  return !!regions?.some(region => time >= region.begin.time && time <= region.end.time);
+}


### PR DESCRIPTION
Resolves #3834

* **UI demo**: https://www.loom.com/share/dfcb19ef243f423d8e6aa95c78613939 
* **Architecture walk through**: https://www.loom.com/share/0e9ea476fc3148f68bd396ccfd70919d

## MVP changes
- [x] Implement basic search functionality.
- [x] Highlight the console row that contains the currently-focused search result.
- [x] Add unit tests for `useSearch` and `useConsoleSearch` hooks.

## Follow up changes
- [ ] Refocus the input inside of `JSTerm` when the CMD+F search input is hidden. (Currently this is refocused if you click the "x" to hide the search, but not if you hide via the "Escape" key.) I don't think this is straight forward to change because it requires an _imperative_ method call on a DOM element rendered deep inside of the "react-codemirror2" library we are using.
- [ ] Wrap subtext matches with `<mark>` tags to highlight (and highlight the currently "selected" match in a special way). 
   * Note that the pre-existing searches, like find-in-file, only highlight the _current_ result– but I think it would be better UX to highlight all matches– with a highlight that updates as you type, but a current cursor that only jumps when you type "Enter").

## Design considerations
* Search is done in the main UI thread to avoid the heavy serialization cost of a data source (console messages) that potentially changes often. (Search-in-file functionality is implemented in a worker, but file content is _static_ for the session.) If this is problematic, we could look into an amortization strategy that only sends _message diffs_ to a worker, but I think the overhead would still potentially not be worth the effort. There's also the precedent of filtering console rows in the main thread for things like the selected timeline range, loaded sections, and top-filter text.)
* The console search state is not global. It's scoped to a small part of the Replay component tree. Because of this, I choose to store it in React state rather than Redux.
* Replay already depends on an experimental version of the "react" NPM package because of [react-devtools-inline](https://github.com/facebook/react/blob/main/packages/react-devtools-inline/README.md#react-devtools-inline). Because of this, I decided to go ahead and build on top of the `useDeferredValue` hook to prepare for _when_ we update Replay to use the [`createRoot` API](https://reactjs.org/docs/react-dom-client.html#createroot).
  * Note this design decouples the query text and current results such that it's expected a component may temporarily render a query that doesn't match its results. This is being done _intentionally_ so that the search input feels responsive and updates quickly, leaving the slower search work to be done in a lower priority update. (Note that this won't matter so long as we use the legacy `render` method.)
* The bulk of the search login has been implemented as a resuable `useSearch` hook (with some basic unit tests). The console-specific Message search logic is implemented in a small `useConsoleSearch` decorator hook. (Neither hook is very large but this pattern should allow us to build additional searches more easily if we wanted to.)