### PR TITLE
Only request at most one column's location per line

### DIFF
--- a/src/devtools/client/debugger/src/client/commands.js
+++ b/src/devtools/client/debugger/src/client/commands.js
@@ -339,12 +339,13 @@ async function getSourceActorBreakpointHitCounts({ id }, lineNumber, onFailure) 
   // explanation of the bounds here.
   const lowerBound = Math.floor(lineNumber / MAX_LINE_HITS_TO_FETCH) * MAX_LINE_HITS_TO_FETCH;
   const upperBound = lowerBound + MAX_LINE_HITS_TO_FETCH;
-  const locationsToFetch = locations.filter(
-    location => location.line >= lowerBound && location.line < upperBound
-  );
+  const locationsToFetch = locations
+    .filter(location => location.line >= lowerBound && location.line < upperBound)
+    .map(location => ({ ...location, columns: [location.columns.sort((a, b) => a - b)[0]] }));
+
   return {
-    min: lowerBound,
     max: upperBound,
+    min: lowerBound,
     ...(await ThreadFront.getHitCounts(id, locationsToFetch).catch(onFailure)),
   };
 }

--- a/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/SourceOutline.tsx
@@ -164,11 +164,11 @@ const mapStateToProps = (state: UIState) => {
   const symbols = selectedSource ? selectors.getSymbols(state, selectedSource) : null;
   const hitCounts = selectedSource ? getHitCountsForSelectedSource(state) : null;
   return {
+    cursorPosition: selectors.getCursorPosition(state),
     cx: selectors.getContext(state),
-    symbols,
     hitCounts,
     selectedSource: selectedSource,
-    cursorPosition: selectors.getCursorPosition(state),
+    symbols,
   };
 };
 

--- a/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
+++ b/src/devtools/client/debugger/src/components/SourceOutline/getOutlineSymbols.tsx
@@ -4,7 +4,11 @@ import { SourceSymbols, ClassSymbol, FunctionSymbol } from "../../types";
 import { HitCount } from "../../reducers/sources";
 import { features } from "ui/utils/prefs";
 
-function addHitCountsToFunctions(functions: FunctionSymbol[], hitCounts: HitCount[]) {
+function addHitCountsToFunctions(functions: FunctionSymbol[], hitCounts: HitCount[] | null) {
+  if (!hitCounts) {
+    return functions;
+  }
+
   return functions.map(functionSymbol => {
     const { start, end } = functionSymbol.location;
 
@@ -31,8 +35,9 @@ export function getOutlineSymbols(
   if (!symbols || symbols.loading) {
     return null;
   }
+
   let { classes, functions } = symbols;
-  functions = hitCounts ? addHitCountsToFunctions(functions, hitCounts) : functions;
+  functions = addHitCountsToFunctions(functions, hitCounts);
   const classNames = new Set(classes.map(s => s.name));
   const functionsByName = keyBy(functions, "name");
   const filteredFunctions = functions.filter(


### PR DESCRIPTION
We might actually want to check whether the user has columnBreakpoints
turned on, because theoretically someday we could show different numbers
hovering on different parts of the line, but for right now, we always
show the first location, so let's just ask for that hitCount.

A nice consequence of this is that it is a lot less likely that we will
have to fallback to analyses because we are asking for too many
locations, because the backend's limit is 1,000 locations, we query in
1,000 line chunks, and so if no line asks for more than one location we
should always be under the limit. (This is not actually necessarily true
because generated locations also have a limit but whatever, close
enough).

Recording of heatmaps working on a big minified file which it was choking on before this change:
https://app.replay.io/recording/gethitcounts-on-big-minified-ebay-file--6dfc9d63-55ca-4e76-ad58-b9ed72c0dbf4