### PR TITLE
Don't assume that error objects must contain a message (#6501)

### DIFF
--- a/src/devtools/packages/devtools-reps/reps/error.js
+++ b/src/devtools/packages/devtools-reps/reps/error.js
@@ -42,7 +42,7 @@ function ErrorRep(props) {
   }
   const content = [];
 
-  if (mode === MODE.TINY) {
+  if (mode === MODE.TINY || !preview.has("message")) {
     content.push(name);
   } else {
     content.push(`${name}: "${preview.get("message").primitive()}"`);


### PR DESCRIPTION
fixes #6501