### PR TITLE
Sort comments by time first, then point

### DIFF
--- a/src/ui/actions/comments.ts
+++ b/src/ui/actions/comments.ts
@@ -1,4 +1,4 @@
-import { RecordingId, TimeStampedPoint } from "@replayio/protocol";
+import { RecordingId } from "@replayio/protocol";
 import { selectLocation } from "devtools/client/debugger/src/actions/sources/select";
 import { setSymbols } from "devtools/client/debugger/src/actions/sources/symbols";
 import { getSymbols } from "devtools/client/debugger/src/reducers/ast";

--- a/src/ui/components/Transcript/Transcript.tsx
+++ b/src/ui/components/Transcript/Transcript.tsx
@@ -24,7 +24,11 @@ export default function Transcript() {
       clonedComments.push(pendingComment.comment);
     }
 
-    const sortedComments = sortBy(clonedComments, [c => BigInt(c.point), "createdAt"]);
+    const sortedComments = sortBy(clonedComments, [
+      c => c.time,
+      c => BigInt(c.point || 0),
+      "createdAt",
+    ]);
     return sortedComments;
   }, [comments, pendingComment]);
 


### PR DESCRIPTION
We are apparently sometimes storing comments without `point`s. This is
an important change to be defensive against that case, but it is *also*
an improvement for cases where the `point` and time were far away from
each other because of time <-> point mapping issues.

Fixes https://github.com/RecordReplay/devtools/issues/6865