### PR TITLE
Log the sessionId into the console for all sessions

### DIFF
--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -239,6 +239,8 @@ class _ThreadFront {
     this.sessionId = sessionId;
     assert(sessionId, "there should be a sessionId");
     this.sessionWaiter.resolve(sessionId);
+    // This helps when trying to debug logRocket sessions and the like
+    console.debug({ sessionId });
 
     if (window.app.prefs.listenForMetrics) {
       window.sessionMetrics = [];


### PR DESCRIPTION
I don't like having a lot of logs sitting around in prod, but I think this one might actually be helpful, since it is such a crucial piece of information. For instance, I'm looking at a log rocket session right now and I can't see the session ID to go pull the logs 😢 