### PR TITLE
More comment unit tests

### DIFF
--- a/src/devtools/client/webconsole/components/Search/useConsoleSearch.test.tsx
+++ b/src/devtools/client/webconsole/components/Search/useConsoleSearch.test.tsx
@@ -7,10 +7,7 @@ import {
   createLoadedRegions,
   createSource,
   createValue,
-  sendLoadedRegionsToMockEnvironment,
-  sendMessageToMockEnvironment,
-  sendSourceToMockEnvironment,
-  createPointDescription,
+  sendValuesToMockEnvironment,
 } from "test/testFixtureUtils";
 import {
   createTestStore,
@@ -51,38 +48,26 @@ describe("useConsoleSearch", () => {
     // This is necessary to unblock various event listeners and parsing.
     await ThreadFront.setSessionId(DEFAULT_SESSION_ID);
 
-    sendSourceToMockEnvironment(
+    sendValuesToMockEnvironment(
       createSource({
         kind: "scriptSource",
-      })
-    );
-
-    sendMessageToMockEnvironment(
+      }),
       createConsoleMessage({
         text: "Plain string message",
-      })
-    );
-    sendMessageToMockEnvironment(
+      }),
       createConsoleMessage({
         argumentValues: [
           createValue({ value: 123 }),
           createValue({ value: "string value" }),
           createValue({ value: true }),
         ],
-      })
-    );
-    sendMessageToMockEnvironment(
+      }),
       createConsoleMessage({
         text: "Another string message",
-      })
-    );
-    sendMessageToMockEnvironment(
+      }),
       createConsoleMessage({
         argumentValues: [createValue({ value: "another string value" })],
-      })
-    );
-
-    sendLoadedRegionsToMockEnvironment(
+      }),
       createLoadedRegions({
         beginTime: 0,
         endTime: 1000,

--- a/src/devtools/client/webconsole/components/__tests__/WebConsoleApp.test.tsx
+++ b/src/devtools/client/webconsole/components/__tests__/WebConsoleApp.test.tsx
@@ -1,18 +1,16 @@
-import React from "react";
-import { render, createTestStore, filterCommonTestWarnings, act, screen } from "test/testUtils";
 import userEvent from "@testing-library/user-event";
-import fs from "fs";
 import WebConsoleApp from "devtools/client/webconsole/components/App";
-import { createSession } from "ui/actions/session";
 import { ThreadFront } from "protocol/thread";
+import React from "react";
+import { render, createTestStore, filterCommonTestWarnings } from "test/testUtils";
 
 import { websocketMessages } from "./fixtures/messageSetupActions";
 
 const useRouter = jest.spyOn(require("next/router"), "useRouter");
 
 useRouter.mockImplementation(() => ({
-  query: { id: "abcd" },
   asPath: "/recording/abcd",
+  query: { id: "abcd" },
 }));
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -25,7 +25,7 @@ const user = { id: userId, uuid: userId };
 const graphqlMocks = [
   ...createUserSettingsMock(),
   ...createRecordingOwnerUserIdMock({ recordingId, user }),
-  ...createGetRecordingMock({ recordingId }),
+  ...createGetRecordingMock({ recordingId, user }),
   ...createGetUserMock({ user }),
 ];
 

--- a/test/mock/scripts/invalid-recording-01.ts
+++ b/test/mock/scripts/invalid-recording-01.ts
@@ -18,7 +18,7 @@ const user = { id: userId, uuid: userId };
 const graphqlMocks = [
   ...createUserSettingsMock(),
   ...createRecordingOwnerUserIdMock({ recordingId, user }),
-  ...createGetRecordingMock({ recordingId }),
+  ...createGetRecordingMock({ recordingId, user }),
   ...createGetUserMock({ user }),
 ];
 const messageHandlers = basicMessageHandlers();

--- a/test/mock/scripts/invalid-recording-02.ts
+++ b/test/mock/scripts/invalid-recording-02.ts
@@ -13,7 +13,7 @@ const user = { id: userId, uuid: userId };
 const graphqlMocks = [
   ...createUserSettingsMock(),
   ...createGetUserMock({ user }),
-  ...createGetRecordingMock({ recordingId }),
+  ...createGetRecordingMock({ recordingId, user }),
 ];
 const messageHandlers = basicMessageHandlers();
 const bindings = basicBindings();

--- a/test/mock/scripts/session-error.ts
+++ b/test/mock/scripts/session-error.ts
@@ -18,7 +18,7 @@ const user = { id: userId, uuid: userId };
 const graphqlMocks = [
   ...createUserSettingsMock(),
   ...createRecordingOwnerUserIdMock({ recordingId, user }),
-  ...createGetRecordingMock({ recordingId, recording: {} }),
+  ...createGetRecordingMock({ recording: {}, recordingId, user }),
   ...createGetUserMock({ user }),
 ];
 const messageHandlers = {

--- a/test/mock/scripts/unload-recording-01.ts
+++ b/test/mock/scripts/unload-recording-01.ts
@@ -42,6 +42,7 @@ const messageHandlers = {
   ...basicMessageHandlers(),
   "Session.listenForLoadChanges": (params: any, h: MockHandlerHelpers) => {
     h.emitEvent("Session.loadedRegions", {
+      indexed: [],
       loaded: [
         {
           begin: { point: "50000", time: 50000 },

--- a/test/mock/scripts/unload-recording-01.ts
+++ b/test/mock/scripts/unload-recording-01.ts
@@ -27,7 +27,7 @@ const graphqlMocks = [
   ...createUserSettingsMock(),
   ...createRecordingOwnerUserIdMock({ recordingId, user }),
   ...createGetUserMock({ user }),
-  ...createGetRecordingMock({ recordingId, recording }),
+  ...createGetRecordingMock({ recording, recordingId, user }),
   ...createEmptyCommentsMock({ recordingId }),
   ...createGetActiveSessionsMock({ recordingId }),
 ];

--- a/test/mock/src/graphql/comments.ts
+++ b/test/mock/src/graphql/comments.ts
@@ -1,9 +1,32 @@
 import { MockedResponse } from "@apollo/client/testing";
+import { GetComments, GetCommentsVariables } from "graphql/GetComments";
+import { GetCommentsTime, GetCommentsTimeVariables } from "graphql/GetCommentsTime";
 import { GET_COMMENTS, GET_COMMENTS_TIME } from "ui/graphql/comments";
+
 import { cloneResponse } from "./utils";
 
+type GetCommentsMockType = {
+  request: {
+    query: typeof GET_COMMENTS;
+    variables: GetCommentsVariables;
+  };
+  result: {
+    data: GetComments;
+  };
+};
+
+type GetCommentsTimeMockType = {
+  request: {
+    query: typeof GET_COMMENTS_TIME;
+    variables: GetCommentsTimeVariables;
+  };
+  result: {
+    data: GetCommentsTime;
+  };
+};
+
 export function createEmptyCommentsMock(opts: { recordingId: string }): MockedResponse[] {
-  const getComments = {
+  const getComments: GetCommentsMockType = {
     request: {
       query: GET_COMMENTS,
       variables: { recordingId: opts.recordingId },
@@ -11,13 +34,14 @@ export function createEmptyCommentsMock(opts: { recordingId: string }): MockedRe
     result: {
       data: {
         recording: {
-          uuid: opts.recordingId,
+          __typename: "Recording",
           comments: [],
+          uuid: opts.recordingId,
         },
       },
     },
   };
-  const getCommentsTime = {
+  const getCommentsTime: GetCommentsTimeMockType = {
     request: {
       query: GET_COMMENTS_TIME,
       variables: { recordingId: opts.recordingId },
@@ -25,8 +49,9 @@ export function createEmptyCommentsMock(opts: { recordingId: string }): MockedRe
     result: {
       data: {
         recording: {
-          uuid: opts.recordingId,
+          __typename: "Recording",
           comments: [],
+          uuid: opts.recordingId,
         },
       },
     },

--- a/test/mock/src/graphql/recordings.ts
+++ b/test/mock/src/graphql/recordings.ts
@@ -1,75 +1,110 @@
 import { MockedResponse } from "@apollo/client/testing";
+import { GetRecording, GetRecordingVariables, GetRecording_recording } from "graphql/GetRecording";
+import {
+  GetRecordingUserId,
+  GetRecordingUserIdVariables,
+  GetRecordingUserId_recording,
+} from "graphql/GetRecordingUserId";
 import { GET_RECORDING, GET_RECORDING_USER_ID } from "ui/graphql/recordings";
-import { Recording, RecordingRole, WorkspaceSubscriptionStatus } from "ui/types";
+import { Recording, RecordingRole, User } from "ui/types";
+
 import { cloneResponse } from "./utils";
 
-const mockRecording = {
-  collaborators: [],
-  comments: [],
-  createdAt: "2021-07-05T10:03:13.466Z",
-  duration: 10,
-  id: "mock-recording-id",
-  isInitialized: true,
-  operations: { scriptDomains: [] },
-  ownerNeedsInvite: false,
-  private: false,
-  title: "Mock Title",
-  url: "https://mock.org",
-  userRole: RecordingRole.None,
-  workspace: null,
-  owner: {
-    id: "00000000-0000-0000-0000-000000000000",
-    name: "Mock User",
-    picture: "",
-    internal: false,
-  },
+type GetRecordingUserIdMockType = {
+  request: {
+    query: typeof GET_RECORDING_USER_ID;
+    variables: GetRecordingUserIdVariables;
+  };
+  result: {
+    data: GetRecordingUserId;
+  };
 };
 
 export function createRecordingOwnerUserIdMock(opts: {
   recordingId: string;
   user?: { id: string; uuid: string };
 }): MockedResponse[] {
-  const rv = {
+  let mockRecording: GetRecordingUserId_recording | null = null;
+  if (opts.user) {
+    mockRecording = {
+      __typename: "Recording",
+      owner: {
+        __typename: "User",
+        id: opts.user.id,
+      },
+      uuid: opts.recordingId,
+    };
+  }
+
+  const mock: GetRecordingUserIdMockType = {
     request: {
       query: GET_RECORDING_USER_ID,
       variables: { recordingId: opts.recordingId },
     },
     result: {
-      data: opts.user
-        ? {
-            recording: {
-              uuid: opts.recordingId,
-              owner: {
-                id: opts.user.id,
-              },
-            },
-          }
-        : null,
+      data: {
+        recording: mockRecording,
+      },
     },
   };
-  return cloneResponse(rv, 100);
+  return cloneResponse(mock, 100);
 }
+
+type GetRecordingMockType = {
+  request: {
+    query: typeof GET_RECORDING;
+    variables: GetRecordingVariables;
+  };
+  result: {
+    data: GetRecording;
+  };
+};
 
 export function createGetRecordingMock(opts: {
   recordingId: string;
   recording?: Partial<Recording>;
+  user?: Partial<User>;
 }): MockedResponse[] {
-  const rv = {
+  let mockRecording: GetRecording_recording = {
+    __typename: "Recording",
+    collaboratorRequests: null as any, // TypeScript fail
+    collaborators: null as any, // TypeScript fail
+    comments: [],
+    createdAt: "2021-07-05T10:03:13.466Z",
+    duration: 10,
+    isInitialized: true,
+    operations: { scriptDomains: [] },
+    owner: {
+      __typename: "User",
+      id: "mock-user-id",
+      internal: false,
+      name: "Mock User",
+      picture: "",
+
+      ...opts.user,
+    },
+    ownerNeedsInvite: false,
+    private: false,
+    resolution: null,
+    title: "Mock Title",
+    url: "https://mock.org",
+    userRole: RecordingRole.None,
+    uuid: opts.recordingId || "mock-recording-id",
+    workspace: null as any, // TypeScript fail
+
+    ...opts.recording,
+  };
+
+  const mock: GetRecordingMockType = {
     request: {
       query: GET_RECORDING,
       variables: { recordingId: opts.recordingId },
     },
     result: {
-      data: opts.recording
-        ? {
-            recording: {
-              uuid: opts.recordingId,
-              ...mockRecording,
-              ...opts.recording,
-            },
-          }
-        : null,
+      data: {
+        recording: mockRecording,
+      },
     },
   };
-  return cloneResponse(rv, 100);
+  return cloneResponse(mock, 100);
 }

--- a/test/mock/src/graphql/recordings.ts
+++ b/test/mock/src/graphql/recordings.ts
@@ -102,7 +102,7 @@ export function createGetRecordingMock(opts: {
     },
     result: {
       data: {
-        recording: mockRecording,
+        recording: opts.recording ? mockRecording : null,
       },
     },
   };

--- a/test/mock/src/graphql/sessions.ts
+++ b/test/mock/src/graphql/sessions.ts
@@ -1,9 +1,21 @@
 import { MockedResponse } from "@apollo/client/testing";
+import { GetActiveSessions, GetActiveSessionsVariables } from "graphql/GetActiveSessions";
 import { GET_ACTIVE_SESSIONS } from "ui/graphql/sessions";
+
 import { cloneResponse } from "./utils";
 
+type GetActiveSessionsType = {
+  request: {
+    query: typeof GET_ACTIVE_SESSIONS;
+    variables: GetActiveSessionsVariables;
+  };
+  result: {
+    data: GetActiveSessions;
+  };
+};
+
 export function createGetActiveSessionsMock(opts: { recordingId: string }): MockedResponse[] {
-  const rv = {
+  const mock: GetActiveSessionsType = {
     request: {
       query: GET_ACTIVE_SESSIONS,
       variables: { recordingId: opts.recordingId },
@@ -11,11 +23,12 @@ export function createGetActiveSessionsMock(opts: { recordingId: string }): Mock
     result: {
       data: {
         recording: {
-          uuid: opts.recordingId,
+          __typename: "Recording",
           activeSessions: [],
+          uuid: opts.recordingId,
         },
       },
     },
   };
-  return cloneResponse(rv, 20);
+  return cloneResponse(mock, 20);
 }

--- a/test/mock/src/graphql/settings.ts
+++ b/test/mock/src/graphql/settings.ts
@@ -1,30 +1,43 @@
 import { MockedResponse } from "@apollo/client/testing";
+import { GetUserSettings } from "graphql/GetUserSettings";
 import { GET_USER_SETTINGS } from "ui/graphql/settings";
-import { ExperimentalUserSettings } from "ui/types";
+
 import { cloneResponse } from "./utils";
 
-export function createUserSettingsMock(): MockedResponse[] {
-  const settings: ExperimentalUserSettings = {
-    apiKeys: [],
-    defaultWorkspaceId: null,
-    disableLogRocket: false,
-    enableEventLink: false,
-    enableTeams: true,
-    showReact: true,
+type GetUserSettingsMockType = {
+  request: {
+    query: typeof GET_USER_SETTINGS;
   };
-  const rv = {
+  result: {
+    data: GetUserSettings;
+  };
+};
+
+export function createUserSettingsMock(): MockedResponse[] {
+  const mockData: GetUserSettings = {
+    viewer: {
+      __typename: "AuthenticatedUser",
+      apiKeys: [],
+      defaultWorkspace: null,
+      settings: {
+        __typename: "AuthenticatedUserSettings",
+        disableLogRocket: false,
+        enableEventLink: false,
+        enableRepaint: false,
+        enableTeams: true,
+        showReact: true,
+      },
+    },
+  };
+
+  const mock: GetUserSettingsMockType = {
     request: {
       query: GET_USER_SETTINGS,
     },
     result: {
-      data: {
-        viewer: {
-          apiKeys: [],
-          settings,
-          defaultWorkspace: null,
-        },
-      },
+      data: mockData,
     },
   };
-  return cloneResponse(rv, 10);
+
+  return cloneResponse(mock, 10);
 }

--- a/test/mock/src/handlers/basic.ts
+++ b/test/mock/src/handlers/basic.ts
@@ -48,6 +48,7 @@ export function basicMessageHandlers(): MockHandlerRecord {
     },
     "Session.listenForLoadChanges": (params: any, h: MockHandlerHelpers) => {
       h.emitEvent("Session.loadedRegions", {
+        indexed: [],
         loaded: [
           {
             begin: { point: "0", time: 0 },


### PR DESCRIPTION
- [x] Refactor test factory functions to be a little less verbose on the test side.

Before:
```js
sendSourceToMockEnvironment(
  createSource({
    kind: "scriptSource",
  })
);
sendMessageToMockEnvironment(
  createConsoleMessage({
    text: "Plain string message",
  })
);
// And so on...
```

After:
```js
sendValuesToMockEnvironment(
  createSource({
    kind: "scriptSource",
  }),
  createConsoleMessage({
    text: "Plain string message",
  }),
  // And so on...
);
```

- [x] Add TypeScript types to GraphQL mocks.
- [x] Fixed some bad mock data (missing `indexed` array in loaded regions mock).

- [ ] ~~Add comment sorting tests to replace ones removed in #6335.~~ Punted for now due to effort.