### PR TITLE
Webconsole message component cleanup

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -1,9 +1,7 @@
-import { PointDescription } from "@recordreplay/protocol";
-import { isNumber } from "lodash";
 import React, { useRef, useState, useEffect, ReactNode } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setHoveredLineNumberLocation } from "ui/actions/app";
-import { clearHoveredItem } from "ui/actions/timeline";
+
 import { KeyModifiers } from "ui/components/KeyModifiers";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import hooks from "ui/hooks";

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -151,26 +151,28 @@ function ToggleWidgetButton({ editor, cx, breakpoints }: ToggleWidgetButtonProps
   const [targetNode, setTargetNode] = useState<HTMLElement | null>(null);
   const [hoveredLineNumber, setHoveredLineNumber] = useState<number | null>(null);
 
-  const onLineEnter = ({
-    lineNumberNode,
-    lineNumber,
-  }: {
-    lineNumberNode: HTMLElement;
-    lineNumber: number;
-  }) => {
-    setHoveredLineNumber(lineNumber);
-    setTargetNode(lineNumberNode);
-  };
-  const onLineLeave = () => {
-    setTargetNode(null);
-    setHoveredLineNumber(null);
-  };
   const bp = breakpoints.find((b: any) => b.location.line === hoveredLineNumber);
   const onMouseDown = (e: React.MouseEvent) => {
     // This keeps the cursor in CodeMirror from moving after clicking on the button.
     e.stopPropagation();
   };
+
   useEffect(() => {
+    const onLineEnter = ({
+      lineNumberNode,
+      lineNumber,
+    }: {
+      lineNumberNode: HTMLElement;
+      lineNumber: number;
+    }) => {
+      setHoveredLineNumber(lineNumber);
+      setTargetNode(lineNumberNode);
+    };
+    const onLineLeave = () => {
+      setTargetNode(null);
+      setHoveredLineNumber(null);
+    };
+
     editor.codeMirror.on("lineMouseEnter", onLineEnter);
     editor.codeMirror.on("lineMouseLeave", onLineLeave);
     return () => {

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -22,11 +22,6 @@ import { getExecutionPoint } from "../../reducers/pause";
 import { PointDescription } from "@recordreplay/protocol";
 import { seek } from "ui/actions/timeline";
 
-const { runAnalysisOnLine } = require("devtools/client/debugger/src/actions/breakpoints/index");
-const {
-  updateHoveredLineNumber,
-} = require("devtools/client/debugger/src/actions/breakpoints/index");
-
 const QuickActionButton: FC<{
   showNag: boolean;
   children: ReactNode;
@@ -182,7 +177,7 @@ function ToggleWidgetButton({ editor, cx, breakpoints }: ToggleWidgetButtonProps
       editor.codeMirror.off("lineMouseEnter", onLineEnter);
       editor.codeMirror.off("lineMouseLeave", onLineLeave);
     };
-  }, []);
+  }, [editor]);
 
   if (!targetNode || !hoveredLineNumber) {
     return null;
@@ -211,11 +206,7 @@ const connector = connect(
     cx: selectors.getThreadContext(state),
     breakpoints: getBreakpointsForSource(state, getSelectedSource(state)!.id),
   }),
-  {
-    runAnalysisOnLine: runAnalysisOnLine,
-    setHoveredLineNumberLocation: actions.setHoveredLineNumberLocation,
-    updateHoveredLineNumber: updateHoveredLineNumber,
-  }
+  {}
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;
 export default connector(ToggleWidgetButton);

--- a/src/devtools/client/webconsole/components/Output/MessageContainer.js
+++ b/src/devtools/client/webconsole/components/Output/MessageContainer.js
@@ -58,7 +58,7 @@ export class MessageContainer extends React.Component {
   render() {
     const message = this.props.message;
     const MessageComponent = getMessageComponent(message);
-    return MessageComponent(Object.assign({ message }, this.props));
+    return <MessageComponent {...this.props} message={message} />;
   }
 }
 

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleApiCall.js
@@ -14,7 +14,6 @@ const ConsoleTable = require("devtools/client/webconsole/components/Output/Conso
 const { isGroupType, l10n } = require("devtools/client/webconsole/utils/messages");
 
 const Message = require("devtools/client/webconsole/components/Output/Message");
-ConsoleApiCall.displayName = "ConsoleApiCall";
 
 ConsoleApiCall.propTypes = {
   dispatch: PropTypes.func.isRequired,

--- a/src/devtools/client/webconsole/components/Output/message-types/ConsoleCommand.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/ConsoleCommand.js
@@ -8,7 +8,6 @@
 const React = require("react");
 const PropTypes = require("prop-types");
 const Message = require("devtools/client/webconsole/components/Output/Message");
-ConsoleCommand.displayName = "ConsoleCommand";
 
 ConsoleCommand.propTypes = {
   message: PropTypes.object.isRequired,

--- a/src/devtools/client/webconsole/components/Output/message-types/DefaultRenderer.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/DefaultRenderer.js
@@ -4,8 +4,6 @@
 
 "use strict";
 
-const dom = require("react-dom-factories");
-
 export default function DefaultRenderer(props) {
-  return dom.div({}, "This message type is not supported yet.");
+  return <div>This message type is not supported yet.</div>;
 }

--- a/src/devtools/client/webconsole/components/Output/message-types/DefaultRenderer.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/DefaultRenderer.js
@@ -6,8 +6,6 @@
 
 const dom = require("react-dom-factories");
 
-DefaultRenderer.displayName = "DefaultRenderer";
-
 export default function DefaultRenderer(props) {
   return dom.div({}, "This message type is not supported yet.");
 }

--- a/src/devtools/client/webconsole/components/Output/message-types/EvaluationResult.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/EvaluationResult.js
@@ -11,8 +11,6 @@ const Message = require("devtools/client/webconsole/components/Output/Message");
 const GripMessageBody =
   require("devtools/client/webconsole/components/Output/GripMessageBody").default;
 
-EvaluationResult.displayName = "EvaluationResult";
-
 EvaluationResult.propTypes = {
   dispatch: PropTypes.func.isRequired,
   message: PropTypes.object.isRequired,

--- a/src/devtools/client/webconsole/components/Output/message-types/PageError.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/PageError.js
@@ -12,8 +12,6 @@ const { createPrimitiveValueFront } = require("protocol/thread");
 
 const { REPS, MODE } = require("devtools/packages/devtools-reps");
 
-PageError.displayName = "PageError";
-
 PageError.propTypes = {
   message: PropTypes.object.isRequired,
   open: PropTypes.bool,

--- a/src/devtools/client/webconsole/components/Output/message-types/PaywallMessage.js
+++ b/src/devtools/client/webconsole/components/Output/message-types/PaywallMessage.js
@@ -8,7 +8,6 @@
 const React = require("react");
 const PropTypes = require("prop-types");
 const Message = require("devtools/client/webconsole/components/Output/Message");
-PaywallMessage.displayName = "PaywallMessage";
 
 PaywallMessage.propTypes = {
   message: PropTypes.object.isRequired,


### PR DESCRIPTION
Stacks on top of #6422 and cleans a few additional things up.

---

Our Playwright tests are _flaky_. For example:
```sh
node ./test/run.js --pattern inspector-05
```

This failed on CI initially, so I ran it locally. It failed once and passed twice. Opening [the Replay it uses locally](http://localhost:8080/recording/replay-of-localhost8080--3dea2aa5-2b4a-46b6-ac97-32b19bc64533) (with this branch checked out) the Console seems to load okay too, so I just re-ran on CI until it passed.