### PR TITLE
Only pass real ranges in to `getHitCounts`

### DIFF
--- a/packages/protocol/thread/thread.ts
+++ b/packages/protocol/thread/thread.ts
@@ -493,7 +493,7 @@ class _ThreadFront {
   ) {
     assert(this.sessionId, "no sessionId");
     let params: getHitCountsParameters = { sourceId, locations, maxHits: 10000 };
-    if (range !== null) {
+    if (range !== null && range.startPoint !== "" && range.endPoint !== "") {
       params.range = { begin: range.startPoint, end: range.endPoint };
     }
     return client.Debugger.getHitCounts(params, this.sessionId);


### PR DESCRIPTION
I think we might be getting back incorrect no hits when we pass empty
strings as the start and end points. I had expected range to just be
missing here, but `""` is also reasonable, when we only have times and
not points.