### PR TITLE
pages/_app.tsx: suppress import/order lint rule

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,3 +1,5 @@
+// @TODO Disabled import/order rule until fix this https://github.com/RecordReplay/devtools/issues/6552
+/* eslint-disable import/order */
 import "../src/test-prep";
 
 import { useAuth0 } from "@auth0/auth0-react";
@@ -20,7 +22,7 @@ import { useLaunchDarkly } from "ui/utils/launchdarkly";
 import { pingTelemetry } from "ui/utils/replay-telemetry";
 import tokenManager from "ui/utils/tokenManager";
 import { ApolloWrapper } from "ui/components/ApolloWrapper";
-
+/* eslint-enable import/order */
 import "image/image.css";
 import "image/icon.css";
 import "tailwindcss/tailwind.css";


### PR DESCRIPTION
[Trunk VSCode extension](https://marketplace.visualstudio.com/items?itemName=Trunk.io) doesn't care [Hold-The-Line] (https://blog.trunk.io/trunk-check-hold-the-line-8aeb0e8d45d) so ignored `import/order` rule on one of most surrounded file.  
I have no plan that send similar PR for every files though. 😅

I'd like to hear forks about this, and if @bvaughn has something plan related https://github.com/RecordReplay/devtools/issues/6552

### Before

<img width="1352" alt="current" src="https://user-images.githubusercontent.com/5501268/168395844-3892a87e-73f3-4e0c-8eff-59af2aa390ca.png">


### After

<img width="1114" alt="ignored" src="https://user-images.githubusercontent.com/5501268/168395863-f479ff86-99c9-423d-a28e-f99892bfca6f.png">

