### PR TITLE
Introduce a new page for stress testing recordings

### DIFF
--- a/pages/team/[id]/stress.tsx
+++ b/pages/team/[id]/stress.tsx
@@ -1,0 +1,37 @@
+import { useRouter } from "next/router";
+import React, { useEffect } from "react";
+import { connect, ConnectedProps } from "react-redux";
+import * as actions from "ui/actions/app";
+import { useUpdateDefaultWorkspace } from "ui/hooks/settings";
+import useAuth0 from "ui/utils/useAuth0";
+
+import { replayRecording } from "stress-test/stress";
+
+function TeamPage({ setWorkspaceId, setModal }: PropsFromRedux) {
+  const { query, replace } = useRouter();
+  const { isAuthenticated } = useAuth0();
+
+  window.replayRecording = replayRecording;
+  console.log("stress test", query);
+
+  const workspaceId = query.id;
+
+  useEffect(() => {
+    if (isAuthenticated && workspaceId) {
+      replayRecording(query.recordingId);
+    }
+  }, [isAuthenticated, workspaceId]);
+
+  return (
+    <div>
+      <h1>Hello</h1>
+    </div>
+  );
+}
+
+const connector = connect(null, {
+  setWorkspaceId: actions.setWorkspaceId,
+  setModal: actions.setModal,
+});
+type PropsFromRedux = ConnectedProps<typeof connector>;
+export default connector(TeamPage);

