### PR TITLE
Don't set pointer-events none to the gutter's + button

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoints.css
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Breakpoints.css
@@ -32,6 +32,10 @@
   pointer-events: none;
 }
 
+.new-breakpoint .CodeMirror-linenumber .line-action-button {
+  pointer-events: all;
+}
+
 .editor-wrapper
   :not(.empty-line):not(.new-breakpoint)
   > .CodeMirror-gutter-wrapper

--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -135,7 +135,7 @@ function QuickActions({
 
   return (
     <div
-      className="absolute -right-1 z-50 flex translate-x-full transform flex-row space-x-px"
+      className="line-action-button absolute -right-1 z-50 flex translate-x-full transform flex-row space-x-px"
       // This is necessary so that we don't move the CodeMirror cursor while clicking.
       onMouseDown={onMouseDown}
       style={{ top: `-${(1 / 2) * (18 - height)}px` }}


### PR DESCRIPTION
Fix #6407.

Replay of the changes: https://app.replay.io/recording/breakpoint-button-bug--8de10e37-25f1-46c4-a55c-b08284e98f42?point=70420526163238873821966193957797888&time=32993&hasFrames=false

https://user-images.githubusercontent.com/15959269/164741362-76378bcc-1e63-4dc5-81bf-502869e5f949.mov


