### PR TITLE
Add error message "modal" to the login page

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -149,7 +149,7 @@ const maintenanceMode = false;
 
 function AppUtilities({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
+  const { isAuthenticated, getAccessTokenSilently, error } = useAuth0();
 
   _handleAuthError = async () => {
     // This handler attempts to handle the scenario in which the frontend and

--- a/src/ui/components/shared/Login/Login.tsx
+++ b/src/ui/components/shared/Login/Login.tsx
@@ -172,13 +172,18 @@ function AuthError({ error }: { error: any }) {
   }
 
   if (message === "Invalid state") {
+    // This is usually caused by waiting too long to go through the auth process
+    // and can be fixed by trying again.
     message = "Your login session expired. Please try logging in again.";
   } else {
+    // We want to capture any other error so we can investigate further.
     sendTelemetryEvent("devtools-auth-error-login", {
       errorMessage: message,
     });
 
     if (message === "Unable to authenticate user") {
+      // This usually occurs because our auth hook threw an error but the
+      // message itself isn't very useful so we show a more friendly message
       message = "We're sorry but we had a problem authenticating you. We're looking into it now!";
     }
   }

--- a/src/ui/components/shared/NewModal.tsx
+++ b/src/ui/components/shared/NewModal.tsx
@@ -17,7 +17,7 @@ export default function Modal({
   actions?: React.ReactNode;
   onMaskClick?: () => void;
   blurMask?: boolean;
-  children: React.ReactElement | React.ReactElement[];
+  children: React.ReactNode;
   options?: {
     maskTransparency: "transparent" | "translucent";
   };

--- a/src/ui/components/shared/Onboarding/index.tsx
+++ b/src/ui/components/shared/Onboarding/index.tsx
@@ -19,9 +19,11 @@ const OnboardingContext = React.createContext({ theme: "dark" });
 export function OnboardingContentWrapper({
   children,
   overlay,
+  noLogo,
 }: {
   children: React.ReactChild | (React.ReactChild | null)[];
   overlay?: boolean;
+  noLogo?: boolean;
 }) {
   const ctx = useContext(OnboardingContext);
 
@@ -35,7 +37,7 @@ export function OnboardingContentWrapper({
         }
       )}
     >
-      <ReplayLogo size={overlay ? "md" : "lg"} wide={overlay} />
+      {noLogo ? null : <ReplayLogo size={overlay ? "md" : "lg"} wide={overlay} />}
       {children}
     </div>
   );
@@ -137,7 +139,7 @@ export function OnboardingModalContainer({
   children,
   theme = "dark",
 }: {
-  children: React.ReactElement;
+  children: React.ReactNode;
   // For randomizing some background elements as controlled by progress
   // on the parent component, e.g. circles/bubbles that change on click
   randomNumber?: number;

--- a/src/ui/utils/useAuth0.ts
+++ b/src/ui/utils/useAuth0.ts
@@ -6,6 +6,7 @@ import { isTest, isMock } from "./environment";
 import useToken from "./useToken";
 
 const TEST_AUTH = {
+  error: undefined,
   isLoading: false,
   isAuthenticated: true,
   user: {
@@ -42,6 +43,7 @@ export default function useAuth0() {
 
   if (external && token) {
     return {
+      error: undefined,
       isLoading: loading,
       isAuthenticated: true,
       user: loading


### PR DESCRIPTION
## Issue

When auth fails, we show nothing and just land the user back on the login view

## Resolution

* Handle Auth0 errors and show them below the login form.
* Send events to telemetry so we can report and take action

<img width="425" alt="image" src="https://user-images.githubusercontent.com/788456/169602416-eb224e22-c44e-46ce-9b90-139fc2ccd688.png">
