### PR TITLE
Circular import fixes, part 8: migrate breakpoints reducers to RTK

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
+++ b/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
@@ -12,6 +12,11 @@ import {
   getBreakpointsForSource,
   getBreakpointsForSourceId,
 } from "../../reducers/breakpoints";
+import {
+  removeRequestedBreakpoint,
+  removeBreakpoints as removeBreakpointsAction,
+} from "../../reducers/breakpoints";
+import { setBreakpoint } from "../../reducers/breakpoints";
 import { Source } from "../../reducers/sources";
 import {
   getBreakpointsList,
@@ -29,7 +34,6 @@ import { setBreakpointPositions } from "./breakpointPositions";
 import {
   _removeBreakpoint,
   removeBreakpointOption,
-  removeRequestedBreakpoint,
   addBreakpoint,
   enableBreakpoint,
   disableBreakpoint,
@@ -152,7 +156,7 @@ export function removeAllBreakpoints(cx: Context): UIThunkAction<Promise<void>> 
 
     const breakpointList = getBreakpointsList(getState());
     await Promise.all(breakpointList.map(bp => dispatch(_removeBreakpoint(cx, bp))));
-    dispatch({ type: "REMOVE_BREAKPOINTS" });
+    dispatch(removeBreakpointsAction());
   };
 }
 
@@ -317,14 +321,14 @@ export function addBreakpointAtColumn(cx: Context, location: Location): UIThunkA
   };
 }
 
