### PR TITLE
Show duration for individual requests

### DIFF
--- a/src/ui/components/ProtocolViewer.module.css
+++ b/src/ui/components/ProtocolViewer.module.css
@@ -215,6 +215,7 @@
 }
 .DetailPanelHeaderSecondary {
   flex: 0 0 auto;
+  padding-right: 0.5rem;
 }
 .DetailPanelHeader {
   font-size: 0.9rem;

--- a/src/ui/components/ProtocolViewer.tsx
+++ b/src/ui/components/ProtocolViewer.tsx
@@ -167,6 +167,7 @@ function ProtocolRequestDetail({
             )}
           </span>
           <small className={styles.DetailPanelHeaderSecondary}>
+            {response ? `(${formatDuration(response.recordedAt - request.recordedAt)}) ` : ""}
             {formatTimestamp(request.recordedAt)}
           </small>
         </>


### PR DESCRIPTION
In the protocol viewer, sometimes you see that a group of requests was slow, but only *some* were slow, and seeing their durations in the detail view helps to narrow down.

![CleanShot 2022-05-25 at 23 57 01](https://user-images.githubusercontent.com/5903784/170434847-0ddd854e-0967-4659-bd21-bbf158d9bcb0.png)

