### PR TITLE
Update workflows to reference new "main" branch

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,17 +1,17 @@
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   mirror_job:
     runs-on: ubuntu-latest
-    name: Mirror master branch to staging branch
+    name: Mirror main branch to staging branch
     steps:
     - name: Mirror action step
       id: mirror
       uses: google/mirror-branch-action@v1.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        source: 'master'
+        source: 'main'
         dest: 'staging'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   download-browser:
@@ -54,7 +54,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 960
           check_interval: 60
-          environment: ${{ fromJSON('["", "production"]')[github.ref == 'refs/heads/master'] }}
+          environment: ${{ fromJSON('["", "production"]')[github.ref == 'refs/heads/main'] }}
     outputs:
       url: ${{ steps.waitFor200.outputs.url }}
   test0:


### PR DESCRIPTION
There aren't many references but this PR updates them. (After #6878, this should be safe to do preemptively since changes to `master` will be auto synced to `main`.)