### PR TITLE
Query annotations separately by kind

### DIFF
--- a/src/ui/actions/reactDevTools.ts
+++ b/src/ui/actions/reactDevTools.ts
@@ -1,5 +1,8 @@
+import { ThreadFront } from "protocol/thread";
 import { Action } from "redux";
 import { Annotation } from "ui/state/reactDevTools";
+
+import { UIStore } from ".";
 
 export type AddAnnotationsAction = Action<"add_annotations"> & { annotations: Annotation[] };
 export type SetHasReactComponentsAction = Action<"set_has_react_components"> & {
@@ -14,6 +17,21 @@ export type ReactDevToolsAction =
 
 export function setHasReactComponents(hasReactComponents: boolean): SetHasReactComponentsAction {
   return { type: "set_has_react_components", hasReactComponents };
+}
+
+export function setupReactDevTools(store: UIStore) {
+  ThreadFront.getAnnotations(annotations => {
+    store.dispatch(
+      // TODO This action should be named more specific to the React usage
+      addAnnotations(
+        annotations.map(({ point, time, contents }) => ({
+          point,
+          time,
+          message: JSON.parse(contents),
+        }))
+      )
+    );
+  }, "react-devtools-bridge");
 }
 
 export function addAnnotations(annotations: Annotation[]): AddAnnotationsAction {

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -5,6 +5,7 @@ import { initSocket, addEventListener } from "protocol/socket";
 import { ThreadFront } from "protocol/thread";
 import { setupGraphics } from "protocol/graphics";
 import { setupLogpoints } from "protocol/logpoint";
+import { setupReactDevTools } from "ui/actions/reactDevTools";
 
 import { extendStore, AppStore } from "../store";
 import app from "ui/reducers/app";
@@ -169,6 +170,7 @@ export default async function DevTools(store: AppStore) {
   setupNetwork(store);
   setupLogpoints(store);
   setupExceptions(store);
+  setupReactDevTools(store);
 }
 
 function bindSelectors(obj: any) {


### PR DESCRIPTION
We recently added support for [Redux DevTools](https://github.com/RecordReplay/devtools/commit/ac248bd53e5687bce15b06928879aa90cbe0513e) to our existing support for React DevTools. This is great, but there's been a couple of realizations since then:

A) The Redux DevTools annotations can be quite large (for a replay of Replay that annotation is around 50MB)
B) We already knew this, but this really highlights why it would be nice to have filtering by annotation kind.

[We have added the ability to filter by annotation kind when requesting annotations](https://github.com/RecordReplay/backend/pull/5585/), so now we just have to use that capability. The tricky part about this is that our protocol's `Session` only expects to have one `annotationsListener` no matter how many queries we have out for annotations. The way I've gotten around this is having a couple of `Map`s that we track in thread and call the correct callbacks when we get results of a particular type. There could be a subtle conflict here where if you have queried for both `all` annotation kinds and a particular annotation kind, you will get your callback called twice with the same item. I think we could actually solve that by returning the protocol message ID in the response (which I feel like maybe we should just always do?). I've also added back in the separate initialization of React DevTools, and left the querying of Redux DevTools annotations behind the feature flag, so it will still have to be turned on for us to even ask about Redux DevTools annotations from the backend.

Fixes #6749 

P.S. Don't merge this yet, it doesn't seem like the backend is responding to `kind` yet.