### PR TITLE
Adjust badge sizes in the console

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelEditor.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelEditor.tsx
@@ -92,7 +92,7 @@ class PanelEditor extends PureComponent<Props, State> {
         )}
       >
         <PrefixBadge
-          style={{ height: "21px", marginLeft: "10px", marginRight: "-4px" }}
+          style={{ height: "21px", marginLeft: "10px", marginRight: "-4px", width: "21px" }}
           prefixBadge={breakpoint.options.prefixBadge}
         />
         <PanelForm

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -126,7 +126,7 @@ function PanelSummary({
   return (
     <div className={classNames("summary flex items-center text-gray-500", { enabled: isLoaded })}>
       <PrefixBadge
-        style={{ height: "21px", marginLeft: "10px", marginRight: "-4px" }}
+        style={{ height: "21px", marginLeft: "10px", marginRight: "-4px", width: "21px" }}
         prefixBadge={breakpoint.options.prefixBadge}
       />
 

--- a/src/devtools/client/webconsole/components/Output/MessageIcon.js
+++ b/src/devtools/client/webconsole/components/Output/MessageIcon.js
@@ -39,7 +39,22 @@ export function MessageIcon(props) {
   }
 
   if (prefixBadge) {
-    return <PrefixBadge prefixBadge={prefixBadge} style={{ margin: "2px 5px 0 5px" }} />;
+    const style =
+      prefixBadge == "unicorn"
+        ? {
+            height: "16px",
+            marginLeft: "4px",
+            marginRight: "8px",
+            marginTop: "2px",
+          }
+        : {
+            height: "9px",
+            marginLeft: "8px",
+            marginRight: "11px",
+            marginTop: "6px",
+            width: "9px",
+          };
+    return <PrefixBadge prefixBadge={prefixBadge} style={style} />;
   }
 
   if (type) {

--- a/src/ui/components/PrefixBadge.jsx
+++ b/src/ui/components/PrefixBadge.jsx
@@ -75,11 +75,11 @@ function _PrefixBadge({ prefixBadge, style, theme, showEmpty = false }) {
     return (
       <div
         style={{
-          ...style,
           backgroundColor: getBadgeColor(prefixBadge, theme, showEmpty),
-          borderRadius: "8px",
+          borderRadius: "16px",
           height: "16px",
           width: "16px",
+          ...style,
         }}
       />
     );


### PR DESCRIPTION
The circles are pretty heavy relative to the unicorn.

<img width="349" alt="Screen Shot 2022-05-01 at 11 46 42 PM" src="https://user-images.githubusercontent.com/254562/166195205-a2e45ef7-a581-4249-9488-5cc6ebd2c112.png">
