### PR TITLE
Disable graphql mutations in e2e tests

### DIFF
--- a/src/ui/utils/apolloClient.tsx
+++ b/src/ui/utils/apolloClient.tsx
@@ -13,6 +13,8 @@ import { MockedResponse, MockLink } from "@apollo/client/testing";
 import { onError } from "@apollo/client/link/error";
 import { RetryLink } from "@apollo/client/link/retry";
 
+import { isE2ETest } from "./environment";
+
 export let clientWaiter = defer<ApolloClient<NormalizedCacheObject>>();
 
 export async function query({ variables = {}, query }: { variables: any; query: DocumentNode }) {
@@ -29,6 +31,9 @@ export async function mutate({
   mutation: DocumentNode;
   refetchQueries?: any;
 }) {
+  if (isE2ETest()) {
+    return;
+  }
   const apolloClient = await clientWaiter.promise;
   return await apolloClient.mutate({ variables, mutation, refetchQueries });
 }

--- a/src/ui/utils/environment.ts
+++ b/src/ui/utils/environment.ts
@@ -49,8 +49,12 @@ export function getTest() {
 
 // Return whether we are running one of the tests in our e2e test suite.
 // We will be connected to a live backend and testing debugging features.
+export function isE2ETest() {
+  return getTest() != null;
+}
+
 export function isTest() {
-  return isMock() || getTest() != null;
+  return isMock() || isE2ETest();
 }
 
 // Return whether we are running a mock test. The backend servers which we


### PR DESCRIPTION
Recordings of failed e2e tests often show the next.js error popup triggered by a failed graphql mutation, making them hard to work with:

![Screenshot from 2022-05-12 14-11-03](https://user-images.githubusercontent.com/16060807/168071818-629e22fd-68ad-45f9-a086-106150acdd0b.png)


https://app.replay.io/recording/replay-of-localhost8080--c4044322-54f3-48c7-b140-b163e860fc50