### PR TITLE
Add skip button to onboarding

### DIFF
--- a/src/ui/components/shared/FirstReplayModal/FirstReplayModal.tsx
+++ b/src/ui/components/shared/FirstReplayModal/FirstReplayModal.tsx
@@ -17,6 +17,7 @@ import {
 } from "../Onboarding/index";
 
 export const REPLAY_DEMO_URL = "https://static.replay.io/demo/";
+export const REPLAY_LIBRARY_URL = "https://app.replay.io/";
 
 function FirstReplayModal({ hideModal }: PropsFromRedux) {
   const dismissNag = hooks.useDismissNag();
@@ -26,6 +27,12 @@ function FirstReplayModal({ hideModal }: PropsFromRedux) {
     hideModal();
     trackEvent("onboarding.demo_replay_launch");
     launchAndRecordUrl(REPLAY_DEMO_URL);
+  };
+
+  const handleSkip = () => {
+    dismissNag(Nag.FIRST_REPLAY_2);
+    hideModal();
+    trackEvent("onboarding.demo_skip");
   };
 
   return (
@@ -40,6 +47,9 @@ function FirstReplayModal({ hideModal }: PropsFromRedux) {
         <OnboardingActions>
           <PrimaryLgButton color="blue" onClick={handleOpen}>
             {`Ready as I'll ever be, Doc`}
+          </PrimaryLgButton>
+          <PrimaryLgButton color="gray" onClick={handleSkip}>
+            {`Skip`}
           </PrimaryLgButton>
         </OnboardingActions>
       </OnboardingContentWrapper>

--- a/src/ui/utils/mixpanel.ts
+++ b/src/ui/utils/mixpanel.ts
@@ -61,6 +61,7 @@ type MixpanelEvent =
   | ["object_inspector.label_click"]
   | ["onboarding.created_team"]
   | ["onboarding.demo_replay_launch"]
+  | ["onboarding.demo_skip"]
   | ["onboarding.demo_replay_prompt"]
   | ["onboarding.download_replay", { OS: "mac" | "linux" | "windows" }]
   | ["onboarding.download_replay_prompt"]


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/design/issues/17

<img width="586" alt="image" src="https://user-images.githubusercontent.com/9154902/164360899-9245a099-6044-4286-b737-ce379398b363.png">

Added a skip button that goes to the library