### PR TITLE
Don't try to create initial pauses in unloaded regions

### DIFF
--- a/src/devtools/client/debugger/src/actions/pause/fetchScopes.js
+++ b/src/devtools/client/debugger/src/actions/pause/fetchScopes.js
@@ -14,7 +14,7 @@ export function fetchScopes(cx) {
       return;
     }
 
-    const scopes = dispatch({
+    dispatch({
       type: "ADD_SCOPES",
       cx,
       thread: cx.thread,


### PR DESCRIPTION
We used to have a simpler pause world before focus and turbo replays. Now, we have to do things like handle pauses that try to get created in regions that it is not possible to create a pause in (at the moment). Upon loading, we could do a few things:
- We could not try to pause in unloaded regions, and just go to the end instead
- We could try to load the requested region
- I think the latter is better, but the former is a *lot* easier 😅 

Related to #6548 , though it's not a perfect solve.