### PR TITLE
Fix setFullTextQuery name and re-export UI action creators

### DIFF
--- a/src/devtools/client/debugger/src/actions/ui.ts
+++ b/src/devtools/client/debugger/src/actions/ui.ts
@@ -46,13 +46,21 @@ import { selectSource, selectLocation } from "./sources/select";
 
 export {
   closeActiveSearch,
-  highlightLineRange,
   clearHighlightLineRange,
+  closeProjectSearch,
+  focusFullTextInput,
+  highlightLineRange,
+  setCursorPosition,
+  setFullTextQuery,
+  setPrimaryPaneTab,
+  setShownSource,
+  setViewport,
+  sourcesDisplayed,
+  sourcesPanelExpanded,
   toggleActiveSearch,
   toggleFrameworkGrouping,
-  setPrimaryPaneTab,
-  setFulltextQuery,
-  focusFullTextInput,
+  toggleStartPanel,
+  toggleSources,
 } from "../reducers/ui";
 
 export function setActiveSearch(activeSearch: ActiveSearchType): UIThunkAction {

--- a/src/devtools/client/debugger/src/reducers/ui.ts
+++ b/src/devtools/client/debugger/src/reducers/ui.ts
@@ -89,7 +89,7 @@ const uiSlice = createSlice({
     setPrimaryPaneTab(state, action: PayloadAction<SelectedPrimaryPaneTabType>) {
       state.selectedPrimaryPaneTab = action.payload;
     },
-    setFulltextQuery(state, action: PayloadAction<string>) {
+    setFullTextQuery(state, action: PayloadAction<string>) {
       state.fullTextSearchQuery = action.payload;
     },
     focusFullTextInput(state, action: PayloadAction<boolean>) {
@@ -131,7 +131,7 @@ export const {
   focusFullTextInput,
   highlightLineRange,
   setCursorPosition,
-  setFulltextQuery,
+  setFullTextQuery,
   setPrimaryPaneTab,
   setShownSource,
   setViewport,


### PR DESCRIPTION
This PR:

- Fixes a typo in `setFullTextQuery`'s name (the 't' was lower-cased), which caused that action creator to not be referenced correctly
- Ensures that all action creators from `reducers/ui` are re-exported from `actions/ui`

also I hate this re-export pattern WHY DO WE DO THIS

Fixes #6716 , where typing text in the full text search input threw an error because the action creator didn't exist .