### PR TITLE
Only pass React-related annotations on to the React DevTools

### DIFF
--- a/src/ui/actions/reactDevTools.ts
+++ b/src/ui/actions/reactDevTools.ts
@@ -17,9 +17,17 @@ export type ReactDevToolsAction =
 
 export function setupReactDevTools(store: UIStore) {
   ThreadFront.getAnnotations(({ annotations }) => {
+    // TODO We're also getting some other annotations here.
+    // It would be nice if we could ask the backend to filter them for us.
+    const reactDevtoolsAnnotations = annotations.filter(annotation => {
+      // `kind` value per React Devtools code in `gecko-dev`
+      return annotation.kind === "react-devtools-bridge";
+    });
+
     store.dispatch(
+      // TODO This action should be named more specific to the React usage
       addAnnotations(
-        annotations.map(({ point, time, contents }) => ({
+        reactDevtoolsAnnotations.map(({ point, time, contents }) => ({
           point,
           time,
           message: JSON.parse(contents),


### PR DESCRIPTION
This PR:

- Just filters the list of annotations received on the client down to "only React-specific annotations" before they're dispatched and added to the store

We do already have _some_ other annotations coming in, and we'll have more as I work on the Redux integration, so this bit of code may need to be rethought so that we don't keep re-pulling the same annotations multiple times.  (Maybe we fetch once, dispatch a single "annotations added" action, but let each reducer pull out just the ones it cares about.)

Fixes #6132