### PR TITLE
Fix removing breakpoints/logpoints from the sidepanel

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/index.js
@@ -106,7 +106,5 @@ export default connect(
   }),
   {
     seek: actions.removeBreakpoint,
-    removeBreakpoint: actions.removeBreakpoint,
-    removeBreakpointsInSource: actions.removeBreakpointsInSource,
   }
 )(Breakpoints);

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/BreakpointsPane.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/BreakpointsPane.tsx
@@ -1,10 +1,14 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { removeBreakpoint, removeBreakpointsInSource } from "../../actions/breakpoints/breakpoints";
+import { Source } from "../../reducers/types";
+import { Breakpoint, Context } from "../../selectors";
 import { getBreakpointSources } from "../../selectors/breakpointSources";
 import Breakpoints from "./Breakpoints";
 
 export default function BreakpointsPane() {
   const breakpointSources = useSelector(getBreakpointSources);
+  const dispatch = useDispatch();
   const emptyContent = "Click on a line number in the editor to add a breakpoint";
 
   return (
@@ -12,6 +16,12 @@ export default function BreakpointsPane() {
       type="breakpoint"
       emptyContent={emptyContent}
       breakpointSources={breakpointSources}
+      onRemoveBreakpoint={(cx: Context, breakpoint: Breakpoint) =>
+        dispatch(removeBreakpoint(cx, breakpoint))
+      }
+      onRemoveBreakpoints={(cx: Context, source: Source) =>
+        dispatch(removeBreakpointsInSource(cx, source))
+      }
     />
   );
 }

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/LogpointsPane.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/LogpointsPane.tsx
@@ -1,10 +1,14 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { getLogpointSources } from "../../selectors/breakpointSources";
 import Breakpoints from "./Breakpoints";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
+import { removeLogpoint, removeLogpointsInSource } from "../../actions/breakpoints/logpoints";
+import { Context } from "../../selectors";
+import { Breakpoint, Source } from "../../reducers/types";
 
 export default function LogpointsPane() {
+  const dispatch = useDispatch();
   const logpointSources = useSelector(getLogpointSources);
   const emptyContent = (
     <>
@@ -21,6 +25,12 @@ export default function LogpointsPane() {
       type="print-statement"
       emptyContent={emptyContent}
       breakpointSources={logpointSources}
+      onRemoveBreakpoint={(cx: Context, breakpoint: Breakpoint) =>
+        dispatch(removeLogpoint(cx, breakpoint))
+      }
+      onRemoveBreakpoints={(cx: Context, source: Source) =>
+        dispatch(removeLogpointsInSource(cx, source))
+      }
     />
   );
 }


### PR DESCRIPTION
This was regressed by https://github.com/RecordReplay/devtools/commit/437dd450081308185ca7256a294542d03bd61626.

[Replay of the fix](https://app.replay.io/recording/deleting-breakpoints-fix--db87dc1e-59ac-41fe-aa39-d1fdd1fce4c8)

Fix #6405.