--- a/src/stress-test/stress.ts
+++ b/src/stress-test/stress.ts
@@ -1,0 +1,711 @@
+/* Copyright 2022 Record Replay Inc. */
+
+import sample from "lodash/sample";
+import sampleSize from "lodash/sampleSize";
+import random from "lodash/random";
+import flattenDeep from "lodash/flattenDeep";
+import flatten from "lodash/flatten";
+
+import { pingTelemetry } from "ui/utils/replay-telemetry";
+
+import {
+  CommandMethods,
+  CommandParams,
+  CommandResult,
+  createPauseResult,
+  ExecutionPoint,
+  findStepOverTargetResult,
+  Location,
+  newSource,
+  NodeBounds,
+  Object as ProtocolObject,
+  PauseData,
+  SameLineSourceLocations,
+  TimeStampedPoint,
+} from "@recordreplay/protocol";
+
+import ProtocolClient from "./utils/ProtocolClient";
+import { MsPerSecond } from "./utils/utils";
+import { defer, Deferred } from "./utils/promise";
+import { waitForTime } from "./utils/timer";
+import { assert } from "./utils/assert";
+
+function log(label: string, args = {}) {
+  console.log(new Date(), label, JSON.stringify(args));
+}
+
+function logError(label: string, error: unknown) {
+  console.error(new Date(), label, error);
+}
+
+// How many snapshots to create/restore when testing.
+let gNumTestSnapshots = 20;
+
+const lowEnd = 3;
+const highEnd = 10;
+const serverUrl = "wss://dispatch.replay.io";
+
+async function withTimeout<T>(name: string, cbk: () => Promise<T>) {
+  return Promise.race([
+    cbk(),
+    waitForTime(60 * 1000).then(() => {
+      throw new Error(`Method timedout ${name}`);
+    }),
+  ]);
+}
+
+async function selectSample<T, U>(
+  items: Array<T>,
+  cbk: (item: T) => Promise<U>
+): Promise<Array<U>> {
+  const n = random(lowEnd, highEnd);
+  const sampledItems = sampleSize(items, n);
+  const results = [];
+  for (let i = 0; i < sampledItems.length; i++) {
+    const result = await cbk(sampledItems[i]);
+    results.push(result);
+  }
+  // const results = await Promise.all(sampledItems.map(item => cbk(item)));
+  return [...results];
+}
+
+async function randomTimes<T>(item: T, cbk: (item: T) => Promise<T>): Promise<Array<T>> {
+  const n = random(lowEnd, highEnd);
+  const results = [item];
+
+  for (let i = 0; i < n; i++) {
+    results.push(await cbk(results[results.length - 1]));
+  }
+
+  return results;
+}
+
+function comparePoints(p1: string, p2: string) {
+  const b1 = BigInt(p1);
+  const b2 = BigInt(p2);
+  return b1 < b2 ? -1 : b1 > b2 ? 1 : 0;
+}
+
+function findRectangle(
+  pixelTest: (x: number, y: number) => boolean,
+  width: number,
+  height: number,
+  minSize = 8
+) {
+  for (let x = 0; x < width; x += minSize) {
+    for (let y = 0; y < width; y += minSize) {
+      if (pixelTest(x, y)) {
+        const rect = growRectangle(x, y);
+        if (rect.right - rect.left > minSize && rect.bottom - rect.top > minSize) {
+          return rect;
+        }
+      }
+    }
+  }
+
+  function growRectangle(x: number, y: number) {
+    let left = x;
+    while (left > 0 && pixelTest(left - 1, y)) {
+      left--;
+    }
+    let right = x;
+    while (right < width - 1 && pixelTest(right + 1, y)) {
+      right++;
+    }
+
+    const lineTest = (y: number) => {
+      for (let x = left; x < right; x++) {
+        if (!pixelTest(x, y)) {
+          return false;
+        }
+      }
+      return true;
+    };
+    let top = y;
+    while (top > 0 && lineTest(top - 1)) {
+      top--;
+    }
+    let bottom = y;
+    while (bottom < height - 1 && lineTest(bottom + 1)) {
+      bottom++;
+    }
+    return { left, right, top, bottom };
+  }
+}
+
+// This is the algorithm that is also used by the node picker in devtools
+function pickNode(elements: NodeBounds[], x: number, y: number) {
+  for (const { node, rect, rects, clipBounds, visibility, pointerEvents } of elements) {
+    if (visibility === "hidden" || pointerEvents === "none") {
+      continue;
+    }
+    if (
+      (clipBounds?.left !== undefined && x < clipBounds.left) ||
+      (clipBounds?.right !== undefined && x > clipBounds.right) ||
+      (clipBounds?.top !== undefined && y < clipBounds.top) ||
+      (clipBounds?.bottom !== undefined && y > clipBounds.bottom)
+    ) {
+      continue;
+    }
+
+    for (const r of rects || [rect]) {
+      const [left, top, right, bottom] = r;
+      if (x >= left && x <= right && y >= top && y <= bottom) {
+        return node;
+      }
+    }
+  }
+}
+
+interface PauseInfo extends TimeStampedPoint {
+  pauseId: string;
+}
+
+export class Fuzzer {
+  dispatchAddress: string;
+  recordingId: string;
+  url: string | undefined;
+  analysis: Map<string, Array<string>> = new Map();
+  sessionId: string | undefined;
+  client: ProtocolClient | undefined;
+
+  constructor(dispatchAddress: string, recordingId: string, url?: string) {
+    this.dispatchAddress = dispatchAddress;
+    this.recordingId = recordingId;
+    this.url = url;
+  }
+
+  async destroy() {
+    const { client, sessionId } = this;
+    if (client) {
+      if (sessionId) {
+        await this.sendCommand("Recording.releaseSession", { sessionId });
+      }
+      client.close();
+    }
+    log("ReplayRecording Finished");
+  }
+
+  // Creates a session and replays the recording. Returns null if there was an error
+  // while replaying.
+  async setup(options: ReplayOptions): Promise<string | null> {
+    const { recordingId } = this;
+    this.client = new ProtocolClient(this.dispatchAddress, {
+      onError: e => log(`Socket error`, { recordingId, error: e }),
+      onClose: (code, reason) => log(`Socket closed`, { code, reason, recordingId }),
+    });
+
+    const successWaiter = defer<boolean>();
+
+    this.client.addEventListener("Recording.sessionError", e => {
+      log(`sessionError`, { error: e, recordingId });
+      successWaiter.resolve(false);
+    });
+    this.client.addEventListener("Recording.uploadedData", () => {
+      // No-op handler so that we don't log warnings about unknown messages if the
+      // recording is still in the process of uploading when this script runs.
+    });
+
+    this.client.addEventListener("Session.missingRegions", () => {});
+    this.client.addEventListener("Session.unprocessedRegions", () => {});
+
+    if (options.apiKey) {
+      await this.sendCommand("Authentication.setAccessToken", {
+        accessToken: options.apiKey,
+      });
+    }
+
+    let experimentalSettings;
+
+    let testSnapshotsWaiter: Deferred<void> | undefined;
+    if (options.testSnapshotCallback) {
+      testSnapshotsWaiter = defer();
+      experimentalSettings = {
+        testSnapshots: gNumTestSnapshots,
+
+        // Ensure we get a different controller every time when testing snapshots.
+        controllerKey: Math.random().toString(),
+      };
+      this.client.addEventListener("Session.experimentalEvent", ({ kind, data }) => {
+        if (kind == "testSnapshotsResult") {
+          assert(testSnapshotsWaiter);
+          assert(options.testSnapshotCallback);
+          const { snapshotsCreated, snapshotsRestored, crashesAfterRestore } = data;
+          options.testSnapshotCallback(
+            sessionId,
+            snapshotsCreated,
+            snapshotsRestored,
+            crashesAfterRestore
+          );
+          testSnapshotsWaiter.resolve();
+        }
+      });
+    }
+
+    const result = await this.sendCommand("Recording.createSession", {
+      recordingId,
+      experimentalSettings,
+    });
+
+    const { sessionId } = result;
+    log(`New Session`, { sessionId, recordingId });
+
+    this.client
+      .sendCommand(
+        "Session.ensureProcessed",
+        {
+          level: options.executionIndexed ? "executionIndexed" : "basic",
+        },
+        sessionId
+      )
+      .then(() => successWaiter.resolve(true));
+
+    const success = await successWaiter.promise;
+    if (!success) {
+      return null;
+    }
+
+    // Wait for snapshot testing to finish if required.
+    if (testSnapshotsWaiter) {
+      await testSnapshotsWaiter.promise;
+    }
+
+    this.sessionId = sessionId;
+    return sessionId;
+  }
+
+  async sendCommandWithTimeout<M extends CommandMethods>(
+    command: M,
+    params: CommandParams<M>,
+    sessionId?: string,
+    pauseId?: string
+  ) {
+    return Promise.race([
+      this.sendCommand(command, params, sessionId, pauseId),
+      waitForTime(20 * 1000).then(() => {
+        throw new Error(`Command timedout ${command}`);
+      }),
+    ]);
+  }
+
+  async sendCommand<M extends CommandMethods>(
+    command: M,
+    params: CommandParams<M>,
+    sessionId?: string,
+    pauseId?: string
+  ): Promise<CommandResult<M>> {
+    let result;
+    try {
+      const initialTime = new Date();
+      assert(this.client);
+      result = await this.client.sendCommand(command, params, sessionId, pauseId);
+      const duration = +new Date() - +initialTime;
+
+      log(`sendCommand ${command}`, {
+        duration,
+        params,
+        sessionId: this.sessionId,
+        pauseId,
+        recordingId: this.recordingId,
+      });
+    } catch (e) {
+      logError(`Command failed ${command}`, { error: e, recordingId: this.recordingId });
+      throw new Error(`Command ${command} failed`);
+    }
+
+    return result;
+  }
+
+  pingTelemetry(event: string, tags: any = {}) {
+    pingTelemetry(event, {
+      recordingId: this.recordingId,
+      sessionId: this.sessionId,
+      ...tags,
+      service_name: "stress-test",
+    });
+  }
+
+  async fetchSources() {
+    const { client, sessionId } = this;
+    assert(client);
+
+    // sources are files that can have possible breakpoint locations in them
+    const sources: Array<newSource> = [];
+    client.addEventListener("Debugger.newSource", source => {
+      sources.push(source);
+    });
+    await client.sendCommand("Debugger.findSources", {}, sessionId);
+    return sources;
+  }
+
+  async getPossibleBreakpoints(source: newSource): Promise<Array<SameLineSourceLocations>> {
+    assert(this.client);
+    const result = await this.client.sendCommand(
+      "Debugger.getPossibleBreakpoints",
+      { sourceId: source.sourceId },
+      this.sessionId
+    );
+
+    return result.lineLocations;
+  }
+
+  async getLogpoints(location: Location): Promise<Array<PauseInfo>> {
+    try {
+      const values: Array<PauseInfo> = [];
+      const initialTime = new Date();
+
+      assert(this.client);
+      assert(this.sessionId);
+      this.client.addEventListener("Analysis.analysisResult", ({ results }) => {
+        values.push(...results.map(r => r.value));
+      });
+      this.client.addEventListener("Analysis.analysisPoints", _ => {});
+
+      const result = await this.sendCommand(
+        "Analysis.createAnalysis",
+        {
+          mapper: `
+        const { point, time, pauseId } = input;
+        return [{
+          key: point,
+          value: { time, pauseId, point }
+        }];`,
+          effectful: true,
+        },
+        this.sessionId
+      );
+      const { analysisId } = result;
+
+      this.analysis.set(analysisId, []);
+
+      await this.sendCommand(
+        "Analysis.addLocation",
+        {
+          location,
+          analysisId,
+        },
+        this.sessionId
+      );
+
+      await Promise.all([
+        this.sendCommandWithTimeout("Analysis.runAnalysis", { analysisId }, this.sessionId),
+        this.sendCommandWithTimeout("Analysis.findAnalysisPoints", { analysisId }, this.sessionId),
+      ]);
+      log(`Logpoints results`, {
+        duration: +new Date() - +initialTime,
+        results: values.length,
+        recordingId: this.recordingId,
+      });
+
+      return values;
+    } catch (e) {
+      log(`Analysis failed for location`, { location });
+      console.error(e);
+      return [];
+    }
+  }
+
+  async step(fromPoint: ExecutionPoint): Promise<TimeStampedPoint> {
+    const directions: CommandMethods[] = ["Debugger.findStepOverTarget"];
+    const dir = sample(directions);
+    assert(dir);
+    const result = await this.sendCommand(dir, { point: fromPoint }, this.sessionId);
+    const { point, time } = (result as findStepOverTargetResult).target;
+    return { point, time };
+  }
+
+  async expandObject(object: ProtocolObject | undefined, pause: createPauseResult) {
+    if (!object || !object.objectId) {
+      return;
+    }
+
+    const preview = await this.sendCommand(
+      "Pause.getObjectPreview",
+      { object: object.objectId },
+      this.sessionId,
+      pause.pauseId
+    );
+
+    const newObject = sample(preview.data.objects);
+    return newObject;
+  }
+
+  fetchPause(point: ExecutionPoint): Promise<createPauseResult> {
+    const result = this.sendCommand("Session.createPause", { point }, this.sessionId);
+    return result;
+  }
+
+  // place logpoints in random locations for a given source
+  async randomLogpoints(source: newSource): Promise<Array<Array<PauseInfo>>> {
+    const lineLocations = await this.getPossibleBreakpoints(source);
+    return selectSample(lineLocations, async ({ line, columns }) => {
+      const column = sample(columns);
+      assert(typeof column === "number");
+      const location = { sourceId: source.sourceId, line, column };
+      const logpoints = await this.getLogpoints(location);
+      return logpoints;
+    });
+  }
+
+  async getEndpoint() {
+    const { endpoint } = await this.sendCommand("Session.getEndpoint", {}, this.sessionId);
+    return endpoint;
+  }
+
+  async getBody(pauseId: string) {
+    const { document } = await this.sendCommand("DOM.getDocument", {}, this.sessionId, pauseId);
+    const { result, data } = await this.sendCommand(
+      "DOM.querySelector",
+      { node: document, selector: "body" },
+      this.sessionId,
+      pauseId
+    );
+    return data.objects?.find(o => o.objectId === result);
+  }
+
+  async getObject(objectId: string, pauseId: string) {
+    const res = await this.sendCommand(
+      "Pause.getObjectPreview",
+      { object: objectId },
+      this.sessionId,
+      pauseId
+    );
+    return res.data.objects?.find(o => o.objectId === objectId);
+  }
+
+  async getChildNodeIds(nodeId: string, pauseId: string) {
+    const object = await this.getObject(nodeId, pauseId);
+    return object?.preview?.node?.childNodes || [];
+  }
+
+  async loadStyles(nodeId: string, pauseId: string) {
+    const node = nodeId;
+    try {
+      await Promise.all([
+        this.sendCommand("CSS.getComputedStyle", { node }, this.sessionId, pauseId),
+        this.sendCommand("CSS.getAppliedRules", { node }, this.sessionId, pauseId),
+        this.sendCommand("DOM.getEventListeners", { node }, this.sessionId, pauseId),
+        this.sendCommand("DOM.getBoxModel", { node }, this.sessionId, pauseId),
+        this.sendCommand("DOM.getBoundingClientRect", { node }, this.sessionId, pauseId),
+      ]);
+    } catch (e: any) {
+      log(`Load styles for node ${nodeId} failed`, e.message);
+    }
+  }
+
+  async loadBoundingClientRects(pauseId: string) {
+    try {
+      const result = await this.sendCommand(
+        "DOM.getAllBoundingClientRects",
+        {},
+        this.sessionId,
+        pauseId
+      );
+      log(`getAllBoundingClientRects results`, {
+        elementCount: result.elements.length,
+        pauseId: pauseId,
+        sessionId: this.sessionId,
+      });
+      return result.elements;
+    } catch (e: any) {
+      log(`getAllBoundingClientRects failed`, e.message);
+    }
+  }
+
+  async repaintGraphics(pauseId: string) {
+    try {
+      const result = await this.sendCommand("DOM.repaintGraphics", {}, this.sessionId, pauseId);
+      log(`repaintGraphics result`, { keys: Object.keys(result) });
+      return result;
+    } catch (e: any) {
+      log(`repaintGraphics failed`, e.message);
+    }
+  }
+
+  loadRandomNodes = (pauseId: string) =>
+    withTimeout(`loadRandomNodes for ${pauseId}`, async () => {
+      const body = await this.getBody(pauseId);
+      let childNodeIds = body?.preview?.node?.childNodes || [];
+      // we descend 10 levels into the document and on each level we load styling information
+      // of all children of the nodes selected on the previous level and randomly select
+      // some children for the next level
+      for (let i = 0; i < highEnd; i++) {
+        // Only load styles for one node at a time, which is what will happen when people
+        // are using the devtools.
+        for (const nodeId of childNodeIds) {
+          await this.loadStyles(nodeId, pauseId);
+        }
+        childNodeIds = flatten(
+          await selectSample(childNodeIds, nodeId => this.getChildNodeIds(nodeId, pauseId))
+        );
+      }
+    });
+
+  loadFrames(pauseId: string) {
+    return this.sendCommand("Pause.getAllFrames", {}, this.sessionId, pauseId);
+  }
+
+  loadFrameSteps(pauseId: string, frameId: string) {
+    return this.sendCommand("Pause.getFrameSteps", { frameId }, this.sessionId, pauseId);
+  }
+
+  loadScope(pauseId: string, scopeId: string) {
+    return this.sendCommand("Pause.getScope", { scope: scopeId }, this.sessionId, pauseId);
+  }
+
+  evaluateInFrame(pauseId: string, frameId: string, expression: string) {
+    return this.sendCommand(
+      "Pause.evaluateInFrame",
+      { frameId, expression },
+      this.sessionId,
+      pauseId
+    );
+  }
+
+  evaluateInGlobal(pauseId: string, expression: string) {
+    return this.sendCommand("Pause.evaluateInGlobal", { expression }, this.sessionId, pauseId);
+  }
+
+  async loadPaintPoints() {
+    const promise = this.sendCommand("Graphics.findPaints", {}, this.sessionId);
+    const paintPoints: string[] = [];
+    assert(this.client);
+    this.client.addEventListener("Graphics.paintPoints", result => {
+      paintPoints.push(...result.paints.map(paint => paint.point));
+    });
+    await promise;
+    paintPoints.sort(comparePoints);
+    return paintPoints;
+  }
+
+  loadGraphics(point: string) {
+    return this.sendCommand(
+      "Graphics.getPaintContents",
+      { mimeType: "image/jpeg", point },
+      this.sessionId
+    );
+  }
+
+  async getWindowSize(pauseId: string) {
+    const width = (await this.evaluateInGlobal(pauseId, "innerWidth")).result?.returned?.value;
+    const height = (await this.evaluateInGlobal(pauseId, "innerHeight")).result?.returned?.value;
+    return { width, height };
+  }
+
+  findClassName(objectId: string, data: PauseData) {
+    for (const objPreview of data.objects || []) {
+      if (objPreview.objectId === objectId) {
+        return objPreview.className;
+      }
+    }
+  }
+}
+
+export async function replayRecording(recordingId: string, url?: string) {
+  log("Replay recording", recordingId);
+  let sessionId: string | null = null;
+  const fuzzer = new Fuzzer(serverUrl, recordingId, url);
+  const startTime = new Date();
+
+  let success = false;
+  try {
+    sessionId = await fuzzer.setup();
+    if (!sessionId) {
+      console.log(`>> no session created`);
+      await fuzzer.destroy();
+      return false;
+    }
+
+    const sources = await fuzzer.fetchSources();
+    const paintPoints = await fuzzer.loadPaintPoints();
+
+    log("\n## Randomly add logpoints in various files", { recordingId, sessionId });
+    const pauseInfos: Array<PauseInfo> = flattenDeep(
+      await selectSample(sources, async source => fuzzer.randomLogpoints(source))
+    );
+
+    log("\n## Randomly step through various points", { recordingId, sessionId });
+    const stepPoints = flattenDeep(
+      await selectSample(pauseInfos, info =>
+        randomTimes<TimeStampedPoint>(info, item => fuzzer.step(item.point))
+      )
+    );
+
+    const endPoint = await fuzzer.getEndpoint();
+    const points = [...pauseInfos, ...stepPoints, endPoint];
+
+    log("\n## Randomly fetch frames for various pauses", { recordingId, sessionId });
+    await selectSample(pauseInfos, info => fuzzer.loadFrames(info.pauseId));
+
+    log("\n## Randomly fetch pauses for various points", { recordingId, sessionId });
+    const pauses = await selectSample(points, async ({ point, time }) => {
+      const pause = await fuzzer.fetchPause(point);
+      return { point, time, ...pause };
+    });
+
+    log("\n## Randomly fetch frame steps for various pauses", {
+      recordingId,
+      sessionId,
+    });
+    await selectSample(pauses, pause =>
+      selectSample(pause.data.frames!, frame => fuzzer.loadFrameSteps(pause.pauseId, frame.frameId))
+    );
+
+    log("\n## Randomly evaluate some global expressions in various pauses");
+    await selectSample(pauses, async pause => {
+      await fuzzer.evaluateInGlobal(pause.pauseId, "location.href");
+      await fuzzer.evaluateInGlobal(pause.pauseId, 'document.querySelectorAll("script")');
+    });
+
+    log("\n## Randomly fetch scopes and evaluate variables in them for various pauses", {
+      recordingId,
+      sessionId,
+    });
+    await selectSample(pauses, pause =>
+      selectSample(pause.data.frames!, frame =>
+        selectSample(frame.scopeChain, async scopeId => {
+          const scope = await fuzzer.loadScope(pause.pauseId, scopeId);
+          const bindings = scope.data.scopes?.[0].bindings;
+          if (bindings) {
+            selectSample(bindings, ({ name }) =>
+              fuzzer.evaluateInFrame(pause.pauseId, frame.frameId, name)
+            );
+          }
+        })
+      )
+    );
+
+    log("\n## Randomly expands objects for various pauses", { recordingId, sessionId });
+    await selectSample(pauses, pause =>
+      selectSample(pause.data.objects!, object =>
+        randomTimes<ProtocolObject | undefined>(object, object =>
+          fuzzer.expandObject(object, pause)
+        )
+      )
+    );
+
+    log("\n## Randomly fetch some DOM nodes", { recordingId, sessionId });
+    await selectSample(pauses, pause => fuzzer.loadRandomNodes(pause.pauseId));
+
+    log("\n## Randomly repaint and look for black rectangles", {
+      recordingId,
+      sessionId,
+    });
+
+    log(`\n## Finished Replaying`, {
+      recordingId,
+      sessionId,
+      duration: +new Date() - +startTime,
+    });
+    success = true;
+  } catch (e) {
+    logError("Encountered error interacting with recording", {
+      error: e,
+      recordingId,
+      sessionId,
+    });
+  }
+
+  await fuzzer.destroy();
+  return success;
+}

