### PR TITLE
Ensure all sources are loaded before running an analysis (#6700)

### DIFF
--- a/src/protocol/analysisManager.ts
+++ b/src/protocol/analysisManager.ts
@@ -54,6 +54,7 @@ class AnalysisManager {
   }
 
   async runAnalysis<T>(params: AnalysisParams, handler: AnalysisHandler<T>) {
+    await ThreadFront.ensureAllSources();
     const { analysisId } = await sendMessage(
       "Analysis.createAnalysis",
       {


### PR DESCRIPTION
Fixes #6700
Follow-up to #6686: now that we update the `sourceId`s of locations received from analyses, we need to ensure that all sources are loaded.