### PR TITLE
Increase timeouts for e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,8 @@ jobs:
         id: waitFor200
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 480
-          check_interval: 60
+          max_timeout: 960
+          check_interval: 10
           environment: ${{ fromJSON('["", "production"]')[github.ref == 'refs/heads/master'] }}
     outputs:
       url: ${{ steps.waitFor200.outputs.url }}

--- a/jest-e2e.config.js
+++ b/jest-e2e.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   setupFilesAfterEnv: ["./test/e2e/setupEnv.ts"],
   testMatch: ["**/e2e/tests/*.test.ts"],
-  testTimeout: 240_000,
+  testTimeout: 480_000,
   transform: {
     // Use babel-jest to transpile tests with the next/babel preset
     // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object


### PR DESCRIPTION
This PR increases 2 timeouts for our e2e tests:
- CI test runs still fail quite often waiting for the Vercel preview branch
- I noticed that [this test run](https://github.com/RecordReplay/devtools/actions/runs/2303277954) had a failed test but didn't upload a recording for it - the reason was that the test ran into the jest timeout and not a timeout within the test