### PR TITLE
Copy events before passing them to redux

### DIFF
--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -164,7 +164,7 @@ function onMouseEvents(events: MouseEvent[], store: UIStore) {
     }
   });
 
-  store.dispatch(setEventsForType({ events: gMouseClickEvents, eventType: "mousedown" }));
+  store.dispatch(setEventsForType({ events: [...gMouseClickEvents], eventType: "mousedown" }));
 }
 
 class VideoPlayer {


### PR DESCRIPTION
I guess redux is freezing the payload of this action after the changes in https://github.com/RecordReplay/devtools/commit/02d24f59a7f2551c47b8f3384fa70da6f4b448dd, and that causes a bunch of errors to be raised when we try to extend the array by pushing more stuff onto it.

![CleanShot 2022-05-10 at 18 31 30](https://user-images.githubusercontent.com/5903784/167750904-9f29da60-998b-4eae-90d5-05b2f637c8e5.png)

Replay of the issue: https://app.replay.io/recording/mouse-event-errors-in-console--cedc8b70-6186-41c4-8a05-9d13b00d03ba

I *think* this will fix https://github.com/RecordReplay/devtools/issues/6679