--- a/src/stress-test/utils/ProtocolClient.ts
+++ b/src/stress-test/utils/ProtocolClient.ts
@@ -1,0 +1,105 @@
+/* Copyright 2022 Record Replay Inc. */
+
+// Simple protocol client for use in writing standalone applications.
+
+import assert from "assert";
+import { defer, Deferred } from "./promise";
+import { Message } from "./websocket";
+import {
+  CommandMethods,
+  CommandParams,
+  CommandResult,
+  EventMethods,
+  EventParams,
+  EventListeners,
+} from "@recordreplay/protocol";
+
+export type ClientCallbacks = {
+  onClose: (code: number, reason: string) => void;
+  onError: (e: unknown) => void;
+};
+
+export default class ProtocolClient {
+  socket: WebSocket;
+  callbacks: ClientCallbacks;
+
+  // Internal state.
+  eventListeners: Partial<EventListeners> = {};
+  pendingMessages = new Map<number, Deferred<CommandResult<CommandMethods>>>();
+  nextMessageId = 1;
+  opened: Deferred<boolean>;
+
+  constructor(address: string, callbacks: ClientCallbacks) {
+    this.socket = new WebSocket(address);
+    this.callbacks = callbacks;
+    this.opened = defer();
+
+    console.log(`>> creating client`);
+    this.socket.addEventListener("close", callbacks.onClose);
+    this.socket.addEventListener("error", callbacks.onError);
+    this.socket.addEventListener("message", message => this.onMessage(message));
+    this.socket.addEventListener("open", () => {
+      console.log("opened");
+      this.opened.resolve(true);
+    });
+  }
+
+  close() {
+    this.socket.close();
+  }
+
+  addEventListener<M extends EventMethods>(event: M, listener: (params: EventParams<M>) => void) {
+    this.eventListeners[event] = listener;
+  }
+
+  async sendCommand<M extends CommandMethods>(
+    method: M,
+    params: CommandParams<M>,
+    sessionId?: string,
+    pauseId?: string
+  ): Promise<CommandResult<M>> {
+    await this.opened.promise;
+
+    const id = this.nextMessageId++;
+    this.socket.send({ id, method, params, sessionId, pauseId });
+    const waiter = defer<CommandResult<M>>();
+    this.pendingMessages.set(id, waiter);
+    return waiter.promise;
+  }
+
+  async sendCommandWithData<M extends CommandMethods>(
+    method: M,
+    params: CommandParams<M>,
+    data: Buffer,
+    sessionId?: string,
+    pauseId?: string
+  ): Promise<CommandResult<M>> {
+    const id = this.nextMessageId++;
+    this.socket.send({ id, method, params, sessionId, pauseId, binary: true }, data);
+    const waiter = defer<CommandResult<M>>();
+    this.pendingMessages.set(id, waiter);
+    return waiter.promise;
+  }
+
+  onMessage({ msg }: Message) {
+    if (msg.id) {
+      const { resolve, reject } = this.pendingMessages.get(msg.id as number)!;
+      this.pendingMessages.delete(msg.id as number);
+      if (msg.result) {
+        resolve(msg.result as any);
+      } else {
+        reject(msg.error);
+      }
+    } else {
+      assert(typeof msg.method === "string");
+      assert(typeof msg.params === "object" && msg.params);
+
+      const handler = this.eventListeners[msg.method as EventMethods];
+      if (handler) {
+        handler({ ...msg.params } as any);
+      } else {
+        console.error("MissingMessageHandler", { method: msg.method });
+      }
+    }
+  }
+}

