### PR TITLE
Fix "OI root item must be a ValueItem" (#6561)

### DIFF
--- a/src/devtools/client/debugger/src/actions/preview.js
+++ b/src/devtools/client/debugger/src/actions/preview.js
@@ -73,12 +73,14 @@ export function setPreview(cx, expression, location, tokenPos, cursorPos, target
       result = createPrimitiveValueFront(undefined);
     }
 
-    const root = new ValueItem({
+    let root = new ValueItem({
       name: expression,
       path: expression,
       contents: result,
     });
     await root.loadChildren();
+    // recreate the ValueItem to update its loading state
+    root = root.recreate();
 
     // The first time a popup is rendered, the mouse should be hovered
     // on the token. If it happens to be hovered on whitespace, it should


### PR DESCRIPTION
What went wrong: a value whose children haven't been loaded yet should be shown in a preview popup. The preview action ensures that the value's children (which are passed as roots to `ObjectInspector`) are loaded, *but* it creates a `ValueItem` *before* loading them and so the `ValueItem`'s `childrenLoaded` property is `false` and `getChildren()` returns a `LoadingItem`. This is passed as the root to `ObjectInspector`, but those roots should always be `ValueItem`s.