### PR TITLE
Catch errors around MessageRenderer

### DIFF
--- a/packages/bvaughn-architecture-demo/components/console/renderers/MessageRenderer.tsx
+++ b/packages/bvaughn-architecture-demo/components/console/renderers/MessageRenderer.tsx
@@ -1,3 +1,4 @@
+import ErrorBoundary from "@bvaughn/components/ErrorBoundary";
 import Expandable from "@bvaughn/components/Expandable";
 import Icon from "@bvaughn/components/Icon";
 import Inspector from "@bvaughn/components/inspector";
@@ -110,7 +111,11 @@ function MessageRenderer({
   const logContents = (
     <span className={styles.LogContents} data-test-name="LogContents">
       {message.text && <span className={styles.MessageText}>{message.text}</span>}
-      {primaryContent}
+      <ErrorBoundary
+        fallback={<div className={styles.ErrorBoundaryFallback}>Something went wrong.</div>}
+      >
+        {primaryContent}
+      </ErrorBoundary>
     </span>
   );
 

--- a/packages/bvaughn-architecture-demo/components/inspector/ValueRenderer.tsx
+++ b/packages/bvaughn-architecture-demo/components/inspector/ValueRenderer.tsx
@@ -22,7 +22,7 @@ import { ObjectPreviewRendererProps } from "./values/types";
 // This renderer only renders a value (no name) and can be used with both horizontal and vertical layouts.
 //
 // https://static.replay.io/protocol/tot/Pause/#type-ObjectPreview
-export default memo(function ValueRenderer({
+function ValueRenderer({
   context,
   layout = "horizontal",
   pauseId,
@@ -96,4 +96,6 @@ export default memo(function ValueRenderer({
   }
 
   return <ClientValueValueRenderer clientValue={clientValue} context={context} />;
-});
+}
+
+export default memo(ValueRenderer);


### PR DESCRIPTION
We were catching evaluation errors around _log points_ but not around console messages that were recorded as part of the Replay. The downside of this was that an issue like BAC-2340 could take down the whole Console– so this PR wraps individual `MessageRenderer` rows too.

Before this change:
![Screen Shot 2022-10-06 at 12 09 14 PM](https://user-images.githubusercontent.com/29597/194363983-e673c210-83b7-483a-ad98-f60ef1555880.png)

After this change:
![Screen Shot 2022-10-06 at 12 09 30 PM](https://user-images.githubusercontent.com/29597/194363985-7d882025-96d4-4aa8-9f70-218442c2457d.png)
