### PR TITLE
An initial (and naive) take on soft-focus

### DIFF
--- a/src/devtools/client/debugger/src/actions/source-actors.ts
+++ b/src/devtools/client/debugger/src/actions/source-actors.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import type { UIThunkAction } from "ui/actions";
+import { getFocusRegion } from "ui/reducers/timeline";
+import { PROMISE } from "ui/setup/redux/middleware/promise";
 
 import {
   getSourceActor,
@@ -12,7 +14,6 @@ import {
   SourceActor,
 } from "../reducers/source-actors";
 import { memoizeableAction } from "../utils/memoizableAction";
-import { PROMISE } from "ui/setup/redux/middleware/promise";
 
 export function insertSourceActor(item: SourceActor) {
   return insertSourceActors([item]);
@@ -101,12 +102,14 @@ export const loadSourceActorBreakpointHitCounts = memoizeableAction(
     getValue: ({ id, lineNumber }, { getState }) =>
       getSourceActorBreakpointHitCounts(getState(), id, lineNumber),
     action: async ({ id, lineNumber, onFailure }, { dispatch, getState, client }) => {
+      const state = getState();
       await dispatch({
         type: "SET_SOURCE_ACTOR_BREAKPOINT_HIT_COUNTS",
         id,
         [PROMISE]: client.getSourceActorBreakpointHitCounts(
-          getSourceActor(getState(), id),
+          getSourceActor(state, id),
           lineNumber,
+          getFocusRegion(state),
           onFailure
         ),
       });

--- a/src/devtools/client/debugger/src/client/commands.ts
+++ b/src/devtools/client/debugger/src/client/commands.ts
@@ -19,6 +19,7 @@ import {
 } from "protocol/logpoint";
 import { ThreadFront, createPrimitiveValueFront, ValueFront } from "protocol/thread";
 import { WiredNamedValue } from "protocol/thread/pause";
+import { FocusRegion } from "ui/state/timeline";
 
 import { MAX_LINE_HITS_TO_FETCH } from "../actions/source-actors";
 import { SelectedFrame } from "../reducers/pause";
@@ -404,6 +405,7 @@ async function getSourceActorBreakableLines({ actor }: { actor: string }) {
 async function getSourceActorBreakpointHitCounts(
   { id }: { id: string },
   lineNumber: number,
+  focusRegion: FocusRegion | null,
   onFailure?: (e: any) => void
 ) {
   const locations = await ThreadFront.getBreakpointPositionsCompressed(id);
@@ -418,7 +420,7 @@ async function getSourceActorBreakpointHitCounts(
   return {
     max: upperBound,
     min: lowerBound,
-    ...(await ThreadFront.getHitCounts(id, locationsToFetch).catch(onFailure)),
+    ...(await ThreadFront.getHitCounts(id, locationsToFetch, focusRegion).catch(onFailure)),
   };
 }
 

--- a/src/devtools/client/debugger/src/reducers/source-actors.ts
+++ b/src/devtools/client/debugger/src/reducers/source-actors.ts
@@ -4,6 +4,8 @@
 
 import type { AnyAction, Action } from "@reduxjs/toolkit";
 import sortBy from "lodash/sortBy";
+import { setLoadedRegions } from "ui/reducers/app";
+import { setFocusRegion } from "ui/reducers/timeline";
 import type { UIState } from "ui/state";
 
 import { asSettled, asyncActionAsValue, AsyncValue } from "../utils/async-value";
@@ -108,8 +110,12 @@ export default function update(state = initial, action: AnyAction) {
       state = updateBreakpointHitCounts(state, action as SetSourceActorBreakpointHitCountsAction);
       break;
 
-    case "app/setLoadedRegions":
-      state.values = clearBreakpointHitCounts(state);
+    case setLoadedRegions.type:
+      state = { ...state, values: clearBreakpointHitCounts(state) };
+      break;
+
+    case setFocusRegion.type:
+      state = { ...state, values: clearBreakpointHitCounts(state) };
       break;
 
     case "SET_SOURCE_ACTOR_BREAKABLE_LINES":

--- a/src/devtools/client/webconsole/selectors/messages.ts
+++ b/src/devtools/client/webconsole/selectors/messages.ts
@@ -14,7 +14,7 @@ const { pointPrecedes } = require("protocol/execution-point-utils");
 const { MESSAGE_TYPE } = require("devtools/client/webconsole/constants");
 const { getCurrentTime, getFocusRegion } = require("ui/reducers/timeline");
 const { getExecutionPoint } = require("devtools/client/debugger/src/reducers/pause");
-const { isInTrimSpan } = require("ui/utils/timeline");
+const { isInFocusSpan } = require("ui/utils/timeline");
 
 export const getAllMessagesUiById = (state: UIState) => state.messages.messagesUiById;
 export const getCommandHistory = (state: UIState) => state.messages.commandHistory;
@@ -44,7 +44,7 @@ export const getVisibleMessages = createSelector(
 
       // Filter out messages that aren't within the focused region.
       if (focusRegion) {
-        if (!isInTrimSpan(executionPointTime, focusRegion)) {
+        if (!isInFocusSpan(executionPointTime, focusRegion)) {
           return false;
         }
       }

--- a/src/protocol/logpoint.ts
+++ b/src/protocol/logpoint.ts
@@ -9,16 +9,16 @@
 import { AnalysisEntry, ExecutionPoint, Location, PointDescription } from "@recordreplay/protocol";
 import { exceptionLogpointErrorReceived } from "devtools/client/webconsole/reducers/messages";
 import { EventId } from "devtools/server/actors/utils/event-breakpoints";
+import { UIStore } from "ui/actions";
+import { getAnalysisPointsForLocation, setAnalysisError, setAnalysisPoints } from "ui/reducers/app";
+import { pointsReceived } from "ui/reducers/timeline";
+import { ProtocolError } from "ui/state/app";
 
-import { assert, compareNumericStrings } from "./utils";
+import analysisManager, { AnalysisHandler, AnalysisParams } from "./analysisManager";
+import { logpointGetFrameworkEventListeners } from "./event-listeners";
 import { ThreadFront, ValueFront, Pause, createPrimitiveValueFront } from "./thread";
 import { PrimitiveValue } from "./thread/value";
-import { logpointGetFrameworkEventListeners } from "./event-listeners";
-import analysisManager, { AnalysisHandler, AnalysisParams } from "./analysisManager";
-import { UIStore } from "ui/actions";
-import { setAnalysisError, setAnalysisPoints } from "ui/reducers/app";
-import { getAnalysisPointsForLocation } from "ui/reducers/app";
-import { ProtocolError } from "ui/state/app";
+import { assert, compareNumericStrings } from "./utils";
 
 const { prefs } = require("ui/utils/prefs");
 
@@ -271,6 +271,7 @@ async function setMultiSourceLogpoint(
 
   handler.onAnalysisPoints = newPoints => {
     points.push(...newPoints);
+    store.dispatch(pointsReceived(points));
     if (showInConsole && !condition) {
       if (primitiveFronts) {
         showPrimitiveLogpoints(logGroupId, newPoints, primitiveFronts);

--- a/src/protocol/thread/thread.ts
+++ b/src/protocol/thread/thread.ts
@@ -36,9 +36,11 @@ import {
   responseBodyData,
   requestBodyData,
   findAnnotationsResult,
+  getHitCountsParameters,
 } from "@recordreplay/protocol";
 import groupBy from "lodash/groupBy";
 import uniqueId from "lodash/uniqueId";
+import { FocusRegion } from "ui/state/timeline";
 
 import { MappedLocationCache } from "../mapped-location-cache";
 import { client, log, addEventListener } from "../socket";
@@ -513,9 +515,17 @@ class _ThreadFront {
     return { contents, contentType };
   }
 
-  async getHitCounts(sourceId: SourceId, locations: SameLineSourceLocations[]) {
+  async getHitCounts(
+    sourceId: SourceId,
+    locations: SameLineSourceLocations[],
+    focusRegion: FocusRegion | null
+  ) {
     assert(this.sessionId, "no sessionId");
-    return client.Debugger.getHitCounts({ sourceId, locations, maxHits: 10000 }, this.sessionId);
+    let params: getHitCountsParameters = { sourceId, locations, maxHits: 10000 };
+    if (focusRegion) {
+      params.range = { begin: focusRegion.start.point, end: focusRegion.end.point };
+    }
+    return client.Debugger.getHitCounts(params, this.sessionId);
   }
 
   async getEventHandlerCounts(eventTypes: string[]) {

--- a/src/ui/components/NetworkMonitor/Table.tsx
+++ b/src/ui/components/NetworkMonitor/Table.tsx
@@ -7,6 +7,7 @@ import {
   useTable,
   TableInstance,
 } from "react-table";
+
 import { CanonicalRequestType, partialRequestsToCompleteSummaries, RequestSummary } from "./utils";
 
 export default function Table({

--- a/src/ui/components/Timeline/UnloadedRegions.tsx
+++ b/src/ui/components/Timeline/UnloadedRegions.tsx
@@ -1,9 +1,9 @@
+import clamp from "lodash/clamp";
 import { FC } from "react";
 import { useSelector } from "react-redux";
 import { getLoadedRegions } from "ui/reducers/app";
 import { getFocusRegion, getZoomRegion } from "ui/reducers/timeline";
 import { getVisiblePosition } from "ui/utils/timeline";
-import clamp from "lodash/clamp";
 
 export const UnloadedRegions: FC = () => {
   const loadedRegions = useSelector(getLoadedRegions);

--- a/src/ui/components/Timeline/index.tsx
+++ b/src/ui/components/Timeline/index.tsx
@@ -1,8 +1,6 @@
-import { mostRecentPaintOrMouseEvent } from "protocol/graphics";
-import { ThreadFront } from "protocol/thread/thread";
 import React, { useLayoutEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { seek, seekToTime, setTimelineState, setTimelineToTime } from "ui/actions/timeline";
+import { seekToTime, setTimelineToTime } from "ui/actions/timeline";
 import { selectors } from "ui/reducers";
 import { getTimeFromPosition } from "ui/utils/timeline";
 
@@ -22,6 +20,7 @@ import ProgressBars from "./ProgressBars";
 import Tooltip from "./Tooltip";
 import UnfocusedRegion from "./UnfocusedRegion";
 import { useFeature } from "ui/hooks/settings";
+import { setTimelineState } from "ui/reducers/timeline";
 
 export type EditMode = {
   dragOffset?: number;

--- a/src/ui/reducers/network.ts
+++ b/src/ui/reducers/network.ts
@@ -15,6 +15,7 @@ import sortBy from "lodash/sortBy";
 import sortedUniqBy from "lodash/sortedUniqBy";
 import { getFocusRegion } from "./timeline";
 import { partialRequestsToCompleteSummaries } from "ui/components/NetworkMonitor/utils";
+import { filterToFocusRegion } from "ui/utils/timeline";
 
 export type NetworkState = {
   events: RequestEventInfo[];
@@ -115,9 +116,7 @@ export const getFocusedRequests = (state: UIState) => {
   const requests = getRequests(state);
   const focusRegion = getFocusRegion(state);
 
-  return requests.filter(
-    r => !focusRegion || (r.time > focusRegion.startTime && r.time <= focusRegion.endTime)
-  );
+  return filterToFocusRegion(requests, focusRegion);
 };
 
 export const getFormattedFrames = createSelector(getFrames, getSources, (frames, sources) => {

--- a/src/ui/reducers/timeline.test.ts
+++ b/src/ui/reducers/timeline.test.ts
@@ -1,11 +1,16 @@
-import { EnhancedStore, Reducer, ThunkDispatch } from "@reduxjs/toolkit";
 import { setHasAllPaintPoints } from "protocol/graphics";
 import { createTestStore } from "test/testUtils";
 import { UIStore } from "ui/actions";
 
 import * as actions from "../actions/timeline";
 
-import { getCurrentTime, getFocusRegion, getHoverTime, getPlayback } from "./timeline";
+import {
+  getCurrentTime,
+  getFocusRegion,
+  getHoverTime,
+  getPlayback,
+  setTimelineState,
+} from "./timeline";
 
 describe("Redux timeline state", () => {
   let store = null as unknown as UIStore;
@@ -18,7 +23,7 @@ describe("Redux timeline state", () => {
 
     // Fill dummy data in by default.
     dispatch(
-      actions.setTimelineState({
+      setTimelineState({
         currentTime: 75,
         zoomRegion: { endTime: 100, scale: 1, startTime: 50 },
       })
@@ -34,7 +39,15 @@ describe("Redux timeline state", () => {
       dispatch(actions.toggleFocusMode());
       expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
         Object {
+          "end": Object {
+            "point": "",
+            "time": 80,
+          },
           "endTime": 80,
+          "start": Object {
+            "point": "",
+            "time": 70,
+          },
           "startTime": 70,
         }
       `);
@@ -130,7 +143,15 @@ describe("Redux timeline state", () => {
       );
       expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
         Object {
+          "end": Object {
+            "point": "",
+            "time": 50,
+          },
           "endTime": 50,
+          "start": Object {
+            "point": "",
+            "time": 50,
+          },
           "startTime": 50,
         }
       `);
@@ -144,7 +165,15 @@ describe("Redux timeline state", () => {
       );
       expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
         Object {
+          "end": Object {
+            "point": "",
+            "time": 110,
+          },
           "endTime": 110,
+          "start": Object {
+            "point": "",
+            "time": 110,
+          },
           "startTime": 110,
         }
       `);
@@ -164,7 +193,15 @@ describe("Redux timeline state", () => {
       );
       expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
         Object {
+          "end": Object {
+            "point": "",
+            "time": 80,
+          },
           "endTime": 80,
+          "start": Object {
+            "point": "",
+            "time": 80,
+          },
           "startTime": 80,
         }
       `);
@@ -184,7 +221,15 @@ describe("Redux timeline state", () => {
       );
       expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
         Object {
+          "end": Object {
+            "point": "",
+            "time": 60,
+          },
           "endTime": 60,
+          "start": Object {
+            "point": "",
+            "time": 60,
+          },
           "startTime": 60,
         }
       `);
@@ -208,7 +253,15 @@ describe("Redux timeline state", () => {
         dispatch(actions.setFocusRegionStartTime(65, false));
         expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
           Object {
+            "end": Object {
+              "point": "",
+              "time": 100,
+            },
             "endTime": 100,
+            "start": Object {
+              "point": "",
+              "time": 65,
+            },
             "startTime": 65,
           }
         `);
@@ -224,7 +277,15 @@ describe("Redux timeline state", () => {
         dispatch(actions.setFocusRegionStartTime(65, false));
         expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
           Object {
+            "end": Object {
+              "point": "",
+              "time": 70,
+            },
             "endTime": 70,
+            "start": Object {
+              "point": "",
+              "time": 65,
+            },
             "startTime": 65,
           }
         `);
@@ -236,7 +297,15 @@ describe("Redux timeline state", () => {
         dispatch(actions.setFocusRegionEndTime(65, false));
         expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
           Object {
+            "end": Object {
+              "point": "",
+              "time": 65,
+            },
             "endTime": 65,
+            "start": Object {
+              "point": "",
+              "time": 50,
+            },
             "startTime": 50,
           }
         `);
@@ -252,7 +321,15 @@ describe("Redux timeline state", () => {
         dispatch(actions.setFocusRegionEndTime(65, false));
         expect(getFocusRegion(store.getState())).toMatchInlineSnapshot(`
           Object {
+            "end": Object {
+              "point": "",
+              "time": 65,
+            },
             "endTime": 65,
+            "start": Object {
+              "point": "",
+              "time": 50,
+            },
             "startTime": 50,
           }
         `);

--- a/src/ui/state/timeline.ts
+++ b/src/ui/state/timeline.ts
@@ -1,4 +1,4 @@
-import { TimeRange, Location } from "@recordreplay/protocol";
+import { TimeRange, Location, TimeStampedPoint } from "@recordreplay/protocol";
 
 export interface ZoomRegion {
   endTime: number;
@@ -7,7 +7,12 @@ export interface ZoomRegion {
 }
 
 export interface FocusRegion {
+  // We are moving towards using TimeStampedPoints for all ranges on the client,
+  // to that end, we should avoid using `endTime` and `startTime` from this
+  // object whenever possible
+  end: TimeStampedPoint;
   endTime: number;
+  start: TimeStampedPoint;
   startTime: number;
 }
 
@@ -23,6 +28,7 @@ export interface TimelineState {
     time: number;
   } | null;
   playbackPrecachedTime: number;
+  points: TimeStampedPoint[];
   recordingDuration: number | null;
   shouldAnimate: boolean;
   showFocusModeControls: boolean;

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -1,7 +1,7 @@
 import { PrefsHelper } from "devtools/client/shared/prefs";
-const { asyncStoreHelper } = require("devtools/shared/async-store-helper");
-
 import { pref } from "devtools/shared/services";
+
+const { asyncStoreHelper } = require("devtools/shared/async-store-helper");
 
 // app prefs.
 pref("devtools.event-listeners-breakpoints", true);
@@ -33,6 +33,7 @@ pref("devtools.features.logProtocol", false);
 pref("devtools.features.unicornConsole", true);
 pref("devtools.features.showRedux", true);
 pref("devtools.features.enableLargeText", false);
+pref("devtools.features.softFocus", false);
 
 export const prefs = new PrefsHelper("devtools", {
   eventListenersBreakpoints: ["Bool", "event-listeners-breakpoints"],
@@ -66,6 +67,7 @@ export const features = new PrefsHelper("devtools.features", {
   unicornConsole: ["Bool", "unicornConsole"],
   showRedux: ["Bool", "showRedux"],
   enableLargeText: ["Bool", "enableLargeText"],
+  softFocus: ["Bool", "softFocus"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {

--- a/src/ui/utils/timeline.ts
+++ b/src/ui/utils/timeline.ts
@@ -1,6 +1,5 @@
-import { TimeStampedPointRange } from "@recordreplay/protocol";
-import { format, isValid } from "date-fns";
-import { clamp } from "lodash";
+import { TimeStamp, TimeStampedPoint, TimeStampedPointRange } from "@recordreplay/protocol";
+import { clamp, sortedIndexBy, sortedLastIndexBy } from "lodash";
 import { FocusRegion, ZoomRegion } from "ui/state/timeline";
 
 import { timelineMarkerWidth } from "../constants";
@@ -207,7 +206,7 @@ export function isSameTimeStampedPointRange(
   return sameBegin && sameEnd;
 }
 
-export function isInTrimSpan(time: number, focusRegion: FocusRegion) {
+export function isInFocusSpan(time: number, focusRegion: FocusRegion) {
   const { startTime, endTime } = focusRegion;
 
   return time >= startTime && time <= endTime;
@@ -274,4 +273,24 @@ export function isFocusRegionSubset(
       nextFocusRegion.endTime <= prevFocusRegion.endTime
     );
   }
+}
+
+export function filterToFocusRegion<T extends TimeStampedPoint>(
+  sortedPoints: T[],
+  focusRegion: FocusRegion | null
+): T[] {
+  if (!focusRegion) {
+    return sortedPoints;
+  }
+  const startIndex = sortedIndexBy(
+    sortedPoints,
+    { time: focusRegion.start.time, point: "" },
+    p => p.time
+  );
+  const endIndex = sortedLastIndexBy(
+    sortedPoints,
+    { time: focusRegion.end.time, point: "" },
+    p => p.time
+  );
+  return sortedPoints.slice(startIndex, endIndex);
 }


### PR DESCRIPTION
### Motivation and Changes

Soft focus has been a theoretical goal of the front-end team for close to a month at this point (although it was really just me tinkering and thinking for the first couple of weeks). And that has produced some results, but there's still quite a bit in motion, as well as some unknowns. Technically, all we need to do to enable V1 of soft focus is *not* onload regions upon the focus window changing (we still issue the load command, because if we are already loaded it is a noop, and if the backend has unloaded a portion of the recording that the user has asked for, we need to ensure that we reload it). One thing that jumps out as soon as you enable soft-focus is that we need more specific points to pass for ranges to backend functions like `getHitCounts`. I tried just using `getPointNearTime` with the focus window times, but that is no good, because it always returns the beginning of the region, so sub-region focus windows end up looking like windows of 0 length in point-terms. Instead, I do a more sophisticated version of what we were doing previously with timeline seeks:

 Any time we get a timestamped point from the backend, we store it in a sorted array in redux. Then, when the user sets the focus window, we use that point array to approximate the point that lies near the user's selected times. This is sometimes not very fine-grained, but here's the elegant part: if there is stuff that *matters* around the area that is being selected (for instance, analysis hits), then we will have stored fine-grained point correlations already, and we won't be vastly off. Conversely, if the points we have are really rough approximations, it is unlikely that they will affect anything anyways, because the user has not looked at anything of interest around them.

I was prepared for this to be terrible, but in my relatively limited experience... it's pretty good? I think at the very least it is good enough to enable it internally and poke around.

Followups:

- We should actually soft-focus analyses, but I will wait on Mark's rewrite of the analysisManager before making that change.

