### PR TITLE
Remove artifacts of how we used to get the indexing progress before

### DIFF
--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -54,7 +54,6 @@ export type SetDisplayedLoadingProgressAction = Action<"set_displayed_loading_pr
   progress: number | null;
 };
 export type SetLoadingFinishedAction = Action<"set_loading_finished"> & { finished: boolean };
-export type IndexingAction = Action<"indexing"> & { indexing: number };
 export type SetSessionIdAction = Action<"set_session_id"> & { sessionId: SessionId };
 export type UpdateThemeAction = Action<"update_theme"> & { theme: AppTheme };
 export type SetInitializedPanelsAction = Action<"set_initialized_panels"> & { panel: PanelName };
@@ -113,7 +112,6 @@ export type AppActions =
   | LoadingAction
   | SetDisplayedLoadingProgressAction
   | SetLoadingFinishedAction
-  | IndexingAction
   | SetSessionIdAction
   | UpdateThemeAction
   | SetInitializedPanelsAction
@@ -162,10 +160,6 @@ export function setupApp(store: UIStore) {
     store.dispatch(onUnprocessedRegions(regions))
   ).then(() => {
     store.dispatch(setLoading(100));
-  });
-
-  ThreadFront.ensureProcessed("executionIndexed").then(() => {
-    store.dispatch(setIndexing(100));
   });
 
   ThreadFront.listenForLoadChanges(parameters => {
@@ -244,10 +238,6 @@ export function setDisplayedLoadingProgress(
 
 export function setLoadingFinished(finished: boolean): SetLoadingFinishedAction {
   return { type: "set_loading_finished", finished };
-}
-
-function setIndexing(indexing: number): IndexingAction {
-  return { type: "indexing", indexing };
 }
 
 export function updateTheme(theme: AppTheme): UpdateThemeAction {

--- a/src/ui/reducers/app.ts
+++ b/src/ui/reducers/app.ts
@@ -31,7 +31,6 @@ export const initialAppState: AppState = {
   events: {},
   expectedError: null,
   hoveredLineNumberLocation: null,
-  indexing: 0,
   initializedPanels: [],
   isNodePickerActive: false,
   isNodePickerInitializing: false,
@@ -65,10 +64,6 @@ export default function update(
     }
     case "set_recording_duration": {
       return { ...state, recordingDuration: action.duration };
-    }
-
-    case "indexing": {
-      return { ...state, indexing: action.indexing };
     }
 
     case "set_uploading": {

--- a/src/ui/state/app.ts
+++ b/src/ui/state/app.ts
@@ -87,7 +87,6 @@ export interface AppState {
   events: Events;
   expectedError: ExpectedError | null;
   hoveredLineNumberLocation: Location | null;
-  indexing: number;
   initializedPanels: PanelName[];
   isNodePickerActive: boolean;
   isNodePickerInitializing: boolean;


### PR DESCRIPTION
Fix #6513.

This is to update the frontend to match the new backend behavior post [this commit](https://github.com/RecordReplay/backend/commit/8881a16ec0a257416802c81ef5c7688fa15df6c0#diff-e6780bcb868085554019c86fb949f4512f7eae513b15e6d2011bd474cd84c6b6R40).