### PR TITLE
Tweak onboarding hat copy

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
@@ -5,9 +5,22 @@ import { Nag } from "ui/hooks/users";
 import { shouldShowNag } from "ui/utils/user";
 
 const TEXT = {
-  editPrompt: "Edit your first print statement",
-  savePrompt: "Add some local variables",
-  success: "Check the console",
+  editPrompt: "Click below to edit your first print statement",
+  savePrompt: "You can add variables here too",
+  success: (
+    <>
+      <span className="flex">Now check the console!</span>
+
+      <span className="flex grow justify-end">
+        <a
+          href="https://www.notion.so/replayio/Print-statements-1dcf7c3a8414423aab122ea7c4a41661"
+          target="_blank"
+        >
+          Learn more
+        </a>
+      </span>
+    </>
+  ),
 };
 
 type Step = keyof typeof TEXT;
@@ -43,7 +56,7 @@ export default function FirstEditNag({ editing }: { editing: boolean }) {
       }}
     >
       <MaterialIcon iconSize="xl">auto_awesome</MaterialIcon>
-      <div className="text-xs font-bold">{TEXT[step]}</div>
+      <div className="flex grow text-xs font-bold">{TEXT[step]}</div>
     </div>
   );
 }

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
@@ -15,7 +15,7 @@ const TEXT = {
         <a
           href="https://www.notion.so/replayio/Print-statements-1dcf7c3a8414423aab122ea7c4a41661"
           target="_blank"
-          rel="noreferrer"
+          rel="noreferrer noopener"
         >
           Learn more
         </a>

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/FirstEditNag.tsx
@@ -15,6 +15,7 @@ const TEXT = {
         <a
           href="https://www.notion.so/replayio/Print-statements-1dcf7c3a8414423aab122ea7c4a41661"
           target="_blank"
+          rel="noreferrer"
         >
           Learn more
         </a>

--- a/src/ui/components/shared/Nags/Nags.tsx
+++ b/src/ui/components/shared/Nags/Nags.tsx
@@ -53,20 +53,14 @@ export function EditorNag() {
     return null;
   }
 
-  return (
-    <NagHat
-      mainText="Ready to add your first print statement?"
-      subText="Click on a line number in the gutter"
-      nagType={Nag.FIRST_BREAKPOINT_ADD}
-    />
-  );
+  return <NagHat subText="Now hover on a line number" nagType={Nag.FIRST_BREAKPOINT_ADD} />;
 }
 
 export function ConsoleNag() {
   return (
     <NagHat
       mainText="Want to see something cool?"
-      subText="Try fast forwarding or rewinding to a console log"
+      subText="Try fast-forwarding or rewinding to a console log"
       nagType={Nag.FIRST_CONSOLE_NAVIGATE}
     />
   );

--- a/src/ui/components/shared/Nags/Nags.tsx
+++ b/src/ui/components/shared/Nags/Nags.tsx
@@ -15,7 +15,7 @@ function NagHat({
   subText,
   nagType,
 }: {
-  mainText: string;
+  mainText?: string;
   subText: string;
   nagType: Nag;
 }) {
@@ -39,7 +39,9 @@ function NagHat({
     >
       <MaterialIcon iconSize="xl">auto_awesome</MaterialIcon>
       <div className="flex flex-col overflow-hidden text-xs">
-        <div className="overflow-hidden overflow-ellipsis whitespace-pre">{mainText}</div>
+        {mainText ? (
+          <div className="overflow-hidden overflow-ellipsis whitespace-pre">{mainText}</div>
+        ) : null}
         <div className="overflow-hidden overflow-ellipsis whitespace-pre font-bold">{subText}</div>
       </div>
     </div>


### PR DESCRIPTION
Fixes https://github.com/orgs/RecordReplay/projects/57/views/16?filterQuery=assignee%3A%40me+iteration%3A%40current&groupedBy%5BcolumnId%5D=Status&sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=90677

Copying from the ticket -->

[Here's a Notion doc](https://www.notion.so/replayio/Hats-overview-c8fb98b59d744d5197cc7096fcb6e519) where I described before/after copy changes

Here are the new screens:

![image](https://user-images.githubusercontent.com/9154902/164122730-e00e8b13-9ee6-4404-adc9-85fe377350fe.png)

![image](https://user-images.githubusercontent.com/9154902/164122746-cea9bcf9-b590-4f4c-9198-cd09252466fb.png)

![image](https://user-images.githubusercontent.com/9154902/164122764-c07b2d3e-8043-442a-a2c8-8ef3267ce8e6.png)

![image](https://user-images.githubusercontent.com/9154902/164122780-f48db253-560f-4f45-8748-0284c5f4f46f.png)

![image](https://user-images.githubusercontent.com/9154902/164122799-f7ed65e6-605e-491c-b1a6-24d45e70bda4.png)

Previously we said "add a local variable" but it's not clear how to do that, or what variables in the demo they should be putting there. So I changed it to a more general "you can do this" message.

![image](https://user-images.githubusercontent.com/9154902/164122813-98e33886-0b70-47eb-ae72-de5e640a0af5.png)

This is the part I'm most interested in upgrading. I want to be able to add unicorns, but that's too hacky for the code right now. So instead I'm adding a "learn more" link and making it feel more like the end of the tour.