### PR TITLE
Try guarding active team block with user id check

### DIFF
--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -85,8 +85,15 @@ function ViewerRouter(props: ViewerRouterProps) {
   const { currentWorkspaceId, setUnexpectedError, setWorkspaceId } = props;
 
   useEffect(() => {
-    if (currentWorkspaceId === null && !features.library && !loading && !nonPendingLoading) {
+    if (
+      currentWorkspaceId === null &&
+      userId &&
+      !features.library &&
+      !loading &&
+      !nonPendingLoading
+    ) {
       if (!workspaces.length) {
+        sendTelemetryEvent("UnableToFindTeam", { userId: userId || "No User" });
         // This shouldn't be reachable because the library can only be disabled
         // by a workspace setting which means the user must be in a workspace
         setUnexpectedError({
@@ -107,6 +114,7 @@ function ViewerRouter(props: ViewerRouterProps) {
     setUnexpectedError,
     setWorkspaceId,
     workspaces,
+    userId,
   ]);
 
   if (loading) {


### PR DESCRIPTION
My theory here is that we're being caught by the fallback `useGetUserInfo` that returns `library: false` to ensure that we don't accidentally / temporarily show the library for orgs with that setting disabled. This only occurs when we haven't received data yet. We should be `loading` still then so this shouldn't be necessary so I've also tacked on a telemetry event to try see who's hitting this.

Might fix https://github.com/RecordReplay/customer-support/issues/73 or might just give us a new clue.