### PR TITLE
Circular import fixes, part 1

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -19,7 +19,7 @@ import { InstallRouteListener } from "ui/utils/routeListener";
 import { useLaunchDarkly } from "ui/utils/launchdarkly";
 import { pingTelemetry } from "ui/utils/replay-telemetry";
 import tokenManager from "ui/utils/tokenManager";
-import { ApolloWrapper } from "ui/utils/apolloClient";
+import { ApolloWrapper } from "ui/components/ApolloWrapper";
 
 import "image/image.css";
 import "image/icon.css";

--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -4,7 +4,8 @@ import { GetStaticProps } from "next/types";
 import React, { useEffect, useState } from "react";
 import { connect, ConnectedProps, useDispatch, useStore } from "react-redux";
 import { setModal } from "ui/actions/app";
-import { getAccessibleRecording, setExpectedError } from "ui/actions/session";
+import { setExpectedError } from "ui/actions/errors";
+import { getAccessibleRecording } from "ui/actions/session";
 import DevTools from "ui/components/DevTools";
 import LoadingScreen from "ui/components/shared/LoadingScreen";
 import {

--- a/pages/team/invitation/[id].tsx
+++ b/pages/team/invitation/[id].tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useRouter } from "next/router";
 import { useDispatch } from "react-redux";
-import { setExpectedError } from "ui/actions/session";
+import { setExpectedError } from "ui/actions/errors";
 import Login from "ui/components/shared/Login/Login";
 import hooks from "ui/hooks";
 import useAuth0 from "ui/utils/useAuth0";

--- a/src/devtools/client/debugger/src/actions/sources/select.ts
+++ b/src/devtools/client/debugger/src/actions/sources/select.ts
@@ -17,7 +17,6 @@ import { tabExists } from "../../reducers/tabs";
 import { getFrames, getSelectedFrameId } from "../../reducers/pause";
 import { setSymbols } from "./symbols";
 import { closeActiveSearch, updateActiveFileSearch } from "../ui";
-import { addTab } from "../tabs";
 import { loadSourceText } from "./loadSourceText";
 import { setBreakableLines, setBreakpointHitCounts } from ".";
 
@@ -28,8 +27,6 @@ import { trackEvent } from "ui/utils/telemetry";
 import { paused } from "../pause/paused";
 
 import { ThreadFront } from "protocol/thread";
-
-import { prefs } from "devtools/shared/services";
 
 import {
   getSource,
@@ -123,6 +120,18 @@ export function deselectSource(): UIThunkAction {
   return (dispatch, getState) => {
     const cx = getThreadContext(getState());
     dispatch(clearSelectedLocation(cx));
+  };
+}
+
+export function addTab(source: Source) {
+  const { url, id: sourceId } = source;
+  const isOriginal = source.isOriginal;
+
+  return {
+    type: "ADD_TAB",
+    url,
+    isOriginal,
+    sourceId,
   };
 }
 

--- a/src/devtools/client/debugger/src/actions/tabs.js
+++ b/src/devtools/client/debugger/src/actions/tabs.js
@@ -27,18 +27,6 @@ export function updateTab(source, framework) {
   };
 }
 
