### PR TITLE
Use the focus window points for console filtering

### DIFF
--- a/src/devtools/client/webconsole/actions/messages.ts
+++ b/src/devtools/client/webconsole/actions/messages.ts
@@ -18,6 +18,7 @@ import { Pause, ValueFront, ThreadFront as ThreadFrontType } from "protocol/thre
 import { WiredMessage, wireUpMessage } from "protocol/thread/thread";
 import type { UIStore, UIThunkAction } from "ui/actions";
 import { onConsoleOverflow } from "ui/actions/session";
+import { pointsReceived } from "ui/reducers/timeline";
 import { FocusRegion } from "ui/state/timeline";
 import { isFocusRegionSubset } from "ui/utils/timeline";
 
@@ -232,6 +233,13 @@ export function messagesAdd(
     }
     // TODO This really a good type here?
     const messages: InternalMessage[] = packets.map(packet => prepareMessage(packet, idGenerator));
+    dispatch(
+      pointsReceived(
+        messages
+          .filter(p => p.executionPoint && p.executionPointTime)
+          .map(p => ({ time: p.executionPointTime!, point: p.executionPoint! }))
+      )
+    );
     dispatch(messagesAdded(messages));
   };
 }


### PR DESCRIPTION
This will now use the closest timeline point, rather than the approximation given by the backend's `findPointNearTime` (which was sometimes off by up to several seconds, blame whoever wrote that [spoiler alert: it was me 😬 ]). While sometimes this could result in a less precise bounding, it will often result in a *more* precise bounding area, because the area that the user is zooming in on is very likely to have had some kind of dense activity which would have (we hope) added entries to `state.timeline.points`.