### PR TITLE
fix network request current time indicator

### DIFF
--- a/src/ui/components/NetworkMonitor/RequestTable.tsx
+++ b/src/ui/components/NetworkMonitor/RequestTable.tsx
@@ -88,7 +88,7 @@ const RequestTable = ({
         {...getTableProps()}
       >
         <HeaderGroups columns={columns} headerGroups={headerGroups} />
-        <div className="w-fit min-w-full overflow-y-auto" {...getTableBodyProps()}>
+        <div className="relative w-fit min-w-full overflow-y-auto" {...getTableBodyProps()}>
           {rows.map((row: Row<RequestSummary>) => {
             let firstInFuture = false;
             if (inPast && row.original.point.time >= currentTime) {


### PR DESCRIPTION
Partly fixes #6978 by making sure the indicator doesn't spill outside the container. Moving the filter inline will be done in a follow-up PR.