### PR TITLE
Hide protocol viewer properly

### DIFF
--- a/src/ui/components/SidePanel.tsx
+++ b/src/ui/components/SidePanel.tsx
@@ -16,7 +16,6 @@ export default function SidePanel() {
   const { value: resolveRecording } = useFeature("resolveRecording");
   const selectedPrimaryPanel = useSelector(getSelectedPrimaryPanel);
 
-  let sidepanel;
   const [replayInfoCollapsed, setReplayInfoCollapsed] = useState(false);
   const [eventsCollapsed, setEventsCollapsed] = useState(false);
 

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -87,7 +87,7 @@ export default function Toolbar() {
   const [showCommentsBadge, setShowCommentsBadge] = useState(false);
   const recordingId = useGetRecordingId();
   const { comments, loading } = hooks.useGetComments(recordingId);
-  const logProtocol = useFeature("logProtocol");
+  const { value: logProtocol } = useFeature("logProtocol");
 
   useEffect(() => {
     if (!loading && comments.length > 0) {


### PR DESCRIPTION
I got the shape of the return value of `useFeature` wrong, so this was also a truthy value.