### PR TITLE
Override mouse cursor for focus UI to not show text selection

### DIFF
--- a/src/ui/components/Timeline/FocusInputs.module.css
+++ b/src/ui/components/Timeline/FocusInputs.module.css
@@ -5,6 +5,9 @@
   column-gap: 0.25rem;
   font-size: 1rem;
   line-height: 1rem;
+
+  /* Don't show text selection cursor because it looks like an input cursor */
+  cursor: default;
 }
 
 .CurrentTimeLabel,


### PR DESCRIPTION
Resolves #6839

By default, Safari shows a text selection cursor when you're hovering over non-clickable text elements. This PR overrides it to use the _default_ cursor instead.

![Kapture 2022-05-19 at 12 10 49](https://user-images.githubusercontent.com/29597/169347919-1132238f-79dc-4050-9795-7d35e49517dc.gif)

