### PR TITLE
Dark mode for tab

### DIFF
--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -112,5 +112,5 @@ overflows its container (https://drafts.csswg.org/css-flexbox-1/#min-size-auto) 
   left: -2rem;
   width: 2rem;
   height: 100%;
-  background-image: linear-gradient(to left, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
+  background-image: linear-gradient(to left, var(--tab-bgcolor), rgba(0, 0, 0, 0));
 }


### PR DESCRIPTION
Fixes #6577

Now:

<img width="156" alt="image" src="https://user-images.githubusercontent.com/9154902/165658474-771a0d91-bf46-48b9-80c8-ed4b9928d62e.png">

<img width="145" alt="image" src="https://user-images.githubusercontent.com/9154902/165658514-1771c04a-b72e-48fb-94bb-7aea199654b0.png">

