### PR TITLE
Don't show outdated graphics

### DIFF
--- a/src/protocol/graphics.ts
+++ b/src/protocol/graphics.ts
@@ -236,6 +236,12 @@ export const Video = new VideoPlayer();
 let onRefreshGraphics: (canvas: Canvas) => void;
 export let hasAllPaintPoints = false;
 
+export const setHasAllPaintPoints = (newValue: boolean) => {
+  hasAllPaintPoints = newValue;
+};
+export const timeIsBeyondKnownPaints = (time: number) =>
+  !hasAllPaintPoints && gPaintPoints[gPaintPoints.length - 1].time < time;
+
 export function setupGraphics(store: UIStore) {
   onRefreshGraphics = (canvas: Canvas) => {
     store.dispatch(setCanvas(canvas));
@@ -254,6 +260,12 @@ export function setupGraphics(store: UIStore) {
 
     client.Session.findMouseEvents({}, sessionId);
     client.Session.addMouseEventsListener(({ events }) => onMouseEvents(events, store));
+
+    const recordingTarget = await ThreadFront.recordingTargetWaiter.promise;
+    if (recordingTarget === "node") {
+      // Make sure we never wait for any paints when trying to do things like playback
+      setHasAllPaintPoints(true);
+    }
 
     if (features.videoPlayback) {
       client.Graphics.getPlaybackVideo({}, sessionId);
@@ -293,6 +305,9 @@ export async function repaint(force = false) {
   if (recordingTarget === "node") {
     return;
   }
+  let graphicsFetched = false;
+  // Show a stalled message if the graphics have not fetched after half a second
+  setTimeout(() => !graphicsFetched && store.dispatch(setPlaybackStalled(true)), 500);
   const { mouse } = await getGraphicsAtTime(ThreadFront.currentTime);
   const point = ThreadFront.currentPoint;
   await ThreadFront.ensureAllSources();
@@ -303,9 +318,6 @@ export async function repaint(force = false) {
   const pause = ThreadFront.currentPause;
   assert(pause, "no pause");
 
-  let graphicsFetched = false;
-  // Show a stalled message if the graphics have not fetched after half a second
-  setTimeout(() => !graphicsFetched && store.dispatch(setPlaybackStalled(true)), 500);
   const rv = await pause.repaintGraphics(force);
   graphicsFetched = true;
   store.dispatch(setPlaybackStalled(false));
@@ -394,7 +406,7 @@ export async function getGraphicsAtTime(
   forPlayback = false
 ): Promise<{ screen?: ScreenShot; mouse?: MouseAndClickPosition }> {
   const paintIndex = mostRecentIndex(gPaintPoints, time);
-  if (paintIndex === undefined) {
+  if (paintIndex === undefined || timeIsBeyondKnownPaints(time)) {
     // There are no graphics to paint here.
     return {};
   }

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -201,15 +201,6 @@ class _ThreadFront {
   private annotationWaiters: Map<string, Promise<findAnnotationsResult>> = new Map();
   private annotationCallbacks: Map<string, ((annotations: Annotation[]) => void)[]> = new Map();
 
-  // Any callback to invoke to adjust the point which we zoom to.
-  warpCallback:
-    | ((
-        point: ExecutionPoint,
-        time: number,
-        hasFrames?: boolean
-      ) => { point: ExecutionPoint; time: number; hasFrames?: boolean } | null)
-    | null = null;
-
   testName: string | undefined;
 
   // added by EventEmitter.decorate(ThreadFront)
@@ -367,17 +358,6 @@ class _ThreadFront {
 
   timeWarp(point: ExecutionPoint, time: number, hasFrames?: boolean, force?: boolean) {
     log(`TimeWarp ${point}`);
-
-    // The warp callback is used to change the locations where the thread is
-    // warping to.
-    if (this.warpCallback && !force) {
-      const newTarget = this.warpCallback(point, time, hasFrames);
-      if (newTarget) {
-        point = newTarget.point;
-        time = newTarget.time;
-        hasFrames = newTarget.hasFrames;
-      }
-    }
 
     this.currentPoint = point;
     this.currentTime = time;

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -2,7 +2,7 @@ import { mostRecentPaintOrMouseEvent } from "protocol/graphics";
 import { ThreadFront } from "protocol/thread/thread";
 import React, { useLayoutEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { seek, setTimelineState, setTimelineToTime } from "ui/actions/timeline";
+import { seek, seekToTime, setTimelineState, setTimelineToTime } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { getTimeFromPosition } from "ui/utils/timeline";
 
@@ -72,15 +72,7 @@ export default function Timeline() {
       return;
     }
 
-    const paintOrMouseEvent = mostRecentPaintOrMouseEvent(mouseTime);
-    if (paintOrMouseEvent?.point) {
-      if (!dispatch(seek(paintOrMouseEvent.point, mouseTime, false))) {
-        // if seeking to the new point failed because it is in an unloaded region,
-        // we reset the timeline back to the current time
-        setTimelineToTime(ThreadFront.currentTime);
-        setTimelineState({ currentTime: ThreadFront.currentTime });
-      }
-    }
+    dispatch(seekToTime(mouseTime));
   };
 
   const onMouseMove = (event: React.MouseEvent) => {


### PR DESCRIPTION
And also when seeking try to get the nearest pause point possible, combining the backend's knowledge of the timeline with the paints array. Also - disable playback if we have no paints here. This is better (I think) than having a broken video player that just never plays. But we should also do some other things that we've talked about: make the hover cursor a disabled sign when we don't have paints that far out yet, maybe gray out the play button if it's going to be impossible (so it doesn't just feel like a focus issue)?

Fixes #6546 
Fixes #4289