### PR TITLE
Test against the token value rather than auth0 state

### DIFF
--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -79,7 +79,7 @@ function getRecordingNotAccessibleError(
   userId?: string
 ): ExpectedError | undefined {
   const isAuthorized = !!((isTest() && !isMock()) || recording);
-  const isAuthenticated = !!(isTest() || isMock() || tokenManager.auth0Client?.isAuthenticated);
+  const isAuthenticated = !!(isTest() || isMock() || !!tokenManager.getState()?.token);
 
   if (isAuthorized) {
     return undefined;


### PR DESCRIPTION
There was a lingering reference to `auth0Client` which doesn't work when we inject the auth token (primarily from Gecko auth but also from automating testing). Replacing it with the token value should fix this up.