### PR TITLE
Add an assert for when we try to send a message without a pauseId

### DIFF
--- a/src/protocol/thread/pause.ts
+++ b/src/protocol/thread/pause.ts
@@ -352,7 +352,8 @@ export class Pause {
     method: (parameters: P, sessionId?: SessionId, pauseId?: PauseId) => R,
     params: P
   ) {
-    return method(params, this.sessionId, this.pauseId!);
+    assert(this.pauseId, "pauseId not set before sending a message");
+    return method(params, this.sessionId, this.pauseId);
   }
 
   async getObjectPreview(object: ObjectId) {


### PR DESCRIPTION
This doesn't fix #6916 but it helps surface how many times users hit it so we have more data when prioritizing it the next time we notice it becoming more common.