### PR TITLE
fix go to definition dark mode icon color

### DIFF
--- a/src/devtools/client/shared/components/reps/images/jump-definition-light.svg
+++ b/src/devtools/client/shared/components/reps/images/jump-definition-light.svg
@@ -1,7 +1,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" stroke="context-stroke" fill="none" stroke-linecap="round">
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" stroke="white" fill="none" stroke-linecap="round">
   <path d="M5.5 3.5l2 2M5.5 7.5l2-2"/>
   <path d="M7 5.5H4.006c-1.012 0-1.995 1.017-2.011 2.024-.005.023-.005 1.347 0 3.971" stroke-linejoin="round"/>
   <path d="M10.5 5.5h4M9.5 3.5h5M9.5 7.5h5"/>

--- a/src/image/image.css
+++ b/src/image/image.css
@@ -140,13 +140,19 @@
 .message.startGroupCollapsed > .indent[data-indent="0"] ~ .collapse-button::before {
   background-image: url(~devtools/client/themes/images/arrow-big.svg) !important;
 }
-button.jump-definition {
+.theme-dark button.jump-definition {
+  background-image: url(~devtools/client/shared/components/reps/images/jump-definition-light.svg) !important;
+}
+.theme-light button.jump-definition {
   background-image: url(~devtools/client/shared/components/reps/images/jump-definition-dark.svg) !important;
 }
 .img.column-marker {
   background-image: url(~devtools/client/debugger/images/column-marker.svg) !important;
 }
-.event-tooltip-debugger-icon {
+.theme-dark .event-tooltip-debugger-icon {
+  background-image: url(~devtools/client/shared/components/reps/images/jump-definition-light.svg) !important;
+}
+.theme-light .event-tooltip-debugger-icon {
   background-image: url(~devtools/client/shared/components/reps/images/jump-definition-dark.svg) !important;
 }
 .invoke-confirm .close-confirm-dialog-button::before {


### PR DESCRIPTION
Fixes the go to definition icon color when in dark mode.

closes #6482

### Light Mode

<img width="505" alt="image" src="https://user-images.githubusercontent.com/2762082/167503052-952c2e14-02b2-44c6-9bbf-b6ae5589f7e1.png">

### Dark Mode

<img width="321" alt="image" src="https://user-images.githubusercontent.com/2762082/167503176-60d88c29-4ea1-4c7c-b49f-b6ad555e72cb.png">
