### PR TITLE
Gracefully handle the case where there is no selected request

### DIFF
--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -89,49 +89,51 @@ export const NetworkMonitor = ({
 
   return (
     <Table events={events} requests={requests} types={types}>
-      {({ table, data }: { table: any; data: RequestSummary[] }) => (
-        <div className="flex h-full min-h-0 flex-col" ref={container}>
-          <FilterBar types={types} toggleType={toggleType} table={table} />
-          <SplitBox
-            className="min-h-0 border-t border-splitter"
-            initialSize="350px"
-            minSize={selectedRequestId ? "30%" : "100%"}
-            maxSize={selectedRequestId ? "70%" : "100%"}
-            startPanel={
-              <RequestTable
-                table={table}
-                data={data}
-                currentTime={currentTime}
-                onRowSelect={row => {
-                  trackEvent("net_monitor.select_request_row");
-                  dispatch(fetchFrames(row.point));
+      {({ table, data }: { table: any; data: RequestSummary[] }) => {
+        let selectedRequest;
+        if (selectedRequestId) {
+          selectedRequest = data.find(request => request.id === selectedRequestId);
+        }
 
-                  if (row.hasResponseBody) {
-                    dispatch(fetchResponseBody(row.id, row.point.point));
-                  }
-                  if (row.hasRequestBody) {
-                    dispatch(fetchRequestBody(row.id, row.point.point));
-                  }
+        return (
+          <div className="flex h-full min-h-0 flex-col" ref={container}>
+            <FilterBar types={types} toggleType={toggleType} table={table} />
+            <SplitBox
+              className="min-h-0 border-t border-splitter"
+              initialSize="350px"
+              minSize={selectedRequestId ? "30%" : "100%"}
+              maxSize={selectedRequestId ? "70%" : "100%"}
+              startPanel={
+                <RequestTable
+                  table={table}
+                  data={data}
+                  currentTime={currentTime}
+                  onRowSelect={row => {
+                    trackEvent("net_monitor.select_request_row");
+                    dispatch(fetchFrames(row.point));
 
-                  dispatch(showRequestDetails(row.id));
-                }}
-                seek={seek}
-                selectedRequest={data.find(request => request.id === selectedRequestId)}
-              />
-            }
-            endPanel={
-              selectedRequestId ? (
-                <RequestDetails
-                  cx={cx}
-                  request={data.find(request => request.id === selectedRequestId)!}
+                    if (row.hasResponseBody) {
+                      dispatch(fetchResponseBody(row.id, row.point.point));
+                    }
+                    if (row.hasRequestBody) {
+                      dispatch(fetchRequestBody(row.id, row.point.point));
+                    }
+
+                    dispatch(showRequestDetails(row.id));
+                  }}
+                  seek={seek}
+                  selectedRequest={selectedRequest}
                 />
-              ) : null
-            }
-            splitterSize={2}
-            vert={vert}
-          />
-        </div>
-      )}
+              }
+              endPanel={
+                selectedRequest ? <RequestDetails cx={cx} request={selectedRequest} /> : null
+              }
+              splitterSize={2}
+              vert={vert}
+            />
+          </div>
+        );
+      }}
     </Table>
   );
 };


### PR DESCRIPTION
Resolves #6510

Previously we were only checking for a selected request ID but not ensuring that we could match it to a request within the loaded region. I'm really new to this code so I'm not sure if this indicates a broader unexpected issue that should be dug into further– but conceptually, it seems like a weak guard we had in place before so I hardened it a little bit.

Best viewed [without whitespace](https://github.com/RecordReplay/devtools/pull/6516/files?w=1).