### PR TITLE
Wait for basic processing before we run analyses

### DIFF
--- a/src/protocol/logpoint.ts
+++ b/src/protocol/logpoint.ts
@@ -226,7 +226,7 @@ export async function setLogpoint(
   condition: string,
   showInConsole: boolean = true
 ) {
-  await ThreadFront.ensureAllSources();
+  await Promise.all([ThreadFront.ensureAllSources(), ThreadFront.ensureProcessed("basic")]);
   const sourceIds = ThreadFront.getCorrespondingSourceIds(location.sourceId);
   const { line, column } = location;
   const locations = sourceIds.map(sourceId => ({ sourceId, line, column }));


### PR DESCRIPTION
There's a common problem in our analyses which is that they sometimes run before the recording is fully loaded. #6549 is one example of this problem (replay at https://app.replay.io/recording/invalid-no-hits--8c51609c-f563-4f53-8857-dba1005ee64a?point=546164725844869027945326080604256823&time=232105&hasFrames=false)

There's another set of problems around *re-running* analyses, and I have a plan for that, but this is just an easy win to start with.

Fixes #6549 