### PR TITLE
Specify load point when creating sessions

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -161,8 +161,11 @@ export function createSession(recordingId: string): UIThunkAction {
 
       dispatch(showLoadingProgress());
 
+      const loadPoint = new URL(window.location.href).searchParams.get("point");
+
       const { sessionId } = await sendMessage("Recording.createSession", {
         recordingId,
+        loadPoint,
         experimentalSettings,
       });
 

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -165,7 +165,7 @@ export function createSession(recordingId: string): UIThunkAction {
 
       const { sessionId } = await sendMessage("Recording.createSession", {
         recordingId,
-        loadPoint || undefined,
+        loadPoint: loadPoint || undefined,
         experimentalSettings,
       });
 

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -165,7 +165,7 @@ export function createSession(recordingId: string): UIThunkAction {
 
       const { sessionId } = await sendMessage("Recording.createSession", {
         recordingId,
-        loadPoint,
+        loadPoint || undefined,
         experimentalSettings,
       });
 


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/5169.  The backend now supports specifying a load point when creating sessions.  If the recording is still in progress, it will only be loaded up to the specified point.  If the recording is not in progress this has no effect, and since the only way we can get points for a recording that is still in progress is in node with the `process.recordreplay.currentPointURL()`, this should only affect that use case.