### PR TITLE
Stop propagation of the click on CommentMarker

### DIFF
--- a/src/ui/components/Comments/CommentMarker.tsx
+++ b/src/ui/components/Comments/CommentMarker.tsx
@@ -36,7 +36,10 @@ class CommentMarker extends React.Component<CommentMarkerProps> {
     return comments[index];
   }
 
-  onClick = () => {
+  onClick = (e: React.MouseEvent) => {
+    // This should not count as a click on the timeline, which would seek to a
+    // particular time.
+    e.stopPropagation();
     const { comment, seekToComment } = this.props;
     trackEvent("timeline.comment_select");
     seekToComment(comment);


### PR DESCRIPTION
Clicking on a comment marker should seek *to that comment*, not to the
time that that comment is sitting on. This fix was pretty easy and is
not too crazy I think, but it might be better to resolve this difference
by changing the DOM hierarchy?

Fixes #6858 