### PR TITLE
ObjectInspector: ensure all ValueFronts are loaded (#6479)

### DIFF
--- a/src/devtools/client/webconsole/utils/connected-object-inspector.tsx
+++ b/src/devtools/client/webconsole/utils/connected-object-inspector.tsx
@@ -20,7 +20,7 @@ type ObjectInspectorProps = PropsFromRedux & PropsFromParent;
 function OI(props: ObjectInspectorProps) {
   const { value, isInCurrentPause } = props;
   const path = value.id();
-  const roots = [new ValueItem({ path, contents: value, isInCurrentPause })];
+  const roots = () => [new ValueItem({ contents: value, isInCurrentPause, path })];
 
   return (
     <ObjectInspector

--- a/src/devtools/packages/devtools-reps/object-inspector/utils/container.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/utils/container.tsx
@@ -3,14 +3,16 @@ import { IItem, Item, LabelAndValue } from ".";
 
 export class ContainerItem implements IItem {
   readonly type = "container";
-  name: string;
-  path: string;
-  contents: Item[];
+  readonly name: string;
+  readonly path: string;
+  readonly contents: Item[];
+  readonly childrenLoaded: boolean;
 
   constructor(opts: { name: string; contents: Item[] } & ({ parent: Item } | { path: string })) {
     this.name = opts.name;
     this.path = "parent" in opts ? `${opts.parent.path}/${opts.name}` : opts.path;
     this.contents = opts.contents;
+    this.childrenLoaded = this.contents.every(item => item.type !== "value" || item.loaded);
   }
 
   isPrimitive(): boolean {
@@ -22,7 +24,13 @@ export class ContainerItem implements IItem {
   }
 
   getChildren(): Item[] {
-    return this.contents;
+    return this.contents.map(item => (item.type === "value" ? item.recreate() : item));
+  }
+
+  async loadChildren() {
+    await Promise.all(
+      this.contents.map(item => item.type === "value" && item.contents.loadIfNecessary())
+    );
   }
 
   shouldUpdate(prevItem: Item) {

--- a/src/devtools/packages/devtools-reps/object-inspector/utils/keyValue.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/utils/keyValue.tsx
@@ -2,15 +2,15 @@ import { ValueFront } from "protocol/thread";
 import { assert } from "protocol/utils";
 import { IItem, isValueLoaded, Item, LabelAndValue, ValueItem } from ".";
 import { ObjectInspectorItemProps } from "../components/ObjectInspectorItem";
-const PropRep = require("../../reps/prop-rep");
+import PropRep from "../../reps/prop-rep";
 
 export class KeyValueItem implements IItem {
   readonly type = "key-value";
-  name: string;
-  path: string;
-  key: ValueFront;
-  value: ValueFront;
-  childrenLoaded: boolean;
+  readonly name: string;
+  readonly path: string;
+  readonly key: ValueFront;
+  readonly value: ValueFront;
+  readonly childrenLoaded: boolean;
 
   constructor(opts: { name: string; path: string; key: ValueFront; value: ValueFront }) {
     this.name = opts.name;
@@ -47,6 +47,10 @@ export class KeyValueItem implements IItem {
       new ValueItem({ parent: this, name: "<key>", contents: this.key }),
       new ValueItem({ parent: this, name: "<value>", contents: this.value }),
     ];
+  }
+
+  async loadChildren() {
+    await Promise.all([this.key.loadIfNecessary(), this.value.loadIfNecessary()]);
   }
 
   shouldUpdate(prevItem: Item) {


### PR DESCRIPTION
This fixes several issues that led to the ObjectInspector showing previews for objects without loading their `ValueItem`s first (i.e. their `ValueFronts` contained only an `objectId` and a `className` but not a preview).
- when the ObjectInspector is rendered with a root `ValueItem` that hasn't been loaded yet, it will load it now and then rerender (ideally this should never happen: the ObjectInspector should only be rendered with a root `ValueItem` that has already been loaded, but that isn't always the case right now and I decided to add this logic to make the ObjectInspector more resilient)
- I added a `loaded` property to `ValueItem` to ensure that it is rerendered when `loaded` changes from `false` to `true`
- the root `ValueItem` created in connected-object-inspector is now recreated on every update, ensuring that its `loaded` property will change after it has been loaded
- the children of `KeyValueItem` and `ContainerItem` are now loaded when the items get expanded
- the `ValueItem` children of a `ContainerItem` are now recreated on every update ensuring that their `loaded` property is up to date