### PR TITLE
Fix the headers that our security scan found

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -45,18 +45,22 @@ module.exports = {
   async headers() {
     return [
       {
-        source: "/(.*)",
         headers: [
           {
             key: "X-Frame-Options",
             value: "SAMEORIGIN",
           },
           {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
             key: "Content-Security-Policy",
             value:
-              "frame-ancestors 'self' https://*.replay.io/; report-uri https://o437061.ingest.sentry.io/api/5399075/security/?sentry_key=41c20dff316f42fea692ef4f0d055261",
+              "frame-ancestors 'self' https://*.replay.io/; report-to https://o437061.ingest.sentry.io/api/5399075/security/?sentry_key=41c20dff316f42fea692ef4f0d055261",
           },
         ],
+        source: "/(.*)",
       },
     ];
   },

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -1,25 +1,26 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
+import { GetStaticProps } from "next/types";
 import React, { useEffect, useState } from "react";
 import { connect, ConnectedProps, useDispatch, useStore } from "react-redux";
-import { isTest } from "ui/utils/environment";
+import { setModal } from "ui/actions/app";
 import { getAccessibleRecording, setExpectedError } from "ui/actions/session";
-import { Recording as RecordingInfo } from "ui/types";
+import DevTools from "ui/components/DevTools";
+import LoadingScreen from "ui/components/shared/LoadingScreen";
 import {
   getRecordingMetadata,
   useGetRecording,
   useGetRecordingId,
   useGetRawRecordingIdWithSlug,
 } from "ui/hooks/recordings";
-import { getRecordingURL } from "ui/utils/recording";
-import LoadingScreen from "ui/components/shared/LoadingScreen";
-import Upload from "./upload";
-import DevTools from "ui/components/DevTools";
 import setup from "ui/setup/dynamic/devtools";
-import { GetStaticProps } from "next/types";
+import { Recording as RecordingInfo } from "ui/types";
+import { isTest } from "ui/utils/environment";
 import { extractIdAndSlug } from "ui/utils/helpers";
-import { setModal } from "ui/actions/app";
+import { getRecordingURL } from "ui/utils/recording";
 import useToken from "ui/utils/useToken";
+
+import Upload from "./upload";
 
 interface MetadataProps {
   metadata?: {
@@ -128,8 +129,8 @@ function RecordingPage({
     }
     if (!recordingId) {
       setExpectedError({
-        message: "Invalid ID",
         content: `"${rawRecordingId}" is not a valid recording ID`,
+        message: "Invalid ID",
       });
       return;
     }
@@ -189,18 +190,16 @@ export const getStaticProps: GetStaticProps = async function ({ params }) {
     props: {
       metadata: id ? await getRecordingMetadata(id) : null,
     },
-    revalidate: 360,
   };
 };
 
 export async function getStaticPaths() {
-  return { paths: [], fallback: "blocking" };
+  return { fallback: "blocking", paths: [] };
 }
 
 type SSRProps = MetadataProps & { headOnly?: boolean };
 
 export default function SSRRecordingPage({ headOnly, metadata }: SSRProps) {
-  const router = useRouter();
   let head: React.ReactNode = <RecordingHead metadata={metadata} />;
 
   if (headOnly) {


### PR DESCRIPTION
Does what it says on the tin :)

A note about the cache-control change:

I was kind of torn on this one, since we have explicitly set recording
pages to cache for 360 seconds, but I think it's reasonable to remove it
for a couple of reasons:

1. our load time is usually several seconds, and an uncached response
   from Vercel seems to take a couple hundred milliseconds, so in terms
   of difference in time-to-replay-ready, it's not doing much.
2. Particularly with recording pages (which is the only pages we have
   set to cache I think) we actually do include some server-injected
   information about the recording into the HTML, so theoretically we
   could wind up storing some private Replay data in the cache of a
   public computer.

Anyways, just figured I would publish my reasoning in case anyone was
curious as to whether this is a worthwhile trade-off or not.

Fixes https://github.com/RecordReplay/ops/issues/763
Fixes https://github.com/RecordReplay/ops/issues/764
Fixes https://github.com/RecordReplay/ops/issues/765