### PR TITLE
Add `document` to HTML request types

### DIFF
--- a/src/ui/components/NetworkMonitor/utils.ts
+++ b/src/ui/components/NetworkMonitor/utils.ts
@@ -64,8 +64,9 @@ export const RequestTypeOptions: { type: CanonicalRequestType; icon: string; lab
 
 // From https://github.com/RecordReplay/gecko-dev/blob/webreplay-release/devtools/server/actors/replay/network-helpers.jsm#L14
 export const REQUEST_TYPES: Record<string, CanonicalRequestType> = {
-  subdocument: CanonicalRequestType.HTML,
+  document: CanonicalRequestType.HTML,
   objectSubdoc: CanonicalRequestType.HTML,
+  subdocument: CanonicalRequestType.HTML,
 
   fetch: CanonicalRequestType.FETCH_XHR,
   xhr: CanonicalRequestType.FETCH_XHR,


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/devtools/issues/6474

Replay before:
https://app.replay.io/recording/html-request-filtering-bug--116d2048-3411-4812-a9b3-6ab2eefb253b?point=52572005696510566831514383634399232&time=26611&hasFrames=false

Replay after:
https://app.replay.io/recording/fixed-filtering-of-html-documents--593d4346-f5ed-423b-b369-20b5e29938c4?point=58413339662243038135877853241147392&time=30388&hasFrames=false