### PR TITLE
Use the content hash when grouping identical sources (#6594)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@auth0/auth0-react": "1.2.0",
         "@headlessui/react": "^1.4.3",
         "@heroicons/react": "^1.0.6",
-        "@recordreplay/protocol": "^0.23.0",
+        "@recordreplay/protocol": "^0.25.0",
         "@redux-devtools/extension": "^3.2.2",
         "@reduxjs/toolkit": "^1.8.1",
         "@sentry/react": "^6.19.4",
@@ -5389,9 +5389,9 @@
       }
     },
     "node_modules/@recordreplay/protocol": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.23.0.tgz",
-      "integrity": "sha512-1xme7eYM/dyfocZMuAy4ra/rWXMJNYyBZcxGQ7N7wr5JdozYCIGbQe91byqxE1Too40mJSAyUXHEXoL6eh4/TQ=="
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.25.0.tgz",
+      "integrity": "sha512-HRNCwriMLrQi1L0tlrQnP7ZfSy+wAY4ES8/5sWqAC5Rv9sxJFwHlhCxFhn2rgLjKtiy7oZiTrhllxEXdY40MPQ=="
     },
     "node_modules/@recordreplay/sourcemap-upload": {
       "version": "0.1.2",
@@ -48379,9 +48379,9 @@
       }
     },
     "@recordreplay/protocol": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.23.0.tgz",
-      "integrity": "sha512-1xme7eYM/dyfocZMuAy4ra/rWXMJNYyBZcxGQ7N7wr5JdozYCIGbQe91byqxE1Too40mJSAyUXHEXoL6eh4/TQ=="
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@recordreplay/protocol/-/protocol-0.25.0.tgz",
+      "integrity": "sha512-HRNCwriMLrQi1L0tlrQnP7ZfSy+wAY4ES8/5sWqAC5Rv9sxJFwHlhCxFhn2rgLjKtiy7oZiTrhllxEXdY40MPQ=="
     },
     "@recordreplay/sourcemap-upload": {
       "version": "0.1.2",
@@ -62491,7 +62491,7 @@
         "git-url-parse": "11.5.0",
         "glob": "7.2.0",
         "global-agent": "2.2.0",
-        "graphql": "14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0",
+        "graphql": "15.8.0",
         "graphql-tag": "2.12.4",
         "listr": "0.14.3",
         "lodash.identity": "3.0.0",
@@ -62781,7 +62781,7 @@
         "cosmiconfig": "^5.0.6",
         "dotenv": "^8.0.0",
         "glob": "^7.1.3",
-        "graphql": "14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0",
+        "graphql": "15.8.0",
         "graphql-tag": "^2.10.1",
         "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.1",
@@ -67560,7 +67560,7 @@
         "@oclif/plugin-help": "3.2.1",
         "cli-ux": "^4.7.3",
         "express": "4.16.3",
-        "graphql": "15.4.0",
+        "graphql": "15.8.0",
         "graphql-language-service-interface": "^2.8.2",
         "graphql-language-service-utils": "2.5.1",
         "isomorphic-fetch": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@auth0/auth0-react": "1.2.0",
     "@headlessui/react": "^1.4.3",
     "@heroicons/react": "^1.0.6",
-    "@recordreplay/protocol": "^0.23.0",
+    "@recordreplay/protocol": "^0.25.0",
     "@redux-devtools/extension": "^3.2.2",
     "@reduxjs/toolkit": "^1.8.1",
     "@sentry/react": "^6.19.4",

--- a/test/mock/src/handlers/basic.ts
+++ b/test/mock/src/handlers/basic.ts
@@ -6,6 +6,7 @@ export function basicBindings() {
       sourceId: "mock-source",
       kind: "scriptSource",
       url: "https://mock.test/source.js",
+      contentHash: "cb502477dde2b1ceeb00c40cb27c13f4fe479cc4fd1d50d06a62e4801da9180a",
     },
     endpoint: {
       point: "100000",


### PR DESCRIPTION
Needs RecordReplay/backend#5462 to be deployed first.
Fixes #6594.
