### PR TITLE
Add devtools focus style

### DIFF
--- a/src/devtools/client/inspector/components/App.tsx
+++ b/src/devtools/client/inspector/components/App.tsx
@@ -1,20 +1,21 @@
-import React, { FC, ReactNode, useMemo } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import "ui/setup/dynamic/inspector";
+
 import classnames from "classnames";
-import { UIState } from "ui/state";
-import { setActiveTab } from "../actions";
-import SplitBox from "devtools/client/shared/components/splitter/SplitBox";
-import { prefs } from "devtools/client/inspector/prefs";
-import MarkupApp from "devtools/client/inspector/markup/components/MarkupApp";
-import { RulesApp } from "devtools/client/inspector/rules/components/RulesApp";
 import ComputedApp from "devtools/client/inspector/computed/components/ComputedApp";
 import LayoutApp from "devtools/client/inspector/layout/components/LayoutApp";
-import { InspectorActiveTab } from "../state";
-
-import "ui/setup/dynamic/inspector";
-import { EventListenersApp } from "../event-listeners/EventListenersApp";
+import MarkupApp from "devtools/client/inspector/markup/components/MarkupApp";
+import { prefs } from "devtools/client/inspector/prefs";
+import { RulesApp } from "devtools/client/inspector/rules/components/RulesApp";
+import SplitBox from "devtools/client/shared/components/splitter/SplitBox";
 import { assert } from "protocol/utils";
+import React, { FC, ReactNode, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { UIState } from "ui/state";
+
 import { ResponsiveTabs } from "../../shared/components/ResponsiveTabs";
+import { setActiveTab } from "../actions";
+import { EventListenersApp } from "../event-listeners/EventListenersApp";
+import { InspectorActiveTab } from "../state";
 
 const INSPECTOR_TAB_TITLES: Record<InspectorActiveTab, string> = {
   ruleview: "Rules",
@@ -117,18 +118,16 @@ const InspectorApp: FC = () => {
                                 className={classnames("tabs-menu-item", {
                                   "is-active": isPanelSelected,
                                 })}
-                                role="presentation"
                               >
                                 <span className="devtools-tab-line"></span>
-                                <a
+                                <button
                                   id={`${panelId}-tab`}
-                                  tabIndex={isPanelSelected ? 0 : -1}
                                   title={INSPECTOR_TAB_TITLES[panelId]}
                                   role="tab"
                                   onClick={() => dispatch(setActiveTab(panelId))}
                                 >
                                   {INSPECTOR_TAB_TITLES[panelId]}
-                                </a>
+                                </button>
                               </span>
                             );
                           })}

