### PR TITLE
Add tests and testRuns views to the library

### DIFF
--- a/src/graphql/GetWorkspaceRecordings.ts
+++ b/src/graphql/GetWorkspaceRecordings.ts
@@ -72,6 +72,7 @@ export interface GetWorkspaceRecordings_node_Workspace {
   __typename: "Workspace";
   id: string;
   recordings: GetWorkspaceRecordings_node_Workspace_recordings | null;
+  tests: any[] | null;
 }
 
 export type GetWorkspaceRecordings_node = GetWorkspaceRecordings_node_Recording | GetWorkspaceRecordings_node_Workspace;

--- a/src/ui/components/Library/Content/Recordings.tsx
+++ b/src/ui/components/Library/Content/Recordings.tsx
@@ -1,0 +1,100 @@
+import { RecordingId } from "@replayio/protocol";
+import { sortBy } from "lodash";
+import { useMemo, useState } from "react";
+import { SecondaryButton } from "ui/components/shared/Button";
+import { Recording } from "ui/types";
+import { isReplayBrowser } from "ui/utils/environment";
+import RecordingRow from "../RecordingRow";
+import styles from "../Library.module.css";
+
+function getErrorText() {
+  if (isReplayBrowser()) {
+    return "Please open a new tab and press the blue record button to record a Replay";
+  }
+
+  return <DownloadLinks />;
+}
+
+function DownloadLinks() {
+  const [clicked, setClicked] = useState(false);
+
+  if (clicked) {
+    return (
+      <div className="flex flex-col space-y-6" style={{ maxWidth: "24rem" }}>
+        <div>Download started.</div>
+        <div>{`Once the download is finished, open the Replay Browser installer to install Replay`}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col space-y-6 text-sm" style={{ maxWidth: "24rem" }}>
+      <div className="text-lg">{`👋 This is where your replays will go!`}</div>
+    </div>
+  );
+}
+
+export function Recordings({
+  recordings,
+  selectedIds,
+  setSelectedIds,
+  isEditing,
+}: {
+  recordings: Recording[];
+  selectedIds: string[];
+  setSelectedIds: (ids: string[]) => void;
+  isEditing: boolean;
+}) {
+  const [showMore, toggleShowMore] = useState(false);
+
+  const shownRecordings = useMemo(() => {
+    const sortedRecordings = sortBy(recordings, recording => {
+      const ascOrder = false;
+      const order = ascOrder ? 1 : -1;
+      return order * new Date(recording.date).getTime();
+    });
+    return showMore ? sortedRecordings : sortedRecordings.slice(0, 100);
+  }, [recordings, showMore]);
+
+  const addSelectedId = (recordingId: RecordingId) => setSelectedIds([...selectedIds, recordingId]);
+  const removeSelectedId = (recordingId: RecordingId) =>
+    setSelectedIds(selectedIds.filter(id => id !== recordingId));
+
+  if (!recordings.length) {
+    const errorText = getErrorText();
+
+    return (
+      <>
+        <section
+          className={`grid flex-grow items-center justify-center text-sm ${styles.recordingsBackground}`}
+        >
+          <span>{errorText}</span>
+        </section>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div
+        className={`recording-list flex flex-col overflow-y-auto rounded-md text-sm shadow-md ${styles.recordingList}`}
+      >
+        {shownRecordings.map((r, i) => (
+          <RecordingRow
+            key={i}
+            recording={r}
+            selected={selectedIds.includes(r.id)}
+            {...{ addSelectedId, removeSelectedId, isEditing }}
+          />
+        ))}
+        {!showMore && recordings.length > 100 && (
+          <div className="flex justify-center p-4">
+            <SecondaryButton className="" color="blue" onClick={() => toggleShowMore(!showMore)}>
+              Show More
+            </SecondaryButton>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/ui/components/Library/Content/TestRuns.tsx
+++ b/src/ui/components/Library/Content/TestRuns.tsx
@@ -1,0 +1,75 @@
+import { useContext } from "react";
+import { useSelector } from "react-redux";
+import { TestRun, useGetTestRunsForWorkspace } from "ui/hooks/tests";
+import { getWorkspaceId } from "ui/reducers/app";
+import { LibraryContext } from "../useFilters";
+import styles from "../Library.module.css";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
+
+export function TestRuns() {
+  const workspaceId = useSelector(getWorkspaceId);
+  const { setPreview } = useContext(LibraryContext);
+  const { testRuns, loading } = useGetTestRunsForWorkspace(workspaceId!);
+
+  if (loading) {
+    return <div>Loading…</div>;
+  }
+
+  return (
+    <>
+      <div
+        className={`recording-list flex flex-col overflow-y-auto rounded-md text-sm shadow-md ${styles.recordingList}`}
+      >
+        {testRuns?.map((t, i) => (
+          <TestRunRow
+            testRun={t}
+            key={i}
+            onClick={() => setPreview({ id: t.id, view: "test-runs" })}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+function TestRunRow({ testRun, onClick }: { testRun: TestRun; onClick: () => void }) {
+  const { id, recordings } = testRun;
+  const results = testRun.recordings.map(r => r.metadata?.test?.result);
+
+  // Todo: Have a separate treatment for the "timedOut" result.
+  return (
+    <div
+      className="flex flex-row items-center justify-between cursor-pointer border-b border-themeBorder flex-grow overflow-hidden py-3 px-4 space-x-r"
+      onClick={onClick}
+    >
+      <div className="flex flex-row space-x-2">
+        <MaterialIcon
+          iconSize="4xl"
+          className={results.every(r => r === "passed") ? "text-green-500" : "text-red-500"}
+        >
+          {results.every(r => r === "passed") ? "check_circle" : "error"}
+        </MaterialIcon>
+        <div className="flex flex-col space-y-0.5">
+          <div>Deploy PR ({id})</div>
+          <div className="flex flex-row space-x-4 items-center text-gray-400 font-light">
+            <div className="flex flex-row space-x-1 items-center">
+              <MaterialIcon>merge</MaterialIcon>
+              <div>{recordings[0].metadata.source?.commit.id.slice(0, 7)}</div>
+            </div>
+            <div>{new Date(recordings[0].date).toDateString()}</div>
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-row space-x-2">
+        <div className="bg-green-100 text-green-500 px-4 py-2 rounded-3xl flex space-x-2 items-center">
+          <MaterialIcon iconSize="2xl">check_circle</MaterialIcon>
+          <div>{`${results.filter(r => r === "passed").length} pass`}</div>
+        </div>
+        <div className="bg-red-100 text-red-500 px-4 py-2 rounded-3xl flex space-x-2 items-center">
+          <MaterialIcon iconSize="2xl">error</MaterialIcon>
+          <div>{`${results.filter(r => r === "failed").length} fail`}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/Library/Content/TestRuns.tsx
+++ b/src/ui/components/Library/Content/TestRuns.tsx
@@ -65,10 +65,12 @@ function TestRunRow({ testRun, onClick }: { testRun: TestRun; onClick: () => voi
           <MaterialIcon iconSize="2xl">check_circle</MaterialIcon>
           <div>{`${results.filter(r => r === "passed").length} pass`}</div>
         </div>
-        <div className="bg-red-100 text-red-500 px-4 py-2 rounded-3xl flex space-x-2 items-center">
-          <MaterialIcon iconSize="2xl">error</MaterialIcon>
-          <div>{`${results.filter(r => r === "failed").length} fail`}</div>
-        </div>
+        {results.filter(r => r === "failed").length === 0 ? null : (
+          <div className="bg-red-100 text-red-500 px-4 py-2 rounded-3xl flex space-x-2 items-center">
+            <MaterialIcon iconSize="2xl">error</MaterialIcon>
+            <div>{`${results.filter(r => r === "failed").length} fail`}</div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/ui/components/Library/Content/Tests.tsx
+++ b/src/ui/components/Library/Content/Tests.tsx
@@ -1,0 +1,65 @@
+import { useContext } from "react";
+import { useSelector } from "react-redux";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
+import { Test, useGetTestsForWorkspace } from "ui/hooks/tests";
+import { getWorkspaceId } from "ui/reducers/app";
+import { LibraryContext } from "../useFilters";
+import styles from "../Library.module.css";
+
+export function Tests() {
+  const workspaceId = useSelector(getWorkspaceId);
+  const { setPreview } = useContext(LibraryContext);
+  const { tests, loading } = useGetTestsForWorkspace(workspaceId!);
+
+  if (loading) {
+    return <div>Loading…</div>;
+  }
+
+  return (
+    <>
+      <div
+        className={`recording-list flex flex-col overflow-y-auto rounded-md text-sm shadow-md ${styles.recordingList}`}
+      >
+        {tests?.map((t, i) => (
+          <TestRow test={t} key={i} onClick={() => setPreview({ id: t.path, view: "tests" })} />
+        ))}
+      </div>
+    </>
+  );
+}
+
+function TestRow({ test, onClick }: { test: Test; onClick: () => void }) {
+  const { path, recordings } = test;
+
+  const results = test.recordings.map(r => r.metadata?.test?.result);
+
+  // Todo: Have a separate treatment for the "timedOut" result.
+  return (
+    <div
+      className="flex flex-row cursor-pointer border-b border-themeBorder flex-grow overflow-hidden py-3 px-4 items-center space-x-4 justify-between"
+      onClick={onClick}
+    >
+      <div className="flex space-x-4 items-center">
+        <div className="flex flex-col space-y-0.5">
+          <div>
+            {path[path.length - 2]} ({recordings.length})
+          </div>
+          <div className="font-light text-gray-400 flex items-center space-x-1">
+            <MaterialIcon>description</MaterialIcon>
+            <div>{path.slice(1).join(" > ")}</div>
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-row space-x-1 h-5">
+        {results.length < 10
+          ? new Array(10 - results.length)
+              .fill("")
+              .map((_, i) => <div key={i} className={`h-full w-2 bg-gray-300`} />)
+          : null}
+        {results.map((r, i) => (
+          <div key={i} className={`h-full w-2 ${r === "passed" ? "bg-green-500" : "bg-red-500"}`} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/Library/FilterBar.tsx
+++ b/src/ui/components/Library/FilterBar.tsx
@@ -3,15 +3,18 @@ import React, { ChangeEvent, KeyboardEvent, useContext } from "react";
 import { TextInput } from "../shared/Forms";
 
 import { FilterDropdown } from "./FilterDropdown";
+import { View } from "./useFilters";
 
 export function FilterBar({
   displayedString,
   setDisplayedText,
   setAppliedText,
+  setView,
 }: {
   displayedString: string;
   setDisplayedText: (str: string) => void;
   setAppliedText: (str: string) => void;
+  setView: (view: View) => void;
 }) {
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     setDisplayedText(e.target.value);
@@ -24,7 +27,7 @@ export function FilterBar({
 
   return (
     <div className="flex flex-grow relative items-center space-x-3">
-      <FilterDropdown setAppliedText={setAppliedText} />
+      <FilterDropdown setAppliedText={setAppliedText} setView={setView} />
       <div className="flex flex-grow">
         <TextInput
           value={displayedString}

--- a/src/ui/components/Library/FilterDropdown.tsx
+++ b/src/ui/components/Library/FilterDropdown.tsx
@@ -1,16 +1,25 @@
 import { useState } from "react";
 
 import PortalDropdown from "../shared/PortalDropdown";
-
-import { Dropdown, DropdownItem } from "./LibraryDropdown";
+import { useFeature } from "ui/hooks/settings";
+import { Dropdown, DropdownDivider, DropdownItem } from "./LibraryDropdown";
+import { View } from "./useFilters";
 
 const daysInSeconds = (days: number) => 1000 * 60 * 60 * 24 * days;
 
-export function FilterDropdown({ setAppliedText }: { setAppliedText: (str: string) => void }) {
+export function FilterDropdown({
+  setAppliedText,
+  setView,
+}: {
+  setAppliedText: (str: string) => void;
+  setView: (view: View) => void;
+}) {
   const [expanded, setExpanded] = useState(false);
+  const { value: testSupport } = useFeature("testSupport");
 
   const setStringAndCollapseDropdown = (str: string) => {
     setAppliedText(str);
+    setView("recordings");
     setExpanded(false);
   };
   const handleCreatedSince = (days: number) => {
@@ -18,6 +27,10 @@ export function FilterDropdown({ setAppliedText }: { setAppliedText: (str: strin
     const isoString = new Date(new Date().getTime() - secondsAgo).toISOString().substr(0, 10);
 
     return setStringAndCollapseDropdown(`created:${isoString}`);
+  };
+  const handleSetView = (view: View) => {
+    setExpanded(false);
+    setView(view);
   };
 
   const button = (
@@ -41,6 +54,18 @@ export function FilterDropdown({ setAppliedText }: { setAppliedText: (str: strin
         <DropdownItem onClick={() => setStringAndCollapseDropdown("target:node")}>
           Node replays
         </DropdownItem>
+        {testSupport ? (
+          <>
+            <DropdownDivider />
+            <DropdownItem onClick={() => handleSetView("recordings")}>
+              Show Recordings View
+            </DropdownItem>
+            <DropdownItem onClick={() => handleSetView("tests")}>Show Tests View</DropdownItem>
+            <DropdownItem onClick={() => handleSetView("test-runs")}>
+              Show Test Runs View
+            </DropdownItem>
+          </>
+        ) : null}
       </Dropdown>
     </PortalDropdown>
   );

--- a/src/ui/components/Library/Library.tsx
+++ b/src/ui/components/Library/Library.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import useAuth0 from "ui/utils/useAuth0";
 import LogRocket from "ui/utils/logrocket";
@@ -12,7 +12,7 @@ import { Nag, useGetUserInfo } from "ui/hooks/users";
 import LoadingScreen from "../shared/LoadingScreen";
 import { FilterBar } from "./FilterBar";
 import Sidebar from "./Sidebar";
-import { LibraryFiltersContext, useFilters } from "./useFilters";
+import { LibraryContext, useFilters, View } from "./useFilters";
 import ViewerRouter from "./ViewerRouter";
 import LaunchButton from "../shared/LaunchButton";
 import { trackEvent } from "ui/utils/telemetry";
@@ -77,6 +77,8 @@ function Library({
 }: LibraryProps) {
   const router = useRouter();
   const { displayedString, setDisplayedText, setAppliedText, filter } = useFilters();
+  const [view, setView] = useState<View>("recordings");
+  const [preview, setPreview] = useState<{ id: string | string[]; view: View } | null>(null);
   const updateDefaultWorkspace = hooks.useUpdateDefaultWorkspace();
   const dismissNag = hooks.useDismissNag();
 
@@ -120,7 +122,7 @@ function Library({
   }
 
   return (
-    <LibraryFiltersContext.Provider value={{ filter }}>
+    <LibraryContext.Provider value={{ filter, view, preview, setPreview }}>
       <main className="flex h-full w-full flex-row">
         <Sidebar nonPendingWorkspaces={workspaces} />
         <div className="flex flex-grow flex-col overflow-x-hidden">
@@ -129,13 +131,14 @@ function Library({
               displayedString={displayedString}
               setDisplayedText={setDisplayedText}
               setAppliedText={setAppliedText}
+              setView={setView}
             />
             <LaunchButton />
           </div>
           <ViewerRouter />
         </div>
       </main>
-    </LibraryFiltersContext.Provider>
+    </LibraryContext.Provider>
   );
 }
 

--- a/src/ui/components/Library/Preview/Preview.tsx
+++ b/src/ui/components/Library/Preview/Preview.tsx
@@ -1,0 +1,16 @@
+import { useContext } from "react";
+import { LibraryContext } from "../useFilters";
+import { TestPreview } from "./TestPreview";
+import { TestRunPreview } from "./TestRunPreview";
+
+export function Preview() {
+  const { preview } = useContext(LibraryContext);
+  return (
+    <div
+      className="flex flex-col bg-white rounded-md shadow-md text-sm p-4 space-y-2"
+      style={{ width: "30rem" }}
+    >
+      {preview?.view === "tests" ? <TestPreview /> : <TestRunPreview />}
+    </div>
+  );
+}

--- a/src/ui/components/Library/Preview/ReplayRows.tsx
+++ b/src/ui/components/Library/Preview/ReplayRows.tsx
@@ -1,0 +1,50 @@
+import MaterialIcon from "ui/components/shared/MaterialIcon";
+import { Recording } from "ui/types";
+
+export function ReplayRows({ recordings }: { recordings: Recording[] }) {
+  return (
+    <>
+      {recordings.map((r, i) => (
+        <ReplayRow recording={r} key={i} />
+      ))}
+    </>
+  );
+}
+
+function ReplayRow({ recording }: { recording: Recording }) {
+  const { metadata, date } = recording;
+
+  return (
+    <a
+      href={`/recording/${recording.id}`}
+      target="_blank"
+      rel="noreferrer noopener"
+      className="hover:underline"
+    >
+      <div className="flex flex-row items-center space-x-2">
+        <ResultIcon result={metadata.test?.result} />
+        <div className="flex flex-row space-x-2 text-gray-500">
+          <div>{new Date(date).toDateString()}</div>
+          <div className="flex flex-row space-x-1 items-center">
+            <div>{metadata.source?.branch || "branch_name"}</div>
+            <div>{metadata.source?.commit.id.slice(0, 7) || "commit_id"}</div>
+            <div>{recording.duration * 1000}s</div>
+          </div>
+        </div>
+      </div>
+    </a>
+  );
+}
+
+function ResultIcon({ result }: { result?: "passed" | "failed" | "timedOut" }) {
+  if (result === "passed") {
+    return <MaterialIcon className="text-green-500">check_circle</MaterialIcon>;
+  } else if (result === "failed") {
+    return <MaterialIcon className="text-red-500">error</MaterialIcon>;
+  } else if (result === "timedOut") {
+    // TODO: Add a timeout icon
+    return null;
+  }
+
+  return null;
+}

--- a/src/ui/components/Library/Preview/TestPreview.tsx
+++ b/src/ui/components/Library/Preview/TestPreview.tsx
@@ -1,0 +1,29 @@
+import { useContext } from "react";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
+import { useGetTest } from "ui/hooks/tests";
+import { LibraryContext } from "../useFilters";
+import { ReplayRows } from "./ReplayRows";
+
+export function TestPreview() {
+  const { preview } = useContext(LibraryContext);
+  const { test, loading } = useGetTest(preview!.id as string[]);
+
+  if (!test || loading) {
+    return <>Loading…</>;
+  }
+
+  return (
+    <>
+      <div className="flex flex-row text-xl items-center space-x-2">
+        <div>{test.title}</div>
+      </div>
+      <div
+        className="overflow-hidden overflow-ellipsis whitespace-pre text-left"
+        style={{ direction: "rtl" }}
+      >
+        {test.path.filter(Boolean).join(" > ")}
+      </div>
+      <ReplayRows recordings={test.recordings} />
+    </>
+  );
+}

--- a/src/ui/components/Library/Preview/TestRunPreview.tsx
+++ b/src/ui/components/Library/Preview/TestRunPreview.tsx
@@ -1,0 +1,23 @@
+import { useContext } from "react";
+import MaterialIcon from "ui/components/shared/MaterialIcon";
+import { useGetTestRun } from "ui/hooks/tests";
+import { LibraryContext } from "../useFilters";
+import { ReplayRows } from "./ReplayRows";
+
+export function TestRunPreview() {
+  const { preview } = useContext(LibraryContext);
+  const { testRun, loading } = useGetTestRun(preview!.id as string);
+
+  if (!testRun || loading) {
+    return <>Loading…</>;
+  }
+
+  return (
+    <>
+      <div className="flex flex-row text-xl items-center space-x-2">
+        <div>{testRun.id}</div>
+      </div>
+      <ReplayRows recordings={testRun.recordings} />
+    </>
+  );
+}

--- a/src/ui/components/Library/TestResult.tsx
+++ b/src/ui/components/Library/TestResult.tsx
@@ -1,13 +1,22 @@
 import MaterialIcon from "../shared/MaterialIcon";
 
-export function TestResult({ result }: { result: "passed" | "failed" }) {
-  return result === "passed" ? (
-    <div className="flex text-green-500">
-      <MaterialIcon>check_circle</MaterialIcon>
-    </div>
-  ) : (
-    <div className="flex text-red-500">
-      <MaterialIcon>error</MaterialIcon>
-    </div>
-  );
+export function TestResult({ result }: { result?: "passed" | "failed" | "timedOut" }) {
+  if (result === "passed") {
+    return (
+      <div className="flex text-green-500">
+        <MaterialIcon>check_circle</MaterialIcon>
+      </div>
+    );
+  } else if (result === "failed") {
+    return (
+      <div className="flex text-red-500">
+        <MaterialIcon>error</MaterialIcon>
+      </div>
+    );
+  } else if (result === "timedOut") {
+    // TODO: Add a timeout icon
+    return null;
+  }
+
+  return null;
 }

--- a/src/ui/components/Library/Viewer.tsx
+++ b/src/ui/components/Library/Viewer.tsx
@@ -1,47 +1,13 @@
-import { RecordingId } from "@replayio/protocol";
-
-import BatchActionDropdown from "./BatchActionDropdown";
-
-import { PrimaryButton, SecondaryButton } from "../shared/Button";
-import ViewerHeader, { ViewerHeaderLeft } from "./ViewerHeader";
-
-import sortBy from "lodash/sortBy";
-import React, { useState, useMemo, useContext } from "react";
-import { useSelector } from "react-redux";
-import { isReplayBrowser } from "ui/utils/environment";
-import { getWorkspaceId } from "ui/reducers/app";
+import ViewerHeader from "./ViewerHeader";
+import React, { useState, useContext } from "react";
 import { Recording } from "ui/types";
 
 import styles from "./Library.module.css";
-import RecordingRow from "./RecordingRow";
-import TeamTrialEnd from "./TeamTrialEnd";
-
-function getErrorText() {
-  if (isReplayBrowser()) {
-    return "Please open a new tab and press the blue record button to record a Replay";
-  }
-
-  return <DownloadLinks />;
-}
-
-function DownloadLinks() {
-  const [clicked, setClicked] = useState(false);
-
-  if (clicked) {
-    return (
-      <div className="flex flex-col space-y-6" style={{ maxWidth: "24rem" }}>
-        <div>Download started.</div>
-        <div>{`Once the download is finished, open the Replay Browser installer to install Replay`}</div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col space-y-6 text-sm" style={{ maxWidth: "24rem" }}>
-      <div className="text-lg">{`👋 This is where your replays will go!`}</div>
-    </div>
-  );
-}
+import { LibraryContext } from "./useFilters";
+import { Preview } from "./Preview/Preview";
+import { TestRuns } from "./Content/TestRuns";
+import { Tests } from "./Content/Tests";
+import { Recordings } from "./Content/Recordings";
 
 export default function Viewer({
   recordings,
@@ -50,115 +16,46 @@ export default function Viewer({
   recordings: Recording[];
   workspaceName: string | React.ReactNode;
 }) {
-  return (
-    <div
-      className={`flex flex-grow flex-col space-y-5 overflow-hidden bg-gray-100 px-8 py-6 ${styles.libraryWrapper}`}
-    >
-      <ViewerContent workspaceName={workspaceName} recordings={recordings} />
-    </div>
-  );
-}
-
-function ViewerContent({
-  recordings,
-  workspaceName,
-}: {
-  recordings: Recording[];
-  workspaceName: string | React.ReactNode;
-}) {
-  const currentWorkspaceId = useSelector(getWorkspaceId);
-  const [isEditing, setIsEditing] = useState(false);
+  const { view, preview } = useContext(LibraryContext);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [showMore, toggleShowMore] = useState(false);
-
-  const shownRecordings = useMemo(() => {
-    const sortedRecordings = sortBy(recordings, recording => {
-      const ascOrder = false;
-      const order = ascOrder ? 1 : -1;
-      return order * new Date(recording.date).getTime();
-    });
-    return showMore ? sortedRecordings : sortedRecordings.slice(0, 100);
-  }, [recordings, showMore]);
-
-  const addSelectedId = (recordingId: RecordingId) => setSelectedIds([...selectedIds, recordingId]);
-  const removeSelectedId = (recordingId: RecordingId) =>
-    setSelectedIds(selectedIds.filter(id => id !== recordingId));
+  const [isEditing, setIsEditing] = useState(false);
   const handleDoneEditing = () => {
     setSelectedIds([]);
     setIsEditing(false);
   };
 
-  const HeaderLeft = (
-    <ViewerHeaderLeft>
-      <span className={styles.workspaceName}>{workspaceName}</span>
-      <span className={styles.workspaceName}>
-        {recordings.length != 0 ? <>({recordings.length})</> : <></>}
-      </span>
-    </ViewerHeaderLeft>
-  );
-
-  if (!recordings.length) {
-    const errorText = getErrorText();
-
-    return (
-      <>
-        <ViewerHeader>{HeaderLeft}</ViewerHeader>
-        <section
-          className={`grid flex-grow items-center justify-center text-sm ${styles.recordingsBackground}`}
-        >
-          <span>{errorText}</span>
-        </section>
-      </>
-    );
-  }
-
   return (
-    <>
-      <ViewerHeader>
-        {HeaderLeft}
-        <div className="flex flex-row items-center space-x-3">
-          {currentWorkspaceId ? <TeamTrialEnd currentWorkspaceId={currentWorkspaceId} /> : null}
-          {isEditing ? (
-            <>
-              <BatchActionDropdown
-                setSelectedIds={setSelectedIds}
-                selectedIds={selectedIds}
-                recordings={shownRecordings}
-              />
-              <PrimaryButton color="blue" onClick={handleDoneEditing}>
-                Done
-              </PrimaryButton>
-            </>
-          ) : (
-            <SecondaryButton
-              className={styles.editButton}
-              color="blue"
-              onClick={() => setIsEditing(true)}
-            >
-              Edit
-            </SecondaryButton>
-          )}
-        </div>
-      </ViewerHeader>
-      <div
-        className={`recording-list flex flex-col overflow-y-auto rounded-md text-sm shadow-md ${styles.recordingList}`}
-      >
-        {shownRecordings.map((r, i) => (
-          <RecordingRow
-            key={i}
-            recording={r}
-            selected={selectedIds.includes(r.id)}
-            {...{ addSelectedId, removeSelectedId, isEditing }}
+    <div
+      className={`flex flex-grow flex-col overflow-hidden bg-gray-100 px-8 py-6 ${styles.libraryWrapper}`}
+    >
+      <div className="flex w-full h-full space-x-4">
+        <div className="flex flex-col flex-grow space-y-5">
+          <ViewerHeader
+            recordings={recordings}
+            selectedIds={selectedIds}
+            setSelectedIds={setSelectedIds}
+            handleDoneEditing={handleDoneEditing}
+            workspaceName={workspaceName}
+            isEditing={isEditing}
+            setIsEditing={setIsEditing}
           />
-        ))}
-        {!showMore && recordings.length > 100 && (
-          <div className="flex justify-center p-4">
-            <SecondaryButton className="" color="blue" onClick={() => toggleShowMore(!showMore)}>
-              Show More
-            </SecondaryButton>
+          <div className="flex-grow overflow-y-auto">
+            {view === "recordings" ? (
+              <Recordings
+                isEditing={isEditing}
+                recordings={recordings}
+                selectedIds={selectedIds}
+                setSelectedIds={setSelectedIds}
+              />
+            ) : view === "test-runs" ? (
+              <TestRuns />
+            ) : (
+              <Tests />
+            )}
           </div>
-        )}
+        </div>
+        {preview ? <Preview /> : null}
       </div>
-    </>
+    </div>
   );
 }

--- a/src/ui/components/Library/ViewerHeader.tsx
+++ b/src/ui/components/Library/ViewerHeader.tsx
@@ -1,14 +1,101 @@
-import React from "react";
+import React, { useContext } from "react";
+import { useSelector } from "react-redux";
+import { getWorkspaceId } from "ui/reducers/app";
+import { Recording } from "ui/types";
+import { PrimaryButton, SecondaryButton } from "../shared/Button";
+import BatchActionDropdown from "./BatchActionDropdown";
 import styles from "./Library.module.css";
+import TeamTrialEnd from "./TeamTrialEnd";
+import { LibraryContext } from "./useFilters";
+
+function ViewerHeaderActions({
+  isEditing,
+  setIsEditing,
+  setSelectedIds,
+  selectedIds,
+  recordings,
+  handleDoneEditing,
+}: {
+  recordings: Recording[];
+  selectedIds: string[];
+  setSelectedIds: (ids: string[]) => void;
+  isEditing: boolean;
+  setIsEditing: (value: boolean) => void;
+  handleDoneEditing: () => void;
+}) {
+  const { view } = useContext(LibraryContext);
+
+  if (view !== "recordings") {
+    return null;
+  }
+
+  if (isEditing) {
+    return (
+      <>
+        <BatchActionDropdown
+          setSelectedIds={setSelectedIds}
+          selectedIds={selectedIds}
+          recordings={recordings}
+        />
+        <PrimaryButton color="blue" onClick={handleDoneEditing}>
+          Done
+        </PrimaryButton>
+      </>
+    );
+  }
+
+  return (
+    <SecondaryButton className={styles.editButton} color="blue" onClick={() => setIsEditing(true)}>
+      Edit
+    </SecondaryButton>
+  );
+}
 
 export default function ViewerHeader({
-  children,
+  recordings,
+  selectedIds,
+  setSelectedIds,
+  handleDoneEditing,
+  workspaceName,
+  isEditing,
+  setIsEditing,
 }: {
-  children: React.ReactChild | (React.ReactChild | null)[];
+  recordings: Recording[];
+  selectedIds: string[];
+  setSelectedIds: (ids: string[]) => void;
+  handleDoneEditing: () => void;
+  workspaceName: string | React.ReactNode;
+  isEditing: boolean;
+  setIsEditing: (value: boolean) => void;
 }) {
+  const { view } = useContext(LibraryContext);
+  const currentWorkspaceId = useSelector(getWorkspaceId);
+
+  const HeaderLeft = (
+    <ViewerHeaderLeft>
+      <span className={styles.workspaceName}>{workspaceName}</span>
+      {view === "recordings" ? (
+        <span className={styles.workspaceName}>
+          {recordings.length != 0 ? <>({recordings.length})</> : <></>}
+        </span>
+      ) : null}
+    </ViewerHeaderLeft>
+  );
+
   return (
     <div className={`flex flex-row items-center justify-between ${styles.libraryHeaderButton}`}>
-      {children}
+      {HeaderLeft}
+      <div className="flex flex-row items-center space-x-3">
+        {currentWorkspaceId ? <TeamTrialEnd currentWorkspaceId={currentWorkspaceId} /> : null}
+        <ViewerHeaderActions
+          recordings={recordings}
+          selectedIds={selectedIds}
+          setSelectedIds={setSelectedIds}
+          handleDoneEditing={handleDoneEditing}
+          isEditing={isEditing}
+          setIsEditing={setIsEditing}
+        />
+      </div>
     </div>
   );
 }
@@ -16,7 +103,7 @@ export default function ViewerHeader({
 export function ViewerHeaderLeft({
   children,
 }: {
-  children: React.ReactChild | React.ReactChild[];
+  children: React.ReactChild | (React.ReactChild | null)[];
 }) {
   return (
     <div

--- a/src/ui/components/Library/ViewerHeader.tsx
+++ b/src/ui/components/Library/ViewerHeader.tsx
@@ -100,11 +100,7 @@ export default function ViewerHeader({
   );
 }
 
-export function ViewerHeaderLeft({
-  children,
-}: {
-  children: React.ReactChild | (React.ReactChild | null)[];
-}) {
+export function ViewerHeaderLeft({ children }: { children: React.ReactNode }) {
   return (
     <div
       className={`flex flex-row items-center space-x-2 text-2xl font-semibold ${styles.libraryHeaderText}`}

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -65,14 +65,14 @@ function NonPendingTeamLibrary({ currentWorkspaceId }: ViewerRouterProps) {
 
   const workspace = workspaces.find(ws => ws.id === currentWorkspaceId)!;
 
-  const workspaceName = (
-    <div className="flex flex-row space-x-2">
-      {workspace.logo ? <Base64Image src={workspace.logo} className="max-h-12" /> : null}
-      <div>{workspace.name}</div>
-    </div>
+  return (
+    <Viewer
+      recordings={recordings}
+      workspaceName={
+        workspace.logo ? <Base64Image src={workspace.logo} className="max-h-12" /> : workspace.name
+      }
+    />
   );
-
-  return <Viewer recordings={recordings} workspaceName={workspaceName} />;
 }
 
 type ViewerRouterProps = PropsFromRedux;

--- a/src/ui/components/Library/ViewerRouter.tsx
+++ b/src/ui/components/Library/ViewerRouter.tsx
@@ -14,7 +14,7 @@ import { BlankViewportWrapper } from "../shared/Viewport";
 import Base64Image from "../shared/Base64Image";
 import { sendTelemetryEvent } from "ui/utils/telemetry";
 
-import { LibraryFiltersContext } from "./useFilters";
+import { LibraryContext } from "./useFilters";
 
 function ViewerLoader() {
   return (
@@ -25,7 +25,7 @@ function ViewerLoader() {
 }
 
 function MyLibrary() {
-  const { filter } = useContext(LibraryFiltersContext);
+  const { filter } = useContext(LibraryContext);
   const { recordings, loading } = hooks.useGetPersonalRecordings(filter);
   const { loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
 
@@ -55,7 +55,7 @@ function TeamLibrary(props: ViewerRouterProps) {
 }
 
 function NonPendingTeamLibrary({ currentWorkspaceId }: ViewerRouterProps) {
-  const { filter } = useContext(LibraryFiltersContext);
+  const { filter } = useContext(LibraryContext);
   const { recordings, loading } = hooks.useGetWorkspaceRecordings(currentWorkspaceId!, filter);
   const { workspaces, loading: nonPendingLoading } = hooks.useGetNonPendingWorkspaces();
 
@@ -65,14 +65,14 @@ function NonPendingTeamLibrary({ currentWorkspaceId }: ViewerRouterProps) {
 
   const workspace = workspaces.find(ws => ws.id === currentWorkspaceId)!;
 
-  return (
-    <Viewer
-      recordings={recordings}
-      workspaceName={
-        workspace.logo ? <Base64Image src={workspace.logo} className="max-h-12" /> : workspace.name
-      }
-    />
+  const workspaceName = (
+    <div className="flex flex-row space-x-2">
+      {workspace.logo ? <Base64Image src={workspace.logo} className="max-h-12" /> : null}
+      <div>{workspace.name}</div>
+    </div>
   );
+
+  return <Viewer recordings={recordings} workspaceName={workspaceName} />;
 }
 
 type ViewerRouterProps = PropsFromRedux;

--- a/src/ui/components/Library/useFilters.ts
+++ b/src/ui/components/Library/useFilters.ts
@@ -1,12 +1,23 @@
 import { createContext, useState } from "react";
 import { getParams, updateUrlWithParams } from "ui/utils/environment";
 
-export type LibraryFilter = {
+type LibraryContextType = {
   filter: string;
+  view: View;
+  setPreview: (preview: Preview) => void;
+  preview: Preview | null;
 };
+type Preview = {
+  view: View;
+  id: string | string[];
+};
+export type View = "recordings" | "tests" | "test-runs";
 
-export const LibraryFiltersContext = createContext<LibraryFilter>({
+export const LibraryContext = createContext<LibraryContextType>({
   filter: "",
+  view: "recordings",
+  setPreview: () => {},
+  preview: null,
 });
 
 const useFilterString = (str: string) => {

--- a/src/ui/hooks/recordings.ts
+++ b/src/ui/hooks/recordings.ts
@@ -473,6 +473,7 @@ export function useGetWorkspaceRecordings(
   if (recordingsData) {
     recordings = recordingsData.edges.map(({ node }: any) => convertRecording(node));
   }
+
   return { recordings, loading };
 }
 

--- a/src/ui/hooks/tests.ts
+++ b/src/ui/hooks/tests.ts
@@ -1,0 +1,183 @@
+import { gql, useQuery } from "@apollo/client";
+import { WorkspaceId } from "ui/state/app";
+import { Recording } from "ui/types";
+
+export interface Test {
+  title: string;
+  path: string[];
+  recordings: Recording[];
+}
+export interface TestRun {
+  id: string;
+  recordings: Recording[];
+  createdAt: string;
+}
+
+const GET_TESTS_FOR_WORKSPACE = gql`
+  query GetTestsForWorkspace($workspaceId: ID!) {
+    node(id: $workspaceId) {
+      ... on Workspace {
+        id
+        tests {
+          title
+          path
+          recordings {
+            edges {
+              node {
+                uuid
+                duration
+                metadata
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const GET_TEST_RUNS_FOR_WORKSPACE = gql`
+  query GetTestsRunsForWorkspace($workspaceId: ID!) {
+    node(id: $workspaceId) {
+      ... on Workspace {
+        id
+        testRuns {
+          id
+          recordings {
+            edges {
+              node {
+                uuid
+                duration
+                createdAt
+                metadata
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const GET_TEST = gql`
+  query GetTest($path: String!) {
+    test(path: $path) {
+      title
+      path
+      recordings {
+        edges {
+          node {
+            uuid
+            duration
+            createdAt
+            metadata
+          }
+        }
+      }
+    }
+  }
+`;
+const GET_TEST_RUN = gql`
+  query GetTest($id: String!) {
+    testRun(id: $id) {
+      id
+      recordings {
+        edges {
+          node {
+            uuid
+            duration
+            createdAt
+            metadata
+          }
+        }
+      }
+    }
+  }
+`;
+
+function unwrapRecordingsData(recordings: any): Recording[] {
+  return recordings.edges.map((e: any) => ({
+    ...e.node,
+    id: e.node.uuid,
+    date: e.node.createdAt,
+  }));
+}
+
+export function useGetTest(path: string[]): { test: Test | null; loading: boolean } {
+  const serializedPath = encodeURIComponent(JSON.stringify(path));
+  const { data, loading } = useQuery(GET_TEST, {
+    variables: { path: serializedPath, test: false },
+  });
+
+  if (loading) {
+    return { test: null, loading };
+  }
+
+  return {
+    test: {
+      ...data.test,
+      recordings: unwrapRecordingsData(data.test.recordings),
+    },
+    loading,
+  };
+}
+
+export function useGetTestRun(id: string): { testRun: TestRun | null; loading: boolean } {
+  const { data, loading } = useQuery(GET_TEST_RUN, {
+    variables: { id },
+  });
+
+  if (loading) {
+    return { testRun: null, loading };
+  }
+
+  return {
+    testRun: {
+      ...data.testRun,
+      recordings: unwrapRecordingsData(data.testRun.recordings),
+    },
+    loading,
+  };
+}
+
+export function useGetTestsForWorkspace(workspaceId: WorkspaceId): {
+  tests: Test[] | null;
+  loading: boolean;
+} {
+  const { data, loading } = useQuery(GET_TESTS_FOR_WORKSPACE, {
+    variables: { workspaceId },
+  });
+
+  if (loading) {
+    return { tests: null, loading };
+  }
+
+  return {
+    tests: data.node.tests.map((t: any) => ({
+      ...t,
+      recordings: unwrapRecordingsData(t.recordings),
+    })),
+    loading,
+  };
+}
+
+export function useGetTestRunsForWorkspace(workspaceId: WorkspaceId): {
+  testRuns: TestRun[] | null;
+  loading: boolean;
+} {
+  const { data, loading } = useQuery(GET_TEST_RUNS_FOR_WORKSPACE, {
+    variables: { workspaceId },
+  });
+
+  if (loading) {
+    return { testRuns: null, loading };
+  }
+
+  return {
+    testRuns: data.node.testRuns.map((t: any) => ({
+      ...t,
+      recordings: unwrapRecordingsData(t.recordings),
+    })),
+    loading,
+  };
+}

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -147,13 +147,37 @@ export interface Recording {
   metadata: RecordingMetadata;
 }
 
-interface RecordingMetadata {
-  test?: TestData;
+export interface RecordingMetadata {
+  test?: TestMetadata;
+  source?: SourceMetadata;
 }
 
-type TestData = {
-  result: "passed" | "failed";
+// https://github.com/Replayio/replay-cli/blob/main/packages/replay/metadata/test.ts
+type TestMetadata = {
+  result: "passed" | "failed" | "timedOut";
+  title: string;
+  version: number;
+  run?: { id: string; title?: string };
+  path?: string[];
   file?: string;
+};
+
+// https://github.com/Replayio/replay-cli/blob/main/packages/replay/metadata/source.ts
+type SourceMetadata = {
+  result: "passed" | "failed";
+  branch?: string;
+  commit: {
+    id: string;
+    title?: string;
+    url?: string;
+  };
+  merge?: {
+    id: string;
+    title: string;
+    url?: string;
+  };
+  provider?: string;
+  repository?: string;
 };
 
 export interface RecordingOptions {

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -35,6 +35,7 @@ pref("devtools.features.showRedux", true);
 pref("devtools.features.enableLargeText", false);
 pref("devtools.features.softFocus", false);
 pref("devtools.features.repaintEvaluations", false);
+pref("devtools.features.testSupport", false);
 
 export const prefs = new PrefsHelper("devtools", {
   eventListenersBreakpoints: ["Bool", "event-listeners-breakpoints"],
@@ -70,6 +71,7 @@ export const features = new PrefsHelper("devtools.features", {
   enableLargeText: ["Bool", "enableLargeText"],
   softFocus: ["Bool", "softFocus"],
   repaintEvaluations: ["Bool", "repaintEvaluations"],
+  testSupport: ["Bool", "testSupport"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {


### PR DESCRIPTION
This PR does a few things:
- Adds a library test run/test runs view as a dropdown option where the filter is (that's locked behind a pref!)
- Adds a test view for showing a grouping of recordings by the test (test path, if we're being specific).
- Adds a test runs view for showing a grouping of recording by the test run.
- Adds a click through action for both views so that you can drill into each test/test run