### PR TITLE
Fixed console CSS to avoid causing icon jump

### DIFF
--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -269,11 +269,6 @@
   margin: var(--console-output-vertical-padding) 0;
 }
 
-.webconsole-app .message.paused:not(.paused-before) > .message-body-wrapper {
-  margin: calc(var(--console-output-vertical-padding) - 1px) 0
-    var(--console-output-vertical-padding);
-}
-
 .webconsole-app .message-body-wrapper .table-widget-body {
   overflow: visible;
 }
@@ -893,19 +888,14 @@ a.learn-more-link.webconsole-learn-more-link {
   fill: currentColor;
 }
 
-.webconsole-app .message.paused.paused-before {
-  border-top: 1px solid var(--purple-50);
-  margin-top: 0px;
-}
-
-.webconsole-app .message.paused:not(.paused-before) {
-  /* always show the border, even for the last child */
-  border-top: 2px solid var(--paused-background-color);
-}
-
-.webconsole-app .message.paused.paused-before .message-body-wrapper,
-.webconsole-app .message.paused.paused-before > .icon {
-  margin-top: calc(var(--console-output-vertical-padding) - 1px);
+.webconsole-app .message.paused::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  top: -1px;
+  background-color: var(--paused-background-color);
 }
 
 .webconsole-output .paused ~ .message:last-of-type,
@@ -915,7 +905,7 @@ a.learn-more-link.webconsole-learn-more-link {
 
 .webconsole-app .message.paused {
   z-index: 3;
-  margin-bottom: 0px;
+  position: relative;
 }
 
 /** Utils **/


### PR DESCRIPTION
Related to #6846

- [x] The unicorn should not be pushed down when paused

Loom: https://www.loom.com/share/031aa1dc80a748ad9d1de65cea4f2325 