### PR TITLE
Improve apollo error handling

### DIFF
--- a/src/ui/utils/telemetry.ts
+++ b/src/ui/utils/telemetry.ts
@@ -14,7 +14,6 @@ export function setupTelemetry() {
     "Current thread has changed",
     "Failed to load Stripe.js",
     "Stripe.js not available",
-    "Received status code 500",
   ];
   // We always initialize mixpanel here. This allows us to force enable mixpanel events even if
   // telemetry events are being skipped for any reason, e.g. development, test, etc.


### PR DESCRIPTION
Reverts RecordReplay/devtools#5669

## Issue

We missed #6538 because there was no notification that something was going wrong

## Resolution

* Revert suppressing all 500 errors to force us to handle server-side errors on the client.
* Improve the console log output to provide more context to sentry

<img width="855" alt="image" src="https://user-images.githubusercontent.com/788456/165391095-c7cbd9ad-18f7-44a7-b7b5-565ca852a7c4.png">
