### PR TITLE
Elevate ESLint react-hooks rules to error level

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,8 @@
     "react/button-has-type": 0,
     "no-nested-ternary": 0,
     "no-restricted-syntax": 0,
+    "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
+    "react-hooks/exhaustive-deps": "error", // Checks effect dependencies
     "react/no-string-refs": 0,
     "react/no-find-dom-node": 0,
     "react/no-children-prop": 0,

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,9 @@ module.exports = {
   eslint: {
     // which folders to run ESLint on during production builds (next build)
     dirs: ["src", "pages", "packages"],
+
+    // We rely on Trunk's hold-the-line functionality.
+    ignoreDuringBuilds: true,
   },
 
   productionBrowserSourceMaps: true,


### PR DESCRIPTION
Relates to #6237

We have a lot of lint violations for the react-hooks rules. Particularly "react-hooks/exhaustive-deps". In many cases, it's probably not going to cause a bug– but there is potential for subtle bugs (like stale closures) and so we should be treating these violations more seriously.

Now that #6452 has landed, `npm run lint` will run with [Trunk's hold-the-line](https://docs.trunk.io/check/overview#hold-the-line approach)– meaning that it won't complain about pre-existing lint errors.

Given that, this PR raises the ESLint level for the react-hooks from "warn" to "error" to prevent new regressions from being added to the repo.

---

Looks like there's an interesting challenge here. Next runs its own linter, which balks at these rule changes. I think this approach only works if we rely on Trunk for linting. Because of this, I've _disabled_ Next's linting during build. I'm not sure how controversial that may be.