### PR TITLE
Update heatmap hits count when the backend unloads a region forcibly

### DIFF
--- a/src/devtools/client/debugger/src/reducers/source-actors.ts
+++ b/src/devtools/client/debugger/src/reducers/source-actors.ts
@@ -105,7 +105,7 @@ export default function update(state = initial, action: AnyAction) {
       state = updateBreakpointHitCounts(state, action as SetSourceActorBreakpointHitCountsAction);
       break;
 
-    case "set_trim_region":
+    case "set_loaded_regions":
       state.values = clearBreakpointHitCounts(state);
       break;
 
@@ -199,7 +199,7 @@ function updateBreakpointHitCounts(
   return updateResources(state, [
     {
       id: sourceId,
-      breakpointHitCounts: [...currentBreakpointHitCounts!, ...action.value.hits],
+      breakpointHitCounts: [...(currentBreakpointHitCounts || []), ...action.value.hits],
       min: Math.min(currentMin, action.value.min),
       max: Math.max(currentMax, action.value.max),
     },


### PR DESCRIPTION
[Replay with the changes](https://app.replay.io/recording/focusing-works--8e41c9f6-b83f-4172-82cf-2be67834bf99)

<img width="2559" alt="image" src="https://user-images.githubusercontent.com/15959269/163861755-0ab7c406-3e78-4738-b400-d710990c79ea.png">

This:
- fixes an error where we had a `null` value is possibly being iterated on.
- refetches the heatmap hit count whenever the focus mode regions are altered.