### PR TITLE
Change console search bgcolor so it doesn't blend in with the console

### DIFF
--- a/src/devtools/client/webconsole/components/Search/ConsoleSearch.module.css
+++ b/src/devtools/client/webconsole/components/Search/ConsoleSearch.module.css
@@ -4,6 +4,7 @@
   display: flex;
   align-items: center;
   border-top: 1px solid var(--theme-splitter-color);
+  background-color: var(--theme-text-field-bgcolor);
 }
 
 .SearchInput {


### PR DESCRIPTION
Was:
![image](https://user-images.githubusercontent.com/9154902/165875095-906179b1-2633-439c-94f5-cf6eeaae64e4.png)

![image](https://user-images.githubusercontent.com/9154902/165875111-8c145729-8717-409e-a047-7e61c0d1bc02.png)

Now:
![image](https://user-images.githubusercontent.com/9154902/165875337-8a11ea9b-cd05-4a54-a89e-2124ae93665d.png)

![image](https://user-images.githubusercontent.com/9154902/165875321-3330b53c-1d73-496f-b336-b53f837265c5.png)

This extra band of colour isn't there until you trigger it, so I think this is a good balance between showing contrast and being too extreme