### PR TITLE
Fix white background field in dark theme

### DIFF
--- a/src/ui/components/shared/SharingModal/EmailForm.tsx
+++ b/src/ui/components/shared/SharingModal/EmailForm.tsx
@@ -112,7 +112,7 @@ export default function EmailForm({ recordingId }: { recordingId: RecordingId })
     <form className="new-collaborator-form" onSubmit={handleSubmit}>
       <TextInput placeholder="Email address" value={inputValue} onChange={onChange} data-private />
       {showAutocomplete ? (
-        <div className="autocomplete bg-white">
+        <div className="autocomplete bg-themeTextFieldBgcolor text-themeTextFieldColor">
           <div className="content">{inputValue}</div>
           <AutocompleteAction {...{ status, handleSubmit }} />
         </div>


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/design/issues/38

Looks like this now:
![image](https://user-images.githubusercontent.com/9154902/165871183-cc43cddf-3236-4125-b796-5ec6afc22b3b.png)

Before the dropdown was white even in dark theme