### PR TITLE
Add the received paint points to the ProtocolTimeline

### DIFF
--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -106,7 +106,9 @@ export interface TimeStampedPointWithPaintHash extends TimeStampedPoint {
 // All paints that have occurred in the recording, in order. Include the
 // beginning point of the recording as well, which is not painted and has
 // a known point and time.
-const gPaintPoints: TimeStampedPointWithPaintHash[] = [{ point: "0", time: 0, paintHash: "" }];
+export const gPaintPoints: TimeStampedPointWithPaintHash[] = [
+  { point: "0", time: 0, paintHash: "" },
+];
 
 // All mouse events that have occurred in the recording, in order.
 const gMouseEvents: MouseEvent[] = [];

--- a/src/ui/components/ProtocolTimeline.tsx
+++ b/src/ui/components/ProtocolTimeline.tsx
@@ -1,4 +1,5 @@
 import { TimeStampedPointRange } from "@recordreplay/protocol";
+import { gPaintPoints } from "protocol/graphics";
 import { useSelector } from "react-redux";
 import { useFeature } from "ui/hooks/settings";
 import { getLoadedRegions } from "ui/reducers/app";
@@ -45,16 +46,28 @@ const Spans = ({
 export default function ProtocolTimeline() {
   const loadedRegions = useSelector(getLoadedRegions);
   const { value: showProtocolTimeline } = useFeature("protocolTimeline");
+  const firstPaint = gPaintPoints[0];
+  const lastPaint = gPaintPoints[gPaintPoints.length - 1];
 
   if (!showProtocolTimeline || !loadedRegions) {
     return null;
   }
 
   return (
-    <div className="absolute -top-3 flex w-full flex-col space-y-1">
+    <div className="absolute -top-4 flex w-full flex-col space-y-1">
       <Spans regions={loadedRegions.loading} color="bg-gray-500" title="Loading" />
       <Spans regions={loadedRegions.loaded} color="bg-orange-500" title="Loaded" />
       <Spans regions={loadedRegions.indexed} color="bg-green-500" title="Indexed" />
+      <Spans
+        regions={[
+          {
+            begin: { point: firstPaint.point, time: firstPaint.time },
+            end: { point: lastPaint.point, time: lastPaint.time },
+          },
+        ]}
+        color="bg-sky-500"
+        title="Paints"
+      />
     </div>
   );
 }


### PR DESCRIPTION
What we show in the viewer is always a little tricky. See this note from `actions/timeline.ts`:

>  Seek to the exact time provided, even if it does not match up with a
>  paint event. This can cause some slight UI weirdness: resumes done in
>  the debugger will be relative to the point instead of the time,
>  so e.g. running forward could land at a point before the time itself.
>  This could be fixed but doesn't seem worth worrying about for now.

This ends up *really* lagging behind sometimes, if it's a long recording and the paints are still loading. Like, you can end up with execution and a paint from 10 seconds before where your timeline says you are.  This seems bad? I think maybe we should do more to signal to the user that a particular section of the recording is still loading and jumping there is not necessarily going to be successful either in terms of execution *or* in terms of video.

I walk through some potential solutions here: https://www.loom.com/share/fcdfddf52a43464dae6e864634692e94 but in the meantime, here's a little additional piece of timeline info: how far into the recording do we have paint points for on the `ProtocolTimeline` (it would be nice if we stored these in redux rather than this global variable, but I think it's probably ok to just recompute the paints each render because when they are loading is also when other stuff is going to be loading, so it will be rendering fairly often anyways.