### PR TITLE
temporarily remove add comment shortcut

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/Breakpoints/Panel/PanelSummary/index.tsx
@@ -91,28 +91,6 @@ function PanelSummary({
     }
   };
 
-  /**
-   * Hacky solution that attaches a keyboard shortcut to "shift+c" for adding comments.
-   * TODO: move to a first-class keyboard shortcut hook that we can use to
-   * display a keyboard shortcut modal
-   *
-   */
-  const addCommentRef = useRef<any>(null);
-
-  addCommentRef.current = addComment;
-
-  useEffect(() => {
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.shiftKey && event.key === "C") {
-        addCommentRef.current(event);
-      }
-    }
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, []);
-
   if (isHot) {
     trackEvent("breakpoint.too_many_points");
     return (


### PR DESCRIPTION
Removes the add comment shortcut introduced in #6742 to prevent blowing away the existing comment. I'll follow-up with another PR that uses our `KeyboardShortcuts` implementation and add the functionality across the app and not just the editor.

fixes #6776