### PR TITLE
Send better errors to sentry

### DIFF
--- a/src/protocol/socket.ts
+++ b/src/protocol/socket.ts
@@ -160,7 +160,12 @@ function onSocketMessage(evt: MessageEvent<any>) {
     gMessageWaiters.delete(msg.id);
     if (msg.error) {
       console.warn("Message failed", method, msg.error, msg.data);
-      reject(msg.error);
+
+      const err = new Error(msg.error.message) as any;
+      err.name = "CommandError";
+      err.code = msg.error.code;
+
+      reject(err);
     } else {
       resolve(msg.result);
     }

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -231,6 +231,7 @@ class _ThreadFront {
 
   async setSessionId(sessionId: SessionId) {
     this.sessionId = sessionId;
+    assert(sessionId, "there should be a sessionId");
     this.sessionWaiter.resolve(sessionId);
 
     if (window.app.prefs.listenForMetrics) {


### PR DESCRIPTION
Fix #6506.

This adds better error handling so that we have a better sense of what we're looking at when we look at Sentry.

(Also it's probably good practice anyway)