### PR TITLE
Handle hot analyses and analyses with errors

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Panel.js
@@ -121,7 +121,12 @@ function Panel({
               toggleEditingOn={toggleEditingOn}
             />
           )}
-          <BreakpointNavigation {...{ breakpoint, editing, showCondition, setShowCondition }} />
+          <BreakpointNavigation
+            breakpoint={breakpoint}
+            editing={editing}
+            showCondition={showCondition}
+            setShowCondition={setShowCondition}
+          />
         </div>
       </div>
     </Widget>

--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Widget.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/Widget.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 const { toEditorLine } = require("devtools/client/debugger/src/utils/editor");
 
@@ -13,7 +13,6 @@ export default function Widget({ location, children, editor, insertAt }: WidgetP
   const [node, setNode] = useState<HTMLDivElement | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // TODO [jaril] Fix react-hooks/exhaustive-deps
   useEffect(() => {
     if (loading) {
       const _node = document.createElement("div");
@@ -26,13 +25,11 @@ export default function Widget({ location, children, editor, insertAt }: WidgetP
       insertAt,
     });
 
-    // We are clearing the widget here because without
+    // We are clearing the widget here because not
     // doing so causes breakpoints to show up on the
     // wrong line number when clicking in the gutter.
-    return () => {
-      _widget.clear();
-    };
-  }, [loading]); // eslint-disable-line react-hooks/exhaustive-deps
+    return () => _widget.clear();
+  }, [loading, node, editor.codeMirror, insertAt, location.line]);
 
   if (!node) {
     return null;

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointNavigation.js
@@ -3,7 +3,7 @@ import { connect } from "devtools/client/debugger/src/utils/connect";
 import find from "lodash/find";
 import findLast from "lodash/findLast";
 import { compareNumericStrings } from "protocol/utils";
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect } from "react";
 import { actions } from "ui/actions";
 import PrefixBadgeButton from "ui/components/PrefixBadge";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
