### PR TITLE
Replace Ten Minute Replay copy with Turbo Replay copy

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -11,15 +11,15 @@ import { getUserId, getUserInfo } from "ui/hooks/users";
 import { setTrialExpired, setCurrentPoint } from "ui/reducers/app";
 import { getSelectedPanel } from "ui/reducers/layout";
 import { Recording } from "ui/types";
+import { getTest, isTest, isMock } from "ui/utils/environment";
 import { endMixpanelSession } from "ui/utils/mixpanel";
 import { features, prefs } from "ui/utils/prefs";
+import { registerRecording, trackEvent } from "ui/utils/telemetry";
 import tokenManager from "ui/utils/tokenManager";
 import { UIThunkAction } from "ui/actions";
 import * as actions from "ui/actions/app";
 import * as selectors from "ui/reducers/app";
-import { getTest, isDevelopment, isTest, isMock } from "ui/utils/environment";
 import LogRocket from "ui/utils/logrocket";
-import { registerRecording, sendTelemetryEvent, trackEvent } from "ui/utils/telemetry";
 import { extractGraphQLError } from "ui/utils/apolloClient";
 import type { ExpectedError, UnexpectedError } from "ui/state/app";
 import { subscriptionExpired } from "ui/utils/workspace";
@@ -144,8 +144,8 @@ export function createSession(recordingId: string): UIThunkAction {
       const experimentalSettings: socket.ExperimentalSettings = {
         listenForMetrics: !!prefs.listenForMetrics,
         disableCache: !!prefs.disableCache,
-        useMultipleControllers: !!features.tenMinuteReplays,
-        multipleControllerUseSnapshots: !!features.tenMinuteReplays,
+        useMultipleControllers: !!features.turboReplay,
+        multipleControllerUseSnapshots: !!features.turboReplay,
       };
 
       dispatch(showLoadingProgress());

--- a/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
+++ b/src/ui/components/shared/UserSettingsModal/ExperimentalSettings.tsx
@@ -58,15 +58,14 @@ const EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
     key: "unicornConsole",
     label: "Unicorn console",
   },
-];
-
-const RISKY_EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [
   {
-    label: "Ten Minute Replays",
-    description: "Supports replaying longer recordings",
-    key: "tenMinuteReplays",
+    label: "Turbo Replay",
+    description: "Replay recordings across multiple instances",
+    key: "turboReplay",
   },
 ];
+
+const RISKY_EXPERIMENTAL_SETTINGS: ExperimentalSetting[] = [];
 
 function Experiment({
   setting,
@@ -104,8 +103,7 @@ export default function ExperimentalSettings({}) {
     useFeature("columnBreakpoints");
   const { value: enableNetworkRequestComments, update: updateEnableNetworkRequestComments } =
     useFeature("networkRequestComments");
-  const { value: enableTenMinuteReplays, update: updateEnableTenMinuteReplays } =
-    useFeature("tenMinuteReplays");
+  const { value: enableTurboReplay, update: updateEnableTurboReplay } = useFeature("turboReplay");
   const { value: enableUnicornConsole, update: updateEnableUnicornConsole } =
     useFeature("unicornConsole");
   const { value: enableReduxDevtools, update: updateEnableReduxDevtools } = useFeature("showRedux");
@@ -125,8 +123,8 @@ export default function ExperimentalSettings({}) {
       updateEnableColumnBreakpoints(!enableColumnBreakpoints);
     } else if (key == "enableNetworkRequestComments") {
       updateEnableNetworkRequestComments(!enableNetworkRequestComments);
-    } else if (key == "tenMinuteReplays") {
-      updateEnableTenMinuteReplays(!enableTenMinuteReplays);
+    } else if (key == "turboReplay") {
+      updateEnableTurboReplay(!enableTurboReplay);
     } else if (key == "codeHeatMaps") {
       updateCodeHeatMaps(!codeHeatMaps);
     } else if (key == "enableResolveRecording") {
@@ -144,7 +142,7 @@ export default function ExperimentalSettings({}) {
     enableColumnBreakpoints,
     enableNetworkRequestComments,
     enableResolveRecording,
-    tenMinuteReplays: enableTenMinuteReplays,
+    turboReplay: enableTurboReplay,
     unicornConsole: enableUnicornConsole,
     showRedux: enableReduxDevtools,
   };
@@ -166,24 +164,26 @@ export default function ExperimentalSettings({}) {
             checked={!!settings[setting.key]}
           />
         ))}
-        <div>
-          <div className="my-4  flex items-center ">
-            <Icon
-              filename="warning"
-              className="mr-2"
-              style={{ backgroundColor: "var(--theme-toolbar-color)" }}
-            />
-            Increased chance of session errors and performance issues.
+        {RISKY_EXPERIMENTAL_SETTINGS.length > 0 && (
+          <div>
+            <div className="my-4  flex items-center ">
+              <Icon
+                filename="warning"
+                className="mr-2"
+                style={{ backgroundColor: "var(--theme-toolbar-color)" }}
+              />
+              Increased chance of session errors and performance issues.
+            </div>
+            {RISKY_EXPERIMENTAL_SETTINGS.map(setting => (
+              <Experiment
+                onChange={onChange}
+                key={setting.key}
+                setting={setting}
+                checked={!!settings[setting.key]}
+              />
+            ))}
           </div>
-          {RISKY_EXPERIMENTAL_SETTINGS.map(setting => (
-            <Experiment
-              onChange={onChange}
-              key={setting.key}
-              setting={setting}
-              checked={!!settings[setting.key]}
-            />
-          ))}
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -19,7 +19,7 @@ export type LocalExperimentalUserSettings = {
   enableBreakpointPanelAutocomplete: boolean;
   enableColumnBreakpoints: boolean;
   enableNetworkRequestComments: boolean;
-  tenMinuteReplays: boolean;
+  turboReplay: boolean;
   enableResolveRecording: boolean;
   unicornConsole: boolean;
   showRedux: boolean;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -24,7 +24,7 @@ pref("devtools.features.httpBodies", true);
 pref("devtools.features.videoPlayback", false);
 pref("devtools.features.commentAttachments", false);
 pref("devtools.features.networkRequestComments", true);
-pref("devtools.features.tenMinuteReplays", false);
+pref("devtools.features.turboReplay", false);
 pref("devtools.features.breakpointPanelAutocomplete", true);
 pref("devtools.features.codeHeatMaps", true);
 pref("devtools.features.resolveRecording", false);
@@ -51,7 +51,7 @@ export const prefs = new PrefsHelper("devtools", {
 });
 
 export const features = new PrefsHelper("devtools.features", {
-  tenMinuteReplays: ["Bool", "tenMinuteReplays"],
+  turboReplay: ["Bool", "turboReplay"],
   columnBreakpoints: ["Bool", "columnBreakpoints"],
   httpBodies: ["Bool", "httpBodies"],
   videoPlayback: ["Bool", "videoPlayback"],


### PR DESCRIPTION
**Rationale**
There are many disadvantages to _Ten Minute Replays_
* We are not ready to handle ten minute replays
* In the future we can do more than ten minutes 
* It comes across as something that should be standard. If we do not include "Ten Minute Replays" by default, it could come across poorly. 
 
In contrast
* Turbo Replay speaks to the fact that we're turbo charging your replaying experience
* It does not imply a time limit
* It screams power feature which we can offer for free while it's in beta, but at the right time can find the right balance for the various tiers

<img width="859" alt="Screen Shot 2022-05-14 at 7 16 07 AM" src="https://user-images.githubusercontent.com/254562/168429550-8213be51-5e2d-45eb-8da1-e8df30fcc7fc.png">