--- a/src/devtools/client/shared/components/PanelTabs.tsx
+++ b/src/devtools/client/shared/components/PanelTabs.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import cx from "classnames";
+import React from "react";
 import { NetworkTab } from "ui/components/NetworkMonitor/RequestDetails";
 
 type Tab = {
@@ -31,7 +31,7 @@ export default function PanelTabs({
                   role="presentation"
                 >
                   <span className="devtools-tab-line"></span>
-                  <a
+                  <button
                     id={`${tab.id}-tab`}
                     onClick={() => setActiveTab(tab.id)}
                     role="tab"
@@ -39,7 +39,7 @@ export default function PanelTabs({
                     title={tab.title}
                   >
                     {tab.title}
-                  </a>
+                  </button>
                 </li>
               ))}
           </ul>

--- a/src/devtools/client/shared/components/tabs/Tabs.css
+++ b/src/devtools/client/shared/components/tabs/Tabs.css
@@ -77,15 +77,12 @@ div[hidetabs="true"] .tabs .tabs-navigation {
   background: var(--tab-bgcolor);
 }
 
-.tabs .tabs-menu-item:hover {
-}
-
 .tabs .tabs-menu-item:hover:not(.is-active) {
   background-color: var(--tab-hover-bgcolor);
   color: var(--tab-hover-color);
 }
 
-.tabs .tabs-menu-item a {
+.tabs .tabs-menu-item :is(a, button) {
   display: flex;
   place-items: center;
   padding: 0 10px;
@@ -97,6 +94,12 @@ div[hidetabs="true"] .tabs .tabs-navigation {
   user-select: none;
   text-align: center;
   height: calc(2px + var(--theme-toolbar-height));
+}
+
+.tabs .tabs-menu-item :is(a, button):is(:focus-visible, :hover) {
+  outline: 0;
+  color: var(--tab-hover-color);
+  background-color: var(--tab-hover-bgcolor);
 }
 
 /* Remove the outline focusring from tabs-menu-item. */

--- a/src/ui/components/NetworkMonitor/RequestRow.tsx
+++ b/src/ui/components/NetworkMonitor/RequestRow.tsx
@@ -1,9 +1,9 @@
 import classNames from "classnames";
 import React, { useLayoutEffect, useRef } from "react";
+import { Row } from "react-table";
 
 import styles from "./RequestTable.module.css";
 import { RequestSummary } from "./utils";
-import { Row } from "react-table";
 
 export const RequestRow = ({
   currentTime,
@@ -57,10 +57,11 @@ export const RequestRow = ({
       onClick={() => onClick(row.original)}
       onContextMenu={onContextMenu}
       ref={ref}
+      tabIndex={0}
     >
       <div {...row.getRowProps()}>
         {row.original.triggerPoint && row.original.triggerPoint.time !== currentTime && (
-          <div
+          <button
             className={classNames(styles.seekBadge, "shadow-md")}
             onClick={() => {
               if (!row.original.triggerPoint) {
@@ -78,7 +79,7 @@ export const RequestRow = ({
             <span className={classNames("px-2 text-white", styles.verbose)}>
               {row.original.triggerPoint.time > currentTime ? "Fast-forward" : "Rewind"}
             </span>
-          </div>
+          </button>
         )}
         {row.cells.map(cell => {
           const { key, ...cellProps } = cell.getCellProps();

--- a/src/ui/components/NetworkMonitor/RequestTable.module.css
+++ b/src/ui/components/NetworkMonitor/RequestTable.module.css
@@ -76,10 +76,15 @@ table.requests {
 
 .seekBadge:is(:hover, :focus-visible) {
   outline: 0;
-  background: linear-gradient(0deg, var(--primary-accent-hover) 0, var(--primary-accent-hover) 100%);
+  background: linear-gradient(
+    0deg,
+    var(--primary-accent-hover) 0,
+    var(--primary-accent-hover) 100%
+  );
 }
 
-.row:is(:hover, :focus-visible) .seekBadge, .seekBadge:is(:hover, :focus-visible) {
+.row:is(:hover, :focus-visible) .seekBadge,
+.seekBadge:is(:hover, :focus-visible) {
   opacity: 1;
 }
 

--- a/src/ui/components/NetworkMonitor/RequestTable.module.css
+++ b/src/ui/components/NetworkMonitor/RequestTable.module.css
@@ -12,7 +12,8 @@ table.requests {
   cursor: pointer;
 }
 
-.row:hover {
+.row:is(:hover, :focus-visible) {
+  outline: 0;
   background-color: var(--theme-toolbar-background);
 }
 
@@ -62,7 +63,8 @@ table.requests {
   border-bottom-right-radius: 8px;
   border-top-right-radius: 8px;
   cursor: pointer;
-  display: none;
+  display: flex;
+  opacity: 0;
   font-weight: 700;
   height: 100%;
   padding-left: 6px;
@@ -72,8 +74,13 @@ table.requests {
   z-index: 1;
 }
 
-.row:hover .seekBadge {
-  display: flex;
+.seekBadge:is(:hover, :focus-visible) {
+  outline: 0;
+  background: linear-gradient(0deg, var(--primary-accent-hover) 0, var(--primary-accent-hover) 100%);
+}
+
+.row:is(:hover, :focus-visible) .seekBadge, .seekBadge:is(:hover, :focus-visible) {
+  opacity: 1;
 }
 
 .seekBadge .fastForward {
@@ -93,6 +100,6 @@ table.requests {
   display: none;
 }
 
-.seekBadge:hover .verbose {
+.seekBadge:is(:hover, :focus-visible) .verbose {
   display: block;
 }

--- a/src/ui/components/NetworkMonitor/TypesDropdown.tsx
+++ b/src/ui/components/NetworkMonitor/TypesDropdown.tsx
@@ -1,8 +1,9 @@
+import classNames from "classnames";
 import React, { useState } from "react";
-
-import PortalDropdown from "ui/components/shared/PortalDropdown";
 import { Dropdown, DropdownItem, DropdownItemContent } from "ui/components/Library/LibraryDropdown";
 import MaterialIcon from "ui/components/shared/MaterialIcon";
+import PortalDropdown from "ui/components/shared/PortalDropdown";
+
 import { CanonicalRequestType, RequestTypeOptions } from "./utils";
 
 export default function TypesDropdown({
@@ -43,7 +44,10 @@ export default function TypesDropdown({
       buttonContent={button}
       setExpanded={setExpanded}
       expanded={expanded}
-      buttonStyle={`${types.size > 0 ? "text-primaryAccent" : "text-gray-400"}`}
+      buttonStyle={classNames({
+        "text-primaryAccent hover:text-primaryAccentHover focus:text-primaryAccentHover": types.size > 0,
+        "text-gray-400 hover:text-primaryAccentHover focus:text-primaryAccentHover": types.size === 0,
+      })}
       distance={0}
       position="bottom-right"
     >

--- a/src/ui/components/NetworkMonitor/TypesDropdown.tsx
+++ b/src/ui/components/NetworkMonitor/TypesDropdown.tsx
@@ -45,8 +45,10 @@ export default function TypesDropdown({
       setExpanded={setExpanded}
       expanded={expanded}
       buttonStyle={classNames({
-        "text-primaryAccent hover:text-primaryAccentHover focus:text-primaryAccentHover": types.size > 0,
-        "text-gray-400 hover:text-primaryAccentHover focus:text-primaryAccentHover": types.size === 0,
+        "text-primaryAccent hover:text-primaryAccentHover focus:text-primaryAccentHover":
+          types.size > 0,
+        "text-gray-400 hover:text-primaryAccentHover focus:text-primaryAccentHover":
+          types.size === 0,
       })}
       distance={0}
       position="bottom-right"

--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -1,12 +1,12 @@
+import classnames from "classnames";
+import Highlighter from "highlighter/highlighter";
+import { getDevicePixelRatio } from "protocol/graphics";
+import { ThreadFront } from "protocol/thread";
+import { EventEmitter } from "protocol/utils";
 import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
 
-import { EventEmitter } from "protocol/utils";
-import classnames from "classnames";
-import { ThreadFront } from "protocol/thread";
-import { getDevicePixelRatio } from "protocol/graphics";
-import Highlighter from "highlighter/highlighter";
 
 export const nodePicker: any = {};
 
@@ -137,14 +137,14 @@ class NodePicker extends React.Component<PropsFromRedux, NodePickerState> {
     const { nodePickerActive } = this.state;
 
     return (
-      <div
+      <button
         id="command-button-pick"
         className={classnames("devtools-button toolbar-panel-button tab", {
           active: nodePickerActive,
         })}
         onClick={() => this.clickNodePickerButton()}
         title="Select an element in the video to inspect it"
-      ></div>
+      />
     );
   }
 }

--- a/src/ui/components/NodePicker.tsx
+++ b/src/ui/components/NodePicker.tsx
@@ -7,7 +7,6 @@ import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { actions } from "ui/actions";
 
-
 export const nodePicker: any = {};
 
 interface Position {

--- a/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
+++ b/src/ui/components/SecondaryToolbox/SecondaryToolbox.css
@@ -50,11 +50,6 @@
   color: var(--tab-color);
 }
 
-.secondary-toolbox-header button:hover {
-  color: var(--tab-hover-color);
-  background-color: var(--tab-hover-bgcolor);
-}
-
 .secondary-toolbox-header button.layoutbutton:hover {
   background-color: var(--tab-bgcolor);
 }
@@ -67,6 +62,11 @@
   background: inherit;
   background: var(--tab-selected-bgcolor);
   color: var(--tab-selected-color);
+}
+
+.secondary-toolbox-header button:is(:hover, :focus-visible) {
+  color: var(--tab-hover-color);
+  background-color: var(--tab-hover-bgcolor);
 }
 
 .secondary-toolbox-header .action-buttons button {


### PR DESCRIPTION
fix #6907 

This PR is adding a focus style in 

* Secondary tabs 

<img width="599" alt="image" src="https://user-images.githubusercontent.com/9127504/169700634-c305b2a4-2e3a-4750-a8fa-4ba2fb8eb40b.png">

* Elements tabs

<img width="369" alt="image" src="https://user-images.githubusercontent.com/9127504/169700658-7510a4c5-50ed-4061-99ee-54a9f0e8dc24.png">

* Network tabs

<img width="381" alt="image" src="https://user-images.githubusercontent.com/9127504/169700673-bfa031b4-c289-4f1c-ad35-eead45db66aa.png">

* Allow to fast-forward / rewind with keyboad

<img width="1776" alt="image" src="https://user-images.githubusercontent.com/9127504/169700720-bb9b71eb-4cbc-4295-bd16-b9d37b7950ab.png">



https://user-images.githubusercontent.com/9127504/169700745-f60a8c83-929c-43e8-a006-7d2f325df00e.mp4


