### PR TITLE
Actually dispatch `setBreakpoint` to apply Unicorn Console badges

### DIFF
--- a/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
+++ b/src/devtools/client/debugger/src/actions/breakpoints/breakpoints.ts
@@ -327,12 +327,14 @@ export function setBreakpointPrefixBadge(
   prefixBadge: Breakpoint["options"]["prefixBadge"]
 ): UIThunkAction {
   return (dispatch, getState, { ThreadFront }) => {
-    setBreakpoint(
-      {
-        ...breakpoint,
-        options: { ...breakpoint.options, prefixBadge },
-      },
-      ThreadFront.recordingId!
+    dispatch(
+      setBreakpoint(
+        {
+          ...breakpoint,
+          options: { ...breakpoint.options, prefixBadge },
+        },
+        ThreadFront.recordingId!
+      )
     );
   };
 }


### PR DESCRIPTION
Fixes the Unicorn Console bustage.  Oops!