### PR TITLE
Fix broken `ThreadFront` usage in `createSession`

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -3,6 +3,7 @@ import { uploadedData } from "@recordreplay/protocol";
 import { findAutomatedTests } from "protocol/find-tests";
 import { videoReady } from "protocol/graphics";
 import * as socket from "protocol/socket";
+import type { ThreadFront as ThreadFrontType } from "protocol/thread";
 import { assert, waitForTime } from "protocol/utils";
 import { getRecording } from "ui/hooks/recordings";
 import { getUserSettings } from "ui/hooks/settings";
@@ -99,8 +100,14 @@ export function getDisconnectionError(): UnexpectedError {
 }
 
 // Create a session to use while debugging.
-export function createSession(recordingId: string): UIThunkAction {
-  return async (dispatch, getState, { ThreadFront }) => {
+// NOTE: This thunk is dispatched _before_ the rest of the devtools logic
+// is initialized, so `extra.ThreadFront` isn't available yet.
+// We pass `ThreadFront` in as an arg here instead.
+export function createSession(
+  recordingId: string,
+  ThreadFront: typeof ThreadFrontType
+): UIThunkAction {
+  return async (dispatch, getState) => {
     try {
       if (ThreadFront.recordingId) {
         assert(

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -1,9 +1,12 @@
+import { ThreadFront } from "protocol/thread";
 import React, { useEffect, useState, useRef, useMemo } from "react";
 import { connect, ConnectedProps, useSelector } from "react-redux";
-import { selectors } from "../reducers";
-import { UIState } from "ui/state";
 import { clearTrialExpired, createSession } from "ui/actions/session";
 import { useGetRecording, useGetRecordingId } from "ui/hooks/recordings";
+import { UIState } from "ui/state";
+
+import { selectors } from "../reducers";
+
 import Header from "./Header/index";
 import LoadingScreen from "./shared/LoadingScreen";
 import WaitForReduxSlice from "./WaitForReduxSlice";
@@ -133,7 +136,7 @@ function _DevTools({
   });
 
   useEffect(() => {
-    createSession(recordingId);
+    createSession(recordingId, ThreadFront);
     return () => {
       clearTrialExpired();
     };


### PR DESCRIPTION
Fixes #6783 by passing `ThreadFront` in as an arg to `createSession`