### PR TITLE
Add qualifier filters to the library

### DIFF
--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -26,7 +26,7 @@ import { TimelineState, ZoomRegion, HoveredItem, FocusRegion } from "ui/state/ti
 import { UIStore, UIThunkAction } from ".";
 import { Action } from "redux";
 import { PauseEventArgs } from "protocol/thread/thread";
-import { getPausePointParams, getTest } from "ui/utils/environment";
+import { getPausePointParams, getTest, updateUrlWithParams } from "ui/utils/environment";
 import { assert, waitForTime } from "protocol/utils";
 import { features } from "ui/utils/prefs";
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";
@@ -164,7 +164,7 @@ function onWarp(store: UIStore) {
 
 function onPaused({ point, time, hasFrames }: PauseEventArgs): UIThunkAction {
   return async dispatch => {
-    updateUrl({ point, time, hasFrames });
+    updatePausePointParams({ point, time, hasFrames });
     dispatch(setTimelineState({ currentTime: time, playback: null }));
   };
 }
@@ -221,7 +221,7 @@ export function setZoomRegion(region: ZoomRegion): SetZoomRegionAction {
   return { type: "set_zoom", region };
 }
 
-function updateUrl({
+function updatePausePointParams({
   point,
   time,
   hasFrames,
@@ -230,11 +230,8 @@ function updateUrl({
   time: number;
   hasFrames: boolean;
 }) {
-  const url = new URL(window.location.toString());
-  url.searchParams.set("point", point);
-  url.searchParams.set("time", `${time}`);
-  url.searchParams.set("hasFrames", `${hasFrames}`);
-  window.history.replaceState({}, "", url.toString());
+  const params = { point, time: `${time}`, hasFrames: `${hasFrames}`};
+  updateUrlWithParams(params);
 }
 
 export function seek(

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -21,20 +21,12 @@ import {
   getFocusRegion,
   getZoomRegion,
 } from "ui/reducers/timeline";
-<<<<<<< HEAD
 import { TimelineState, ZoomRegion, HoveredItem, FocusRegion } from "ui/state/timeline";
-=======
-import { getPausePointParams, getTest, updateUrlWithParams } from "ui/utils/environment";
->>>>>>> 259baabaf (Tidied up the file structure and lint fixes)
 
 import { UIStore, UIThunkAction } from ".";
 import { Action } from "redux";
 import { PauseEventArgs } from "protocol/thread/thread";
-<<<<<<< HEAD
 import { getPausePointParams, getTest, updateUrlWithParams } from "ui/utils/environment";
-=======
-import { TimelineState, ZoomRegion, HoveredItem, FocusOperation } from "ui/state/timeline";
->>>>>>> 259baabaf (Tidied up the file structure and lint fixes)
 import { assert, waitForTime } from "protocol/utils";
 import { features } from "ui/utils/prefs";
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -21,12 +21,20 @@ import {
   getFocusRegion,
   getZoomRegion,
 } from "ui/reducers/timeline";
+<<<<<<< HEAD
 import { TimelineState, ZoomRegion, HoveredItem, FocusRegion } from "ui/state/timeline";
+=======
+import { getPausePointParams, getTest, updateUrlWithParams } from "ui/utils/environment";
+>>>>>>> 259baabaf (Tidied up the file structure and lint fixes)
 
 import { UIStore, UIThunkAction } from ".";
 import { Action } from "redux";
 import { PauseEventArgs } from "protocol/thread/thread";
+<<<<<<< HEAD
 import { getPausePointParams, getTest, updateUrlWithParams } from "ui/utils/environment";
+=======
+import { TimelineState, ZoomRegion, HoveredItem, FocusOperation } from "ui/state/timeline";
+>>>>>>> 259baabaf (Tidied up the file structure and lint fixes)
 import { assert, waitForTime } from "protocol/utils";
 import { features } from "ui/utils/prefs";
 import KeyShortcuts, { isEditableElement } from "ui/utils/key-shortcuts";
@@ -230,7 +238,7 @@ function updatePausePointParams({
   time: number;
   hasFrames: boolean;
 }) {
-  const params = { point, time: `${time}`, hasFrames: `${hasFrames}`};
+  const params = { point, time: `${time}`, hasFrames: `${hasFrames}` };
   updateUrlWithParams(params);
 }
 

--- a/src/ui/components/Library/Filter.ts
+++ b/src/ui/components/Library/Filter.ts
@@ -1,5 +1,6 @@
 import { createContext, useState } from "react";
 import { Recording } from "ui/types";
+import { getParams, updateUrlWithParams } from "ui/utils/environment";
 
 export type LibraryFilters = {
   searchString: string;
@@ -31,10 +32,14 @@ const useFilterString = (str: string) => {
   const [appliedString, setAppliedString] = useState(str);
   const [displayedString, setDisplayedString] = useState(str);
 
-  const applyDisplayedString = () => setAppliedString(displayedString);
+  const applyDisplayedString = () => {
+    setAppliedString(displayedString);
+    updateUrlWithParams({ q: displayedString });
+  };
   const forceSetAppliedString = (newStr: string) => {
     setAppliedString(newStr);
     setDisplayedString(newStr);
+    updateUrlWithParams({ q: newStr });
   };
 
   return {
@@ -46,7 +51,8 @@ const useFilterString = (str: string) => {
   };
 };
 
-export function useFilters(initialString: string = "") {
+export function useFilters() {
+  const initialString = getParams().q || "";
   const {
     appliedString,
     displayedString,

--- a/src/ui/components/Library/Filter.ts
+++ b/src/ui/components/Library/Filter.ts
@@ -27,11 +27,42 @@ function parseFilterString(str: string): LibraryFilters {
   return { qualifiers: { created, target }, searchString };
 }
 
-export function useFilters() {
-  const [displayedSearchString, setFilterString] = useState("");
-  const filters = parseFilterString(displayedSearchString);
+const useFilterString = (str: string) => {
+  const [appliedString, setAppliedString] = useState(str);
+  const [displayedString, setDisplayedString] = useState(str);
 
-  return { displayedSearchString, filters, setFilterString };
+  const applyDisplayedString = () => setAppliedString(displayedString);
+  const forceSetAppliedString = (newStr: string) => {
+    setAppliedString(newStr);
+    setDisplayedString(newStr);
+  };
+
+  return {
+    appliedString,
+    displayedString,
+    applyDisplayedString,
+    setDisplayedString,
+    setAppliedString: forceSetAppliedString,
+  };
+};
+
+export function useFilters(initialString: string = "") {
+  const {
+    appliedString,
+    displayedString,
+    applyDisplayedString,
+    setDisplayedString,
+    setAppliedString,
+  } = useFilterString(initialString);
+  const filters = parseFilterString(appliedString);
+
+  return {
+    displayedString,
+    applyDisplayedString,
+    setDisplayedString,
+    setAppliedString,
+    filters,
+  };
 }
 
 const subStringInString = (subString: string, string: string | null) => {

--- a/src/ui/components/Library/Filter.ts
+++ b/src/ui/components/Library/Filter.ts
@@ -1,0 +1,66 @@
+import { createContext, useState } from "react";
+import { Recording } from "ui/types";
+
+export type LibraryFilters = {
+  searchString: string;
+  qualifiers: {
+    created?: string;
+    target?: string;
+  };
+};
+
+export const LibraryFiltersContext = createContext({
+  searchString: "",
+  qualifiers: {},
+});
+
+function parseFilterString(str: string): LibraryFilters {
+  const words = str.split(" ");
+
+  // If there are multiple matching entries for the same filter, use the last one.
+  // TODO: Add validation for created and target. It should return null if the user didn't comply with
+  // the expected format.
+  const created = words.filter(w => !!w.match(/^created:/)).pop();
+  const target = words.filter(w => !!w.match(/^target:/)).pop();
+  const searchString = words.filter(w => !w.match(/created:|target:/)).join(" ");
+
+  return { qualifiers: { created, target }, searchString };
+}
+
+export function useFilters() {
+  const [displayedSearchString, setFilterString] = useState("");
+  const filters = parseFilterString(displayedSearchString);
+
+  return { displayedSearchString, filters, setFilterString };
+}
+
+const subStringInString = (subString: string, string: string | null) => {
+  if (!string) {
+    return false;
+  }
+
+  return string.toLowerCase().includes(subString.toLowerCase());
+};
+
+export const filterRecordings = (recordings: Recording[], filters: LibraryFilters) => {
+  const { searchString, qualifiers } = filters;
+  let filteredRecordings = recordings;
+
+  filteredRecordings = searchString
+    ? recordings.filter(
+        r => subStringInString(searchString, r.url) || subStringInString(searchString, r.title)
+      )
+    : recordings;
+  filteredRecordings =
+    qualifiers.target && qualifiers.target === "target:node"
+      ? filteredRecordings.filter(r => !r.user)
+      : filteredRecordings;
+  filteredRecordings =
+    qualifiers.created && new Date(qualifiers.created)
+      ? filteredRecordings.filter(
+          r => new Date(r.date).getTime() > new Date(qualifiers.created!).getTime()
+        )
+      : filteredRecordings;
+
+  return filteredRecordings;
+};

--- a/src/ui/components/Library/FilterBar.tsx
+++ b/src/ui/components/Library/FilterBar.tsx
@@ -1,8 +1,9 @@
-import React, { ChangeEvent, KeyboardEvent } from "react";
+import React, { ChangeEvent, KeyboardEvent, useContext } from "react";
 
 import { TextInput } from "../shared/Forms";
 
 import { FilterDropdown } from "./FilterDropdown";
+import { LibraryFilters, LibraryFiltersContext } from "./useFilters";
 
 export function FilterBar({
   displayedString,
@@ -23,14 +24,32 @@ export function FilterBar({
   };
 
   return (
-    <>
+    <div className="flex flex-grow relative items-center space-x-3">
       <FilterDropdown setAppliedText={setAppliedText} />
-      <TextInput
-        value={displayedString}
-        onChange={onChange}
-        placeholder="Search"
-        onKeyDown={onKeyPress}
-      />
-    </>
+      <div className="flex flex-grow">
+        <TextInput
+          value={displayedString}
+          onChange={onChange}
+          placeholder="Search"
+          onKeyDown={onKeyPress}
+        />
+        <InvalidFilterWarning />
+      </div>
+    </div>
+  );
+}
+
+function InvalidFilterWarning() {
+  const filters = useContext(LibraryFiltersContext);
+  const errantQualifier = Object.entries(filters.qualifiers).find(q => q[1].error);
+
+  if (!errantQualifier) {
+    return null;
+  }
+
+  return (
+    <div className="bg-errorBgcolor rounded-md border border-errorColor text-errorColor p-2 text-xs absolute transform translate-y-full mt-1">
+      Invalid filter string: {errantQualifier[1].error}
+    </div>
   );
 }

--- a/src/ui/components/Library/FilterBar.tsx
+++ b/src/ui/components/Library/FilterBar.tsx
@@ -6,27 +6,25 @@ import { FilterDropdown } from "./FilterDropdown";
 
 export function FilterBar({
   displayedString,
-  setAppliedString,
-  setDisplayedString,
-  applyDisplayedString,
+  setDisplayedText,
+  setAppliedText,
 }: {
   displayedString: string;
-  setAppliedString: (str: string) => void;
-  setDisplayedString: (str: string) => void;
-  applyDisplayedString: () => void;
+  setDisplayedText: (str: string) => void;
+  setAppliedText: (str: string) => void;
 }) {
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setDisplayedString(e.target.value);
+    setDisplayedText(e.target.value);
   };
   const onKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      applyDisplayedString();
+      setAppliedText(e.currentTarget.value);
     }
   };
 
   return (
     <>
-      <FilterDropdown setSearchString={setAppliedString} />
+      <FilterDropdown setAppliedText={setAppliedText} />
       <TextInput
         value={displayedString}
         onChange={onChange}

--- a/src/ui/components/Library/FilterBar.tsx
+++ b/src/ui/components/Library/FilterBar.tsx
@@ -1,0 +1,38 @@
+import React, { ChangeEvent, KeyboardEvent } from "react";
+
+import { TextInput } from "../shared/Forms";
+
+import { FilterDropdown } from "./FilterDropdown";
+
+export function FilterBar({
+  displayedString,
+  setAppliedString,
+  setDisplayedString,
+  applyDisplayedString,
+}: {
+  displayedString: string;
+  setAppliedString: (str: string) => void;
+  setDisplayedString: (str: string) => void;
+  applyDisplayedString: () => void;
+}) {
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setDisplayedString(e.target.value);
+  };
+  const onKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      applyDisplayedString();
+    }
+  };
+
+  return (
+    <>
+      <FilterDropdown setSearchString={setAppliedString} />
+      <TextInput
+        value={displayedString}
+        onChange={onChange}
+        placeholder="Search"
+        onKeyDown={onKeyPress}
+      />
+    </>
+  );
+}

--- a/src/ui/components/Library/FilterDropdown.tsx
+++ b/src/ui/components/Library/FilterDropdown.tsx
@@ -6,11 +6,11 @@ import { Dropdown, DropdownItem } from "./LibraryDropdown";
 
 const daysInSeconds = (days: number) => 1000 * 60 * 60 * 24 * days;
 
-export function FilterDropdown({ setSearchString }: { setSearchString: (str: string) => void }) {
+export function FilterDropdown({ setAppliedText }: { setAppliedText: (str: string) => void }) {
   const [expanded, setExpanded] = useState(false);
 
   const setStringAndCollapseDropdown = (str: string) => {
-    setSearchString(str);
+    setAppliedText(str);
     setExpanded(false);
   };
   const handleCreatedSince = (days: number) => {

--- a/src/ui/components/Library/FilterDropdown.tsx
+++ b/src/ui/components/Library/FilterDropdown.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import PortalDropdown from "../shared/PortalDropdown";
+import { Dropdown, DropdownItem } from "./LibraryDropdown";
+
+const daysInSeconds = (days: number) => 1000 * 60 * 60 * 24 * days;
+
+export function FilterDropdown({
+  setSearchString,
+}: {
+  setSearchString: (str: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  
+  const setStringAndCollapseDropdown = (str: string) => {
+    setSearchString(str);
+    setExpanded(false);
+  }
+  const handleCreatedSince = (days: number) => {
+    const secondsAgo = daysInSeconds(days);
+    const isoString = new Date(new Date().getTime() - secondsAgo).toISOString().substr(0, 10);
+
+    return setStringAndCollapseDropdown(`created:${isoString}`);
+  };
+
+  const button = (
+    <div className="text-sm flex border border-textFieldBorder bg-themeTextFieldBgcolor px-2.5 py-1.5 text-themeTextFieldColor rounded-md space-x-2">
+      <div className="text-sm">Filter</div>
+      <div className="material-icons text-sm">expand_more</div>
+    </div>
+  );
+
+  return (
+    <PortalDropdown
+      buttonContent={button}
+      // buttonStyle="flex flex-grow flex-row items-center text-sm text-gray-500"
+      setExpanded={setExpanded}
+      expanded={expanded}
+      position="top-right"
+      distance={0}
+    >
+      <Dropdown menuItemsClassName="z-50">
+        <DropdownItem onClick={() => setStringAndCollapseDropdown("")}>All Replays</DropdownItem>
+        <DropdownItem onClick={() => handleCreatedSince(7)}>Last 7 days</DropdownItem>
+        <DropdownItem onClick={() => setStringAndCollapseDropdown("target:node")}>Node replays</DropdownItem>
+      </Dropdown>
+    </PortalDropdown>
+  )
+}

--- a/src/ui/components/Library/FilterDropdown.tsx
+++ b/src/ui/components/Library/FilterDropdown.tsx
@@ -1,20 +1,18 @@
 import { useState } from "react";
+
 import PortalDropdown from "../shared/PortalDropdown";
+
 import { Dropdown, DropdownItem } from "./LibraryDropdown";
 
 const daysInSeconds = (days: number) => 1000 * 60 * 60 * 24 * days;
 
-export function FilterDropdown({
-  setSearchString,
-}: {
-  setSearchString: (str: string) => void;
-}) {
+export function FilterDropdown({ setSearchString }: { setSearchString: (str: string) => void }) {
   const [expanded, setExpanded] = useState(false);
-  
+
   const setStringAndCollapseDropdown = (str: string) => {
     setSearchString(str);
     setExpanded(false);
-  }
+  };
   const handleCreatedSince = (days: number) => {
     const secondsAgo = daysInSeconds(days);
     const isoString = new Date(new Date().getTime() - secondsAgo).toISOString().substr(0, 10);
@@ -32,7 +30,6 @@ export function FilterDropdown({
   return (
     <PortalDropdown
       buttonContent={button}
-      // buttonStyle="flex flex-grow flex-row items-center text-sm text-gray-500"
       setExpanded={setExpanded}
       expanded={expanded}
       position="top-right"
@@ -41,8 +38,10 @@ export function FilterDropdown({
       <Dropdown menuItemsClassName="z-50">
         <DropdownItem onClick={() => setStringAndCollapseDropdown("")}>All Replays</DropdownItem>
         <DropdownItem onClick={() => handleCreatedSince(7)}>Last 7 days</DropdownItem>
-        <DropdownItem onClick={() => setStringAndCollapseDropdown("target:node")}>Node replays</DropdownItem>
+        <DropdownItem onClick={() => setStringAndCollapseDropdown("target:node")}>
+          Node replays
+        </DropdownItem>
       </Dropdown>
     </PortalDropdown>
-  )
+  );
 }

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, KeyboardEvent, useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import useAuth0 from "ui/utils/useAuth0";
 import LogRocket from "ui/utils/logrocket";
@@ -8,10 +8,12 @@ import { Workspace } from "ui/types";
 import { UIState } from "ui/state";
 import * as selectors from "ui/reducers/app";
 import { Nag, useGetUserInfo } from "ui/hooks/users";
+
 import LoadingScreen from "../shared/LoadingScreen";
+import { FilterBar } from "./FilterBar";
 import Sidebar from "./Sidebar";
+import { LibraryFiltersContext, useFilters } from "./useFilters";
 import ViewerRouter from "./ViewerRouter";
-import { TextInput } from "../shared/Forms";
 import LaunchButton from "../shared/LaunchButton";
 import { trackEvent } from "ui/utils/telemetry";
 import styles from "./Library.module.css";
@@ -22,8 +24,6 @@ import {
   singleInvitation,
 } from "ui/utils/onboarding";
 import { useRouter } from "next/router";
-import { LibraryFiltersContext, useFilters } from "./Filter";
-import { FilterDropdown } from "./FilterDropdown";
 
 function isUnknownWorkspaceId(
   id: string | null,
@@ -38,39 +38,6 @@ function isUnknownWorkspaceId(
   }
 
   return !associatedWorkspaces.map(ws => ws.id).includes(id);
-}
-
-function FilterBar({
-  displayedString,
-  setAppliedString,
-  setDisplayedString,
-  applyDisplayedString,
-}: {
-  displayedString: string;
-  setAppliedString: (str: string) => void;
-  setDisplayedString: (str: string) => void;
-  applyDisplayedString: () => void;
-}) {
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setDisplayedString(e.target.value);
-  };
-  const onKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      applyDisplayedString();
-    }
-  };
-
-  return (
-    <>
-      <FilterDropdown setSearchString={setAppliedString} />
-      <TextInput
-        value={displayedString}
-        onChange={onChange}
-        placeholder="Search"
-        onKeyDown={onKeyPress}
-      />
-    </>
-  );
 }
 
 function LibraryLoader(props: PropsFromRedux) {

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -76,8 +76,7 @@ function Library({
   nags,
 }: LibraryProps) {
   const router = useRouter();
-  const { displayedString, setDisplayedString, applyDisplayedString, setAppliedString, filters } =
-    useFilters();
+  const { displayedString, setDisplayedText, setAppliedText, filters } = useFilters();
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
   const dismissNag = hooks.useDismissNag();
 
@@ -128,9 +127,8 @@ function Library({
           <div className={`flex h-16 flex-row items-center space-x-3 p-5 ${styles.libraryHeader}`}>
             <FilterBar
               displayedString={displayedString}
-              setDisplayedString={setDisplayedString}
-              setAppliedString={setAppliedString}
-              applyDisplayedString={applyDisplayedString}
+              setDisplayedText={setDisplayedText}
+              setAppliedText={setAppliedText}
             />
             <LaunchButton />
           </div>

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -12,7 +12,7 @@ import { Nag, useGetUserInfo } from "ui/hooks/users";
 import LoadingScreen from "../shared/LoadingScreen";
 import { FilterBar } from "./FilterBar";
 import Sidebar from "./Sidebar";
-import { LibraryFiltersContext, useFilters } from "./useFilters";
+import { LibraryFilters, LibraryFiltersContext, useFilters } from "./useFilters";
 import ViewerRouter from "./ViewerRouter";
 import LaunchButton from "../shared/LaunchButton";
 import { trackEvent } from "ui/utils/telemetry";

--- a/src/ui/components/Library/LibraryDropdown.tsx
+++ b/src/ui/components/Library/LibraryDropdown.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Menu } from "@headlessui/react";
 import classNames from "classnames";
-import MaterialIcon from "../shared/MaterialIcon";
 import Icon from "../shared/Icon";
 import styles from "./Library.module.css";
 

--- a/src/ui/components/Library/Viewer.tsx
+++ b/src/ui/components/Library/Viewer.tsx
@@ -52,13 +52,16 @@ export default function Viewer({
   workspaceName: string | React.ReactNode;
 }) {
   const filters = useContext(LibraryFiltersContext);
-  const filteredRecordings = filterRecordings(recordings, filters);
+  const filteredRecordings = useMemo(
+    () => filterRecordings(recordings, filters),
+    [filters, recordings]
+  );
 
   return (
     <div
       className={`flex flex-grow flex-col space-y-5 overflow-hidden bg-gray-100 px-8 py-6 ${styles.libraryWrapper}`}
     >
-      <ViewerContent {...{ workspaceName }} recordings={filteredRecordings} />
+      <ViewerContent workspaceName={workspaceName} recordings={filteredRecordings} />
     </div>
   );
 }
@@ -74,8 +77,6 @@ function ViewerContent({
   const [isEditing, setIsEditing] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [showMore, toggleShowMore] = useState(false);
-
-  console.log(recordings);
 
   const shownRecordings = useMemo(() => {
     const sortedRecordings = sortBy(recordings, recording => {

--- a/src/ui/components/Library/Viewer.tsx
+++ b/src/ui/components/Library/Viewer.tsx
@@ -1,17 +1,21 @@
-import React, { useState, useMemo, useContext } from "react";
-import { Recording } from "ui/types";
 import { RecordingId } from "@recordreplay/protocol";
+
 import BatchActionDropdown from "./BatchActionDropdown";
+
 import { isReplayBrowser } from "ui/utils/environment";
 import { PrimaryButton, SecondaryButton } from "../shared/Button";
-import RecordingRow from "./RecordingRow";
 import ViewerHeader, { ViewerHeaderLeft } from "./ViewerHeader";
+
 import sortBy from "lodash/sortBy";
-import styles from "./Library.module.css";
+import React, { useState, useMemo, useContext } from "react";
 import { useSelector } from "react-redux";
 import { getWorkspaceId } from "ui/reducers/app";
+import { Recording } from "ui/types";
+
+import styles from "./Library.module.css";
+import RecordingRow from "./RecordingRow";
 import TeamTrialEnd from "./TeamTrialEnd";
-import { filterRecordings, LibraryFiltersContext } from "./Filter";
+import { filterRecordings, LibraryFiltersContext } from "./useFilters";
 
 function getErrorText() {
   if (isReplayBrowser()) {

--- a/src/ui/components/Library/Viewer.tsx
+++ b/src/ui/components/Library/Viewer.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useContext } from "react";
 import { Recording } from "ui/types";
 import { RecordingId } from "@recordreplay/protocol";
 import BatchActionDropdown from "./BatchActionDropdown";
 import { isReplayBrowser } from "ui/utils/environment";
 import { PrimaryButton, SecondaryButton } from "../shared/Button";
-import { LibraryFilters } from "./Library";
 import RecordingRow from "./RecordingRow";
 import ViewerHeader, { ViewerHeaderLeft } from "./ViewerHeader";
 import sortBy from "lodash/sortBy";
@@ -12,14 +11,7 @@ import styles from "./Library.module.css";
 import { useSelector } from "react-redux";
 import { getWorkspaceId } from "ui/reducers/app";
 import TeamTrialEnd from "./TeamTrialEnd";
-
-const subStringInString = (subString: string, string: string | null) => {
-  if (!string) {
-    return false;
-  }
-
-  return string.toLowerCase().includes(subString.toLowerCase());
-};
+import { filterRecordings, LibraryFiltersContext } from "./Filter";
 
 function getErrorText() {
   if (isReplayBrowser()) {
@@ -48,38 +40,14 @@ function DownloadLinks() {
   );
 }
 
-const filterRecordings = (recordings: Recording[], filters: LibraryFilters) => {
-  const { searchString, qualifiers } = filters;
-  let filteredRecordings = recordings;
-
-  filteredRecordings = searchString
-    ? recordings.filter(
-        r => subStringInString(searchString, r.url) || subStringInString(searchString, r.title)
-      )
-    : recordings;
-  filteredRecordings =
-    qualifiers.target && qualifiers.target === "target:node"
-      ? filteredRecordings.filter(r => !r.user)
-      : filteredRecordings;
-  filteredRecordings =
-    (qualifiers.created && new Date(qualifiers.created))
-      ? filteredRecordings.filter(
-          r => new Date(r.date).getTime() > new Date(qualifiers.created!).getTime()
-        )
-      : filteredRecordings;
-
-  return filteredRecordings;
-};
-
 export default function Viewer({
   recordings,
   workspaceName,
-  filters,
 }: {
   recordings: Recording[];
   workspaceName: string | React.ReactNode;
-  filters: LibraryFilters;
 }) {
+  const filters = useContext(LibraryFiltersContext);
   const filteredRecordings = filterRecordings(recordings, filters);
 
   return (

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -62,14 +62,10 @@ function NonPendingTeamLibrary({ currentWorkspaceId }: ViewerRouterProps) {
 
   return (
     <Viewer
-      {...{
-        recordings,
-        workspaceName: workspace.logo ? (
-          <Base64Image src={workspace.logo} className="max-h-12" />
-        ) : (
-          workspace.name
-        ),
-      }}
+      recordings={recordings}
+      workspaceName={
+        workspace.logo ? <Base64Image src={workspace.logo} className="max-h-12" /> : workspace.name
+      }
     />
   );
 }

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -13,8 +13,6 @@ import { BlankViewportWrapper } from "../shared/Viewport";
 import Base64Image from "../shared/Base64Image";
 import { sendTelemetryEvent } from "ui/utils/telemetry";
 
-import { LibraryFilters } from "./Library";
-
 function ViewerLoader() {
   return (
     <div className="grid h-full w-full items-center justify-items-center bg-chrome">
@@ -23,7 +21,7 @@ function ViewerLoader() {
   );
 }
 
-function MyLibrary({ filters }: ViewerRouterProps) {
+function MyLibrary() {
   const { recordings, loading } = hooks.useGetPersonalRecordings();
   const { loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
 
@@ -31,7 +29,7 @@ function MyLibrary({ filters }: ViewerRouterProps) {
     return <ViewerLoader />;
   }
 
-  return <Viewer {...{ filters, recordings, workspaceName: MY_LIBRARY }} />;
+  return <Viewer {...{ recordings, workspaceName: MY_LIBRARY }} />;
 }
 
 function TeamLibrary(props: ViewerRouterProps) {
@@ -52,7 +50,7 @@ function TeamLibrary(props: ViewerRouterProps) {
   }
 }
 
-function NonPendingTeamLibrary({ currentWorkspaceId, filters }: ViewerRouterProps) {
+function NonPendingTeamLibrary({ currentWorkspaceId }: ViewerRouterProps) {
   const { recordings, loading } = hooks.useGetWorkspaceRecordings(currentWorkspaceId!);
   const { workspaces, loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
 
@@ -65,7 +63,6 @@ function NonPendingTeamLibrary({ currentWorkspaceId, filters }: ViewerRouterProp
   return (
     <Viewer
       {...{
-        filters,
         recordings,
         workspaceName: workspace.logo ? (
           <Base64Image src={workspace.logo} className="max-h-12" />
@@ -77,9 +74,7 @@ function NonPendingTeamLibrary({ currentWorkspaceId, filters }: ViewerRouterProp
   );
 }
 
-type ViewerRouterProps = PropsFromRedux & {
-  filters: LibraryFilters;
-};
+type ViewerRouterProps = PropsFromRedux;
 
 function ViewerRouter(props: ViewerRouterProps) {
   const { workspaces, loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
@@ -124,7 +119,7 @@ function ViewerRouter(props: ViewerRouterProps) {
   }
 
   if (currentWorkspaceId === null && features.library) {
-    return <MyLibrary {...props} />;
+    return <MyLibrary />;
   } else if (currentWorkspaceId) {
     return <TeamLibrary {...props} />;
   }

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -13,6 +13,8 @@ import { BlankViewportWrapper } from "../shared/Viewport";
 import Base64Image from "../shared/Base64Image";
 import { sendTelemetryEvent } from "ui/utils/telemetry";
 
+import { LibraryFilters } from "./Library";
+
 function ViewerLoader() {
   return (
     <div className="grid h-full w-full items-center justify-items-center bg-chrome">
@@ -21,7 +23,7 @@ function ViewerLoader() {
   );
 }
 
-function MyLibrary({ searchString }: ViewerRouterProps) {
+function MyLibrary({ filters }: ViewerRouterProps) {
   const { recordings, loading } = hooks.useGetPersonalRecordings();
   const { loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
 
@@ -29,7 +31,7 @@ function MyLibrary({ searchString }: ViewerRouterProps) {
     return <ViewerLoader />;
   }
 
-  return <Viewer {...{ recordings, workspaceName: MY_LIBRARY, searchString }} />;
+  return <Viewer {...{ filters, recordings, workspaceName: MY_LIBRARY }} />;
 }
 
 function TeamLibrary(props: ViewerRouterProps) {
@@ -50,7 +52,7 @@ function TeamLibrary(props: ViewerRouterProps) {
   }
 }
 
-function NonPendingTeamLibrary({ currentWorkspaceId, searchString }: ViewerRouterProps) {
+function NonPendingTeamLibrary({ currentWorkspaceId, filters }: ViewerRouterProps) {
   const { recordings, loading } = hooks.useGetWorkspaceRecordings(currentWorkspaceId!);
   const { workspaces, loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
 
@@ -63,20 +65,20 @@ function NonPendingTeamLibrary({ currentWorkspaceId, searchString }: ViewerRoute
   return (
     <Viewer
       {...{
+        filters,
         recordings,
         workspaceName: workspace.logo ? (
           <Base64Image src={workspace.logo} className="max-h-12" />
         ) : (
           workspace.name
         ),
-        searchString,
       }}
     />
   );
 }
 
 type ViewerRouterProps = PropsFromRedux & {
-  searchString: string;
+  filters: LibraryFilters;
 };
 
 function ViewerRouter(props: ViewerRouterProps) {

--- a/src/ui/components/Library/useFilters.ts
+++ b/src/ui/components/Library/useFilters.ts
@@ -28,6 +28,37 @@ function parseFilterString(str: string): LibraryFilters {
   return { qualifiers: { created, target }, searchString };
 }
 
+const subStringInString = (subString: string, string: string | null) => {
+  if (!string) {
+    return false;
+  }
+
+  return string.toLowerCase().includes(subString.toLowerCase());
+};
+
+export const filterRecordings = (recordings: Recording[], filters: LibraryFilters) => {
+  const { searchString, qualifiers } = filters;
+  let filteredRecordings = recordings;
+
+  filteredRecordings = searchString
+    ? recordings.filter(
+        r => subStringInString(searchString, r.url) || subStringInString(searchString, r.title)
+      )
+    : recordings;
+  filteredRecordings =
+    qualifiers.target && qualifiers.target === "target:node"
+      ? filteredRecordings.filter(r => !r.user)
+      : filteredRecordings;
+  filteredRecordings =
+    qualifiers.created && new Date(qualifiers.created)
+      ? filteredRecordings.filter(
+          r => new Date(r.date).getTime() > new Date(qualifiers.created!).getTime()
+        )
+      : filteredRecordings;
+
+  return filteredRecordings;
+};
+
 const useFilterString = (str: string) => {
   const [appliedString, setAppliedString] = useState(str);
   const [displayedString, setDisplayedString] = useState(str);
@@ -70,34 +101,3 @@ export function useFilters() {
     filters,
   };
 }
-
-const subStringInString = (subString: string, string: string | null) => {
-  if (!string) {
-    return false;
-  }
-
-  return string.toLowerCase().includes(subString.toLowerCase());
-};
-
-export const filterRecordings = (recordings: Recording[], filters: LibraryFilters) => {
-  const { searchString, qualifiers } = filters;
-  let filteredRecordings = recordings;
-
-  filteredRecordings = searchString
-    ? recordings.filter(
-        r => subStringInString(searchString, r.url) || subStringInString(searchString, r.title)
-      )
-    : recordings;
-  filteredRecordings =
-    qualifiers.target && qualifiers.target === "target:node"
-      ? filteredRecordings.filter(r => !r.user)
-      : filteredRecordings;
-  filteredRecordings =
-    qualifiers.created && new Date(qualifiers.created)
-      ? filteredRecordings.filter(
-          r => new Date(r.date).getTime() > new Date(qualifiers.created!).getTime()
-        )
-      : filteredRecordings;
-
-  return filteredRecordings;
-};

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -1,4 +1,5 @@
 import { MockedResponse } from "@apollo/client/testing";
+import { ExecutionPoint } from "@recordreplay/protocol";
 import { Editor } from "codemirror";
 import { usesWindow } from "../../ssr";
 
@@ -107,6 +108,20 @@ export function getPausePointParams() {
   }
 
   return null;
+}
+
+export function getParams() {
+  const url = new URL(window.location.toString());
+  return { q: url.searchParams.get("q") };
+}
+export function updateUrlWithParams(params: Record<string, string>) {
+  const url = new URL(window.location.toString());
+
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+
+  window.history.replaceState({}, "", url.toString());
 }
 
 export function getLoginReferrerParam() {


### PR DESCRIPTION
<img width="1796" alt="image" src="https://user-images.githubusercontent.com/15959269/167709501-0f1c2acb-5525-4112-9f33-ef660b0ab54e.png">

This PR adds some of the scaffolding necessary to have [advanced search syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests). For now we're going to support two qualifiers (`created` and `target` ). This allows us to have a dropdown where the user can specify if they want to only see replays recorded in the last 7 days, or replays that targeted node recordings.

Some notes:
- The filtering will still be done client side. It won't be for much longer — the immediate follow-up to this will be to figure out how to ask the backend for a filtered list of recordings based on the current filter string.
- The qualifiers aren't fully implemented. Right now, only the necessary parts to support the dropdown have been implemented. So `created` doesn't support comparison prefixes (eg >, <=), and `target` can only filter for `node` targets.
- One change this introduces is we will no longer filter the displayed replays whenever the filter string changes. Instead, we now require the user to explicit commit to the filtering by pressing enter.
- The URL is updated to take a url param `q` which will contain the currently-applied filter string, so that the filter persists on refresh and users can share the link. Those aren't particularly big use cases for now, but it wasn't much more work to put in and it's something which we will need for the test suite use case anyway, so I decided to include it here.

Fix #6533.