### PR TITLE
Ignore CommandErrors

### DIFF
--- a/src/ui/components/ErrorBoundary.tsx
+++ b/src/ui/components/ErrorBoundary.tsx
@@ -22,7 +22,7 @@ export default function ErrorBoundary({ children }: { children: ReactNode }) {
       return dispatch(setUnexpectedError(ReplayUpdatedError, true));
     }
 
-    if (isDevelopment()) {
+    if (error.name === "CommandError" || isDevelopment()) {
       return;
     }
 


### PR DESCRIPTION
We're reporting `CommandError`s to sentry which is not that helpful. Sentry is best used for TypeErrors and other unexpected frontend errors