### PR TITLE
Prevent Object Labels from wrapping

### DIFF
--- a/src/devtools/packages/devtools-reps/object-inspector/components/ObjectInspector.css
+++ b/src/devtools/packages/devtools-reps/object-inspector/components/ObjectInspector.css
@@ -10,6 +10,7 @@
 .tree.object-inspector .object-label,
 .tree.object-inspector .object-label * {
   color: var(--theme-highlight-blue);
+  flex-shrink: 0;
 }
 
 .tree.object-inspector .node .unavailable {


### PR DESCRIPTION
Notice `classList` wraps. This is a fairly modest example, but there are plenty of more extreme ones

### Before
<img width="609" alt="Screen Shot 2022-05-02 at 8 00 21 AM" src="https://user-images.githubusercontent.com/254562/166256816-c1c8234f-a2b6-46f5-9db5-e3584418ba34.png">

### After
<img width="608" alt="Screen Shot 2022-05-02 at 8 00 11 AM" src="https://user-images.githubusercontent.com/254562/166256822-c43b136d-2f93-4173-b2ea-fc3b96802a44.png">
