### PR TITLE
Changed error dialog wording for unknown fatal errors

### DIFF
--- a/src/ui/components/shared/Dialog.tsx
+++ b/src/ui/components/shared/Dialog.tsx
@@ -39,7 +39,7 @@ export const DialogDescription = ({
   ...props
 }: HTMLProps<HTMLParagraphElement>) => {
   return (
-    <p {...props} className="mb-2 text-center text-sm text-gray-500">
+    <p {...props} className="mb-2 whitespace-pre-wrap text-center text-sm text-gray-500">
       {children}
     </p>
   );

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -72,8 +72,7 @@ enum SessionError {
 const SessionErrorMessages: Record<number, string> = {
   [SessionError.BackendDeploy]: "Please wait a few minutes and try again.",
   [SessionError.NodeTerminated]: "Our servers hiccuped but things should be back to normal soon.",
-  [SessionError.UnknownFatalError]:
-    "Something went wrong. Refreshing the page should help. Please try recording again if the problem persists.",
+  [SessionError.UnknownFatalError]: "Refreshing should help.\nIf not, please try recording again.",
   [SessionError.KnownFatalError]:
     "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
   [SessionError.OldBuild]:

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -72,7 +72,8 @@ enum SessionError {
 const SessionErrorMessages: Record<number, string> = {
   [SessionError.BackendDeploy]: "Please wait a few minutes and try again.",
   [SessionError.NodeTerminated]: "Our servers hiccuped but things should be back to normal soon.",
-  [SessionError.UnknownFatalError]: "There was an error. Please try recording again.",
+  [SessionError.UnknownFatalError]:
+    "Something went wrong. Refreshing the page should help. Please try recording again if the problem persists.",
   [SessionError.KnownFatalError]:
     "This error has been fixed in an updated version of Replay. Please try upgrading Replay and trying a new recording.",
   [SessionError.OldBuild]:


### PR DESCRIPTION
Resolves #6920.

<img width="961" alt="Screen Shot 2022-05-24 at 7 04 17 PM" src="https://user-images.githubusercontent.com/29597/170145921-40810f86-769c-42ff-8adb-7f9dcdded0ff.png">

