### PR TITLE
Define "ready" as "indexed and loaded"

### DIFF
--- a/src/devtools/client/debugger/src/utils/sources-tree/utils.test.js
+++ b/src/devtools/client/debugger/src/utils/sources-tree/utils.test.js
@@ -5,15 +5,7 @@
 
 import { makeMockSource } from "devtools/client/debugger/src/utils/test-mockup";
 
-import {
-  createDirectoryNode,
-  getRelativePath,
-  isExactUrlMatch,
-  isDirectory,
-  isNotJavaScript,
-  getPathWithoutThread,
-} from "./utils";
-import { addToTree } from "./addToTree";
+import { getRelativePath, isExactUrlMatch, isNotJavaScript, getPathWithoutThread } from "./utils";
 
 describe("sources tree", () => {
   describe("isExactUrlMatch", () => {

--- a/src/devtools/client/webconsole/components/Input/JSTerm.tsx
+++ b/src/devtools/client/webconsole/components/Input/JSTerm.tsx
@@ -1,15 +1,18 @@
-import React, { useContext, useRef, useState } from "react";
 import { Editor } from "codemirror";
+import React, { useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
-import { evaluateExpression, paywallExpression } from "../../actions/input";
-import EagerEvalFooter from "./EagerEvalFooter";
-import useEvaluationHistory from "./useEvaluationHistory";
-import { getIsInLoadedRegion, getPlayback } from "ui/reducers/timeline";
 import {
   EditorWithAutocomplete,
   Keys,
 } from "ui/components/shared/CodeEditor/EditorWithAutocomplete";
+import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
+import { getIsInLoadedRegion } from "ui/reducers/app";
+import { getPlayback } from "ui/reducers/timeline";
+
+import { evaluateExpression, paywallExpression } from "../../actions/input";
+
+import EagerEvalFooter from "./EagerEvalFooter";
+import useEvaluationHistory from "./useEvaluationHistory";
 
 const getJsTermApi = (
   editor: Editor,

--- a/src/ui/actions/app.ts
+++ b/src/ui/actions/app.ts
@@ -7,6 +7,7 @@ import {
   Location,
   MouseEvent,
   KeyboardEvent,
+  TimeStampedPointRange,
 } from "@recordreplay/protocol";
 import { ThreadFront, RecordingTarget } from "protocol/thread/thread";
 import * as selectors from "ui/reducers/app";

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -1,4 +1,4 @@
-import { ExecutionPoint, PauseId } from "@recordreplay/protocol";
+import { ExecutionPoint, PauseId, TimeStampedPointRange } from "@recordreplay/protocol";
 import { Pause, ThreadFront } from "protocol/thread";
 import { client, log, sendMessage } from "protocol/socket";
 import {

--- a/src/ui/components/ProtocolTimeline.tsx
+++ b/src/ui/components/ProtocolTimeline.tsx
@@ -34,7 +34,7 @@ const Spans = ({
   const { endTime } = useSelector(getZoomRegion)!;
 
   return (
-    <div className="w-full h-1 z-50 relative" title={title}>
+    <div className="relative z-50 h-1 w-full" title={title}>
       {regions.map((r, i) => (
         <Span regions={r} endTime={endTime} className={color} key={i} />
       ))}
@@ -42,16 +42,16 @@ const Spans = ({
   );
 };
 
-export default function OgreTimeline() {
+export default function ProtocolTimeline() {
   const loadedRegions = useSelector(getLoadedRegions);
-  const { value: showAdvancedTimeline } = useFeature("advancedTimeline");
+  const { value: showProtocolTimeline } = useFeature("protocolTimeline");
 
-  if (!showAdvancedTimeline || !loadedRegions) {
+  if (!showProtocolTimeline || !loadedRegions) {
     return null;
   }
 
   return (
-    <div className="flex flex-col space-y-1 absolute -top-3 w-full">
+    <div className="absolute -top-3 flex w-full flex-col space-y-1">
       <Spans regions={loadedRegions.loading} color="bg-gray-500" title="Loading" />
       <Spans regions={loadedRegions.loaded} color="bg-orange-500" title="Loaded" />
       <Spans regions={loadedRegions.indexed} color="bg-green-500" title="Indexed" />

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -37,7 +37,7 @@ import { trackEvent } from "ui/utils/telemetry";
 import IndexingLoader from "../shared/IndexingLoader";
 import { EditFocusButton } from "./EditFocusButton";
 import { MouseDownMask } from "./MouseDownMask";
-import OgreTimeline from "../OgreTimeline";
+import ProtocolTimeline from "../ProtocolTimeline";
 
 import NonLoadingRegions from "./NonLoadingRegions";
 
@@ -389,7 +389,7 @@ class Timeline extends Component<PropsFromRedux, { isDragging: boolean }> {
               onMouseUp={e => this.onPlayerMouseUp(e)}
               onMouseEnter={this.onPlayerMouseEnter}
             >
-              <OgreTimeline />
+              <ProtocolTimeline />
               <div className="progress-line full" />
               <div
                 className="progress-line preview-max"

--- a/src/ui/components/shared/IndexingLoader.tsx
+++ b/src/ui/components/shared/IndexingLoader.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
 import { useSelector } from "react-redux";
 import { getIndexingProgress } from "ui/reducers/app";
-import { getViewMode } from "ui/reducers/layout";
 
 export default function IndexingLoader() {
   const progress = useSelector(getIndexingProgress);

--- a/src/ui/reducers/timeline.ts
+++ b/src/ui/reducers/timeline.ts
@@ -2,24 +2,22 @@ import { getExecutionPoint } from "devtools/client/debugger/src/reducers/pause";
 import { TimelineActions } from "ui/actions/timeline";
 import { UIState } from "ui/state";
 import { TimelineState } from "ui/state/timeline";
-import { isPointInRegions } from "ui/utils/timeline";
-
-import { getLoadedRegions } from "./app";
+import { isPointInRegions, overlap } from "ui/utils/timeline";
 
 function initialTimelineState(): TimelineState {
   return {
-    zoomRegion: { startTime: 0, endTime: 0, scale: 1 },
     currentTime: 0,
+    focusRegion: null,
     hoverTime: null,
+    hoveredItem: null,
     playback: null,
     playbackPrecachedTime: 0,
-    unprocessedRegions: [],
-    shouldAnimate: true,
     recordingDuration: null,
-    timelineDimensions: { left: 1, top: 1, width: 1 },
-    hoveredItem: null,
-    focusRegion: null,
+    shouldAnimate: true,
     stalled: false,
+    timelineDimensions: { left: 1, top: 1, width: 1 },
+    unprocessedRegions: [],
+    zoomRegion: { startTime: 0, endTime: 0, scale: 1 },
   };
 }
 
@@ -73,16 +71,6 @@ export const getIsInFocusMode = (state: UIState) =>
   state.timeline.focusRegion &&
   (state.timeline.focusRegion.startTime !== 0 ||
     state.timeline.focusRegion.endTime !== state.timeline.zoomRegion.endTime);
-export const getIsInLoadedRegion = (state: UIState) => {
-  const currentPausePoint = getExecutionPoint(state);
-  const loadedRegions = getLoadedRegions(state)?.loaded;
-
-  if (!currentPausePoint || !loadedRegions || loadedRegions.length === 0) {
-    return false;
-  }
-
-  return isPointInRegions(loadedRegions, currentPausePoint);
-};
 export const getIsAtFocusSoftLimit = (state: UIState) => {
   const focusRegion = getFocusRegion(state);
 

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -28,7 +28,7 @@ pref("devtools.features.tenMinuteReplays", false);
 pref("devtools.features.breakpointPanelAutocomplete", true);
 pref("devtools.features.codeHeatMaps", true);
 pref("devtools.features.resolveRecording", false);
-pref("devtools.features.advancedTimeline", false);
+pref("devtools.features.protocolTimeline", false);
 pref("devtools.features.unicornConsole", false);
 
 export const prefs = new PrefsHelper("devtools", {
@@ -58,7 +58,7 @@ export const features = new PrefsHelper("devtools.features", {
   breakpointPanelAutocomplete: ["Bool", "breakpointPanelAutocomplete"],
   codeHeatMaps: ["Bool", "codeHeatMaps"],
   resolveRecording: ["Bool", "resolveRecording"],
-  advancedTimeline: ["Bool", "advancedTimeline"],
+  protocolTimeline: ["Bool", "protocolTimeline"],
   unicornConsole: ["Bool", "unicornConsole"],
 });
 

--- a/src/ui/utils/timeline.test.ts
+++ b/src/ui/utils/timeline.test.ts
@@ -1,0 +1,30 @@
+import { overlap } from "./timeline";
+
+const point = (time: number) => {
+  return { point: "", time };
+};
+const range = (begin: number, end: number) => {
+  return {
+    begin: point(begin),
+    end: point(end),
+  };
+};
+
+describe("overlap", () => {
+  it("correctly merges overlapping regions when the second begins during the first", () => {
+    expect(overlap([range(0, 5)], [range(2, 7)])).toStrictEqual([range(2, 5)]);
+  });
+
+  it("correctly merges overlapping regions when the first begins during the second", () => {
+    expect(overlap([range(2, 7)], [range(0, 5)])).toStrictEqual([range(2, 5)]);
+  });
+
+  it("leaves non-overlapping regions alone", () => {
+    expect(overlap([range(0, 2)], [range(3, 5)])).toStrictEqual([]);
+  });
+
+  it("does not blow up with empty inputs", () => {
+    expect(overlap([range(0, 2)], [])).toStrictEqual([]);
+    expect(overlap([], [range(0, 2)])).toStrictEqual([]);
+  });
+});

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -1,5 +1,6 @@
 import { TimeStampedPointRange } from "@recordreplay/protocol";
 import { FocusRegion, ZoomRegion } from "ui/state/timeline";
+
 import { timelineMarkerWidth } from "../constants";
 
 // calculate pixel distance from two times
@@ -149,3 +150,18 @@ export function isPointInRegions(regions: TimeStampedPointRange[], point: string
 export function isTimeInRegions(time: number, regions?: TimeStampedPointRange[]): boolean {
   return !!regions?.some(region => time >= region.begin.time && time <= region.end.time);
 }
+
+export const overlap = (a: TimeStampedPointRange[], b: TimeStampedPointRange[]) => {
+  const overlapping: TimeStampedPointRange[] = [];
+  a.forEach(aRegion => {
+    b.forEach(bRegion => {
+      if (aRegion.begin.time <= bRegion.end.time && aRegion.end.time >= bRegion.begin.time) {
+        overlapping.push({
+          begin: aRegion.begin.time > bRegion.begin.time ? aRegion.begin : bRegion.begin,
+          end: aRegion.end.time < bRegion.end.time ? aRegion.end : bRegion.end,
+        });
+      }
+    });
+  });
+  return overlapping;
+};


### PR DESCRIPTION
We can get into a state where things are indexed, but not loaded, and that results in some bad UI where things no longer look like they are loading, but not all of the data is present either. This is more of a bandaid for https://github.com/RecordReplay/backend/issues/5429 than a real solution, but at least it communicates to the user when we are still waiting on things and they shouldn't expect everything to work or be accurate