### PR TITLE
Unsquish console message badge

### DIFF
--- a/src/devtools/client/webconsole/components/Output/MessageIcon.js
+++ b/src/devtools/client/webconsole/components/Output/MessageIcon.js
@@ -42,17 +42,18 @@ export function MessageIcon(props) {
     const style =
       prefixBadge == "unicorn"
         ? {
-            height: "16px",
-            marginLeft: "4px",
-            marginRight: "8px",
-            marginTop: "2px",
+            height: 16,
+            marginLeft: 4,
+            marginRight: 8,
+            marginTop: 2,
           }
         : {
-            height: "7px",
-            marginLeft: "9px",
-            marginRight: "12px",
-            marginTop: "8px",
-            width: "7px",
+            height: 7,
+            marginLeft: 9,
+            marginRight: 12,
+            marginTop: 8,
+            width: 7,
+            minWidth: 7,
           };
     return <PrefixBadge prefixBadge={prefixBadge} style={style} />;
   }


### PR DESCRIPTION
I noticed that if the console message is really long the badge ends up
getting squished, so I've set a minWidth in addition to a width, which
seems to work. Also, I've migrated this particular set of styles to
using numbers instead of `"Xpx"`. I've only ever seen numbers elsewhere
in this codebase  (the px is implied), so I'm just going for consistency
here.

![CleanShot 2022-05-09 at 20 30 24](https://user-images.githubusercontent.com/5903784/167538089-df9403fc-ba9b-45de-89fd-c1739ea85c3a.png)

