### PR TITLE
Call Stack: show original function name if available (#3150)

### DIFF
--- a/src/devtools/client/debugger/src/client/create.js
+++ b/src/devtools/client/debugger/src/client/create.js
@@ -30,7 +30,7 @@ export async function createFrame(frame, index = 0, asyncIndex = 0) {
     };
   }
 
-  const displayName = frame.functionName || `(${frame.type})`;
+  const displayName = frame.originalFunctionName || frame.functionName || `(${frame.type})`;
 
   return {
     id: `${asyncIndex}:${index}`,


### PR DESCRIPTION
Follow-up to RecordReplay/backend#5677, supersedes #6847.