### PR TITLE
Still show the team dropdown even if the user doesn't have any teams

### DIFF
--- a/src/ui/components/UploadScreen/Sharing.tsx
+++ b/src/ui/components/UploadScreen/Sharing.tsx
@@ -37,9 +37,7 @@ function EditableSettings({
 
   return (
     <div className="grid w-full grid-cols-2 gap-5 text-base">
-      {workspaces.length ? (
-        <TeamSelect {...{ workspaces, handleWorkspaceSelect, selectedWorkspaceId }} />
-      ) : null}
+      <TeamSelect {...{ handleWorkspaceSelect, selectedWorkspaceId, workspaces }} />
       <div
         className={classNames(
           publicDisabled ? "opacity-60" : undefined,


### PR DESCRIPTION
Fix #6344.

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/15959269/164369702-3082281f-93f1-4749-b290-592d47f2deae.png">
