### PR TITLE
Don't show broken next and previous buttons

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
+++ b/src/devtools/client/debugger/src/components/Editor/ToggleWidgetButton.tsx
@@ -123,11 +123,11 @@ function QuickActions({
 
   let button;
 
-  if (isMetaActive && isShiftActive) {
+  if (analysisPoints && isMetaActive && isShiftActive) {
     button = (
       <ContinueToPrevious showNag={showNag} onClick={onContinueToPrevious} disabled={!prev} />
     );
-  } else if (isMetaActive) {
+  } else if (analysisPoints && isMetaActive) {
     button = <ContinueToNext showNag={showNag} onClick={onContinueToNext} disabled={!next} />;
   } else {
     button = <AddLogpoint breakpoint={breakpoint} showNag={showNag} onClick={onAddLogpoint} />;


### PR DESCRIPTION
If there are no analysisPoints for a particular line, then we should not
offer to run forward to the next hit, or back to the previous hit. We
could go back to the old way of running an `Analysis.findPoints` for each
location that this button is held on, but that also seems like not a
great idea, given how performance heavy that can be. I do think it would
be reasonable to make a `Debugger.stepToLocation` method, but we don't
have that yet, so here we are.