### PR TITLE
Remove external imports from protocol graphics

### DIFF
--- a/packages/protocol/graphics.ts
+++ b/packages/protocol/graphics.ts
@@ -15,8 +15,6 @@ import { getVideoNode } from "./videoNode";
 
 const MINIMUM_VIDEO_CONTENT = 5000;
 
-const { features } = require("ui/utils/prefs");
-
 // Temporary experimental feature flag
 let syncVideoPlaybackExperimentalFlag: boolean = false;
 export function setSyncVideoPlaybackExperimentalFlag(value: boolean): void {

--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/BreakpointTimeline.tsx
@@ -7,7 +7,7 @@ import { timelineMarkerWidth as pointWidth } from "ui/constants";
 const BreakpointTimelinePoint = require("./BreakpointTimelinePoint").default;
 import { getVisiblePosition } from "ui/utils/timeline";
 import PortalTooltip from "ui/components/shared/PortalTooltip";
-import { mostRecentPaintOrMouseEvent, precacheScreenshots } from "protocol/graphics";
+import { mostRecentPaintOrMouseEvent } from "protocol/graphics";
 
 import TimeTooltip from "devtools/client/debugger/src/components/SecondaryPanes/Breakpoints/TimeTooltip";
 import { UIState } from "ui/state";

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -341,7 +341,7 @@ function playback(startTime: number, endTime: number): UIThunkAction {
     const shouldContinuePlayback = () => getPlayback(getState());
     prepareNextGraphics();
 
-    Video.play();
+    Video.play(currentTime);
 
     while (shouldContinuePlayback()) {
       await new Promise(resolve => requestAnimationFrame(resolve));

--- a/src/ui/actions/timeline.ts
+++ b/src/ui/actions/timeline.ts
@@ -341,7 +341,9 @@ function playback(startTime: number, endTime: number): UIThunkAction {
     const shouldContinuePlayback = () => getPlayback(getState());
     prepareNextGraphics();
 
-    Video.play(currentTime);
+    // Note: This matches the previous behavior of the VideoPlayer.
+    // Maybe we should be passing the currentTime instead?
+    Video.play(getCurrentTime(getState()));
 
     while (shouldContinuePlayback()) {
       await new Promise(resolve => requestAnimationFrame(resolve));

--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -75,7 +75,7 @@ function Video({
     if (playback) {
       refreshGraphics();
       VideoPlayer.seek(currentTime);
-      VideoPlayer.play();
+      VideoPlayer.play(currentTime);
     }
 
     return () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,7 +52,9 @@
         "node_modules/*"
       ],
       "components": ["packages/components/index.ts"],
-      "icons": ["packages/icons/index.tsx"]
+      "icons": ["packages/icons/index.tsx"],
+      "protocol": ["packages/protocol/index.ts"],
+      "shared": ["packages/shared/index.ts"]
     } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
Follow up to #6955 and a bunch of other cleanup PRs.

This PR **removes the last of the external references** from the new "protocol" package.
- [x] 7008ab6: Moved `precacheScreenshots` thunk out of the `protocol/graphics` package and into `ui/actions/timeline`.
- [x] b2a3406: Replaced various `store.dispatch` calls in `protocol/graphics` with optional event handlers (added in `devtools` setup).

Commits are atomic and so they can be reviewed individually if that's easier.

I think we should still invest in rearchitecting that package, but this at least unblocks a proof of concept for #6932.