### PR TITLE
Add a unicorn to onboarding 

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/SummaryExpression.tsx
@@ -6,6 +6,8 @@ import Popup from "./Popup";
 import hooks from "ui/hooks";
 const { getCodeMirror } = require("devtools/client/debugger/src/utils/editor/create-editor");
 const { prefs } = require("ui/utils/prefs");
+import { Nag } from "ui/hooks/users";
+import { shouldShowNag } from "ui/utils/user";
 
 export interface SummaryExpressionProps {
   value: string;
@@ -36,6 +38,15 @@ function Expression({ value, isEditable }: { value: string; isEditable: boolean 
 
 export function SummaryExpression({ isEditable, value }: SummaryExpressionProps & {}) {
   const { isTeamDeveloper } = hooks.useIsTeamDeveloper();
+
+  // first-run special messaging
+  const { nags } = hooks.useGetUserInfo();
+  if (
+    shouldShowNag(nags, Nag.FIRST_BREAKPOINT_EDIT) ||
+    shouldShowNag(nags, Nag.FIRST_BREAKPOINT_SAVE)
+  ) {
+    value = "🦄 " + value;
+  }
 
   return isEditable ? (
     <div className="group flex space-x-1 px-1 hover:text-primaryAccent">


### PR DESCRIPTION
Addresses RecordReplay/design#22 (but is not working yet)

Copied from that thread:

Hey @jaril and @jasonLaster, I came up with a quick hack for our onboarding problems. I added a quick unicorn emoji for our first print statements, so at least it will show up in the console. And that means we're not waiting on our Rainbow Console designs to land.

I have it half working, but need help with the other half:
https://www.loom.com/share/656f9a0a7c144039afc2716b1635e14f

(In the interest of time, I'd rather just have someone fix this up and send it out. Learning opportunities are great, but it takes a lot more time to set up a call, do the screen share, talk about it, etc than just shipping it async)