### PR TITLE
Don't use interpolated tailwind classnames

### DIFF
--- a/src/ui/components/OgreTimeline.tsx
+++ b/src/ui/components/OgreTimeline.tsx
@@ -28,7 +28,7 @@ const Spans = ({ regions, color }: { regions: TimeStampedPointRange[]; color: st
   return (
     <div className="w-full h-1 z-50 relative">
       {regions.map((r, i) => (
-        <Span regions={r} endTime={endTime} className={`bg-${color}-500`} key={i} />
+        <Span regions={r} endTime={endTime} className={color} key={i} />
       ))}
     </div>
   );
@@ -44,9 +44,9 @@ export default function OgreTimeline() {
 
   return (
     <div className="flex flex-col space-y-1 absolute -top-3 w-full">
-      <Spans regions={loadedRegions.loading} color="gray" />
-      <Spans regions={loadedRegions.loaded} color="orange" />
-      <Spans regions={loadedRegions.indexed} color="green" />
+      <Spans regions={loadedRegions.loading} color="bg-gray-500" />
+      <Spans regions={loadedRegions.loaded} color="bg-orange-500" />
+      <Spans regions={loadedRegions.indexed} color="bg-green-500" />
     </div>
   );
 }


### PR DESCRIPTION
Colors were missing from the advanced timeline and it was because it was interpolating the background colors classes, which were then being excluded from the generated stylesheet. More on this [here](https://stackoverflow.com/questions/66096170/tailwindcss-missing-colors-in-production-vs-development-laravel-jetstream).