### PR TITLE
Only show security warnings if the recording has operations data

### DIFF
--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -191,7 +191,7 @@ export default function UploadScreen({ recording, userSettings, onUpload }: Uplo
                   isPublic={isPublic}
                   setIsPublic={setIsPublic}
                 />
-                {isPublic ? (
+                {isPublic && recording.operations ? (
                   <ToggleShowPrivacyButton
                     showPrivacy={showPrivacy}
                     operations={recording.operations}

--- a/src/ui/components/shared/SharingModal/SharingModal.tsx
+++ b/src/ui/components/shared/SharingModal/SharingModal.tsx
@@ -143,7 +143,9 @@ function SharingModal({ recording, hideModal }: SharingModalProps) {
             <div className="flex flex-col space-y-1 overflow-hidden">
               <div className="font-bold">Privacy Settings</div>
               <PrivacyDropdown {...{ recording }} />
-              <SecurityWarnings operations={recording.operations} onClick={() => {}} />
+              {recording.operations ? (
+                <SecurityWarnings operations={recording.operations} onClick={() => {}} />
+              ) : null}
               {showEnvironmentVariables ? <EnvironmentVariablesRow /> : null}
             </div>
           </div>

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -139,7 +139,7 @@ export interface Recording {
   collaborators?: string[];
   comments?: any;
   userRole?: RecordingRole;
-  operations: OperationsData;
+  operations?: OperationsData;
   resolution: { resolvedAt: string; resolvedBy: string };
   collaboratorRequests: CollaboratorRequest[];
 }


### PR DESCRIPTION
Fix #6756.

[We already guard the `recording.operations` field](https://github.com/RecordReplay/devtools/blob/05d554e89aafc7a6536375f88fe7d2c2cc43d6ad/src/ui/components/Events/ReplayInfo.tsx#L91-L93), since there are still replays around that don't have those operations. 

This PR just applies that same guard to another component that assumes that there will be `recording.operations`.