### PR TITLE
Remove duplicate assert function

### DIFF
--- a/src/ui/utils/assert.tsx
+++ b/src/ui/utils/assert.tsx
@@ -1,9 +1,0 @@
-import * as Sentry from "@sentry/browser";
-
-export function assert(v: any, why = ""): asserts v {
-  if (!v) {
-    const error = new Error(`Assertion Failed: ${why}`);
-    Sentry.captureException(error);
-    throw error;
-  }
-}


### PR DESCRIPTION
We already have an `assert()` function which also sends an error to sentry and doesn't throw in prod, I don't think we need another one with slightly different semantics.
https://github.com/RecordReplay/devtools/blob/9563b7d63ae77d796eeda94e61e9574b066b7f42/src/protocol/utils.ts#L51-L60