### PR TITLE
Fix hover UI for unfocused network request

### DIFF
--- a/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
+++ b/src/ui/components/Comments/TranscriptComments/CommentCard.tsx
@@ -273,8 +273,8 @@ function CommentCard({
   return (
     <div
       className={classNames(
-        `comment-card relative mx-auto w-full cursor-pointer border-b border-splitter transition`,
-        isOutsideFocusedRegion ? "opacity-30" : "bg-bodyBgcolor",
+        `comment-card relative mx-auto w-full border-b border-splitter transition`,
+        isOutsideFocusedRegion ? "opacity-30" : "cursor-pointer bg-bodyBgcolor",
         isUpdating ? "bg-themeBase-90" : ""
       )}
       onMouseDown={e => {

--- a/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
@@ -1,9 +1,11 @@
+import classNames from "classnames";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setSelectedPanel } from "ui/actions/layout";
 import { selectAndFetchRequest } from "ui/actions/network";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { getSummaryById } from "ui/reducers/network";
+import { getFocusRegion } from "ui/reducers/timeline";
 import { UIState } from "ui/state";
 
 import { trackEvent } from "ui/utils/telemetry";
@@ -11,6 +13,11 @@ import { trackEvent } from "ui/utils/telemetry";
 export default function NetworkRequestPreview({ networkRequestId }: { networkRequestId: string }) {
   const dispatch = useDispatch();
   const request = useSelector((state: UIState) => getSummaryById(state, networkRequestId));
+  const focusRegion = useSelector(getFocusRegion);
+
+  if (!request) {
+    return null;
+  }
 
   const onClick = () => {
     trackEvent("comments.select_request");
@@ -18,16 +25,19 @@ export default function NetworkRequestPreview({ networkRequestId }: { networkReq
     dispatch(selectAndFetchRequest(networkRequestId));
   };
 
-  if (!request) {
-    return null;
-  }
+  const isSeekEnabled =
+    focusRegion == null ||
+    (request.point.time >= focusRegion.startTime && request.point.time <= focusRegion.endTime);
 
   const { method, name } = request;
 
   return (
     <div
-      onClick={onClick}
-      className="group cursor-pointer rounded-md border-gray-200 bg-chrome px-2 py-0.5 hover:bg-themeTextFieldBgcolor"
+      onClick={isSeekEnabled ? onClick : undefined}
+      className={classNames(
+        "group rounded-md border-gray-200 bg-chrome px-2 py-0.5",
+        isSeekEnabled && "cursor-pointer hover:bg-themeTextFieldBgcolor"
+      )}
     >
       <div className="mono flex flex-col font-medium">
         <div className="flex w-full flex-row justify-between space-x-1">
@@ -39,7 +49,10 @@ export default function NetworkRequestPreview({ networkRequestId }: { networkReq
             <span>{name}</span>
           </div>
           <div
-            className="flex flex-shrink-0 opacity-0 transition group-hover:opacity-100"
+            className={classNames(
+              "flex flex-shrink-0 opacity-0 transition",
+              isSeekEnabled && "group-hover:opacity-100"
+            )}
             title="Show in the Network Monitor"
           >
             <MaterialIcon iconSize="sm">keyboard_arrow_right</MaterialIcon>


### PR DESCRIPTION
Hovering over a Network request (or a comment) that's outside of focus no longer shows cursor and hover highlight

https://www.loom.com/share/39685884ee6244048c4fd06ef6f0b521

Resolves #5606