### PR TITLE
Upgrade patrickedqvist/wait-for-vercel-preview from 1.2.0 ->  1.2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Waiting for 200 from the Vercel Preview
-        uses: patrickedqvist/wait-for-vercel-preview@v1.2.0
+        uses: patrickedqvist/wait-for-vercel-preview@v1.2.6
         id: waitFor200
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Let's see if this fixes the "never finishes waiting" issue.

Looks like it currently _never_ finishes waiting (even after the Vercel deploy has finished).

Possibly related to https://github.com/patrickedqvist/wait-for-vercel-preview/issues/20