### PR TITLE
Don't log about loadedRegions

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -308,12 +308,7 @@ class _ThreadFront {
     // This is a placeholder which logs loading changes to the console.
     const sessionId = await this.waitForSession();
 
-    client.Session.addLoadedRegionsListener((parameters: loadedRegions) => {
-      // TODO Remove this once we have a better region loading indicator
-      // Log loaded regions to help with diagnostics.
-      console.debug("LoadedRegions", parameters);
-      listenerCallback(parameters);
-    });
+    client.Session.addLoadedRegionsListener(listenerCallback);
 
     await client.Session.listenForLoadChanges({}, sessionId);
   }

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -62,8 +62,6 @@ export const filterLoggingInTests = (
 };
 
 export const filterCommonTestWarnings = () => {
-  // Skip LoadedRegions debug messages
-  filterLoggingInTests(message => message === "LoadedRegions", "debug");
   // Skip websocket "Socket Open" message
   filterLoggingInTests(
     message =>


### PR DESCRIPTION
We have the protocol timeline now! So we can stop logging every time we
get a loaded regions event.