--- a/src/stress-test/utils/abort.ts
+++ b/src/stress-test/utils/abort.ts
@@ -1,0 +1,416 @@
+/* Copyright 2022 Record Replay Inc. */
+
+/**
+ * Utility functions for working with AbortSignal objects and generally
+ * interacting with asynchronous operations that you may want to cancel.
+ *
+ * The core tenets of abortable code that we want to aim for are:
+ *  1. Only functions that are passed a signal may throw an AbortError.
+ *  2. A function may only throw an abort error if given a signal that then aborted.
+ *
+ * These rules are our means of encoding our expectations about what aborting means.
+ * Described another way, they can be viewed through the lense of:
+ *  * An AbortSignal indicates that a function may be aborted.
+ *  * An AbortError must only be thrown in response to an aborted signal.
+ *  * Only the caller of a function can know if the result is needed,
+ *    so only the caller is allowed to externally trigger an abort.
+ */
+
+import events from "events";
+import { assert, ThrowError } from "./assert";
+import { newPromise, Reject, Resolve } from "./promise";
+import { Result, resultForFailure, resultForSuccess } from "./result";
+
+// We're only exporting the type because don't want anything outside of this
+// file to be constructing these abort errors. Those places should be using
+// the helpers below.
+export type { AbortError };
+
+class AbortError extends Error {
+  name = "AbortError";
+
+  constructor() {
+    super("aborted with signal");
+  }
+}
+
+/**
+ * Create a new signal object that will abort its signal as soon as the handler has
+ * completed so that any unexpected exceptions or exit paths ensure that we abort
+ * as much as possible in-progress work, since we know it won't be used.
+ * If a signal is passed as the second argument, the inner signal will also abort
+ * if the parent signal aborts.
+ *
+ * This function returns an AbortResult because if it threw an AbortError, it would
+ * be breaking our requirement that things only throw AbortErrors across boundaries
+ * where the parent signal has been aborted, but for this case the function may also
+ * abort if the doAbort callback is called.
+ *
+ * Example:
+ *
+ *   // Start a bunch of parallel processing, and if any fail then the abort
+ *   // scope will abort the signal and any other in-progress operations can stop.
+ *   await createAbortScope(async signal => {
+ *     await Promise.all(items.map(item => doThing(item, signal)))
+ *   }, handler.signal);
+ */
+export async function createAbortRoot<T>(
+  handler: (signal: AbortSignal, doAbort: () => void) => Promise<T>,
+  parentSignal?: AbortSignal
+): Promise<AbortResult<T>> {
+  const controller = new AbortController();
+  const { signal } = controller;
+  const doAbort = () => controller.abort();
+
+  try {
+    const value = await withSignalAbortHandler(
+      () => verifyAbortBoundary(() => handler(signal, doAbort), signal),
+      parentSignal,
+      doAbort
+    );
+    return resultForSuccess(value);
+  } catch (err) {
+    if (err instanceof AbortError) {
+      return resultForFailure(undefined);
+    }
+    throw err;
+  } finally {
+    controller.abort();
+  }
+}
+
+/**
+ * Create a new signal object that will abort its signal as soon as the handler has
+ * completed so that any unexpected exceptions or exit paths ensure that we abort
+ * as much as possible in-progress work, since we know it won't be used.
+ * If a signal is passed as the second argument, the inner signal will also abort
+ * if the parent signal aborts.
+ *
+ * Example:
+ *
+ *   // Start a bunch of parallel processing, and if any fail then the abort
+ *   // scope will abort the signal and any other in-progress operations can stop.
+ *   await createAbortScope(async signal => {
+ *     await Promise.all(items.map(item => doThing(item, signal)))
+ *   }, handler.signal);
+ */
+export async function createAbortScope<T>(
+  handler: (signal: AbortSignal) => Promise<T>,
+  parentSignal?: AbortSignal
+): Promise<T> {
+  const controller = new AbortController();
+  const { signal } = controller;
+  const doAbort = () => controller.abort();
+
+  try {
+    return await withSignalAbortHandler(
+      () => verifyAbortBoundary(() => handler(signal), signal),
+      parentSignal,
+      doAbort
+    );
+  } finally {
+    controller.abort();
+  }
+}
+
+/**
+ * If we want to swallow errors, we want it to be very obvious when
+ * we're doing that, so using an enum instead of a boolean.
+ */
+export enum PostAbortErrorHandling {
+  // Log the error to the logger. This is the default and is probably
+  // what you want if you're got a promise that rejects.
+  LogError,
+  // Silently ignore any errors that are thrown after abort.
+  // This is what you want if you're 100% sure you're logging or
+  // handling any post-abort errors.
+  // If you use this, please try to add a comment about why you're
+  // confident it is safe.
+  Swallow,
+}
+
+/**
+ * Allow people to use a callback to decide what to do with a post-abort error.
+ */
+export type PostAbortErrorCallback = (err: unknown) => Promise<void> | void;
+
+/**
+ * Run a handler either returning the handler's result, or aborting immediately
+ * if the signal fires. If the signal is already aborted, the handler will
+ * be skipped entirely.
+ *
+ * This function serves two similar tasks:
+ *
+ * 1. Adding abort supprt to logic that does not support aborting.
+ * 2. Add racing behavior to a logic that can handle aborting, but may do so
+ *    more slowly that is desirable in some cases. Ideally functions that are
+ *    _known_ to be slow to throw on abort would use this internally so that all
+ *    functions that take an abort signal will abort on the next possible moment
+ *    where it wouldn't interfere with their ability to do their job.
+ *
+ * Note: When wrapping a handler with this function, keep in mind that the
+ * handler itself can still succeed, so it if would have caused side-effects,
+ * those affects can still happen and may need to be handled somehow.
+ *
+ * Example:
+ *
+ *   // If doSlowAsyncOperation doesn't accept a signal, this will allow your code
+ *   // to abort instead of waiting for the slow operation.
+ *   const value = await abortOnSignal(() => doSlowAsyncOperation(), signal);
+ *
+ *   // If doSlowAsyncOperation does accept a signal, this will allow your code
+ *   // to abort immediately rather than having to wait for the abort
+ *   // signal to be recognized and handled by the operation logic.
+ *   const value = await abortOnSignal(() => doSlowAsyncOperation(signal), signal);
+ */
+export async function abortOnSignal<T>(
+  handler: () => Promise<T>,
+  signal: AbortSignal | undefined,
+  errorHandling: PostAbortErrorHandling | PostAbortErrorCallback = PostAbortErrorHandling.LogError
+): Promise<T> {
+  return newAbortablePromise((resolve, reject) => {
+    let didAbort = false;
+    handler().then(
+      v => {
+        if (didAbort) {
+          // If the abort was called, we silently discard this result value. This
+          // is a big part of what makes this function a bit dangerous.
+          return;
+        }
+        resolve(v);
+      },
+      err => {
+        if (didAbort) {
+          // Allow the handler to throw an abort error silently after abort,
+          // since that's entirely reasonable and allows us to use this
+          // function to race other abortable code easily.
+          if (!(err instanceof AbortError)) {
+            logAbortOnSignalPostAbortError(err, errorHandling);
+          }
+          return;
+        }
+
+        reject(err);
+      }
+    );
+    return () => {
+      // We have no logic to perform to clean up this abort signal, which
+      // is one of the things that makes this function a bit dangerous.
+      didAbort = true;
+    };
+  }, signal);
+}
+function logAbortOnSignalPostAbortError(
+  err: unknown,
+  errorHandling: PostAbortErrorHandling | PostAbortErrorCallback
+) {
+  if (errorHandling === PostAbortErrorHandling.Swallow) {
+    return;
+  }
+
+  if (errorHandling === PostAbortErrorHandling.LogError) {
+    return;
+  }
+
+  try {
+    errorHandling(err);
+  } catch (err) {}
+}
+
+/**
+ * Run a handler similar to the one passed to "new Promise()" with additional
+ * abort handling and strict expectations around when callbacks may run. The
+ * core requirement of this function is that neither the resolve nor reject
+ * functions may be called once an abort has occured, and once a resolve/reject
+ * handler have been called, the abort handler is guaranteed _not_ to be called.
+ *
+ * This function is critical for cases where yielding back to the event loop could
+ * put us at risk of racy behavior. It's also just nicer to use than abortOnSignal
+ * and makes it easier to adapt existing code to be abortable.
+ */
+export type AbortPromiseCleanupCallback = () => void;
+export async function newAbortablePromise<T>(
+  executor: (resolve: Resolve<T>, reject: Reject) => AbortPromiseCleanupCallback,
+  signal: AbortSignal | undefined
+): Promise<T> {
+  let onAbort = () => {};
+  return await withSignalAbortHandler(
+    async () =>
+      verifyAbortBoundary(
+        async () =>
+          newPromise((resolve, reject) => {
+            let abortDone = false;
+            let executorDone = false;
+
+            const executorOnAbort = executor(
+              value => {
+                assert(
+                  !abortDone,
+                  "unexpected resolve callback after abort, abort handler should have cleaned up"
+                );
+                executorDone = true;
+                resolve(value);
+              },
+              err => {
+                assert(
+                  !abortDone,
+                  "unexpected reject callback after abort, abort handler should have cleaned up"
+                );
+                executorDone = true;
+                reject(err);
+              }
+            );
+
+            onAbort = () => {
+              assert(signal);
+              abortDone = true;
+
+              if (!executorDone) {
+                reject(createAbortError(signal));
+                executorOnAbort();
+              }
+            };
+            // The executor could have aborted the handler before we assigned the
+            // this onAbort handler, so we have to manually run it.
+            if (signal?.aborted) {
+              onAbort();
+            }
+          }),
+        signal
+      ),
+    signal,
+    () => onAbort()
+  );
+}
+
+/**
+ * Run a given handler and while the result is pending, listen for abort
+ * notifications on the given signal. If an already-aborted signal is passed,
+ * the handler will be skipped entirely.
+ *
+ * This function that is most likely to come up when interfacing between
+ * code that may be passed an abort signal, but has to interact with
+ * logic that doesn't know how to handle that signal, but can be aborted.
+ */
+export async function withSignalAbortHandler<T>(
+  handler: () => Promise<T>,
+  signal: AbortSignal | undefined,
+  onAbort: () => void
+): Promise<T> {
+  if (!signal) {
+    return handler();
+  }
+
+  throwIfAborted(signal);
+
+  // Make sure the callback has a unique object identity.
+  const callback = onAbort.bind(undefined);
+
+  // There don't appear to be type definitions for this but it's there!
+  // Without this we'll get MaxListenersExceededWarning warnings.
+  (events as any).setMaxListeners(0, signal);
+  try {
+    signal.addEventListener("abort", callback);
+    return await handler();
+  } finally {
+    signal.removeEventListener("abort", callback);
+  }
+}
+
+/**
+ * Wrap a promise in a handler to silence abort exceptions by converting them
+ * into a value instead.
+ *
+ * Example:
+ *
+ *   // If doOperation is aborted, 'value' will be 42 instead of the result
+ *   // of the operation.
+ *   const value = await abortToDefaultValue(doOperation(signal), 42);
+ *   console.log(value);
+ */
+export async function abortToDefaultValue<T>(promise: Promise<T>, value: T): Promise<T> {
+  try {
+    return await promise;
+  } catch (err) {
+    if (err instanceof AbortError) {
+      return value;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Wrap a promise in a handler to silence abort exceptions by converting them
+ * into a simple Result object instead.
+ *
+ * Example:
+ *
+ *   // If doOperation is aborted, 'value' will be 42 instead of the result
+ *   // of the operation.
+ *   const result = await abortToResult(doOperation(signal));
+ *   if (result.type === "success") {
+ *     console.log(result.value);
+ *   } else {
+ *     console.log(42);
+ *   }
+ *
+ */
+export type AbortResult<T> = Result<T, undefined>;
+export async function abortToResult<T>(promise: Promise<T>): Promise<AbortResult<T>> {
+  try {
+    return resultForSuccess(await promise);
+  } catch (err) {
+    if (err instanceof AbortError) {
+      return resultForFailure(undefined);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Throw an abort error if the signal has been aborted.
+ */
+export function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw createAbortError(signal);
+  }
+}
+
+/**
+ * Throw an abort error.
+ */
+export function throwAborted(signal: AbortSignal): never {
+  throw createAbortError(signal);
+}
+
+/**
+ * Create an error object without throwing it.
+ *
+ * This shouldn't come up very often since the throwing functions are generally
+ * earlier to use in day-to-day code, but it happens.
+ */
+export function createAbortError(signal: AbortSignal): AbortError {
+  assert(signal.aborted, "tried to abort without aborted signal");
+  return new AbortError();
+}
+
+/**
+ * A utility function to enforce some of our expectations around abortable functions.
+ */
+async function verifyAbortBoundary<T>(
+  handler: () => Promise<T>,
+  signal: AbortSignal | undefined
+): Promise<T> {
+  try {
+    return await handler();
+  } catch (err) {
+    if (err instanceof AbortError) {
+      if (signal) {
+        assert(signal.aborted, "unexpected abort across an un-aborted boundary");
+      } else {
+        ThrowError("unexpected abort when no abort signal was passed");
+      }
+    }
+    throw err;
+  }
+}

--- a/src/stress-test/utils/assert.ts
+++ b/src/stress-test/utils/assert.ts
@@ -1,0 +1,15 @@
+export function assert(v: any, why = ""): asserts v {
+  if (!v) {
+    const error = new Error(`Assertion Failed: ${why}`);
+    error.name = "AssertionFailure";
+    console.error("AssertionFailure", error);
+    throw error;
+  }
+}
+
+export function ThrowError(msg: string, tags?: Tags): never {
+  const error = new Error(msg);
+  error.name = "ThrowError";
+  console.error("ThrowError", error, tags);
+  throw error;
+}

--- a/src/stress-test/utils/logger.ts
+++ b/src/stress-test/utils/logger.ts
@@ -1,0 +1,3 @@
+export function logError(msg: string): void {
+  console.error(msg);
+}

--- a/src/stress-test/utils/promise.ts
+++ b/src/stress-test/utils/promise.ts
@@ -1,0 +1,131 @@
+/* Copyright 2022 Record Replay Inc. */
+
+// Utility functions for promise handling.
+
+import { assert, ThrowError } from "./assert";
+
+type ObjectWithPromiseProps = Record<string, Promise<unknown>>;
+
+export type AllProps<O extends ObjectWithPromiseProps> = {
+  [K in keyof O]: O[K] extends Promise<infer U> ? U : O[K];
+};
+
+/**
+ * Given an array of promises, return the index of the promise
+ * that won the race.
+ */
+export async function racePromisesForIndex(promises: Array<Promise<unknown>>): Promise<number> {
+  return Promise.race(
+    promises.map((promise, i) =>
+      promise.then(
+        () => i,
+        () => i
+      )
+    )
+  );
+}
+
+/**
+ * Like Promise.all(), but for an object instead of an array, and similarly
+ * useful for running many process in parallel in a readable way.
+ *
+ * Given an object with promise properties, return a promise that will wait
+ * for all of the properties to resolve, and then resolve with a new object
+ * where each property is the resolved value. e.g.
+ *
+ *   const { one, two } = await allPromiseProps({
+ *     one: fetch("/one").then(r => r.text()),
+ *     two: fetch("/two").then(r => r.text()),
+ *   });
+ *   assert(typeof one === "string");
+ *   assert(typeof two === "string");
+ */
+export async function allPromiseProps<O extends ObjectWithPromiseProps>(
+  obj: O
+): Promise<AllProps<O>> {
+  return Object.fromEntries(
+    await Promise.all(Object.entries(obj).map(async ([key, value]) => [key, await value]))
+  );
+}
+
+// Time a promise from now.
+export function timeAwait(promise: Promise<unknown>): Promise<number> {
+  const start = Date.now();
+  return new Promise(resolve => {
+    const resolver = () => resolve(Date.now() - start);
+    promise.then(resolver, resolver);
+  });
+}
+
+export type Resolve<T> = (value: T) => void;
+export type Reject = (reason: any) => void;
+
+export interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: Resolve<T>;
+  reject: Reject;
+}
+
+export function defer<T>(): Deferred<T> {
+  let resolve!: Resolve<T>;
+  let reject!: Reject;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export async function hangForever(): Promise<never> {
+  await new Promise(() => {});
+  ThrowError("unreachable");
+}
+
+/**
+ * Run an executor function the same way "new Promise()", but enforce additional
+ * guarantees to ensure that we don't swallow data unexpectedly.
+ *
+ * An executor may do only one of:
+ *   * Throw an exception
+ *   * Call the resolve callback
+ *   * Call the reject callback.
+ *
+ * Additionally, if the handler calls resolve or reject and then throws,
+ * the exception will be logged instead of silently swallowed.
+ */
+export async function newPromise<T>(
+  executor: (resolve: Resolve<T>, reject: Reject) => void
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    let executorDone = false;
+    let executorThrew = false;
+
+    try {
+      executor(
+        value => {
+          assert(!executorThrew, "unexpected resolve callback after executor threw");
+          assert(!executorDone, "unexpected resolve call after another resolve/reject");
+          executorDone = true;
+          resolve(value);
+        },
+        err => {
+          assert(!executorThrew, "unexpected resolve callback after executor threw");
+          assert(!executorDone, "unexpected reject call after another resolve/reject");
+          executorDone = true;
+          reject(err);
+        }
+      );
+    } catch (err) {
+      executorThrew = true;
+      if (executorDone) {
+        // If something called resolve/reject synchronously and _then_ threw, the promise
+        // constructor will swallow it, so here log it first.
+        console.error("UnexpectedAbortExecutorFailure", err);
+        return;
+      }
+
+      executorDone = true;
+      throw err;
+    }
+  });
+}

--- a/src/stress-test/utils/result.ts
+++ b/src/stress-test/utils/result.ts
@@ -1,0 +1,52 @@
+/* Copyright 2022 Record Replay Inc. */
+
+// Utilities for fallible operations that may want to separate out failures
+// from exceptions to allow for cleaner handling of specific categories of errors.
+
+export type SuccessResult<T> = { type: "success"; value: T; error?: undefined };
+export type FailureResult<U = unknown> = { type: "failure"; value?: undefined; error: U };
+
+export type Result<T, U = unknown> = SuccessResult<T> | FailureResult<U>;
+
+/**
+ * Create a result for a success value.
+ */
+export function resultForSuccess<T>(value: T): SuccessResult<T> {
+  return {
+    type: "success",
+    value,
+    error: undefined,
+  };
+}
+
+/**
+ * Create a result for a failue value.
+ */
+export function resultForFailure<U = unknown>(err: U): FailureResult<U> {
+  return {
+    type: "failure",
+    value: undefined,
+    error: err,
+  };
+}
+
+/**
+ * Convert a promise that may throw into a promise for a Result that will not throw.
+ */
+export async function resultFromPromise<T>(promise: Promise<T>): Promise<Result<T>> {
+  try {
+    return resultForSuccess(await promise);
+  } catch (err) {
+    return resultForFailure(err);
+  }
+}
+
+/**
+ * Return the value from a result or throw the failure value.
+ */
+export function resultUnwrap<T, U = unknown>(result: Result<T, U>): T {
+  if (result.type === "success") {
+    return result.value;
+  }
+  throw result.error;
+}

--- a/src/stress-test/utils/timer.ts
+++ b/src/stress-test/utils/timer.ts
@@ -1,0 +1,98 @@
+/* Copyright 2022 Record Replay Inc. */
+
+// General utilities for timers.
+
+import { newAbortablePromise } from "./abort";
+
+/**
+ * Queue up an interval like setInterval, but don't start a new handler until
+ * the previous one has finished, and log a message if the handler takes longer
+ * than the interval time to complete.
+ */
+export function setSingletonInterval(fn: () => unknown, ms: number) {
+  const stack = new Error().stack;
+
+  let shouldUnref = false;
+  let timer: NodeJS.Timeout;
+
+  async function handleInterval() {
+    const start = Date.now();
+    try {
+      await fn();
+    } finally {
+      const duration = Date.now() - start;
+      const timeToNextInterval = ms - duration;
+      if (timeToNextInterval < 0) {
+        console.debug("IntervalOvertime", {
+          ms,
+          duration,
+          stack,
+        });
+      }
+      timer = setTimeout(handleInterval, Math.max(timeToNextInterval, 0));
+      if (shouldUnref) {
+        timer.unref();
+      }
+    }
+  }
+  timer = setTimeout(handleInterval, ms);
+
+  return {
+    unref: () => {
+      shouldUnref = true;
+      timer.unref();
+    },
+  };
+}
+
+// Return a new callback that invokes the given callback at most every time ms.
+export function throttle(callback: () => any, time: number) {
+  let scheduled = false;
+
+  return () => {
+    if (scheduled) {
+      return;
+    }
+    scheduled = true;
+    setTimeout(() => {
+      scheduled = false;
+      callback();
+    }, time);
+  };
+}
+
+export async function waitForTime(
+  ms: number,
+  { signal, unref }: { signal?: AbortSignal; unref?: boolean } = {}
+): Promise<undefined> {
+  await newAbortablePromise(resolve => {
+    const timer = setTimeout(resolve, ms);
+    if (unref) {
+      timer.unref();
+    }
+    return () => clearTimeout(timer);
+  }, signal);
+
+  return undefined;
+}
+
+export function timeoutAfterTime(ms: number) {
+  return new Promise((_, reject) => setTimeout(() => reject("Timeout"), ms));
+}
+
+// Set a timeout that runs at the specified time, per Date.now().
+export function setTimeoutAbsolute(callback: () => void, time: number): NodeJS.Timeout {
+  const now = Date.now();
+  const duration = Math.max(time - now, 0);
+  return setTimeout(callback, duration);
+}
+
+export function hrtimeToMs([s, ns]: [number, number]): number {
+  return s * 1000 + ns / (1000 * 1000);
+}
+
+// Resolve the promise at some point after all microtasks have
+// been flushed and control has returned to the event loop.
+export async function waitForEventLoop() {
+  await waitForTime(1);
+}

--- a/src/stress-test/utils/utils.ts
+++ b/src/stress-test/utils/utils.ts
@@ -1,0 +1,7 @@
+/* Copyright 2022 Record Replay Inc. */
+
+// Utility functions for promise handling.
+
+export const MsPerSecond = 1000;
+export const MsPerMinute = MsPerSecond * 60;
+export const MsPerHour = MsPerMinute * 60;

--- a/src/stress-test/utils/websocket.ts
+++ b/src/stress-test/utils/websocket.ts
@@ -1,0 +1,408 @@
+/* Copyright 2022 Record Replay Inc. */
+
+import type http from "http";
+import type https from "https";
+import type net from "net";
+import WSWebSocket from "ws";
+
+import { logError } from "./logger";
+import { EventEmitter } from "events";
+import { assert } from "./assert";
+import { MsPerSecond } from "./utils";
+
+enum CloseCode {
+  Normal = 1000,
+
+  // The WebSocket spec reserves to 4000-4999 codes for application-specific
+  // purposes, so we can throw anything specific we want in here.
+  MissingBinaryMessage = 4000,
+  UnexpectedBinaryMessage = 4001,
+  InvalidJSONMessage = 4002,
+  InvalidObjectMessage = 4003,
+  InvalidBinaryPropery = 4004,
+}
+
+function getCodeReason(code: CloseCode): string {
+  switch (code) {
+    case CloseCode.MissingBinaryMessage:
+      return "All messages with binary:true must be followed by a binary message.";
+    case CloseCode.UnexpectedBinaryMessage:
+      return "All binary messages must have a preceding JSON message with binary:true.";
+    case CloseCode.InvalidJSONMessage:
+      return "All text messages must be valid JSON.";
+    case CloseCode.InvalidObjectMessage:
+      return "All JSON payloads must be objects.";
+    case CloseCode.InvalidBinaryPropery:
+      return "All JSON objects with a 'binary' key must have a boolean value.";
+  }
+
+  return "";
+}
+
+export type MessageObject = {
+  binary?: boolean | undefined;
+  [key: string]: unknown;
+};
+
+// We export the message type so that it can be reference in other files
+// easily, but we don't export the class itself because it should only be
+// constructed inside this file.
+export type { Message };
+
+class Message {
+  readonly text: string;
+  readonly msg: MessageObject;
+  readonly data: Buffer | null;
+
+  constructor(text: string, msg: MessageObject, data: Buffer | null) {
+    this.text = text;
+    this.msg = msg;
+    this.data = data;
+  }
+}
+
+type ServerPingOptions = {
+  pingInterval: number;
+  responseTimeout: number;
+};
+
+type ServerOptions = {
+  server?: http.Server | https.Server;
+  maxPayload?: number;
+  ping?: ServerPingOptions;
+  compression?: boolean;
+};
+
+export declare interface WebSocketServer {
+  on(event: "error", listener: (err: Error) => void): this;
+  on(
+    event: "connection",
+    listener: (connection: WebSocket, req: http.IncomingMessage) => void
+  ): this;
+}
+
+export class WebSocketServer extends EventEmitter {
+  private server: WSWebSocket.Server;
+  private sockets: WeakMap<WSWebSocket, WebSocket> = new WeakMap();
+  private pingInterval: NodeJS.Timeout | null = null;
+  private pingResponseTimeout: number = 0;
+
+  constructor({ server, maxPayload, ping, compression }: ServerOptions) {
+    super();
+    this.server = new WSWebSocket.Server({
+      server: server || undefined,
+      noServer: !server,
+      perMessageDeflate: compression
+        ? {
+            zlibDeflateOptions: {
+              chunkSize: 1024,
+              memLevel: 7,
+              level: 3,
+            },
+            zlibInflateOptions: { chunkSize: 10 * 1024 },
+            clientNoContextTakeover: false,
+            serverNoContextTakeover: false,
+            serverMaxWindowBits: 12,
+            concurrencyLimit: 10,
+            threshold: 1024,
+          }
+        : false,
+      maxPayload,
+    });
+    this.server.on("connection", this.onConnection.bind(this));
+    this.server.on("error", this.onError.bind(this));
+    this.server.on("close", this.onClose.bind(this));
+
+    if (ping) {
+      this.pingResponseTimeout = ping.responseTimeout;
+      this.pingInterval = setInterval(this.pingSockets.bind(this), ping.pingInterval).unref();
+    }
+  }
+
+  // Allow for easy shutdown of all connections if we want to
+  // shut down the event loop ASAP. Don't use this otherwise.
+  terminateActiveConnections(): void {
+    for (const socket of Array.from(this.server.clients)) {
+      socket.terminate();
+    }
+  }
+
+  doUpgrade(request: http.IncomingMessage, socket: net.Socket, upgradeHead: Buffer): void {
+    this.server.handleUpgrade(request, socket, upgradeHead, ws => {
+      this.server.emit("connection", ws, request);
+    });
+  }
+
+  activeConnectionCount(): number {
+    return this.server.clients.size;
+  }
+
+  private pingSockets() {
+    const lastMessageLimit = Date.now() - this.pingResponseTimeout;
+
+    for (const connection of this.server.clients) {
+      const socket = this.sockets.get(connection);
+      assert(socket);
+
+      if (socket.lastMessageTime < lastMessageLimit) {
+        logError("TerminatingSocket", {
+          delay: lastMessageLimit - socket.lastMessageTime,
+        });
+        connection.terminate();
+        continue;
+      }
+
+      if (connection.readyState === WSWebSocket.OPEN) {
+        connection.ping();
+      }
+    }
+  }
+
+  private onError(err: Error) {
+    this.emit("error", err);
+  }
+
+  private onClose() {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+    }
+  }
+
+  private onConnection(connection: WSWebSocket, req: http.IncomingMessage) {
+    const socket = new WebSocket(connection);
+    this.sockets.set(connection, socket);
+    this.emit("connection", socket, req);
+  }
+}
+
+type ClientPingOptions = {
+  pingInterval: number;
+  responseTimeout: number;
+  openTimeout?: number;
+};
+
+type ClientHeaders = { [name: string]: string };
+type ClientOptions = {
+  headers?: ClientHeaders;
+  maxPayload?: number;
+  ping?: ClientPingOptions;
+};
+
+export declare interface WebSocket {
+  on(event: "open", listener: () => void): this;
+  on(event: "close", listener: (code: number, reason: string) => void): this;
+  on(event: "error", listener: (err: Error) => void): this;
+  on(event: "message", listener: (message: Message) => void): this;
+}
+
+export class WebSocket extends EventEmitter {
+  private connection: WSWebSocket;
+  private pendingBinaryMessage: { text: string; msg: MessageObject } | null = null;
+  private pendingMessages: Array<{
+    text: string;
+    data: Buffer | null;
+    callback?: (e: unknown) => void;
+  }> = [];
+  lastMessageTime = Date.now();
+  private pingInterval: NodeJS.Timeout | null = null;
+  private pingResponseTimeout: number = 0;
+  private openTimeout: number = 0;
+
+  constructor(connection: WSWebSocket | string, options: ClientOptions = {}) {
+    super();
+
+    if (typeof connection === "string") {
+      connection = new WSWebSocket(connection, undefined, {
+        maxPayload: options.maxPayload,
+        headers: options.headers || {},
+      });
+    } else {
+      assert(
+        options.maxPayload === undefined,
+        "Can't specify maxPayload for an already-connected socket"
+      );
+      assert(!options.headers, "Can't specify headers for an already-connected socket");
+    }
+    this.connection = connection;
+    this.connection.on("message", this.onMessage.bind(this));
+    this.connection.on("open", this.onOpen.bind(this));
+    this.connection.on("close", this.onClose.bind(this));
+    this.connection.on("error", this.onError.bind(this));
+    this.connection.on("pong", this.onPong.bind(this));
+
+    if (options.ping) {
+      // If a socket is being pinged, we're expecting it to be important that we
+      // detect errors. In this case, we default to assuming the socket should open
+      // within a second as a reasonable baseline.
+      this.openTimeout = options.ping.openTimeout ?? MsPerSecond;
+      this.pingResponseTimeout = options.ping.responseTimeout;
+      this.pingInterval = setInterval(
+        this.pingSocket.bind(this),
+        options.ping.pingInterval
+      ).unref();
+    }
+  }
+
+  private pingSocket() {
+    if (this.connection.readyState === WSWebSocket.CONNECTING) {
+      const openTimeLimit = Date.now() - this.openTimeout;
+      if (this.lastMessageTime < openTimeLimit) {
+        this.connection.terminate();
+      }
+      return;
+    }
+
+    const lastMessageLimit = Date.now() - this.pingResponseTimeout;
+
+    if (this.lastMessageTime < lastMessageLimit) {
+      logError("TerminatingSocket", {
+        delay: lastMessageLimit - this.lastMessageTime,
+        timeout: this.pingResponseTimeout,
+      });
+      this.connection.terminate();
+      return;
+    }
+
+    if (this.connection.readyState === WSWebSocket.OPEN) {
+      this.connection.ping();
+    }
+  }
+
+  isOpen() {
+    const { readyState } = this.connection;
+    // Since sendData will queue up messages until the connection opens, we consider
+    // CONNECTING to be an open state as well.
+    return readyState === WSWebSocket.CONNECTING || readyState === WSWebSocket.OPEN;
+  }
+
+  close(code: CloseCode = CloseCode.Normal) {
+    this.connection.close(code, getCodeReason(code));
+  }
+
+  forward(message: Message) {
+    assert(message instanceof Message, "expected a message");
+    this.sendData(message.text, message.data);
+  }
+
+  send(msg: MessageObject, data: Buffer | null = null, callback?: (e: unknown) => void) {
+    assert(typeof msg === "object" && msg !== null, "message must be an object");
+    assert(!(msg instanceof Buffer), "message object must a simple JSON object");
+    assert(typeof msg.binary === "boolean" || msg.binary === undefined);
+    assert(!data || data instanceof Buffer, "websocket outgoing data must be a Buffer");
+    if (msg.binary === true) {
+      assert(data, "cannot send binary === true message with no data");
+    } else {
+      assert(!data, "cannot send binary !== true message with data");
+    }
+
+    this.sendData(JSON.stringify(msg), data, callback);
+  }
+
+  private sendData(text: string, data: Buffer | null, callback?: (e: unknown) => void) {
+    const { readyState } = this.connection;
+    switch (readyState) {
+      case WSWebSocket.CONNECTING:
+        this.pendingMessages.push({ text, data, callback });
+        return;
+      case WSWebSocket.OPEN:
+        break;
+      case WSWebSocket.CLOSING:
+      case WSWebSocket.CLOSED:
+        break;
+      default:
+        logError("UnknownReadyState");
+        break;
+    }
+
+    if (data) {
+      this.connection.send(text);
+      this.connection.send(data, callback);
+    } else {
+      this.connection.send(text, callback);
+    }
+  }
+
+  private onOpen() {
+    this.lastMessageTime = Date.now();
+    for (const { text, data, callback } of this.pendingMessages) {
+      this.sendData(text, data, callback);
+    }
+    this.pendingMessages = [];
+
+    this.emit("open");
+  }
+
+  private onClose(code: number, reason: string) {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+    }
+
+    if (this.pendingBinaryMessage) {
+      this.pendingBinaryMessage = null;
+
+      if (code === 1000) {
+        // If the connection didn't close cleanly there's not much reason to
+        // expect any missing binary messages anyway.
+        this.emit("error", new Error("Server closed cleaning with pending binary message"));
+      }
+    }
+
+    this.emit("close", code, reason);
+  }
+
+  private onError(err: WSWebSocket.ErrorEvent) {
+    this.emit("error", err);
+  }
+
+  private onPong() {
+    this.lastMessageTime = Date.now();
+  }
+
+  private onMessage(data: string | Buffer) {
+    this.lastMessageTime = Date.now();
+
+    if (this.pendingBinaryMessage) {
+      const { text, msg } = this.pendingBinaryMessage;
+      this.pendingBinaryMessage = null;
+
+      if (typeof data !== "string") {
+        this.emit("message", new Message(text, msg, data));
+        return;
+      }
+
+      this.close(CloseCode.MissingBinaryMessage);
+      return;
+    }
+
+    if (typeof data !== "string") {
+      this.close(CloseCode.UnexpectedBinaryMessage);
+      return;
+    }
+
+    let json;
+    try {
+      json = JSON.parse(data);
+    } catch (err) {
+      this.close(CloseCode.InvalidJSONMessage);
+      return;
+    }
+
+    if (typeof json !== "object" || json === null) {
+      this.close(CloseCode.InvalidObjectMessage);
+      return;
+    }
+
+    if (json.binary !== undefined && typeof json.binary !== "boolean") {
+      this.close(CloseCode.InvalidBinaryPropery);
+      return;
+    }
+
+    if (json.binary === true) {
+      this.pendingBinaryMessage = { text: data, msg: json };
+      return;
+    }
+
+    this.emit("message", new Message(data, json, null));
+  }
+}

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -36,6 +36,7 @@ function TeamLibrary(props: ViewerRouterProps) {
   const { pendingWorkspaces, loading } = hooks.useGetPendingWorkspaces();
   const { currentWorkspaceId } = props;
 
+  console.log(currentWorkspaceId);
   if (loading) {
     return <ViewerLoader />;
   }


### PR DESCRIPTION
This is an early version of a page that will make it easy to stress-test recordings based on our internal fuzzer.
https://github.com/RecordReplay/devtools/discussions/6761

**Why is this important now?**
Being able to fuzz recordings will make it easier to ensure that our backend can handle the load from real world recordings.

**Why add stress testing to our library?**
It is important that we can document this feature for VIP users because they are the ones who have permission to run the stress test.

**What are the next steps?**
It would be nice to surface failed and slow requests.

**Additional benefit**
It is exciting to document more uses of the protocol so that others can see what is possible.