### PR TITLE
Add allow/block list support to org settings

### DIFF
--- a/src/stories/UploadScreen/Sharing.stories.tsx
+++ b/src/stories/UploadScreen/Sharing.stories.tsx
@@ -58,6 +58,8 @@ OrgLibraryDisabled.args = {
           },
           recording: {
             public: true,
+            allowList: [],
+            blockList: [],
           },
         },
         motd: null,
@@ -88,6 +90,8 @@ OrgPublicDisabled.args = {
           },
           recording: {
             public: false,
+            allowList: [],
+            blockList: [],
           },
         },
         motd: null,
@@ -118,6 +122,8 @@ OrgLibraryAndPublicDisabled.args = {
           },
           recording: {
             public: false,
+            allowList: [],
+            blockList: [],
           },
         },
         motd: null,

--- a/src/ui/components/shared/SettingsModal/SettingsBody.tsx
+++ b/src/ui/components/shared/SettingsModal/SettingsBody.tsx
@@ -8,7 +8,7 @@ interface SettingsBodyProps<T extends string, P extends Record<string, unknown>>
 }
 
 function SettingsBodyWrapper({ children }: { children: (React.ReactChild | null)[] }) {
-  return <main className="text-sm">{children}</main>;
+  return <main className="overflow-y-auto text-sm">{children}</main>;
 }
 
 export function SettingsHeader({ children }: { children: React.ReactNode }) {

--- a/src/ui/components/shared/WorkspaceSettingsModal/OrganizationSettings.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/OrganizationSettings.tsx
@@ -112,24 +112,25 @@ const OrganizationSettings = ({ workspaceId }: { workspaceId: string }) => {
   );
 
   const features: PartialWorkspaceSettingsFeatures = workspace?.settings?.features || {};
-  const [, updateFeature, resetFeatures] = useDebounceState(
-    features,
-    (features: PartialWorkspaceSettingsFeatures) => {
-      updateWorkspaceSettings({
-        variables: {
-          workspaceId,
-          features,
-        },
-      });
-    }
-  );
+  const updateFeature = (features: PartialWorkspaceSettingsFeatures) => {
+    updateWorkspaceSettings({
+      variables: {
+        workspaceId,
+        features,
+      },
+    });
+  };
 
   useEffect(() => {
     if (workspace) {
-      resetFeatures(workspace.settings.features);
       resetMessage(workspace.settings.motd || "");
     }
-  }, [workspace?.id, resetFeatures, resetMessage]);
+    // workspace can referentially change from polling for changes without the
+    // workspace actually having changed so we're tying this hook invocation to
+    // the id change which will indicate when the workspace becomes loaded (or if
+    // a new workspace is somehow selected) eslint-disable-line
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspace?.id, resetMessage]);
 
   if (!workspace) {
     return null;

--- a/src/ui/components/shared/WorkspaceSettingsModal/OrganizationSettings.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/OrganizationSettings.tsx
@@ -5,39 +5,7 @@ import hooks from "ui/hooks";
 import { PartialWorkspaceSettingsFeatures } from "ui/types";
 
 import useDebounceState from "./useDebounceState";
-
-const extractUrlParts = new RegExp(
-  "^" +
-    // protocol
-    "([^:/?#.]+:)" +
-    "//" +
-    // domain - adapted from https://stackoverflow.com/questions/3117218/matching-url-with-wildcards
-    // full supported list https://www.icann.org/en/system/files/files/idna-protocol-2003-2008.txt
-    "([*\\w\\d\\-\\u0100-\\uffff.%]*)" +
-    // port
-    "(?::([*0-9]+))?",
-  "u"
-);
-
-function sanitizeUrlList(input: string) {
-  return input
-    .split(",")
-    .map(s => s.trim())
-    .map(v => {
-      try {
-        const [, protocol, hostname, port] = v.match(extractUrlParts) || [];
-
-        if (!protocol || !hostname) {
-          return "";
-        }
-
-        return `${protocol}//${hostname}${port ? ":" + port : ""}`;
-      } catch {
-        return "";
-      }
-    })
-    .filter(Boolean);
-}
+import { sanitizeUrlList } from "./utils";
 
 function CSVInput({
   disabled,

--- a/src/ui/components/shared/WorkspaceSettingsModal/__tests__/utils.test.ts
+++ b/src/ui/components/shared/WorkspaceSettingsModal/__tests__/utils.test.ts
@@ -1,0 +1,49 @@
+import { sanitizeUrlList } from "../utils";
+
+describe("WorkspaceSettingsModal", () => {
+  describe("utils", () => {
+    describe("sanitizeUrlList", () => {
+      it("should ignore extra whitespace", async () => {
+        const expected = ["http://app.replay.io"];
+        const actual = sanitizeUrlList("      \t \n http://app.replay.io   \t \n ");
+
+        expect(actual).toEqual(expected);
+      });
+
+      it("should omit invalid urls", async () => {
+        const expected = ["http://app.replay.io"];
+        const actual = sanitizeUrlList("this-will-be-omitted, http://app.replay.io, 🐶");
+
+        expect(actual).toEqual(expected);
+      });
+
+      it("should support wildcards", async () => {
+        const expected = ["http://*.replay.io", "https://google.com"];
+        const actual = sanitizeUrlList("http://*.replay.io, https://google.com");
+
+        expect(actual).toEqual(expected);
+      });
+
+      it("should omit paths", async () => {
+        const expected = ["http://app.replay.io"];
+        const actual = sanitizeUrlList("http://app.replay.io/this/is/a/path");
+
+        expect(actual).toEqual(expected);
+      });
+
+      it("should support a port", async () => {
+        const expected = ["http://app.replay.io:8080"];
+        const actual = sanitizeUrlList("http://app.replay.io:8080");
+
+        expect(actual).toEqual(expected);
+      });
+
+      it("should ignore a non-numeric port", async () => {
+        const expected = ["http://app.replay.io"];
+        const actual = sanitizeUrlList("http://app.replay.io:abc");
+
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+});

--- a/src/ui/components/shared/WorkspaceSettingsModal/useDebounceState.ts
+++ b/src/ui/components/shared/WorkspaceSettingsModal/useDebounceState.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 
-export default function useDebounceState(
-  original: string | undefined,
-  callback: (value: string) => void,
+export default function useDebounceState<T>(
+  original: T | undefined,
+  callback: (value: T) => void,
   timeout = 500
-): [string | undefined, (value: string) => void] {
+): [T | undefined, (value: T) => void] {
   const [value, updateValue] = useState(original); // nosemgrep typescript.react.best-practice.react-props-in-state.react-props-in-state
   const ref = useRef<NodeJS.Timeout | undefined>();
 
@@ -14,7 +14,7 @@ export default function useDebounceState(
     }
   }, [original]);
 
-  const setValue = (updated: string) => {
+  const setValue = (updated: T) => {
     updateValue(updated);
 
     if (ref.current) {

--- a/src/ui/components/shared/WorkspaceSettingsModal/useDebounceState.ts
+++ b/src/ui/components/shared/WorkspaceSettingsModal/useDebounceState.ts
@@ -4,15 +4,9 @@ export default function useDebounceState<T>(
   original: T | undefined,
   callback: (value: T) => void,
   timeout = 500
-): [T | undefined, (value: T) => void] {
+): [T | undefined, (value: T) => void, (value: T) => void] {
   const [value, updateValue] = useState(original); // nosemgrep typescript.react.best-practice.react-props-in-state.react-props-in-state
   const ref = useRef<NodeJS.Timeout | undefined>();
-
-  useEffect(() => {
-    if (original !== undefined) {
-      updateValue(original);
-    }
-  }, [original]);
 
   const setValue = (updated: T) => {
     updateValue(updated);
@@ -24,5 +18,5 @@ export default function useDebounceState<T>(
     ref.current = setTimeout(() => callback(updated), timeout);
   };
 
-  return [value, setValue];
+  return [value, setValue, updateValue];
 }

--- a/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/utils.tsx
@@ -137,3 +137,36 @@ export function formatPercentage(amount: number) {
   const formatter = new Intl.NumberFormat("en-us", { style: "percent" });
   return formatter.format(amount);
 }
+
+const extractUrlParts = new RegExp(
+  "^" +
+    // protocol
+    "([^:/?#.]+:)" +
+    "//" +
+    // domain - adapted from https://stackoverflow.com/questions/3117218/matching-url-with-wildcards
+    // full supported list https://www.icann.org/en/system/files/files/idna-protocol-2003-2008.txt
+    "([*\\w\\d\\-\\u0100-\\uffff.%]*)" +
+    // port
+    "(?::([*0-9]+))?",
+  "u"
+);
+
+export function sanitizeUrlList(input: string) {
+  return input
+    .split(",")
+    .map(s => s.trim())
+    .map(v => {
+      try {
+        const [, protocol, hostname, port] = v.match(extractUrlParts) || [];
+
+        if (!protocol || !hostname) {
+          return "";
+        }
+
+        return `${protocol}//${hostname}${port ? ":" + port : ""}`;
+      } catch {
+        return "";
+      }
+    })
+    .filter(Boolean);
+}

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -187,6 +187,8 @@ export interface WorkspaceSettings {
     };
     recording: {
       public: boolean;
+      allowList: string[] | null;
+      blockList: string[] | null;
     };
   };
   motd: string | null;

--- a/src/ui/utils/org.ts
+++ b/src/ui/utils/org.ts
@@ -12,6 +12,8 @@ export function getDefaultOrganizationSettings(): WorkspaceSettings {
       },
       recording: {
         public: true,
+        allowList: [],
+        blockList: [],
       },
     },
     motd: null,


### PR DESCRIPTION
Blocked by https://github.com/RecordReplay/backend/pull/5639

Adds input fields to the org settings pane to set allow / block lists

https://app.replay.io/recording/add-allowblock-list-to-org-settings--598e9fa4-af0a-4cf5-988e-8822d94b8ff7