### PR TITLE
Add workaround for #6774

### DIFF
--- a/src/test/harness.js
+++ b/src/test/harness.js
@@ -548,9 +548,12 @@ async function toggleScopeNode(text) {
   return toggleObjectInspectorNode(node);
 }
 
-function writeInConsole(value) {
+async function writeInConsole(value) {
   window.jsterm.setValue(value);
-  return waitUntil(() => window.jsterm.editor.getValue() === value);
+  await waitUntil(() => window.jsterm.editor.getValue() === value);
+  // workaround for #6774
+  // TODO [hbenl] remove this workaround once JSTerm is fixed (#6778)
+  await waitForTime(100);
 }
 
 async function executeInConsole(value) {


### PR DESCRIPTION
@bvaughn I don't like this workaround, but the interaction between all those `useState()` and `useRef()` hooks in `JSTerm` and `ControlledCodeMirror` is making my head spin. Please have a look at #6774, perhaps you've got an idea for a proper fix.