### PR TITLE
Do not force repainting upon evaluations

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -38,6 +38,7 @@ import {
   findAnnotationsResult,
   getHitCountsParameters,
 } from "@replayio/protocol";
+import { features } from "ui/utils/prefs";
 import groupBy from "lodash/groupBy";
 import uniqueId from "lodash/uniqueId";
 
@@ -726,8 +727,12 @@ class _ThreadFront {
     } else if (rv.exception) {
       rv.exception = new ValueFront(pause, rv.exception);
     }
-    const { repaint } = await import("protocol/graphics");
-    repaint(true);
+
+    if (features.repaintEvaluations) {
+      const { repaint } = await import("protocol/graphics");
+      repaint(true);
+    }
+
     return rv;
   }
 

--- a/src/ui/utils/prefs.ts
+++ b/src/ui/utils/prefs.ts
@@ -34,6 +34,7 @@ pref("devtools.features.unicornConsole", true);
 pref("devtools.features.showRedux", true);
 pref("devtools.features.enableLargeText", false);
 pref("devtools.features.softFocus", false);
+pref("devtools.features.repaintEvaluations", false);
 
 export const prefs = new PrefsHelper("devtools", {
   eventListenersBreakpoints: ["Bool", "event-listeners-breakpoints"],
@@ -68,6 +69,7 @@ export const features = new PrefsHelper("devtools.features", {
   showRedux: ["Bool", "showRedux"],
   enableLargeText: ["Bool", "enableLargeText"],
   softFocus: ["Bool", "softFocus"],
+  repaintEvaluations: ["Bool", "repaintEvaluations"],
 });
 
 export const asyncStore = asyncStoreHelper("devtools", {


### PR DESCRIPTION
Right now, we force a repaint after every evaluation, and we run an
evaluation on every token hover when paused. This can result in a ton of
protocol messages when just moving around the editor. While those are
not necessarily a problem, it does not seem like doing them is
accomplishing anything as far as I can tell. I'm guessing that after
*some* evaluations it *might* be useful to repaint, but if that's the
case, we should figure out how to pass that flag into `evaluate`, rather
than always doing it.

See https://www.notion.so/replayio/How-we-use-Pauses-057fc6b63ace4095bd19926cec135596 for more detail/discussion