### PR TITLE
Show original function names in the Call Stack panel (#3150)

### DIFF
--- a/src/devtools/client/debugger/src/client/create.js
+++ b/src/devtools/client/debugger/src/client/create.js
@@ -30,7 +30,12 @@ export async function createFrame(frame, index = 0, asyncIndex = 0) {
     };
   }
 
-  const displayName = frame.functionName || `(${frame.type})`;
+  let originalFunctionName;
+  const scopes = await ThreadFront.getScopes(asyncIndex, frame.frameId);
+  if (!scopes.originalScopesUnavailable) {
+    originalFunctionName = scopes.scopes.find(scope => scope.functionName)?.functionName;
+  }
+  const displayName = originalFunctionName || frame.functionName || `(${frame.type})`;
 
   return {
     id: `${asyncIndex}:${index}`,


### PR DESCRIPTION
This shows how to get the original function names when we have proper stack frames including their scopes.
1. The performance isn't optimal since it fetches all scopes for all stackframes before displaying them. Ideally we should add the original function name to the stack frames in the backend.
2. It does not address stacktraces shown in the console, where we only have a location, but no scope information. In this case the source worker in the backend needs to provide the function names for the location in the original source.