### PR TITLE
Keep a record of whether the upload progress was shown during loading idle time

### DIFF
--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -105,10 +105,7 @@ function _DevTools({
   const { isAuthenticated } = useAuth0();
   const recordingId = useGetRecordingId();
   const { recording } = useGetRecording(recordingId);
-  const { trackLoadingIdleTime } = useTrackLoadingIdleTime(
-    uploadComplete ? "warm" : "cold",
-    recording
-  );
+  const { trackLoadingIdleTime } = useTrackLoadingIdleTime(uploadComplete, recording);
   const { userIsAuthor, loading } = useUserIsAuthor();
   const isExternalRecording = useMemo(
     () => recording?.user && !recording.user.internal,

--- a/src/ui/hooks/tracking.ts
+++ b/src/ui/hooks/tracking.ts
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { getUploading } from "ui/reducers/app";
 import { Recording } from "ui/types";
 import { trackTiming } from "ui/utils/telemetry";
 
-type LoadingContext = "warm" | "cold";
-
-export function useTrackLoadingIdleTime(context: LoadingContext, recording?: Recording) {
+export function useTrackLoadingIdleTime(uploadComplete: boolean, recording?: Recording) {
+  const uploading = useSelector(getUploading);
+  const context = uploadComplete ? "warm" : "cold";
   const [started, setStarted] = useState(false);
+  const [uploadProgressShown, setUploadProgressShown] = useState(false);
 
   useEffect(() => {
     if (recording && !started) {
@@ -13,9 +16,14 @@ export function useTrackLoadingIdleTime(context: LoadingContext, recording?: Rec
       trackTiming("kpi-loading-idle-time");
     }
   }, [recording, started, setStarted]);
+  useEffect(() => {
+    if (uploading) {
+      setUploadProgressShown(true);
+    }
+  }, [uploading]);
 
   const trackLoadingIdleTime = (sessionId: string) => {
-    trackTiming("kpi-loading-idle-time", { sessionId, context });
+    trackTiming("kpi-loading-idle-time", { sessionId, context, uploadProgressShown });
   };
 
   return { trackLoadingIdleTime };


### PR DESCRIPTION
This was from a conversation with @gideonred.

We wanted to track the duration that the user is looking at our loading progress bar so [we added a duration tracker](https://github.com/RecordReplay/devtools/pull/6804) (`kpi-loading-idle-time`). 

Turns out our loading/uploading progress logic is so convoluted that the initial implementation of that tracker was reporting incorrect durations. Right now, doing this the "correct" way would require a refactor (probably significant) of how we [load the devtools app](https://github.com/RecordReplay/devtools/issues/5848).

For now, so we have actionable data in honeycomb, @gideonred requested that we add a boolean flag in the event. This way, we can use that flag in honeycomb to filter out warm start events that showed the upload progress screen. For those cases, we're assuming that the user's internet connection is causing the upload progress screen to show up at all — and that's data that we don't particularly care about.

That, theoretically, leaves us with the warm start events where the loading progress bar was shown.