### PR TITLE
Remove external import from protocol package

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -17,7 +17,11 @@ const MINIMUM_VIDEO_CONTENT = 5000;
 
 const { features } = require("ui/utils/prefs");
 
-// TODO [bvaughn] protocol – Remove external package imports
+// Temporary experimental feature flag
+let syncVideoPlaybackExperimentalFlag: boolean = false;
+export function setSyncVideoPlaybackExperimentalFlag(value: boolean): void {
+  syncVideoPlaybackExperimentalFlag = value;
+}
 
 declare global {
   interface Window {
@@ -213,7 +217,7 @@ class VideoPlayer {
       this.commands &&
       this.commands.then(async () => {
         const video = getVideoNode();
-        if (features.videoPlayback && video) {
+        if (syncVideoPlaybackExperimentalFlag && video) {
           video.pause();
           video.currentTime = timeMs / 1000;
         }
@@ -226,7 +230,7 @@ class VideoPlayer {
       this.commands.then(() => {
         const video = getVideoNode();
         const currentTime = this.store?.getState().timeline.currentTime;
-        if (features.videoPlayback && video) {
+        if (syncVideoPlaybackExperimentalFlag && video) {
           video.currentTime = (currentTime || 0) / 1000;
           return video.play();
         }
@@ -270,7 +274,7 @@ export function setupGraphics(store: UIStore) {
       setHasAllPaintPoints(true);
     }
 
-    if (features.videoPlayback) {
+    if (syncVideoPlaybackExperimentalFlag) {
       client.Graphics.getPlaybackVideo({}, sessionId);
       client.Graphics.addPlaybackVideoFragmentListener(param => Video.append(param.fragment));
     }
@@ -420,7 +424,7 @@ export async function getGraphicsAtTime(
   }
 
   const screenPromise = forPlayback
-    ? features.videoPlayback
+    ? syncVideoPlaybackExperimentalFlag
       ? Promise.resolve(undefined)
       : screenshotCache.getScreenshotForPlayback(point, paintHash)
     : screenshotCache.getScreenshotForPreview(point, paintHash);
@@ -470,7 +474,7 @@ export function paintGraphics(
   playing?: boolean
 ) {
   window.currentScreenshotHash = screenShot?.hash;
-  if (!screenShot || (playing && features.videoPlayback)) {
+  if (!screenShot || (playing && syncVideoPlaybackExperimentalFlag)) {
     clearGraphics();
   } else {
     assert(screenShot.data, "no screenshot data");

--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -117,10 +117,10 @@ declare global {
   }
 }
 
-// Experimental feature
-let repaintAfterEvaluations: boolean = false;
-export function setRepaintAfterEvaluations(value: boolean): void {
-  repaintAfterEvaluations = value;
+// Temporary experimental feature flag
+let repaintAfterEvaluationsExperimentalFlag: boolean = false;
+export function setRepaintAfterEvaluationsExperimentalFlag(value: boolean): void {
+  repaintAfterEvaluationsExperimentalFlag = value;
 }
 
 class _ThreadFront {
@@ -715,7 +715,7 @@ class _ThreadFront {
       rv.exception = new ValueFront(pause, rv.exception);
     }
 
-    if (repaintAfterEvaluations) {
+    if (repaintAfterEvaluationsExperimentalFlag) {
       const { repaint } = await import("protocol/graphics");
       repaint(true);
     }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,7 +5,8 @@ import Head from "next/head";
 import type { AppContext, AppProps } from "next/app";
 import { useRouter } from "next/router";
 import NextApp from "next/app";
-import { setRepaintAfterEvaluations } from "protocol/thread/thread";
+import { setSyncVideoPlaybackExperimentalFlag } from "protocol/graphics";
+import { setRepaintAfterEvaluationsExperimentalFlag } from "protocol/thread/thread";
 import React, { ReactNode, useEffect, useState } from "react";
 import { Provider } from "react-redux";
 import { Store } from "redux";
@@ -138,7 +139,10 @@ if (isMock()) {
 
 // Expose app feature flags to the protocol through an app-agnostic API.
 if (features.repaintEvaluations) {
-  setRepaintAfterEvaluations(true);
+  setRepaintAfterEvaluationsExperimentalFlag(true);
+}
+if (features.videoPlayback) {
+  setSyncVideoPlaybackExperimentalFlag(true);
 }
 
 interface AuthProps {

--- a/src/ui/actions/logpoint.ts
+++ b/src/ui/actions/logpoint.ts
@@ -22,8 +22,6 @@ import { assert, compareNumericStrings } from "protocol/utils";
 
 const { prefs } = require("ui/utils/prefs");
 
-// TODO [bvaughn] protocol – Remove external package imports
-
 // Hooks for adding messages to the console.
 export const LogpointHandlers: {
   onResult?: (


### PR DESCRIPTION
Follow up to #6955; relates to feature flag added in #2471.

Just another incremental clean up step for the protocol package.