### PR TITLE
Only update locations when they are received from the backend

### DIFF
--- a/src/protocol/analysisManager.ts
+++ b/src/protocol/analysisManager.ts
@@ -12,6 +12,7 @@ import {
   SessionId,
 } from "@recordreplay/protocol";
 import { sendMessage, addEventListener } from "protocol/socket";
+import { ThreadFront } from "protocol/thread";
 
 import { assert } from "./utils";
 
@@ -166,6 +167,7 @@ class AnalysisManager {
   private readonly onAnalysisPoints = ({ analysisId, points }: analysisPoints) => {
     const handler = this.handlers.get(analysisId);
     assert(handler, "no handler for given analysisId");
+    points.forEach(point => ThreadFront.updateMappedLocation(point.frame));
     handler.onAnalysisPoints?.(points);
   };
 

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -1055,7 +1055,10 @@ class _ThreadFront {
     const { sourceId } = this._chooseSourceId(locations.map(l => l.sourceId));
     const preferredLocation = locations.find(l => l.sourceId == sourceId);
     assert(preferredLocation, "no preferred location found");
-    this.updateLocation(preferredLocation);
+    assert(
+      preferredLocation.sourceId === this.getCorrespondingSourceIds(preferredLocation.sourceId)[0],
+      "location.sourceId should be updated to the first corresponding sourceId"
+    );
     return preferredLocation;
   }
 


### PR DESCRIPTION
Fixes RecordReplay/customer-support#87

To reproduce the issue:
- open any recording
- set a logpoint anywhere
- remove the logpoint and set it again

The first time the logpoint is set, it shows up in the console, but not the second time.
The reason is that after the first time, it is cached in redux and the second time we try to reuse it, but now it's a readonly object (I guess this is done by RTK) and we try to update the `sourceId` in it, which fails.
Updating the `sourceId` is part of how we handle multiple identical sources in a recording (see #3183): we pick on source from each set of identical sources and modify the `sourceId`s in all incoming locations so that they point to the picked source. This usually happens immediately after receiving the location from the backend, but there was one instance where we did this when a location is *used* (in `ThreadFront.getPreferredLocationRaw()`), simply because I wasn't sure at the time if I had found all places where we receive locations.
I have tracked down one more place where a received location needs to be updated and replaced the update in `ThreadFront.getPreferredLocationRaw()` with an assertion that will alert us if we try to use a location whose `sourceId` was not updated.
