### PR TITLE
Attempt to fix Redux DevTools UI crash bug

### DIFF
--- a/src/ui/components/SecondaryToolbox/ReduxDevTools.tsx
+++ b/src/ui/components/SecondaryToolbox/ReduxDevTools.tsx
@@ -75,35 +75,68 @@ export const ReduxDevToolsPanel = () => {
     const rootComponent = rootRef.current;
     const store = rootComponent.store!;
 
-    const matchingAnnotationsByTimeRange = reduxAnnotations.filter(annotation => {
-      return currentTimestamp != null && annotation.time < currentTimestamp;
+    /*
+
+     The Redux DevTools UI has its own Redux store with its own reducers.
+     The primary part that we care about is the slice reducer that manages 
+     which "store instances" are connected, and calculates the "lifted state" 
+     for each store (ie, "after 3 increment actions, the state is `{value: 3}`".
+     See [`reducers/instances.ts` in the Redux DevTools repo for the logic](https://github.com/reduxjs/redux-devtools/blob/b82de745928211cd9b7daa7a61b197ad9e11ec36/packages/redux-devtools-app/src/reducers/instances.ts).
+
+     The RDT internals first pass along an `INIT_INSTANCE` action to let the UI 
+     know that a given store instance exists, and then later pass along the serialized  
+     actions  for processing to update that instance's calculated state.
+
+     Internally, the `instances` reducer appears to have handling for a 
+     "default" state, and falls back to that value if no instances are connected.  
+     In my experimenting I found I needed to dispatch an action related to that 
+     as part of resetting the internal state.
+
+    */
+
+    const allInstanceIds: string[] = ["default"];
+
+    reduxAnnotations.forEach(annotation => {
+      // @ts-ignore ignore "this comparison never matches" error
+      if (annotation.action?.request?.type === "INIT_INSTANCE") {
+        // @ts-ignore-error TS is _really_ getting confused here
+        allInstanceIds.push(annotation.action.request.instanceId);
+      }
     });
 
-    if (!matchingAnnotationsByTimeRange.length) {
-      return;
-    }
-
     batch(() => {
+      // We may receive the Redux annotations in several groups over time.
+      // Rather than try to figure out which ones we have and haven't loaded into
+      // the RDT Redux store, we'll just try to reset its internal instance state entirely,
+      // and always reload all of the received annotation actions.
+
       // TODO THIS IS A TERRIBLE IDEA COME UP WITH SOMETHING BETTER AND YET THIS WORKS
-      // Seemingly reset the DevTools internal knowledge of actions,
-      // so we can re-send in all actions up to this point in the recording
+      // Seemingly reset the DevTools internal knowledge of actions.
+      // @ts-ignore this is legal to dispatch
       store.dispatch({
-        type: "devTools/UPDATE_STATE",
-        request: {
-          type: "LIFTED",
-          id: "default",
-        },
+        type: "socket/DISCONNECTED",
       });
 
-      // TODO Is this how we want to actually behave here?
-      // Update the store with the actions up to this point in time
-      matchingAnnotationsByTimeRange.forEach(annotation => {
+      // For each connection instance that we know will exist from annotations,
+      // re-create an empty state value in the instances data.
+      allInstanceIds.forEach(instanceId => {
+        store.dispatch({
+          type: "devTools/UPDATE_STATE",
+          request: {
+            type: "LIFTED",
+            id: instanceId,
+          },
+        });
+      });
+
+      // Originally I had this showing only actions up to the current pause point,
+      // but that led to a situation where there could be partly-initialized state and
+      // the RDT UI would end up crashing. Now, always load everything we've received.
+      reduxAnnotations.forEach(annotation => {
         store.dispatch(annotation.action);
       });
     });
-
-    // TODO This only gets updated when we actually _pause_, not during playback.
-  }, [ReduxDevToolsAppRoot, currentTimestamp, reduxAnnotations]);
+  }, [ReduxDevToolsAppRoot, reduxAnnotations]);
 
   if (!ReduxDevToolsAppRoot) {
     return null;

--- a/src/ui/components/SecondaryToolbox/redux-devtools/redux-annotations.ts
+++ b/src/ui/components/SecondaryToolbox/redux-devtools/redux-annotations.ts
@@ -58,6 +58,12 @@ export const createDevtoolsAction = <S, A extends Action<unknown>>(
     action.request.instanceId = instanceId;
   }
 
+  // Crank up the max actions the RDT logic will process before compacting old ones
+  // This is usually 50 by default, but hey, let's be generous.  (We'll see if this
+  // ends up causing any memory issues or anything)
+  // @ts-ignore
+  request.maxAge = 500;
+
   // @ts-ignore
   if (request.libConfig) {
     // Try to mark RDT features as "disabled", since these aren't relevant in Replay


### PR DESCRIPTION
This PR :

- Attempts to fix the Redux DevTools crash bug that I and Ryota Murakami have seen
  - Removed attempt to only show "actions up to this point in time",  which was failing due to edge cases (instance was initialized, but the first "here's some state" action for the instance was never loaded in)
- Cranks up the "maxAge" value for how many actions will get held  in memory by the RDT store before compacting old ones

(Hopefully) fixes #6831 .

The bug can currently be reproduced in prod by opening up https://app.replay.io/recording/nsx-random-input--bfc7fe51-de07-43ab-82be-7189aad44d9e?point=6165852525064618446129693546514554&time=3540&hasFrames=false and selecting the "Redux" tab, at which point the UI should crash.  That particular timestamp is in between when the RDT data had an "instance" entry initialized, and when it actually sees the first action with data for that instance.

Opening up that same recording + params on the preview branch (make sure you're signed in and have the Redux DevTools setting enabled) _should_ work if this fix is good.