### PR TITLE
Remove protocol reference to test harness

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -203,8 +203,6 @@ class _ThreadFront {
   private annotationWaiters: Map<string, Promise<findAnnotationsResult>> = new Map();
   private annotationCallbacks: Map<string, ((annotations: Annotation[]) => void)[]> = new Map();
 
-  testName: string | undefined;
-
   // added by EventEmitter.decorate(ThreadFront)
   eventListeners!: Map<ThreadFrontEvent, ((value?: any) => void)[]>;
   on!: (name: ThreadFrontEvent, handler: (value?: any) => void) => void;
@@ -267,19 +265,8 @@ class _ThreadFront {
     await this.waitForSession();
     await this.initializedWaiter.promise;
     await this.ensureAllSources();
+
     this.ensureCurrentPause();
-
-    if (this.testName) {
-      await gToolbox.selectTool("debugger");
-      window.Test = await import("test/harness");
-      const script = document.createElement("script");
-      script.src = `/test/scripts/${this.testName}`;
-      document.head.appendChild(script);
-    }
-  }
-
-  setTest(test: string | undefined) {
-    this.testName = test;
   }
 
   waitForSession() {

--- a/src/ui/actions/session.ts
+++ b/src/ui/actions/session.ts
@@ -10,7 +10,7 @@ import {
 } from "protocol/socket";
 import { ThreadFront as ThreadFrontType } from "protocol/thread";
 import { assert, waitForTime } from "protocol/utils";
-import { getTest, isTest, isMock } from "ui/utils/environment";
+import { isTest, isMock } from "ui/utils/environment";
 import { UIThunkAction } from "ui/actions";
 import * as actions from "ui/actions/app";
 import { getRecording } from "ui/hooks/recordings";
@@ -156,8 +156,6 @@ export function createSocket(
       ) {
         return dispatch(setTrialExpired());
       }
-
-      ThreadFront.setTest(getTest() || undefined);
 
       const experimentalSettings: ExperimentalSettings = {
         listenForMetrics: !!prefs.listenForMetrics,

--- a/src/ui/utils/devtools-toolbox.ts
+++ b/src/ui/utils/devtools-toolbox.ts
@@ -8,6 +8,7 @@ import * as inspectorReducers from "devtools/client/inspector/reducers";
 import { DebuggerPanel } from "devtools/client/debugger/panel";
 import { Inspector } from "devtools/client/inspector/inspector";
 import Selection from "devtools/client/framework/selection";
+import { getTest } from "./environment";
 
 export type StartablePanelName = "debugger" | "inspector" | "react-components" | "redux-devtools";
 
@@ -56,6 +57,18 @@ export class DevToolsToolbox {
 
   async init(selectedPanel: StartablePanelName) {
     await this.threadFront.initializeToolbox();
+
+    const testName = getTest();
+    if (testName) {
+      await gToolbox.selectTool("debugger");
+
+      window.Test = await import("test/harness");
+
+      const script = document.createElement("script");
+      script.src = `/test/scripts/${testName}`;
+
+      document.head.appendChild(script);
+    }
 
     // The debugger has to be started immediately on init so that when we click
     // on any of those messages, either on the console or the timeline, the debugger


### PR DESCRIPTION
Continuing the work in #6955  and related to #6977.

This PR removes another reference (this time to `test/harness`) from the new `packages/protocol` folder.

This is a soft blocker to the proof of concept app for #6932.