### PR TITLE
Disable eslint/import/order rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
   "rules": {
     "curly": "error",
     "import/order": [
-      "warn",
+      "off",
       {
         "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "object"],
         "newlines-between": "always",


### PR DESCRIPTION
This rule is introducing a lot of unfixed errors from existing code in #6954 and it sounds like there's some debate on its utility. Rather than block that PR, suggesting we disable the rule for now and re-enable it either with different config or with a set of fixes for the existing issues.