-export function setBreakpointPrefixBadge(breakpoint: Breakpoint, prefixBadge: string) {
-  return {
-    breakpoint: {
-      ...breakpoint,
-      options: { ...breakpoint.options, prefixBadge },
-    },
-    type: "SET_BREAKPOINT",
-  };
+export function setBreakpointPrefixBadge(
+  breakpoint: Breakpoint,
+  prefixBadge: Breakpoint["options"]["prefixBadge"]
+) {
+  return setBreakpoint({
+    ...breakpoint,
+    options: { ...breakpoint.options, prefixBadge },
+  });
 }
 
 function getLogValue(source: Source, state: UIState, location: Location) {

--- a/src/devtools/client/debugger/src/actions/breakpoints/logpoints.ts
+++ b/src/devtools/client/debugger/src/actions/breakpoints/logpoints.ts
@@ -4,12 +4,13 @@ import { trackEvent } from "ui/utils/telemetry";
 
 import { Breakpoint, getBreakpointsForSourceId } from "../../reducers/breakpoints";
 import { getLogpointsForSource } from "../../reducers/breakpoints";
+import { removeRequestedBreakpoint } from "../../reducers/breakpoints";
 import { Source } from "../../reducers/sources";
 import { getRequestedBreakpointLocations } from "../../selectors/breakpoints";
 import { isBreakable } from "../../utils/breakpoint";
 
 import { _addBreakpointAtLine } from "./breakpoints";
-import { _removeBreakpoint, removeBreakpointOption, removeRequestedBreakpoint } from "./modify";
+import { _removeBreakpoint, removeBreakpointOption } from "./modify";
 
 export function removeLogpointsInSource(cx: Context, source: Source): UIThunkAction {
   return async (dispatch, getState) => {

--- a/src/devtools/client/debugger/src/actions/breakpoints/modify.d.ts
+++ b/src/devtools/client/debugger/src/actions/breakpoints/modify.d.ts
@@ -9,11 +9,6 @@ export function removeBreakpointOption(
   breakpoint: Breakpoint,
   option: "logValue" | "shouldPause"
 ): UIThunkAction;
-export function removeRequestedBreakpoint(
-  location: Omit<Location, "column">
-): Action<"REMOVE_REQUESTED_BREAKPOINT"> & {
-  location: Omit<Location, "column">;
-};
 export function addBreakpoint(
   cx: Context,
   initialLocation: Location,

--- a/src/devtools/client/debugger/src/actions/breakpoints/syncBreakpoint.js
+++ b/src/devtools/client/debugger/src/actions/breakpoints/syncBreakpoint.js
@@ -8,6 +8,7 @@ import { setSymbols } from "../sources/symbols";
 import { assertPendingBreakpoint, findFunctionByName } from "../../utils/breakpoint";
 
 import { getSource } from "../../selectors";
+import { removePendingBreakpoint } from "../../reducers/pending-breakpoints";
 import { addBreakpoint } from "./modify";
 
 async function findNewLocation(cx, { name, offset, index }, location, source, dispatch) {
@@ -42,7 +43,7 @@ export function syncBreakpoint(cx, sourceId, pendingBreakpoint) {
     const previousLocation = { ...location, sourceId };
     const newLocation = await findNewLocation(cx, astLocation, previousLocation, source, dispatch);
 
-    dispatch({ type: "REMOVE_PENDING_BREAKPOINT", location });
+    dispatch(removePendingBreakpoint(location));
 
     return dispatch(
       addBreakpoint(cx, newLocation, pendingBreakpoint.options, pendingBreakpoint.disabled)

--- a/src/devtools/client/debugger/src/actions/sources/newSources.ts
+++ b/src/devtools/client/debugger/src/actions/sources/newSources.ts
@@ -14,6 +14,7 @@ import type { UIThunkAction } from "ui/actions";
 
 import { insertSourceActors } from "../../actions/source-actors";
 import { makeSourceId } from "../../client/create";
+import { setRequestedBreakpoint } from "../../reducers/breakpoints";
 import type { Context } from "../../reducers/pause";
 import { SourceActor } from "../../reducers/source-actors";
 import type { Source } from "../../reducers/sources";
@@ -109,7 +110,7 @@ function checkPendingBreakpoints(cx: Context, sourceId: string): UIThunkAction {
 
     for (const bp of pendingBreakpoints) {
       const line = bp.location.line;
-      dispatch({ location: { line, sourceId }, type: "SET_REQUESTED_BREAKPOINT" });
+      dispatch(setRequestedBreakpoint({ line, sourceId }));
     }
 
     // load the source text if there is a pending breakpoint for it

--- a/src/devtools/client/debugger/src/client/index.js
+++ b/src/devtools/client/debugger/src/client/index.js
@@ -15,7 +15,6 @@ import { asyncStore, verifyPrefSchema } from "../utils/prefs";
 import actions from "../actions";
 import * as selectors from "../selectors";
 
-import { updatePrefs } from "../utils/bootstrap";
 import { initialBreakpointsState } from "../reducers/breakpoints";
 import { prepareSourcePayload } from "./create";
 
@@ -57,7 +56,6 @@ export function bootstrap(_store) {
   verifyPrefSchema();
   setupCommands();
   setupEvents({ actions: boundActions });
-  store.subscribe(() => updatePrefs(store.getState()));
 }
 
 export function onConnect() {

--- a/src/devtools/client/debugger/src/reducers/types.ts
+++ b/src/devtools/client/debugger/src/reducers/types.ts
@@ -195,9 +195,9 @@ export type BreakpointResult = {
 export type PendingBreakpoint = {
   readonly location: PendingLocation;
   readonly astLocation: ASTLocation;
-  readonly generatedLocation: PendingLocation;
+  readonly generatedLocation?: PendingLocation;
   readonly disabled: boolean;
-  readonly text: string;
+  readonly text?: string;
   readonly options: BreakpointOptions;
 };
 

--- a/src/devtools/client/debugger/src/utils/bootstrap.js
+++ b/src/devtools/client/debugger/src/utils/bootstrap.js
@@ -5,9 +5,6 @@
 import * as search from "../workers/search";
 import { ParserDispatcher } from "../workers/parser";
 
-import * as selectors from "../selectors";
-import { asyncStore } from "./prefs";
-
 export let parser;
 
 export function bootstrapWorkers(panelWorkers) {
@@ -20,15 +17,4 @@ export function bootstrapWorkers(panelWorkers) {
 export function teardownWorkers() {
   parser.stop();
   search.stop();
-}
-
-let currentPendingBreakpoints;
-
-export function updatePrefs(state) {
-  const previousPendingBreakpoints = currentPendingBreakpoints;
-  currentPendingBreakpoints = selectors.getPendingBreakpoints(state);
-
-  if (previousPendingBreakpoints && currentPendingBreakpoints !== previousPendingBreakpoints) {
-    asyncStore.pendingBreakpoints = currentPendingBreakpoints;
-  }
 }

--- a/src/devtools/client/debugger/src/utils/breakpoint/index.ts
+++ b/src/devtools/client/debugger/src/utils/breakpoint/index.ts
@@ -148,7 +148,7 @@ function createPendingLocation(location: SourceLocation) {
   return { sourceUrl, line, column };
 }
 
-export function createPendingBreakpoint(bp: Breakpoint) {
+export function createPendingBreakpoint(bp: Breakpoint): PendingBreakpoint {
   const pendingLocation = createPendingLocation(bp.location);
 
   assertPendingLocation(pendingLocation);
@@ -157,7 +157,7 @@ export function createPendingBreakpoint(bp: Breakpoint) {
     options: bp.options,
     disabled: bp.disabled,
     location: pendingLocation,
-    astLocation: bp.astLocation,
+    astLocation: bp.astLocation!,
   };
 }
 

--- a/src/devtools/client/debugger/src/utils/context.ts
+++ b/src/devtools/client/debugger/src/utils/context.ts
@@ -31,8 +31,6 @@ import { getThreadContext } from "../selectors";
 import type { UIState } from "ui/state";
 import type { Context } from "../reducers/pause";
 
-export function validateNavigateContext(state: UIState, cx: Context) {}
-
 export class ContextError extends Error {}
 
 export function validateContext(state: UIState, cx: Context) {

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -52,7 +52,8 @@ function createPrefsUpdater<T extends Record<string, any>>(prefObj: T) {
     selector: (state: UIState) => T[typeof field]
   ) {
     const newValue = selector(newState);
-    if (newValue != selector(oldState)) {
+    const oldValue = selector(oldState);
+    if (newValue != oldValue) {
       prefObj[field] = newValue;
     }
   };
@@ -62,8 +63,9 @@ const updateStandardPrefs = createPrefsUpdater(prefs);
 const updateAsyncPrefs = createPrefsUpdater(asyncStore);
 const updateWebconsolePrefs = createPrefsUpdater(webconsolePrefs);
 const updateDebuggerPrefs = createPrefsUpdater(debuggerPrefs);
+const updateDebuggerAsyncPrefs = createPrefsUpdater(debuggerAsyncPrefs);
 
-const actualUpdatePrefs = (state: UIState, oldState: UIState) => {
+export const updatePrefs = (state: UIState, oldState: UIState) => {
   updateStandardPrefs(state, oldState, "viewMode", getViewMode);
   updateStandardPrefs(state, oldState, "theme", getTheme);
 
@@ -101,9 +103,6 @@ const actualUpdatePrefs = (state: UIState, oldState: UIState) => {
   }
   maybeUpdateReplaySessions(state);
 };
-
-// Avoid a small bit of overhead of checking prefs after _every_ dispatch
-export const updatePrefs = debounce(actualUpdatePrefs, 50);
 
 async function getReplaySessions() {
   return await asyncStore.replaySessions;

--- a/src/ui/setup/prefs.ts
+++ b/src/ui/setup/prefs.ts
@@ -1,4 +1,7 @@
-import { prefs as debuggerPrefs } from "devtools/client/debugger/src/utils/prefs";
+import {
+  prefs as debuggerPrefs,
+  asyncStore as debuggerAsyncPrefs,
+} from "devtools/client/debugger/src/utils/prefs";
 import { prefs as webconsolePrefs } from "devtools/client/webconsole/utils/prefs";
 import debounce from "lodash/debounce";
 import { UIStore } from "ui/actions";
@@ -22,6 +25,7 @@ import { RecordingId } from "@recordreplay/protocol";
 import { getTheme } from "ui/reducers/app";
 import { getAllFilters } from "devtools/client/webconsole/selectors";
 import { getRecording } from "ui/hooks/recordings";
+import { getPendingBreakpoints } from "devtools/client/debugger/src/selectors";
 
 export interface ReplaySessions {
   [id: string]: ReplaySession;
@@ -100,6 +104,11 @@ export const updatePrefs = (state: UIState, oldState: UIState) => {
     );
 
     updateDebuggerPrefs(state, oldState, "sourcesCollapsed", state => state.ui.sourcesCollapsed);
+  }
+
+  if (state.pendingBreakpoints && oldState.pendingBreakpoints) {
+    // @ts-ignore `asyncStoreHelper` is untyped, so TS doesn't know keys here
+    updateDebuggerAsyncPrefs(state, oldState, "pendingBreakpoints", getPendingBreakpoints);
   }
   maybeUpdateReplaySessions(state);
 };

--- a/src/ui/setup/redux/middleware/context.js
+++ b/src/ui/setup/redux/middleware/context.js
@@ -8,12 +8,12 @@ import { validateContext } from "devtools/client/debugger/src/utils/context";
 
 const { log } = require("protocol/socket");
 
-function validateActionContext(getState, action) {
+function validateActionContext(getState, cx, action) {
   // Watch for other actions which are unaffected by thread changes.
 
   try {
     // Validate using all available information in the context.
-    validateContext(getState(), action.cx);
+    validateContext(getState(), cx);
   } catch (e) {
     console.log(`ActionContextFailure ${action.type}`);
     throw e;
@@ -40,8 +40,9 @@ function logAction(action) {
 // them if the context is no longer valid.
 function context(storeApi) {
   return next => action => {
-    if ("cx" in action) {
-      validateActionContext(storeApi.getState, action);
+    const cx = action.cx ?? action.meta?.cx ?? null;
+    if (cx) {
+      validateActionContext(storeApi.getState, cx, action);
     }
 
     logAction(action);

--- a/src/ui/setup/redux/middleware/context.js
+++ b/src/ui/setup/redux/middleware/context.js
@@ -4,35 +4,19 @@
 
 //
 
-import {
-  validateNavigateContext,
-  validateContext,
-} from "../../../../devtools/client/debugger/src/utils/context";
+import { validateContext } from "devtools/client/debugger/src/utils/context";
 
 const { log } = require("protocol/socket");
 
 function validateActionContext(getState, action) {
-  if (action.type == "COMMAND" && action.status == "done") {
-    // The thread will have resumed execution since the action was initiated,
-    // so just make sure we haven't navigated.
-    validateNavigateContext(getState(), action.cx);
-    return;
-  }
-
   // Watch for other actions which are unaffected by thread changes.
-  switch (action.type) {
-    case "SET_BREAKPOINT":
-    case "SET_SYMBOLS":
-      validateNavigateContext(getState(), action.cx);
-      break;
-    default:
-      try {
-        // Validate using all available information in the context.
-        validateContext(getState(), action.cx);
-      } catch (e) {
-        console.log(`ActionContextFailure ${action.type}`);
-        throw e;
-      }
+
+  try {
+    // Validate using all available information in the context.
+    validateContext(getState(), action.cx);
+  } catch (e) {
+    console.log(`ActionContextFailure ${action.type}`);
+    throw e;
   }
 }
 


### PR DESCRIPTION
Part of #6673 for fixing circular imports.

This PR:

- Removes the dead portion of the "context" middleware
- Updates the "context" middleware to handle looking for `action.meta.cx`, to work with RTK actions
- Removes an attempt to debounce prefs persistence, which was breaking persistence because the new/old state values were ending up the same somehow
- Migrates the `breakpoints and `pendingBreakpoints` reducers to RTK

This doesn't fix many import cycles by itself.  However, a bunch of the cycles go through `utils/breakpoint/index.ts`, which imports `ThreadFront` just to read `ThreadFront.recordingId`.  _That_ in turn gets used while generating some ID strings.

The next step is to refactor our `ThreadFront` usages to minimize imports, including injecting it into `extraThunkArgs`.  From there I can update these actions to accept `recordingId` as part of the payload, and _that_ will let me knock out about another 10 cycles.

I've done some checks and at least confirmed that I can still add and remove breakpoints and that the "requested breakpoints" are getting persisted into IndexedDB correctly.  But, some additional hands-on QA checks would be helpful.