### PR TITLE
Add tracking for a user's loading idle time

### DIFF
--- a/pages/recording/[[...id]].tsx
+++ b/pages/recording/[[...id]].tsx
@@ -18,7 +18,9 @@ import setup from "ui/setup/dynamic/devtools";
 import { Recording as RecordingInfo } from "ui/types";
 import { isTest } from "ui/utils/environment";
 import { extractIdAndSlug } from "ui/utils/helpers";
+import { startUploadWaitTracking } from "ui/utils/mixpanel";
 import { getRecordingURL } from "ui/utils/recording";
+import { trackTiming } from "ui/utils/telemetry";
 import useToken from "ui/utils/useToken";
 
 import Upload from "./upload";
@@ -155,6 +157,10 @@ function RecordingPage({
     store,
     token.token,
   ]);
+  const onUpload = () => {
+    startUploadWaitTracking();
+    setUploadComplete(true);
+  };
 
   if (!recording || typeof window === "undefined") {
     return (
@@ -169,7 +175,7 @@ function RecordingPage({
   // We skip the upload step if there's no associated user ID, which
   // is the case for CI test recordings.
   if (!uploadComplete && recording.isInitialized === false && !isTest() && recording.userId) {
-    return <Upload onUpload={() => setUploadComplete(true)} />;
+    return <Upload onUpload={onUpload} />;
   } else {
     return (
       <>

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -31,6 +31,8 @@ import Video from "./Video";
 import { prefs } from "ui/utils/prefs";
 import { getPaneCollapse } from "devtools/client/debugger/src/selectors";
 import { getViewMode } from "ui/reducers/layout";
+import { useTrackLoadingIdleTime } from "ui/hooks/tracking";
+
 const Viewer = React.lazy(() => import("./Viewer"));
 
 type _DevToolsProps = PropsFromRedux & DevToolsProps;
@@ -103,6 +105,10 @@ function _DevTools({
   const { isAuthenticated } = useAuth0();
   const recordingId = useGetRecordingId();
   const { recording } = useGetRecording(recordingId);
+  const { trackLoadingIdleTime } = useTrackLoadingIdleTime(
+    uploadComplete ? "warm" : "cold",
+    recording
+  );
   const { userIsAuthor, loading } = useUserIsAuthor();
   const isExternalRecording = useMemo(
     () => recording?.user && !recording.user.internal,
@@ -146,6 +152,11 @@ function _DevTools({
       endUploadWaitTracking(sessionId!);
     }
   }, [loadingFinished, uploadComplete, sessionId]);
+  useEffect(() => {
+    if (loadingFinished) {
+      trackLoadingIdleTime(sessionId!);
+    }
+  }, [loadingFinished, trackLoadingIdleTime, sessionId]);
 
   useEffect(() => {
     if (recording && document.title !== recording.title) {

--- a/src/ui/components/UploadScreen/UploadScreen.tsx
+++ b/src/ui/components/UploadScreen/UploadScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, ReactNode, SetStateAction, Dispatch } from "react";
 import hooks from "ui/hooks";
 import ReplayTitle from "./ReplayTitle";
-import classNames from "classnames";
 import Modal from "ui/components/shared/NewModal";
 import { Recording, ExperimentalUserSettings } from "ui/types";
 import LoadingScreen from "../shared/LoadingScreen";
@@ -10,7 +9,6 @@ import { trackEvent } from "ui/utils/telemetry";
 import Sharing, { MY_LIBRARY } from "./Sharing";
 import { Privacy, ToggleShowPrivacyButton } from "./Privacy";
 import { UploadRecordingTrialEnd } from "./UploadRecordingTrialEnd";
-import { startUploadWaitTracking } from "ui/utils/mixpanel";
 import { BubbleViewportWrapper } from "../shared/Viewport";
 import { showDurationWarning } from "ui/utils/recording";
 import ReplayLogo from "../shared/ReplayLogo";
@@ -142,7 +140,6 @@ export default function UploadScreen({ recording, userSettings, onUpload }: Uplo
     trackEvent("upload.create_replay", {
       workspaceUuid: decodeWorkspaceId(workspaceId),
     });
-    startUploadWaitTracking();
 
     await initializeRecording({
       variables: { recordingId, title: inputValue, workspaceId },

--- a/src/ui/hooks/tracking.ts
+++ b/src/ui/hooks/tracking.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { Recording } from "ui/types";
+import { trackTiming } from "ui/utils/telemetry";
+
+type LoadingContext = "warm" | "cold";
+
+export function useTrackLoadingIdleTime(context: LoadingContext, recording?: Recording) {
+  const [started, setStarted] = useState(false);
+
+  useEffect(() => {
+    if (recording && !started) {
+      setStarted(true);
+      trackTiming("kpi-loading-idle-time");
+    }
+  }, [recording, started, setStarted]);
+
+  const trackLoadingIdleTime = (sessionId: string) => {
+    trackTiming("kpi-loading-idle-time", { sessionId, context });
+  };
+
+  return { trackLoadingIdleTime };
+}


### PR DESCRIPTION
x | 1) Newly-uploaded recording | 2) Existing recording
--- | --- | ---
a) Open replay | ✅ | ✅
b) Open upload screen | ✅ | ❌
c) Start uploading replay | ✅ | ❌
d) Start loading replay | ✅ | ✅
e) Replay is ready | ✅ | ✅

Right now, our tracking is very limited. We're only tracking `kpi-time-to-view-replay` for case 1, which tracks the duration of `1c->1e`. See the second graph in [this honeycomb board](https://ui.honeycomb.io/replay/board/e73oPhYrEpb/Terrible-Warm-Start).

What we're trying to track is `1d->1e` and `2d->2e` in honeycomb. This accomplishes that and tracks it under `kpi-loading-idle-time`.