### PR TITLE
Organization only can edit team name

### DIFF
--- a/src/ui/components/shared/WorkspaceSettingsModal/GeneralSettings.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/GeneralSettings.tsx
@@ -83,14 +83,21 @@ const GeneralSettings = ({ workspaceId }: { workspaceId: string }) => {
     <div className="space-y-4">
       <Row>
         <Label>Name</Label>
-        <Input>
-          <input
-            className="w-full rounded-md border-textFieldBorder bg-themeTextFieldBgcolor text-sm"
-            type="text"
-            value={name}
-            onChange={e => setName(e.currentTarget.value)}
-          />
-        </Input>
+        {/* Only enable workspace name edit if team is organization https://github.com/RecordReplay/devtools/issues/6799 */}
+        {workspace.isOrganization ? (
+          <Input>
+            <input
+              className="w-full rounded-md border-textFieldBorder bg-themeTextFieldBgcolor text-sm"
+              type="text"
+              value={name}
+              onChange={e => setName(e.currentTarget.value)}
+            />
+          </Input>
+        ) : (
+          <div className="w-8/12">
+            <div className="text-sm py-2">{name}</div>
+          </div>
+        )}
       </Row>
       <Row>
         <Label className="self-start">Logo</Label>

--- a/src/ui/components/shared/WorkspaceSettingsModal/OrganizationSettings.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/OrganizationSettings.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
 import hooks from "ui/hooks";
-import { PartialWorkspaceSettingsFeatures, WorkspaceSettings } from "ui/types";
+import { PartialWorkspaceSettingsFeatures } from "ui/types";
 import useDebounceState from "./useDebounceState";
 
 const Label = ({ className, children }: { className?: string; children: React.ReactNode }) => {

--- a/src/ui/components/shared/WorkspaceSettingsModal/OrganizationSettings.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/OrganizationSettings.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
 import hooks from "ui/hooks";
 import { PartialWorkspaceSettingsFeatures } from "ui/types";
+
 import useDebounceState from "./useDebounceState";
 
 const Label = ({ className, children }: { className?: string; children: React.ReactNode }) => {


### PR DESCRIPTION
fix #6799

Disabled text input if team is not Organization.

### Screen Shot (When edit disabled)
<img width="624" alt="Screen Shot 2022-05-24 at 19 06 11" src="https://user-images.githubusercontent.com/5501268/170007542-8f3f6a5e-f363-456c-8d5b-46dd7c8d0958.png">

