### PR TITLE
Hide the hitCount tooltip on breakpoint lines

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/LineNumberTooltip.tsx
@@ -89,6 +89,7 @@ export default function LineNumberTooltip({
   const hitCounts = useSelector(getHitCountsForSelectedSource);
   const source = useSelector(getSelectedSource);
   const analysisPoints = useSelector(selectors.getPointsForHoveredLineNumber);
+  const breakpoints = useSelector(selectors.getBreakpointsList);
 
   let analysisPointsCount: number | undefined;
 
@@ -157,6 +158,17 @@ export default function LineNumberTooltip({
       trackEvent("breakpoint.preview_hits", { hitsCount: analysisPointsCount || null });
     }
   }, [analysisPointsCount]);
+
+  if (
+  breakpoints.some(
+    b =>
+      !b.disabled &&
+      b.location.sourceId === source?.id &&
+      b.location.line === lastHoveredLineNumber.current
+  )
+  ) {
+    return null;
+  }
 
   if (!targetNode || isMetaActive) {
     return null;


### PR DESCRIPTION
See https://www.loom.com/share/bba1f5fad9f54f95914c8747ee420e35 or
https://www.notion.so/replayio/Loading-Region-Problems-b8dc0d03c49840f8b504e967c7ea5778
for a longer format explanation of why this happens, but basically,
hitCounts and breakpoint point counts might disagree while focused. And,
since the point count will be right there anyways, we don't really need
to show the hitCount on that same line. True, there are other places for
this difference to be noticed (for instance, in a straight-forward block
on the line before this breakpoint line I would expect that the
hitCounts would match this breakpoint's point count). But at least this
is deemphasizes the "wrong" count a bit and (hopefully) reduces
cognitive dissonance for the user.

https://user-images.githubusercontent.com/5903784/165633652-0b934168-aa13-437d-9e4d-815ddfcfcb47.mp4
