### PR TITLE
Fix ObjectInspector for objects with a property called "loading" (#6703)

### DIFF
--- a/src/devtools/packages/devtools-reps/object-inspector/utils/value.tsx
+++ b/src/devtools/packages/devtools-reps/object-inspector/utils/value.tsx
@@ -220,8 +220,8 @@ export class ValueItem implements IItem {
   }
 
   shouldUpdate(prevItem: Item) {
-    assert(this.type === prevItem.type, "OI items for the same path must have the same type");
     return (
+      this.type !== prevItem.type ||
       this.childrenLoaded !== prevItem.childrenLoaded ||
       this.isInCurrentPause !== prevItem.isInCurrentPause
     );


### PR DESCRIPTION
Fixes #6703
The issue happened when expanding an object with a `loading` property in the ObjectInspector: first we show a "Loading..." item with a path `<objectPath>/loading`, then we replace that with items for all its properties with paths `<objectPath>/<propertyName>`. So the assumption that items with the same path are of the same type (`LoadingItem` vs. `ValueItem`) was wrong in this case.