### PR TITLE
Extract "Replay app" logic files from `protocol` folder

### DIFF
--- a/packages/protocol/thread/node.ts
+++ b/packages/protocol/thread/node.ts
@@ -1,7 +1,6 @@
 import { Node as NodeDescription, AppliedRule, BoxModel, Quads } from "@replayio/protocol";
 import uniqBy from "lodash/uniqBy";
 
-import { FrameworkEventListener, getFrameworkEventListeners } from "../event-listeners";
 import { client } from "../socket";
 import { defer, assert, DisallowEverythingProxyHandler, Deferred } from "../utils";
 
@@ -29,7 +28,6 @@ export class NodeFront {
   private _pause: Pause;
   private _object: WiredObject;
   private _node: NodeDescription;
-  private _frameworkListenersWaiter: Deferred<FrameworkEventListener[]> | null;
   private _quads: BoxModel | null;
 
   private _waiters: {
@@ -48,8 +46,6 @@ export class NodeFront {
     this._object = data;
     this._node = data.preview.node;
 
-    // Additional data that can be loaded for the node.
-    this._frameworkListenersWaiter = null;
     this._waiters = {
       computedStyle: null,
       rules: null,
@@ -256,16 +252,6 @@ export class NodeFront {
     }
 
     return this._waiters.listeners.promise;
-  }
-
-  async getFrameworkEventListeners() {
-    if (this._frameworkListenersWaiter) {
-      return this._frameworkListenersWaiter.promise;
-    }
-    this._frameworkListenersWaiter = defer<FrameworkEventListener[]>();
-    const listeners = await getFrameworkEventListeners(this);
-    this._frameworkListenersWaiter.resolve(listeners);
-    return listeners;
   }
 
   async getAppliedRules() {

--- a/src/devtools/client/debugger/src/client/commands.ts
+++ b/src/devtools/client/debugger/src/client/commands.ts
@@ -16,7 +16,7 @@ import {
   setEventLogpoints,
   setExceptionLogpoint,
   removeLogpoint,
-} from "protocol/logpoint";
+} from "ui/actions/logpoint";
 import { ThreadFront, createPrimitiveValueFront, ValueFront } from "protocol/thread";
 import { WiredNamedValue } from "protocol/thread/pause";
 import { FocusRegion, UnsafeFocusRegion } from "ui/state/timeline";

--- a/src/devtools/client/inspector/event-listeners/EventListenersApp.tsx
+++ b/src/devtools/client/inspector/event-listeners/EventListenersApp.tsx
@@ -1,4 +1,4 @@
-import { FrameworkEventListener } from "protocol/event-listeners";
+import { FrameworkEventListener, getFrameworkEventListeners } from "ui/actions/event-listeners";
 import { NodeFront, WiredEventListener } from "protocol/thread/node";
 import React, { FC, useEffect, useMemo, useRef, useState } from "react";
 import { ExpandableItem } from "./ExpandableItem";
@@ -24,7 +24,7 @@ export const EventListenersApp: FC = () => {
       }
 
       const listeners = (await node.getEventListeners()) ?? [];
-      const fwListeners = await node.getFrameworkEventListeners();
+      const fwListeners = await getFrameworkEventListeners(node);
       setListeners([...listeners, ...fwListeners]);
     };
 

--- a/src/devtools/client/webconsole/actions/messages.ts
+++ b/src/devtools/client/webconsole/actions/messages.ts
@@ -9,8 +9,8 @@ import {
   prepareMessage,
   isBrowserInternalMessage,
 } from "devtools/client/webconsole/utils/messages";
-import { TestMessageHandlers } from "protocol/find-tests";
-import { LogpointHandlers } from "protocol/logpoint";
+import { TestMessageHandlers } from "ui/actions/find-tests";
+import { LogpointHandlers } from "ui/actions/logpoint";
 import { client } from "protocol/socket";
 import { Pause, ValueFront, ThreadFront as ThreadFrontType } from "protocol/thread";
 import { WiredMessage, wireUpMessage } from "protocol/thread/thread";

--- a/src/ui/actions/find-tests.ts
+++ b/src/ui/actions/find-tests.ts
@@ -3,12 +3,12 @@
 import { AnalysisEntry, ExecutionPoint, Location, PointDescription } from "@replayio/protocol";
 import { assert } from "protocol/utils";
 
-import analysisManager, { AnalysisHandler, AnalysisParams } from "./analysisManager";
-import { comparePoints, pointPrecedes } from "./execution-point-utils";
+import analysisManager, { AnalysisHandler, AnalysisParams } from "protocol/analysisManager";
+import { comparePoints, pointPrecedes } from "protocol/execution-point-utils";
 import { Helpers } from "./logpoint";
-import { client } from "./socket";
-import { Pause, ThreadFront, ValueFront } from "./thread";
-import { WiredMessage } from "./thread/thread";
+import { client } from "protocol/socket";
+import { Pause, ThreadFront, ValueFront } from "protocol/thread";
+import { WiredMessage } from "protocol/thread/thread";
 
 // Information about a jest test which ran in the recording.
 interface JestTestInfo {

--- a/src/ui/actions/logpoint.ts
+++ b/src/ui/actions/logpoint.ts
@@ -14,11 +14,11 @@ import { getAnalysisPointsForLocation, setAnalysisError, setAnalysisPoints } fro
 import { pointsReceived } from "ui/reducers/timeline";
 import { ProtocolError } from "ui/state/app";
 
-import analysisManager, { AnalysisHandler, AnalysisParams } from "./analysisManager";
+import analysisManager, { AnalysisHandler, AnalysisParams } from "protocol/analysisManager";
 import { logpointGetFrameworkEventListeners } from "./event-listeners";
-import { ThreadFront, ValueFront, Pause, createPrimitiveValueFront } from "./thread";
-import { PrimitiveValue } from "./thread/value";
-import { assert, compareNumericStrings } from "./utils";
+import { ThreadFront, ValueFront, Pause, createPrimitiveValueFront } from "protocol/thread";
+import { PrimitiveValue } from "protocol/thread/value";
+import { assert, compareNumericStrings } from "protocol/utils";
 
 const { prefs } = require("ui/utils/prefs");
 

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -1,6 +1,6 @@
 import { ApolloError } from "@apollo/client";
 import { uploadedData } from "@replayio/protocol";
-import { findAutomatedTests } from "protocol/find-tests";
+import { findAutomatedTests } from "ui/actions/find-tests";
 import { videoReady } from "protocol/graphics";
 import {
   CommandRequest,

--- a/src/ui/setup/dynamic/devtools.ts
+++ b/src/ui/setup/dynamic/devtools.ts
@@ -17,7 +17,7 @@ import { prefs as consolePrefs } from "devtools/client/webconsole/utils/prefs";
 import { initOutputSyntaxHighlighting } from "devtools/client/webconsole/utils/syntax-highlighted";
 import { LocalizationHelper } from "devtools/shared/l10n";
 import { setupGraphics } from "protocol/graphics";
-import { setupLogpoints } from "protocol/logpoint";
+import { setupLogpoints } from "ui/actions/logpoint";
 import { initSocket, addEventListener } from "protocol/socket";
 import { ThreadFront } from "protocol/thread";
 import { assert } from "protocol/utils";


### PR DESCRIPTION
- Moved `logpoint`, `event-listeners`, and `find-tests` files out
  from the `protocol` folder, because they really represent specific
  Replay app functionality, not "generic client" logic
- Removed "framework listeners" function from `NodeFront`, and
  added a `WeakMap` cache to `event-listeners.ts`