### PR TITLE
NetworkMonitor ResizeObserver

### DIFF
--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -56,10 +56,19 @@ export const NetworkMonitor = ({
   );
 
   useEffect(() => {
-    if (container.current) {
-      resizeObserver.current.observe(container.current);
+    const observer = resizeObserver.current;
+    const splitBoxContainer = container.current;
+
+    if (splitBoxContainer) {
+      observer.observe(splitBoxContainer);
     }
-  });
+    
+    return () => {
+      if (splitBoxContainer) {
+        observer.unobserve(splitBoxContainer);
+      }
+    }
+  }, []);
 
   if (loading) {
     timeMixpanelEvent("net_monitor.open_network_monitor");

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -4,11 +4,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { connect, ConnectedProps, useDispatch, useSelector } from "react-redux";
 import { actions } from "ui/actions";
 import { hideRequestDetails, selectAndFetchRequest } from "ui/actions/network";
-import { getLoadedRegions } from "ui/reducers/app";
 import {
-  getFormattedFrames,
-  getResponseBodies,
-  getRequestBodies,
   getFocusedEvents,
   getFocusedRequests,
   getSelectedRequestId,
@@ -38,7 +34,6 @@ export const NetworkMonitor = ({
   const [types, setTypes] = useState<Set<CanonicalRequestType>>(new Set([]));
   const [vert, setVert] = useState<boolean>(false);
   const dispatch = useDispatch();
-  const loadedRegions = useSelector(getLoadedRegions);
 
   const container = useRef<HTMLDivElement>(null);
 
@@ -124,16 +119,11 @@ const connector = connect(
     currentTime: getCurrentTime(state),
     cx: getThreadContext(state),
     events: getFocusedEvents(state),
-    frames: getFormattedFrames(state),
-    loadedRegions: getLoadedRegions(state)?.loaded,
     loading: state.network.loading,
-    requestBodies: getRequestBodies(state),
     requests: getFocusedRequests(state),
-    responseBodies: getResponseBodies(state),
   }),
   {
     seek: actions.seek,
-    selectFrame: actions.selectFrame,
   }
 );
 type PropsFromRedux = ConnectedProps<typeof connector>;

--- a/src/ui/components/NetworkMonitor/index.tsx
+++ b/src/ui/components/NetworkMonitor/index.tsx
@@ -4,11 +4,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { connect, ConnectedProps, useDispatch, useSelector } from "react-redux";
 import { actions } from "ui/actions";
 import { hideRequestDetails, selectAndFetchRequest } from "ui/actions/network";
-import {
-  getFocusedEvents,
-  getFocusedRequests,
-  getSelectedRequestId,
-} from "ui/reducers/network";
+import { getFocusedEvents, getFocusedRequests, getSelectedRequestId } from "ui/reducers/network";
 import { getCurrentTime } from "ui/reducers/timeline";
 import { UIState } from "ui/state";
 import { timeMixpanelEvent } from "ui/utils/mixpanel";
@@ -62,12 +58,12 @@ export const NetworkMonitor = ({
     if (splitBoxContainer) {
       observer.observe(splitBoxContainer);
     }
-    
+
     return () => {
       if (splitBoxContainer) {
         observer.unobserve(splitBoxContainer);
       }
-    }
+    };
   }, []);
 
   if (loading) {


### PR DESCRIPTION
The network monitor resize observe is being call on each render of the component, unfortunally this component get's render a lot when some panel get resize or the timeline change 


https://user-images.githubusercontent.com/9127504/169877220-61c3f33c-e91a-494e-acbf-5433dc23b3b7.mp4

Reading the [spec](https://drafts.csswg.org/resize-observer/#dom-resizeobserver-observe)

```
observe(target, options)

Adds target to the list of observed elements.

1. If target is in [[observationTargets]] slot, call unobserve(target).

2. Let resizeObservation be new ResizeObservation(target, options).

3. Add the resizeObservation to the [[observationTargets]] slot.
```

Basically on each render we're removing and setting back the observer again

With this PR, the observer will be set once and then clean up on NetworkMonitor unmount