-export function addTab(source) {
-  const { url, id: sourceId } = source;
-  const isOriginal = source.isOriginal;
-
-  return {
-    type: "ADD_TAB",
-    url,
-    isOriginal,
-    sourceId,
-  };
-}
-
 export function moveTab(url, tabIndex) {
   return {
     type: "MOVE_TAB",

--- a/src/devtools/client/debugger/src/components/App.js
+++ b/src/devtools/client/debugger/src/components/App.js
@@ -9,7 +9,7 @@ import { connect } from "../utils/connect";
 import { features } from "../utils/prefs";
 import { prefs } from "../../../../../ui/utils/prefs";
 import actions from "../actions";
-import { setUnexpectedError } from "ui/actions/session";
+import { setUnexpectedError } from "ui/actions/errors";
 import A11yIntention from "./A11yIntention";
 import { ShortcutsModal } from "./ShortcutsModal";
 import SplitBox from "devtools/client/shared/components/splitter/SplitBox";

--- a/src/devtools/client/debugger/src/components/Editor/EditorPane.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/EditorPane.tsx
@@ -10,7 +10,7 @@ import WelcomeBox from "../WelcomeBox";
 import { Redacted } from "ui/components/Redacted";
 import useWidthObserver from "ui/utils/useWidthObserver";
 import { waitForEditor } from "../../utils/editor/create-editor";
-import { setUnexpectedError } from "ui/actions/session";
+import { setUnexpectedError } from "ui/actions/errors";
 import { ReplayUpdatedError } from "ui/components/ErrorBoundary";
 import { getToolboxLayout } from "ui/reducers/layout";
 import { getSelectedSource } from "../../reducers/sources";

--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -6,7 +6,6 @@ import { DownloadCancelledError, ScreenshotCache } from "./screenshot-cache";
 import ResizeObserverPolyfill from "resize-observer-polyfill";
 import { TimeStampedPoint, MouseEvent, paintPoints, ScreenShot } from "@recordreplay/protocol";
 import { decode } from "base64-arraybuffer";
-import { client } from "./socket";
 import { UIStore, UIThunkAction } from "ui/actions";
 import { Canvas } from "ui/state/app";
 import { setCanvas, setEventsForType, setVideoUrl } from "ui/actions/app";
@@ -241,7 +240,8 @@ export function setupGraphics(store: UIStore) {
 
   Video.init(store);
 
-  ThreadFront.sessionWaiter.promise.then((sessionId: string) => {
+  ThreadFront.sessionWaiter.promise.then(async (sessionId: string) => {
+    const { client } = await import("./socket");
     client.Graphics.findPaints({}, sessionId).then(async () => {
       hasAllPaintPoints = true;
       await Promise.all(gPaintPromises);

--- a/src/protocol/mapped-location-cache.ts
+++ b/src/protocol/mapped-location-cache.ts
@@ -1,4 +1,3 @@
-import { client } from "./socket";
 import { defer } from "./utils";
 import { Location, MappedLocation } from "@recordreplay/protocol";
 import { ThreadFront } from "./thread";
@@ -26,6 +25,7 @@ export class MappedLocationCache {
 
     const { promise, resolve } = defer<MappedLocation>();
     this.runningRequests.set(cacheKey, promise);
+    const { client } = await import("./socket");
     const { mappedLocation } = await client.Debugger.getMappedLocation(
       { location },
       ThreadFront.sessionId!

--- a/src/protocol/screenshot-cache.ts
+++ b/src/protocol/screenshot-cache.ts
@@ -1,6 +1,5 @@
 import { ThreadFront } from "./thread";
 import { defer } from "./utils";
-import { client } from "./socket";
 import { ScreenShot } from "@recordreplay/protocol";
 
 export class DownloadCancelledError extends Error {}
@@ -122,6 +121,7 @@ export class ScreenshotCache {
   }
 
   private async download(point: string, resizeHeight?: number): Promise<ScreenShot> {
+    const { client } = await import("./socket");
     const screen = (
       await client.Graphics.getPaintContents(
         { point, mimeType: "image/jpeg", resizeHeight },

--- a/src/protocol/socket.ts
+++ b/src/protocol/socket.ts
@@ -9,7 +9,7 @@ import {
   CommandResult,
 } from "@recordreplay/protocol";
 import { UIStore, UIThunkAction } from "ui/actions";
-import { setUnexpectedError } from "ui/actions/session";
+import { setUnexpectedError } from "ui/actions/errors";
 import { UnexpectedError } from "ui/state/app";
 import { isMock, mockEnvironment, waitForMockEnvironment } from "ui/utils/environment";
 import { endMixpanelSession } from "ui/utils/mixpanel";

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -38,7 +38,6 @@ import {
   requestBodyData,
 } from "@recordreplay/protocol";
 import uniqueId from "lodash/uniqueId";
-import { repaint } from "protocol/graphics";
 
 import { MappedLocationCache } from "../mapped-location-cache";
 import { client, log, addEventListener, sendMessage } from "../socket";
@@ -715,6 +714,7 @@ class _ThreadFront {
     } else if (rv.exception) {
       rv.exception = new ValueFront(pause, rv.exception);
     }
+    const { repaint } = await import("protocol/graphics");
     repaint(true);
     return rv;
   }

--- a/src/ui/actions/errors.ts
+++ b/src/ui/actions/errors.ts
@@ -1,0 +1,47 @@
+import type { Action } from "redux";
+
+import { UIThunkAction } from "ui/actions";
+import * as selectors from "ui/reducers/app";
+import { isDevelopment } from "ui/utils/environment";
+import { sendTelemetryEvent } from "ui/utils/telemetry";
+import type { ExpectedError, UnexpectedError } from "ui/state/app";
+import { getRecordingId } from "ui/utils/recording";
+
+export type SetUnexpectedErrorAction = Action<"set_unexpected_error"> & {
+  error: UnexpectedError;
+};
+
+export type SetExpectedErrorAction = Action<"set_expected_error"> & { error: ExpectedError };
+
+export function setExpectedError(error: ExpectedError): UIThunkAction {
+  return (dispatch, getState) => {
+    const state = getState();
+
+    sendTelemetryEvent("DevtoolsExpectedError", {
+      message: error.message,
+      action: error.action,
+      recordingId: getRecordingId(),
+      sessionId: selectors.getSessionId(state),
+      environment: isDevelopment() ? "dev" : "prod",
+    });
+
+    dispatch({ type: "set_expected_error", error });
+  };
+}
+
+export function setUnexpectedError(error: UnexpectedError, skipTelemetry = false): UIThunkAction {
+  return (dispatch, getState) => {
+    const state = getState();
+
+    if (!skipTelemetry) {
+      sendTelemetryEvent("DevtoolsUnexpectedError", {
+        ...error,
+        recordingId: getRecordingId(),
+        sessionId: selectors.getSessionId(state),
+        environment: isDevelopment() ? "dev" : "prod",
+      });
+    }
+
+    dispatch({ type: "set_unexpected_error", error });
+  };
+}

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -14,7 +14,7 @@ import LogRocket from "ui/utils/logrocket";
 import { registerRecording, sendTelemetryEvent, trackEvent } from "ui/utils/telemetry";
 import { extractGraphQLError } from "ui/utils/apolloClient";
 
-import { ExpectedError, UnexpectedError } from "ui/state/app";
+import type { ExpectedError, UnexpectedError } from "ui/state/app";
 import { getRecording } from "ui/hooks/recordings";
 import { getRecordingId } from "ui/utils/recording";
 import { getUserId, getUserInfo } from "ui/hooks/users";
@@ -26,12 +26,13 @@ import { getUserSettings } from "ui/hooks/settings";
 import { setViewMode } from "./layout";
 import { getSelectedPanel } from "ui/reducers/layout";
 import { videoReady } from "protocol/graphics";
+import type { SetExpectedErrorAction, SetUnexpectedErrorAction } from "./errors";
+import { setUnexpectedError, setExpectedError } from "./errors";
 
-export type SetUnexpectedErrorAction = Action<"set_unexpected_error"> & {
-  error: UnexpectedError;
-};
+export { setUnexpectedError, setExpectedError };
+
 export type SetTrialExpiredAction = Action<"set_trial_expired"> & { expired: boolean };
-export type SetExpectedErrorAction = Action<"set_expected_error"> & { error: ExpectedError };
+
 export type ClearExpectedError = Action<"clear_expected_error">;
 export type SetCurrentPointAction = Action<"set_current_point"> & {
   currentPoint: ExecutionPoint | null;
@@ -253,45 +254,12 @@ export function onUploadedData({ uploaded, length }: uploadedData): UIThunkActio
   };
 }
 
-export function setExpectedError(error: ExpectedError): UIThunkAction {
-  return (dispatch, getState) => {
-    const state = getState();
-
-    sendTelemetryEvent("DevtoolsExpectedError", {
-      message: error.message,
-      action: error.action,
-      recordingId: getRecordingId(),
-      sessionId: selectors.getSessionId(state),
-      environment: isDevelopment() ? "dev" : "prod",
-    });
-
-    dispatch({ type: "set_expected_error", error });
-  };
-}
-
 export function setTrialExpired(expired = true): SetTrialExpiredAction {
   return { type: "set_trial_expired", expired };
 }
 
 export function clearTrialExpired(): UIThunkAction {
   return dispatch => dispatch(setTrialExpired(false));
-}
-
-export function setUnexpectedError(error: UnexpectedError, skipTelemetry = false): UIThunkAction {
-  return (dispatch, getState) => {
-    const state = getState();
-
-    if (!skipTelemetry) {
-      sendTelemetryEvent("DevtoolsUnexpectedError", {
-        ...error,
-        recordingId: getRecordingId(),
-        sessionId: selectors.getSessionId(state),
-        environment: isDevelopment() ? "dev" : "prod",
-      });
-    }
-
-    dispatch({ type: "set_unexpected_error", error });
-  };
 }
 
 export function clearExpectedError(): UIThunkAction {

--- a/src/ui/components/ApolloWrapper.tsx
+++ b/src/ui/components/ApolloWrapper.tsx
@@ -1,0 +1,72 @@
+import React, { ReactNode, useState, useEffect } from "react";
+import { ApolloProvider, from } from "@apollo/client";
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { isTest, isMock, waitForMockEnvironment } from "ui/utils/environment";
+import useToken from "ui/utils/useToken";
+import { PopupBlockedError } from "ui/components/shared/Error";
+import {
+  createRetryLink,
+  createErrorLink,
+  createMockLink,
+  createApolloCache,
+  clientWaiter,
+  createApolloClient,
+} from "ui/utils/apolloClient";
+
+export function ApolloWrapper({
+  children,
+  onAuthError,
+}: {
+  children: ReactNode;
+  onAuthError?: () => void;
+}) {
+  const { loading, token, error } = useToken();
+
+  const [mocks, setMocks] = useState<MockedResponse<Record<string, any>>[]>();
+
+  useEffect(() => {
+    async function waitForMocks() {
+      const mockEnvironment = await waitForMockEnvironment();
+      setMocks(mockEnvironment!.graphqlMocks);
+    }
+    if (isMock()) {
+      waitForMocks();
+    }
+  }, []);
+
+  if (isMock()) {
+    if (!mocks) {
+      return null;
+    }
+
+    const retryLink = createRetryLink();
+    const errorLink = createErrorLink(onAuthError);
+    const mockLink = createMockLink(mocks);
+
+    return (
+      <MockedProvider
+        link={from([retryLink, errorLink, mockLink])}
+        cache={createApolloCache()}
+        ref={mockRef => mockRef && clientWaiter.resolve(mockRef!.state.client)}
+      >
+        <>{children}</>
+      </MockedProvider>
+    );
+  }
+
+  if (!isTest() && loading) {
+    return null;
+  }
+
+  if (error) {
+    if (error.message === "Could not open popup") {
+      return <PopupBlockedError />;
+    } else {
+      return null;
+    }
+  }
+
+  return (
+    <ApolloProvider client={createApolloClient(token, onAuthError)}>{children}</ApolloProvider>
+  );
+}

--- a/src/ui/components/ErrorBoundary.tsx
+++ b/src/ui/components/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { UnexpectedError } from "ui/state/app";
 import { getUnexpectedError } from "ui/reducers/app";
-import { setUnexpectedError } from "ui/actions/session";
+import { setUnexpectedError } from "ui/actions/errors";
 import { isDevelopment } from "ui/utils/environment";
 import { BlankViewportWrapper } from "./shared/Viewport";
 import * as Sentry from "@sentry/react";

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -9,7 +9,7 @@ import { UIState } from "ui/state";
 import * as selectors from "ui/reducers/app";
 import { Nag, useGetUserInfo } from "ui/hooks/users";
 import { removeUrlParameters } from "ui/utils/environment";
-import { setExpectedError } from "ui/actions/session";
+import { setExpectedError } from "ui/actions/errors";
 import LoadingScreen from "../shared/LoadingScreen";
 import Sidebar from "./Sidebar";
 import ViewerRouter from "./ViewerRouter";

--- a/src/ui/components/shared/Error.tsx
+++ b/src/ui/components/shared/Error.tsx
@@ -13,7 +13,7 @@ import { PrimaryButton } from "./Button";
 import { useRouter } from "next/dist/client/router";
 import { BubbleViewportWrapper } from "./Viewport";
 import { getRecordingId } from "ui/utils/recording";
-import { setExpectedError } from "ui/actions/session";
+import { setExpectedError } from "ui/actions/errors";
 import { useRequestRecordingAccess } from "ui/hooks/recordings";
 
 export function PopupBlockedError() {


### PR DESCRIPTION
This PR does some initial code refactoring to try to fix some of our circular imports:

- Imports of ` { client } from "./socket"` are moved to use `await import("./socket")` inside the functions where that's used
- The "set error" thunks were extracted from `actions/session` and moved into their own file
- The "async layout initial state" calculation logic was moved to `ui/setup/index`, where it's actually used
- `<ApolloWrapper>` was moved out to its own file
- `addTab()` was moved over to the file where it's used

These appear to resolve the first few circular deps errors I'm seeing, but there's many more where those came from :(

See #6673 for some examples of what the circle errors look like when logged by the Webpack plugin.