### PR TITLE
Address pre-existing 'react-hooks/exhaustive-deps' rule violations.

### DIFF
--- a/packages/accordion/index.tsx
+++ b/packages/accordion/index.tsx
@@ -102,6 +102,9 @@ export function AccordionPane({
   // do this by intercepting the expanded state in the Accordion so we only have one
   // expanded prop (the one from the Accordion) being considered by the AccordionPane.
   // https://gist.github.com/jaril/dfad5343f141c175d767d21cd6fdaab2
+  //
+  // TODO [jcmorrow] Fix react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => dispatch(expanded ? expandSection(index!) : collapseSection(index!)), [expanded]);
 
   return (

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -10,7 +10,7 @@ export default function LoginPage() {
 
   useEffect(() => {
     dispatch(clearExpectedError());
-  }, []);
+  }, [dispatch]);
 
   return <Login returnToPath={"" + router.query.returnTo} />;
 }

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -143,7 +143,16 @@ function RecordingPage({
       }
     }
     getRecording();
-  }, [recordingId, rawRecordingId, store, getAccessibleRecording, setExpectedError, token.token]);
+  }, [
+    dispatch,
+    getAccessibleRecording,
+    query.id,
+    rawRecordingId,
+    recordingId,
+    setExpectedError,
+    store,
+    token.token,
+  ]);
 
   if (!recording || typeof window === "undefined") {
     return (

--- a/pages/recording/[id]/sourcemap/[sourceId].tsx
+++ b/pages/recording/[id]/sourcemap/[sourceId].tsx
@@ -98,11 +98,13 @@ function SourcemapVisualizer({
 }) {
   const dispatch = useDispatch();
 
+  // TODO [hbenl] Fix react-hooks/exhaustive-deps
+  // Is this really something we only want to do on-mount (even if source/map/url change)?
   useEffect(() => {
     document.body.className = "sourcemap-visualizer";
     dispatch(setAppMode("sourcemap-visualizer"));
     renderSourcemap(source, map, url, document);
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>
@@ -131,7 +133,7 @@ export default function SourceMapLoader() {
 
   useEffect(() => {
     loadSourceMap(recordingId, sourceId, store).then(setSourcemapResult);
-  }, []);
+  }, [recordingId, sourceId, store]);
 
   if (!sourcemapResult) {
     return <LoadingScreen />;

--- a/pages/team/invitation/[id].tsx
+++ b/pages/team/invitation/[id].tsx
@@ -29,6 +29,7 @@ export default function Share() {
     );
   }
 
+  // TODO [jaril] Fix react-hooks/exhaustive-deps
   useEffect(
     function handleTeamInvitationCode() {
       // The auth0 object is not reliable until the token has finished loading,
@@ -45,7 +46,7 @@ export default function Share() {
         push({ pathname: "/login", query: { returnTo: returnToPath } });
       }
     },
-    [loading]
+    [loading] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return null;

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
@@ -12,6 +12,7 @@ const TEXT = {
 
 type Step = keyof typeof TEXT;
 
+// TODO [jaril] Fix react-hooks/exhaustive-deps
 export default function FirstEditNag({ editing }: { editing: boolean }) {
   const [step, setStep] = useState<Step | null>(null);
   const { nags } = hooks.useGetUserInfo();
@@ -27,7 +28,7 @@ export default function FirstEditNag({ editing }: { editing: boolean }) {
     if (step === "savePrompt" && !shouldShowNag(nags, Nag.FIRST_BREAKPOINT_SAVE)) {
       setStep("success");
     }
-  }, [nags, editing]);
+  }, [nags, editing]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!step) {
     return null;

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import classnames from "classnames";
 import PanelEditor from "./PanelEditor";
 import BreakpointNavigation from "devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation";
@@ -52,13 +52,17 @@ function Panel({
     (analysisPoints.error || (analysisPoints.data.length || 0) > prefs.maxHitsDisplayed);
 
   useEffect(() => {
-    editor.editor.on("refresh", updateWidth);
-    dismissNag(Nag.FIRST_BREAKPOINT_ADD);
+    const updateWidth = () => setWidth(getPanelWidth(editor));
 
+    editor.editor.on("refresh", updateWidth);
     return () => {
       editor.editor.off("refresh", updateWidth);
     };
-  }, []);
+  }, [editor]);
+
+  useEffect(() => {
+    dismissNag(Nag.FIRST_BREAKPOINT_ADD);
+  }, [dismissNag]);
 
   const toggleEditingOn = () => {
     dismissNag(Nag.FIRST_BREAKPOINT_EDIT);
@@ -69,8 +73,6 @@ function Panel({
     dismissNag(Nag.FIRST_BREAKPOINT_SAVE);
     setEditing(false);
   };
-
-  const updateWidth = () => setWidth(getPanelWidth(editor));
 
   const onMouseEnter = () => {
     const hoveredItem = {

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Widget.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Widget.tsx
@@ -13,6 +13,7 @@ export default function Widget({ location, children, editor, insertAt }: WidgetP
   const [node, setNode] = useState<HTMLDivElement | null>(null);
   const [loading, setLoading] = useState(true);
 
+  // TODO [jaril] Fix react-hooks/exhaustive-deps
   useEffect(() => {
     if (loading) {
       const _node = document.createElement("div");
@@ -31,7 +32,7 @@ export default function Widget({ location, children, editor, insertAt }: WidgetP
     return () => {
       _widget.clear();
     };
-  }, [loading]);
+  }, [loading]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!node) {
     return null;

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -44,7 +44,7 @@ function BreakpointNavigation({
     if (executionPoint && lastExecutionPoint !== executionPoint) {
       setLastExecutionPoint(executionPoint);
     }
-  }, [executionPoint]);
+  }, [executionPoint, lastExecutionPoint]);
 
   useEffect(() => {
     if (analysisPoints) {

--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -36,13 +36,14 @@ export function SourceOutline({
   );
   const [focusedSymbol, setFocusedSymbol] = useState<ClassSymbol | FunctionSymbol | null>(null);
   const listRef = useRef<any>();
+
   const closestSymbolIndex = useMemo(() => {
     if (!cursorPosition) {
       return;
     }
     const symbol = findClosestEnclosedSymbol(symbols, cursorPosition);
     return outlineSymbols?.findIndex(a => a === symbol);
-  }, [cursorPosition, outlineSymbols, symbols, listRef]);
+  }, [cursorPosition, outlineSymbols, symbols]);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -50,8 +51,9 @@ export function SourceOutline({
       // We start by loading the first N lines of hits, where N is the line limit.
       dispatch(setBreakpointHitCounts(selectedSource.id, 1));
     }
-  }, [selectedSource?.id]);
+  }, [dispatch, selectedSource]);
 
+  // TODO [jasonLaster] Fix react-hooks/exhaustive-deps
   useEffect(() => {
     if (outlineSymbols && closestSymbolIndex) {
       const symbol = outlineSymbols[closestSymbolIndex];
@@ -60,7 +62,7 @@ export function SourceOutline({
         listRef.current.scrollToItem(closestSymbolIndex, "center");
       }
     }
-  }, [closestSymbolIndex]);
+  }, [closestSymbolIndex]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSelectSymbol = useCallback(
     (symbol: ClassSymbol | FunctionSymbol) => {
@@ -72,7 +74,7 @@ export function SourceOutline({
       });
       setFocusedSymbol(symbol);
     },
-    [selectedSource, cx]
+    [selectLocation, selectedSource, cx]
   );
 
   const MemoizedOutlineItem = useCallback(

--- a/src/devtools/client/inspector/markup/components/MarkupApp.tsx
+++ b/src/devtools/client/inspector/markup/components/MarkupApp.tsx
@@ -20,10 +20,12 @@ function setupLegacyComponents(inspector: Inspector) {
   new HTMLBreadcrumbs(inspector);
 }
 
-function MarkupApp(props: PropsFromRedux & { inspector: Inspector }) {
-  const isMarkupEmpty = (props.markupRootNode?.children?.length || 0) == 0;
+type PropsFromParent = { inspector: Inspector };
 
-  useEffect(() => setupLegacyComponents(props.inspector), []);
+function MarkupApp({ inspector, markupRootNode }: PropsFromRedux & PropsFromParent) {
+  const isMarkupEmpty = (markupRootNode?.children?.length || 0) == 0;
+
+  useEffect(() => setupLegacyComponents(inspector), [inspector]);
 
   return (
     <div className="devtools-inspector-tab-panel">
@@ -61,7 +63,7 @@ function MarkupApp(props: PropsFromRedux & { inspector: Inspector }) {
         <div id="markup-box" className="devtools-monospace bg-bodyBgcolor">
           <div id="markup-root-wrapper" role="presentation">
             <div id="markup-root" role="presentation">
-              {<Nodes {...props.inspector.markup.getMarkupProps()} />}
+              {<Nodes {...inspector.markup.getMarkupProps()} />}
             </div>
           </div>
           {isMarkupEmpty ? <LoadingProgressBar /> : null}

--- a/src/devtools/client/inspector/rules/components/RulesApp.tsx
+++ b/src/devtools/client/inspector/rules/components/RulesApp.tsx
@@ -50,7 +50,14 @@ export const RulesApp: FC<RulesAppProps> = ({
       showNewDeclarationEditor,
       showSelectorEditor,
     }),
-    []
+    [
+      onToggleDeclaration,
+      onToggleSelectorHighlighter,
+      showDeclarationNameEditor,
+      showDeclarationValueEditor,
+      showNewDeclarationEditor,
+      showSelectorEditor,
+    ]
   );
 
   const onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {

--- a/src/ui/components/Account/index.tsx
+++ b/src/ui/components/Account/index.tsx
@@ -13,7 +13,7 @@ export default function Account() {
 
   useEffect(() => {
     dispatch(setLoadingFinished(true));
-  }, [])
+  }, [dispatch]);
 
   if (isLoading) {
     return null;

--- a/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentEditor/TipTapEditor.tsx
@@ -108,13 +108,13 @@ const TipTapEditor = ({
     if (editable) {
       editor?.commands.focus("end");
     }
-  }, [editable]);
+  }, [editable, editor]);
 
   useEffect(() => {
     if (takeFocus) {
       editor?.commands.focus("end");
     }
-  }, [takeFocus]);
+  }, [editor, takeFocus]);
 
   return (
     <div

--- a/src/ui/components/Comments/TranscriptComments/CommentSource.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentSource.tsx
@@ -24,6 +24,7 @@ function CommentSource({
     secondary: comment.secondaryLabel,
   });
 
+  // TODO [hbenl] Fix react-hooks/exhaustive-deps
   useEffect(() => {
     async function updateLabels() {
       setLabels(await createLabels(comment.sourceLocation!));
@@ -31,7 +32,7 @@ function CommentSource({
     if (comment.sourceLocation && !labels.primary && !labels.secondary) {
       updateLabels();
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onSelectSource = () => {
     setViewMode("dev");

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -127,18 +127,18 @@ function _DevTools({
       userIsAuthor: !!userIsAuthor,
       workspaceUuid: recording?.workspace?.id || null,
     });
-  }, [loading]);
+  });
 
   useEffect(() => {
     createSession(recordingId);
     return () => clearTrialExpired();
-  }, [clearTrialExpired, recordingId]);
+  }, [clearTrialExpired, createSession, recordingId]);
 
   useEffect(() => {
     if (uploadComplete && loadingFinished) {
       endUploadWaitTracking(sessionId!);
     }
-  }, [uploadComplete, loadingFinished]);
+  }, [loadingFinished, uploadComplete, sessionId]);
 
   useEffect(() => {
     if (recording && document.title !== recording.title) {

--- a/src/ui/components/KeyboardShortcuts.tsx
+++ b/src/ui/components/KeyboardShortcuts.tsx
@@ -48,76 +48,77 @@ function KeyboardShortcuts({
   toggleFocusMode,
   togglePaneCollapse,
   viewMode,
-  toggleTheme,
+  toggleThemeAction,
   toggleQuickOpen,
   closeOpenModalsOnEscape,
 }: PropsFromRedux) {
-  const openFullTextSearch = (e: KeyboardEvent) => {
-    e.preventDefault();
-    if (viewMode !== "dev") {
-      setViewMode("dev");
-    }
-    trackEvent("key_shortcut.full_text_search");
-    setSelectedPrimaryPanel("search");
-    focusFullTextInput(true);
-  };
-  const toggleLeftSidebar = (e: KeyboardEvent) => {
-    e.preventDefault();
-
-    trackEvent("key_shortcut.toggle_left_sidebar");
-    togglePaneCollapse();
-  };
-  const togglePalette = (e: KeyboardEvent) => {
-    e.preventDefault();
-    trackEvent("key_shortcut.show_command_palette");
-
-    if (viewMode === "dev" && !selectedSource && toolboxLayout === "ide") {
-      // Show the command palette in the editor
-      showCommandPaletteInEditor();
-    } else {
-      toggleCommandPalette();
-    }
-
-    const paletteInput = getCommandPaletteInput();
-    if (paletteInput) {
-      paletteInput.focus();
-    }
-  };
-  const onToggleTheme = (e: KeyboardEvent) => {
-    if (!e.target || !isEditableElement(e.target)) {
-      e.preventDefault();
-      toggleTheme();
-    }
-  };
-  const toggleEditFocusMode = (e: KeyboardEvent) => {
-    if (!e.target || !isEditableElement(e.target)) {
-      e.preventDefault();
-      toggleFocusMode();
-    }
-  };
-
-  const toggleQuickOpenModal = (e: KeyboardEvent, query = "", project = false) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    toggleQuickOpen(query, project);
-  };
-
-  const toggleFunctionQuickOpenModal = (e: KeyboardEvent) => {
-    toggleQuickOpenModal(e, "@");
-  };
-
-  const toggleProjectFunctionQuickOpenModal = (e: KeyboardEvent) => {
-    toggleQuickOpenModal(e, "@", true);
-  };
-
-  const toggleLineQuickOpenModal = (e: KeyboardEvent) => {
-    toggleQuickOpenModal(e, ":");
-  };
-
   const globalKeyboardShortcuts = useMemo(() => {
-    // The shortcuts have to be reassigned every time the dependencies change,
-    // otherwise we end up with a stale prop.
+    const openFullTextSearch = (e: KeyboardEvent) => {
+      e.preventDefault();
+      if (viewMode !== "dev") {
+        setViewMode("dev");
+      }
+      trackEvent("key_shortcut.full_text_search");
+      setSelectedPrimaryPanel("search");
+      focusFullTextInput(true);
+    };
+
+    const toggleEditFocusMode = (e: KeyboardEvent) => {
+      if (!e.target || !isEditableElement(e.target)) {
+        e.preventDefault();
+        toggleFocusMode();
+      }
+    };
+
+    const toggleFunctionQuickOpenModal = (e: KeyboardEvent) => {
+      toggleQuickOpenModal(e, "@");
+    };
+
+    const toggleLeftSidebar = (e: KeyboardEvent) => {
+      e.preventDefault();
+
+      trackEvent("key_shortcut.toggle_left_sidebar");
+      togglePaneCollapse();
+    };
+
+    const toggleLineQuickOpenModal = (e: KeyboardEvent) => {
+      toggleQuickOpenModal(e, ":");
+    };
+
+    const togglePalette = (e: KeyboardEvent) => {
+      e.preventDefault();
+      trackEvent("key_shortcut.show_command_palette");
+
+      if (viewMode === "dev" && !selectedSource && toolboxLayout === "ide") {
+        // Show the command palette in the editor
+        showCommandPaletteInEditor();
+      } else {
+        toggleCommandPalette();
+      }
+
+      const paletteInput = getCommandPaletteInput();
+      if (paletteInput) {
+        paletteInput.focus();
+      }
+    };
+
+    const toggleProjectFunctionQuickOpenModal = (e: KeyboardEvent) => {
+      toggleQuickOpenModal(e, "@", true);
+    };
+
+    const toggleQuickOpenModal = (e: KeyboardEvent, query = "", project = false) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      toggleQuickOpen(query, project);
+    };
+
+    const toggleTheme = (e: KeyboardEvent) => {
+      if (!e.target || !isEditableElement(e.target)) {
+        e.preventDefault();
+        toggleThemeAction();
+      }
+    };
 
     const shortcuts: Record<string, (e: KeyboardEvent) => void> = {
       "CmdOrCtrl+Shift+F": openFullTextSearch,
@@ -125,7 +126,7 @@ function KeyboardShortcuts({
       "CmdOrCtrl+K": togglePalette,
 
       // Should be ignored when an editable element is focused
-      "Shift+T": onToggleTheme,
+      "Shift+T": toggleTheme,
       "Shift+F": toggleEditFocusMode,
 
       // Quick Open-related toggles
@@ -141,9 +142,21 @@ function KeyboardShortcuts({
     };
 
     return shortcuts;
-    // TODO We're getting "hooks exhaustive deps" warnings here
-    // due to the callbacks, but the code is valid as-is.
-  }, [viewMode, selectedSource]);
+  }, [
+    showCommandPaletteInEditor,
+    setSelectedPrimaryPanel,
+    focusFullTextInput,
+    setViewMode,
+    selectedSource,
+    toolboxLayout,
+    toggleCommandPalette,
+    toggleFocusMode,
+    togglePaneCollapse,
+    viewMode,
+    toggleThemeAction,
+    toggleQuickOpen,
+    closeOpenModalsOnEscape,
+  ]);
 
   useEffect(() => {
     for (let [keyCombo, eventHandler] of Object.entries(globalKeyboardShortcuts)) {
@@ -175,7 +188,7 @@ const connector = connect(
     toggleCommandPalette: actions.toggleCommandPalette,
     toggleFocusMode: actions.toggleFocusMode,
     showCommandPaletteInEditor: deselectSource,
-    toggleTheme: actions.toggleTheme,
+    toggleThemeAction: actions.toggleTheme,
     toggleQuickOpen,
     closeOpenModalsOnEscape,
   }

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -102,6 +102,7 @@ function Library({
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
   const dismissNag = hooks.useDismissNag();
 
+  // TODO [jaril] Fix react-hooks/exhaustive-deps
   useEffect(function handleDeletedTeam() {
     // After rendering null, update the workspaceId to display the user's library
     // instead of the non-existent team.
@@ -109,7 +110,9 @@ function Library({
       setWorkspaceId(null);
       updateDefaultWorkspace({ variables: { workspaceId: null } });
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // TODO [jaril] Fix react-hooks/exhaustive-deps
   useEffect(function handleOnboardingModals() {
     if (singleInvitation(pendingWorkspaces?.length || 0, workspaces.length)) {
       trackEvent("onboarding.team_invite");
@@ -121,7 +124,7 @@ function Library({
       trackEvent("onboarding.demo_replay_prompt");
       setModal("first-replay");
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // FIXME [ryanjduffy]: Backwards compatibility for ?replayinvite=true flow
   if (isTeamLeaderInvite()) {

--- a/src/ui/components/NetworkMonitor/HttpBody.tsx
+++ b/src/ui/components/NetworkMonitor/HttpBody.tsx
@@ -60,7 +60,7 @@ const HttpBody = ({
   const theme = useSelector(getTheme);
   const raw = useMemo(() => {
     return BodyPartsToArrayBuffer(bodyParts, contentType);
-  }, [bodyParts]);
+  }, [contentType, bodyParts]);
 
   const displayable = useMemo(() => {
     return StringToObjectMaybe(URLEncodedToPlaintext(RawToUTF8(raw)));

--- a/src/ui/components/NetworkMonitor/Table.tsx
+++ b/src/ui/components/NetworkMonitor/Table.tsx
@@ -66,7 +66,7 @@ export default function Table({
   );
   const data = useMemo(
     () => partialRequestsToCompleteSummaries(requests, events, types),
-    [requests, types]
+    [events, requests, types]
   );
 
   const defaultColumn = useMemo(

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react";
+import React, { FC, useEffect, useRef } from "react";
 import { connect, ConnectedProps, useDispatch, useSelector } from "react-redux";
 import { installObserver, refreshGraphics, Video as VideoPlayer } from "../../protocol/graphics";
 import { setVideoNode } from "../../protocol/videoNode";
@@ -63,13 +63,24 @@ function Video({
   }, []);
 
   // Seek and resume playback if playing when swapping between Viewer and DevTools
+  const didSeekOnMountRef = useRef(false);
   useEffect(() => {
+    if (didSeekOnMountRef.current) {
+      return;
+    }
+
+    didSeekOnMountRef.current = true;
+
     if (playback) {
       refreshGraphics();
       VideoPlayer.seek(currentTime);
       VideoPlayer.play();
     }
-  }, []);
+
+    return () => {
+      didSeekOnMountRef.current = false;
+    };
+  });
 
   // This is intentionally mousedown. Otherwise, the NodePicker's mouseup callback fires
   // first. This updates the isNodePickerActive value and makes it look like the node picker is

--- a/src/ui/components/shared/APIKeys.tsx
+++ b/src/ui/components/shared/APIKeys.tsx
@@ -134,11 +134,10 @@ export default function APIKeys({
     [apiKeys]
   );
 
-  // focus the input on mount (when the ref is valued) and when returning to the
-  // form (when keyValue changes)
+  // focus the input on mount and when returning to the form (when keyValue changes)
   useEffect(() => {
     labelRef.current?.focus();
-  }, [labelRef.current, keyValue]);
+  }, [keyValue]);
 
   return (
     <div className="flex h-0 flex-auto flex-col space-y-8">

--- a/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -113,9 +113,9 @@ function NextButton({
     // allowNext to true is finished. This allows us to do mutations
     // in between navigations.
     if (allowNext && nextClicked) {
-      setCurrent(current + 1);
+      setCurrent(current => current + 1);
     }
-  }, [allowNext, nextClicked]);
+  }, [allowNext, nextClicked, setCurrent]);
 
   const inferLoading = nextClicked && !allowNext;
   const buttonText = inferLoading ? "Loading" : "Next";
@@ -186,7 +186,7 @@ function SlideBody1({ hideModal, setNewWorkspace, setCurrent, total, current }: 
 
   useEffect(() => {
     textInputRef.current?.focus();
-  }, [textInputRef.current]);
+  }, []);
 
   return (
     <>
@@ -269,7 +269,7 @@ function SlideBody2({ hideModal, setCurrent, newWorkspace, total, current }: Sli
 
   useEffect(() => {
     textInputRef.current?.focus();
-  }, [textInputRef.current]);
+  }, []);
 
   return (
     <>

--- a/src/ui/components/shared/Onboarding/DownloadingPage.tsx
+++ b/src/ui/components/shared/Onboarding/DownloadingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import hooks from "ui/hooks";
 import { Nag } from "ui/hooks/users";
 import { PrimaryLgButton } from "../Button";
@@ -6,10 +6,17 @@ import { OnboardingActions, OnboardingBody, OnboardingHeader } from "../Onboardi
 
 export function DownloadingPage({ onFinished }: { onFinished: () => void }) {
   const dismissNag = hooks.useDismissNag();
+  const didMountRef = useRef(false);
 
   useEffect(() => {
+    if (didMountRef.current) {
+      return;
+    }
+
+    didMountRef.current = true;
+
     dismissNag(Nag.DOWNLOAD_REPLAY);
-  }, []);
+  });
 
   return (
     <>

--- a/src/ui/components/shared/Onboarding/index.tsx
+++ b/src/ui/components/shared/Onboarding/index.tsx
@@ -93,9 +93,9 @@ export function NextButton({
     // allowNext to true is finished. This allows us to do mutations
     // in between navigations.
     if (allowNext && nextClicked) {
-      setCurrent(current + 1);
+      setCurrent(current => current + 1);
     }
-  }, [allowNext, nextClicked]);
+  }, [allowNext, nextClicked, setCurrent]);
 
   const inferLoading = nextClicked && !allowNext;
   const buttonText = inferLoading ? "Loading" : text || "Next";

--- a/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
+++ b/src/ui/components/shared/OnboardingModal/SingleInviteModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import * as actions from "ui/actions/app";
@@ -29,7 +29,7 @@ function SingleInviteModalLoader(props: PropsFromRedux) {
     if (!loading && pendingWorkspaces && !workspace) {
       setWorkspace(pendingWorkspaces[0]);
     }
-  }, [pendingWorkspaces]);
+  }, [loading, pendingWorkspaces, workspace]);
 
   if (!workspace) {
     return <ModalLoader />;
@@ -50,9 +50,17 @@ function AutoAccept(props: SingleInviteModalProps) {
     setAccepted(true);
   });
 
+  const didMountRef = useRef(false);
+
   useEffect(() => {
+    if (didMountRef.current) {
+      return;
+    }
+
+    didMountRef.current = true;
+
     acceptPendingInvitation({ variables: { workspaceId: workspace.id } });
-  }, []);
+  });
 
   if (!accepted) {
     return <ModalLoader />;

--- a/src/ui/components/shared/PortalDropdown.tsx
+++ b/src/ui/components/shared/PortalDropdown.tsx
@@ -16,14 +16,6 @@ type ViewportOverflows = Direction[];
 export default function PortalDropdown(props: PortalDropdownProps) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [dropdownNode, setDropdownNode] = useState<HTMLDivElement | null>(null);
-  const dropdownRef = useCallback(
-    node => {
-      if (node !== null) {
-        setDropdownNode(node);
-      }
-    },
-    [props.expanded]
-  );
 
   const expand = (e: React.MouseEvent) => {
     if (e.button === 0) {
@@ -66,7 +58,7 @@ export default function PortalDropdown(props: PortalDropdownProps) {
               <div
                 className={`content ${position}`}
                 style={{ ...style, ...contentPosition }}
-                ref={dropdownRef}
+                ref={setDropdownNode}
               >
                 {children}
               </div>

--- a/src/ui/components/shared/TeamOnboarding.tsx
+++ b/src/ui/components/shared/TeamOnboarding.tsx
@@ -103,7 +103,7 @@ function TeamNamePage({
 
   useEffect(() => {
     textInputRef.current?.focus();
-  }, [textInputRef.current]);
+  }, []);
 
   return (
     <>

--- a/src/ui/components/shared/UserSettingsModal/PreferencesSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/PreferencesSettings.tsx
@@ -77,7 +77,7 @@ function PrivacyPreferences() {
 
   useEffect(() => {
     setDisableLogRocket(userSettings.disableLogRocket);
-  }, [loading]);
+  }, [userSettings]);
 
   if (loading) {
     return null;

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -42,6 +42,7 @@ import {
   GetWorkspaceRecordings,
   GetWorkspaceRecordingsVariables,
 } from "graphql/GetWorkspaceRecordings";
+import { useMemo } from "react";
 
 function isTest() {
   return new URL(window.location.href).searchParams.get("test");
@@ -170,7 +171,8 @@ export function useGetRecording(recordingId: RecordingId | null | undefined): {
     console.error("Apollo error while getting the recording", error);
   }
 
-  const recording = convertRecording(data?.recording);
+  const recording = useMemo(() => convertRecording(data?.recording), [data]);
+
   // Tests don't have an associated user so we just let it bypass the check here.
   const isAuthorized = isTest() || recording;
 

--- a/src/ui/hooks/settings.ts
+++ b/src/ui/hooks/settings.ts
@@ -8,7 +8,7 @@ import type { ExperimentalUserSettings } from "../types";
 import { ADD_USER_API_KEY, DELETE_USER_API_KEY, GET_USER_SETTINGS } from "ui/graphql/settings";
 import { features } from "ui/utils/prefs";
 import { prefs as prefsService } from "devtools/shared/services";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { maybeTrackTeamChange } from "ui/utils/mixpanel";
 import {
   UpdateUserDefaultWorkspace,
@@ -62,6 +62,8 @@ export function useGetUserSettings() {
   const { isAuthenticated } = useAuth0();
   const { data, error, loading } = useQuery<GetUserSettings>(GET_USER_SETTINGS);
 
+  const userSettings = useMemo(() => convertUserSettings(data), [data]);
+
   if (isTest()) {
     return { userSettings: testSettings, loading: false };
   }
@@ -79,7 +81,7 @@ export function useGetUserSettings() {
     return { userSettings: emptySettings, error, loading };
   }
 
-  return { userSettings: convertUserSettings(data), error, loading };
+  return { userSettings, error, loading };
 }
 
 export const useFeature = (prefKey: keyof typeof features) => {

--- a/src/ui/utils/useAuth0.ts
+++ b/src/ui/utils/useAuth0.ts
@@ -23,9 +23,8 @@ const TEST_AUTH = {
 
 export type AuthContext = Auth0ContextInterface | typeof TEST_AUTH;
 
-/**
- * A wrapper around useAuth0() that returns dummy data in tests
- */
+// TODO [hbenl, ryanjduffy] This function should `useMemo` to memoize the "user" object it returns.
+// As it is, this hooks prevents components like CommentTool from limiting how often their effects run.
 export default function useAuth0() {
   const router = useRouter();
   const auth = useOrigAuth0();


### PR DESCRIPTION
In most cases, I tried to _fix_ the rule violation.

When the fix seemed unclear (e.g. I wasn't sure if the change would "break" the desired behavior) then I left a `TODO [authorname]` comment for the original author. (We'll rely on Trunk hold-the-line to prevent new ones from being added.)

Things to keep in mind about the following changes:
* `useEditor` from `@tiptap/react` returns a _stable_ "editor" provided the dependencies array values don't change.
* `useDispatch` from `react-redux` returns a _stable_ `dispatch` function so long as you don't change the Redux `store` (which we don't).
* There were a few places we could have been memoizing that we weren't, so I added them (e.g. `useGetRecording()` -> `convertRecording(recording.data)`).