@@ -15,18 +15,15 @@ import { PanelStatus } from "./PanelStatus";
 const { trackEvent } = require("ui/utils/telemetry");
 
 function BreakpointNavigation({
-  executionPoint,
-  indexed,
-  breakpoint,
-  seek,
   analysisPoints,
+  breakpoint,
   editing,
+  executionPoint,
+  seek,
   setShowCondition,
-  showCondition,
   setZoomedBreakpoint = () => {},
+  showCondition,
 }) {
-  const [lastExecutionPoint, setLastExecutionPoint] = useState(0);
-
   const navigateToPoint = point => {
     trackEvent("breakpoint.navigate");
     if (point) {
@@ -41,12 +38,6 @@ function BreakpointNavigation({
     prev = findLast(analysisPoints.data, p => compareNumericStrings(p.point, executionPoint) < 0);
     next = find(analysisPoints.data, p => compareNumericStrings(p.point, executionPoint) > 0);
   }
-
-  useEffect(() => {
-    if (executionPoint && lastExecutionPoint !== executionPoint) {
-      setLastExecutionPoint(executionPoint);
-    }
-  }, [executionPoint, lastExecutionPoint]);
 
   useEffect(() => {
     if (analysisPoints) {
@@ -78,7 +69,7 @@ function BreakpointNavigation({
 
   return (
     <div className={classnames("breakpoint-navigation justify-between p-1.5", { empty: isEmpty })}>
-      {!isEmpty ? (
+      {!isEmpty && !analysisPoints?.error ? (
         <BreakpointNavigationCommands prev={prev} next={next} navigateToPoint={navigateToPoint} />
       ) : null}
       {analysisPoints && !analysisPoints.error ? (
@@ -87,12 +78,7 @@ function BreakpointNavigation({
         <div className="flex-grow" />
       )}
       <div className="text-center">
-        <PanelStatus
-          prefixBadge={breakpoint.options.prefixBadge}
-          indexed={indexed}
-          executionPoint={lastExecutionPoint}
-          analysisPoints={analysisPoints}
-        />
+        <PanelStatus prefixBadge={breakpoint.options.prefixBadge} analysisPoints={analysisPoints} />
       </div>
     </div>
   );
@@ -129,7 +115,6 @@ const mapStateToProps = (state, { breakpoint }) => ({
     breakpoint.location,
     breakpoint.options.condition
   ),
-  indexed: selectors.getIsIndexed(state),
   executionPoint: selectors.getExecutionPoint(state),
 });
 

--- a/src/protocol/analysisManager.ts
+++ b/src/protocol/analysisManager.ts
@@ -12,18 +12,19 @@ import {
   SessionId,
 } from "@recordreplay/protocol";
 import { sendMessage, addEventListener } from "protocol/socket";
+
 import { assert } from "./utils";
 
 export interface AnalysisParams {
-  mapper: string;
-  reducer?: string;
   effectful: boolean;
-  locations?: AnalysisLocation[];
-  functionEntryPoints?: FunctionEntryPoint[];
   eventHandlerEntryPoints?: EventHandlerEntryPoint[];
   exceptionPoints?: boolean;
-  randomPoints?: number;
+  functionEntryPoints?: FunctionEntryPoint[];
+  locations?: AnalysisLocation[];
+  mapper: string;
   points?: ExecutionPoint[];
+  randomPoints?: number;
+  reducer?: string;
   sessionId: SessionId;
 }
 
@@ -33,9 +34,9 @@ export type FunctionEntryPoint = Omit<addFunctionEntryPointsParameters, OmitPara
 export type EventHandlerEntryPoint = Omit<addEventHandlerEntryPointsParameters, OmitParams>;
 
 export interface AnalysisHandler<T> {
-  onAnalysisResult?: (result: AnalysisEntry[]) => void;
-  onAnalysisPoints?: (points: PointDescription[]) => void;
   onAnalysisError?: (error: string) => void;
+  onAnalysisPoints?: (points: PointDescription[]) => void;
+  onAnalysisResult?: (result: AnalysisEntry[]) => void;
   onFinished?(): T;
 }
 

--- a/src/protocol/logpoint.ts
+++ b/src/protocol/logpoint.ts
@@ -293,13 +293,8 @@ async function setMultiSourceLogpoint(
   try {
     await analysisManager.runAnalysis(params, handler);
   } catch (e: any) {
-    // Only save the error if we're only grabbing the points for a location.
-    // This means that we're not handling cases where the full analysis
-    // throws. We should add that as a follow-up.
-    if (!shouldGetResults) {
-      console.error("Cannot get analysis points", e);
-      saveAnalysisError(locations, condition, e?.code);
-    }
+    console.error("Cannot get analysis points", e);
+    saveAnalysisError(locations, condition, e?.code);
     return;
   }
 


### PR DESCRIPTION
OK, this is kind of a few fixes rolled into one, so let me see if I can break them all down.

- Display error messages when analyses error
  - I think the situation we were trying to avoid here was when a user has used an analysis to correctly get the points for a given line, but then some further analysis errored and we overwrote the count which we had before. There are a few reasons we don't need to do this anymore:
    - We use getHitCounts by default now, so it's likely that we won't be overwriting an analysis result which was being used
    - We differentiate between TooManyPoints and other errors now, so we won't accidentally show 10K+ hits like we did in https://github.com/RecordReplay/customer-support/issues/18
  - I think there might be fancier things to do later around analyses and errors, but for now, this feels like a major simplification which will make room for additional complexity later as it makes sense
- Including `Loading` as a possible text length, and use `width` rather than `maxWidth`. Using `width` stops things from bouncing around when the user is playing/pausing, and including `Loading` in the calculation means that we won't get stuck rendering things as 3 characters wide because we expect things like `2/5` when in fact `Loading` is also a possible expression.
- Favor `Loading` over `Indexing` as a term we display to the user.
- Use the current timestamp to show what hit is closest to the current time, even for cases where the user cannot edit the print statement
- Show a breakpoint timeline and allow the user to move around it even when the print statement is not editable
- Reduce the number of points we will show on a compressed timeline. If there are 10,000 hits, we don't want to render 10,000 circles which mostly overlap with each other. Instead, we show at most 1 circle per half-second (so the max number is 120 * number of minutes in a recording, in most cases it will be a lot less of course) and also the current pause, if it lines up with any of the hits. Note: this is just for display, the arrows still go backwards and forwards just fine.


Fixes https://github.com/RecordReplay/devtools/issues/6420