### PR TITLE
Circular import fixes, part 4: centralize debugger UI prefs logic

### DIFF
--- a/src/devtools/client/debugger/src/actions/sources/newSources.ts
+++ b/src/devtools/client/debugger/src/actions/sources/newSources.ts
@@ -30,9 +30,10 @@ import {
 import { ContextError } from "../../utils/context";
 import { getRawSourceURL, isInlineScript } from "../../utils/source";
 import { syncBreakpoint } from "../breakpoints";
-import { selectLocation, setBreakableLines } from "../sources";
+import { selectLocation } from "../sources/select";
 
 import { toggleBlackBox } from "./blackbox";
+import { setBreakableLines } from "./breakableLines";
 import { loadSourceText } from "./loadSourceText";
 
 interface SourceData {

--- a/src/devtools/client/debugger/src/actions/sources/select.ts
+++ b/src/devtools/client/debugger/src/actions/sources/select.ts
@@ -18,7 +18,7 @@ import { getFrames, getSelectedFrameId } from "../../reducers/pause";
 import { setSymbols } from "./symbols";
 import { closeActiveSearch, updateActiveFileSearch } from "../ui";
 import { loadSourceText } from "./loadSourceText";
-import { setBreakableLines, setBreakpointHitCounts } from ".";
+import { setBreakableLines } from "./breakableLines";
 
 import { createLocation } from "../../utils/location";
 import { getToolboxLayout } from "ui/reducers/layout";

--- a/src/devtools/client/debugger/src/reducers/ui.ts
+++ b/src/devtools/client/debugger/src/reducers/ui.ts
@@ -60,7 +60,6 @@ function update(state = createUIState(), action: AnyAction) {
     }
 
     case "TOGGLE_FRAMEWORK_GROUPING": {
-      prefs.frameworkGroupingOn = action.value;
       return { ...state, frameworkGroupingOn: action.value };
     }
 
@@ -69,17 +68,14 @@ function update(state = createUIState(), action: AnyAction) {
     }
 
     case "TOGGLE_PANE": {
-      prefs.startPanelCollapsed = action.paneCollapsed;
       return { ...state, startPanelCollapsed: action.paneCollapsed };
     }
 
     case "set_selected_primary_panel": {
-      prefs.startPanelCollapsed = false;
       return { ...state, startPanelCollapsed: false };
     }
 
     case "TOGGLE_SOURCES": {
-      prefs.sourcesCollapsed = action.sourcesCollapsed;
       return { ...state, sourcesCollapsed: action.sourcesCollapsed };
     }
 

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -1,8 +1,9 @@
+import { prefs as debuggerPrefs } from "devtools/client/debugger/src/utils/prefs";
+import { prefs as webconsolePrefs } from "devtools/client/webconsole/utils/prefs";
 import debounce from "lodash/debounce";
 import { UIStore } from "ui/actions";
 import { UIState } from "ui/state";
 import { prefs, asyncStore } from "ui/utils/prefs";
-import { prefs as webconsolePrefs } from "devtools/client/webconsole/utils/prefs";
 import { getRecordingId } from "ui/utils/recording";
 import {
   getConsoleFilterDrawerExpanded,
@@ -60,6 +61,7 @@ function createPrefsUpdater<T extends Record<string, any>>(prefObj: T) {
 const updateStandardPrefs = createPrefsUpdater(prefs);
 const updateAsyncPrefs = createPrefsUpdater(asyncStore);
 const updateWebconsolePrefs = createPrefsUpdater(webconsolePrefs);
+const updateDebuggerPrefs = createPrefsUpdater(debuggerPrefs);
 
 const actualUpdatePrefs = (state: UIState, oldState: UIState) => {
   updateStandardPrefs(state, oldState, "viewMode", getViewMode);
@@ -69,20 +71,33 @@ const actualUpdatePrefs = (state: UIState, oldState: UIState) => {
     state,
     oldState,
     "eventListenerBreakpoints",
-    (state: UIState) => state.eventListenerBreakpoints
+    state => state.eventListenerBreakpoints
   );
-  updateAsyncPrefs(
-    state,
-    oldState,
-    "commandHistory",
-    (state: UIState) => state.messages?.commandHistory
-  );
+  updateAsyncPrefs(state, oldState, "commandHistory", state => state.messages?.commandHistory);
 
   // This is lazy-loaded, so it may not exist on startup
   if (state.consoleUI && oldState.consoleUI) {
-    updateWebconsolePrefs(state, oldState, "timestampsVisible", (state: UIState) => {
+    updateWebconsolePrefs(state, oldState, "timestampsVisible", state => {
       return state.consoleUI.timestampsVisible;
     });
+  }
+
+  if (state.ui && oldState.ui) {
+    updateDebuggerPrefs(
+      state,
+      oldState,
+      "frameworkGroupingOn",
+      state => state.ui.frameworkGroupingOn
+    );
+
+    updateDebuggerPrefs(
+      state,
+      oldState,
+      "startPanelCollapsed",
+      state => state.ui.startPanelCollapsed
+    );
+
+    updateDebuggerPrefs(state, oldState, "sourcesCollapsed", state => state.ui.sourcesCollapsed);
   }
   maybeUpdateReplaySessions(state);
 };


### PR DESCRIPTION
Part of #6673 for fixing circular imports

This PR:

- Restructures the persistence of debugger UI prefs so that the reducer is no longer responsible for that
  - Consolidated the "select and diff" logic into a reusable func
  - Extracted diff function outside the subscriber
  - Debounced pref subscriber by 50ms
- Updates some `setBreakableLines` imports