### PR TITLE
Show when all paints loaded

### DIFF
--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -234,7 +234,7 @@ class VideoPlayer {
 export const Video = new VideoPlayer();
 
 let onRefreshGraphics: (canvas: Canvas) => void;
-let hasAllPaintPoints = false;
+export let hasAllPaintPoints = false;
 
 export function setupGraphics(store: UIStore) {
   onRefreshGraphics = (canvas: Canvas) => {

--- a/src/ui/components/ProtocolTimeline.tsx
+++ b/src/ui/components/ProtocolTimeline.tsx
@@ -1,5 +1,5 @@
 import { TimeStampedPointRange } from "@recordreplay/protocol";
-import { gPaintPoints } from "protocol/graphics";
+import { gPaintPoints, hasAllPaintPoints } from "protocol/graphics";
 import { useSelector } from "react-redux";
 import { useFeature } from "ui/hooks/settings";
 import { getLoadedRegions } from "ui/reducers/app";
@@ -59,12 +59,21 @@ export default function ProtocolTimeline() {
       <Spans regions={loadedRegions.loaded} color="bg-orange-500" title="Loaded" />
       <Spans regions={loadedRegions.indexed} color="bg-green-500" title="Indexed" />
       <Spans
-        regions={[
-          {
-            begin: { point: firstPaint.point, time: firstPaint.time },
-            end: { point: lastPaint.point, time: lastPaint.time },
-          },
-        ]}
+        regions={
+          hasAllPaintPoints
+            ? [
+                {
+                  begin: { point: firstPaint.point, time: firstPaint.time },
+                  end: { point: "", time: Infinity },
+                },
+              ]
+            : [
+                {
+                  begin: { point: firstPaint.point, time: firstPaint.time },
+                  end: { point: lastPaint.point, time: lastPaint.time },
+                },
+              ]
+        }
         color="bg-sky-500"
         title="Paints"
       />


### PR DESCRIPTION
The protocol timeline right now uses a strict interpretation of the
paints that we have, but that makes it look as if the paints might not
be loaded completely. Instead, when `hasAllPaintPoints` is `true` (which
means the protocol call has returned and we are done getting paint
points) we should just say that all points for the whole recording are
loaded.