### PR TITLE
Fix open-file fuzzy matching highlihgt bug

### DIFF
--- a/src/devtools/client/debugger/src/components/QuickOpenModal.js
+++ b/src/devtools/client/debugger/src/components/QuickOpenModal.js
@@ -339,7 +339,14 @@ export class QuickOpenModal extends Component {
         tagOpen: '<mark class="highlight">',
       },
     };
-    const html = fuzzyAldrin.wrap(candidateString, query, options);
+
+    // There might be a match in the path but not the title.
+    // In this case just render the whole title, un-styled.
+    //
+    // Note that "fuzzaldrin-plus" returns an HTML string usually,
+    // but if either the input string or the query string are empty, it returns an array.
+    const html = query ? fuzzyAldrin.wrap(candidateString, query, options) : candidateString;
+
     return <div dangerouslySetInnerHTML={{ __html: html }} />;
   }
 


### PR DESCRIPTION
Resolves #6360

Loom walk through of the change:
https://www.loom.com/share/0b4db4e890be44d181a469d8d1442de4

Strange behavioral quirk in our NPM package to return an empty array instead of `""` or `null`:
https://github.com/jeancroy/fuzz-aldrin-plus/blob/84eac1d73bacbbd11978e6960f4aa89f8396c540/src/fuzzaldrin.coffee#L31-L35