### PR TITLE
Avoid pasting HTML to the Header's contenteditable

### DIFF
--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -21,6 +21,12 @@ import { trackEvent } from "ui/utils/telemetry";
 import css from "./Header.module.css";
 const cx = classNames.bind(css);
 
+function pasteText(ev: React.ClipboardEvent) {
+  ev.preventDefault();
+  var text = ev.clipboardData.getData("text/plain");
+  document.execCommand("insertText", false, text);
+}
+
 function Avatars({ recordingId }: { recordingId: RecordingId | null }) {
   const { users, loading, error } = useGetActiveSessions(
     recordingId || "00000000-0000-0000-0000-000000000000"
@@ -133,6 +139,7 @@ function HeaderTitle({
       onKeyPress={onKeyPress}
       onKeyDown={onKeyPress}
       onFocus={onFocus}
+      onPaste={pasteText}
       ref={inputNode}
     />
   );


### PR DESCRIPTION
I often copy a piece of code from VScode and paste it as the title into the Header. It is annoying that initially the text is being pasted together with its HTML and then saved without it:
<img width="218" alt="Screenshot 2022-05-11 at 20 08 03" src="https://user-images.githubusercontent.com/9800850/167917179-453e4488-e6d4-45a3-956a-7c436cfe71a0.png">

You might notice a slightly different bg color and text color on this title.
