### PR TITLE
Fix team member scroll and invite link styling

### DIFF
--- a/src/ui/components/shared/NewWorkspaceModal/InvitationLink.tsx
+++ b/src/ui/components/shared/NewWorkspaceModal/InvitationLink.tsx
@@ -92,11 +92,13 @@ export default function InvitationLink({
   showDomainCheck = true,
   isLarge = false,
   hideHeader = false,
+  overlay = false,
 }: {
   workspaceId: string;
   showDomainCheck?: boolean;
   isLarge?: boolean;
   hideHeader?: boolean;
+  overlay?: boolean;
 }) {
   const { workspaces, loading } = hooks.useGetNonPendingWorkspaces();
 
@@ -111,7 +113,9 @@ export default function InvitationLink({
 
   return (
     <div className="relative flex w-full flex-col space-y-3">
-      <div className="absolute -inset-8 top-0 bg-themeBase-60 opacity-10" />
+      {overlay ? (
+        <div className="pointer-events-none absolute -inset-8 top-0 bg-themeBase-60 opacity-10" />
+      ) : null}
       {!hideHeader ? <div className="font-bold">{`Invite link`}</div> : null}
       <TextInputCopy text={inputText} isLarge={isLarge} />
       {showDomainCheck ? <InvationDomainCheck workspace={workspace} /> : null}

--- a/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
+++ b/src/ui/components/shared/WorkspaceSettingsModal/WorkspaceSettingsModal.tsx
@@ -152,14 +152,14 @@ const settings: Settings<
           <div>{`Manage members here so that everyone who belongs to this team can see each other's replays.`}</div>
           <WorkspaceForm {...rest} workspaceId={workspaceId} members={members} />
           <div className="text-xs font-semibold uppercase">{`Members`}</div>
-          <div className="flex-grow overflow-auto">
+          <div className="flex-grow overflow-y-auto">
             <div className="workspace-members-container flex flex-col space-y-1.5">
-              <div className="flex flex-col space-y-1.5">
+              <div className="flex h-0 flex-col space-y-1.5">
                 {members ? <WorkspaceMembers members={members} isAdmin={isAdmin} /> : null}
               </div>
             </div>
           </div>
-          <InvitationLink workspaceId={workspaceId} showDomainCheck={isAdmin} />
+          <InvitationLink workspaceId={workspaceId} showDomainCheck={isAdmin} overlay />
         </div>
       );
     },


### PR DESCRIPTION
## Issue

Fixes #6966 and #6965 

* Team members list isn't height limited to scroll
* Invite link show bg color in the onboarding flow
* Unable to click checkbox in invite link

## Resolution

* Set zero height on team member list to coerce flexbox columns to work correctly
* Add an optional prop to style the bg of the invite link
* Set `pointer-events: none` on the bg so it doesn't steal pointer events from checkbox


https://app.replay.io/recording/fix-sharing-modal-invite-links--0afe76d9-d60d-496f-a122-264cc13ce5e6