### PR TITLE
Move asserts to their end time

### DIFF
--- a/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestStepItem.tsx
@@ -202,7 +202,7 @@ export function TestStepItem({ step, argString, index, id }: TestStepItemProps) 
   const bump = isPaused || isPast ? 10 : 0;
   const actualProgress = bump + 90 * ((currentTime - step.absoluteStartTime) / step.duration);
   const progress = actualProgress > 100 ? 100 : actualProgress;
-  const displayedProgress = step.duration === 1 && isPaused ? 100 : progress == 100 ? 0 : progress;
+  const displayedProgress = (step.duration === 1 && isPaused) || progress == 100 ? 0 : progress;
 
   const color = step.error ? "border-l-red-500" : "border-l-primaryAccent";
 

--- a/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
+++ b/src/devtools/client/debugger/src/components/TestInfo/TestSteps.tsx
@@ -61,9 +61,22 @@ function useGetTestSections(
         start: annotationsStart.find(a => a.message.id === s.id),
       };
 
-      const duration = s.name === "assert" ? 1 : s.duration || 1;
-      const absoluteStartTime = annotations.start?.time ?? startTime + s.relativeStartTime;
-      const absoluteEndTime = annotations.end?.time ?? absoluteStartTime + duration;
+      let duration = s.duration || 1;
+      let absoluteStartTime = annotations.start?.time ?? startTime + s.relativeStartTime;
+      let absoluteEndTime = annotations.end?.time ?? absoluteStartTime + duration;
+
+      if (s.name === "assert") {
+        // start failed asserts at their end time so they line up with the end
+        // of the failed command but successful asserts with their start time
+        if (s.error) {
+          absoluteStartTime = absoluteEndTime - 1;
+          annotations.start = annotations.end;
+        } else {
+          absoluteEndTime = absoluteStartTime + 1;
+          annotations.end = annotations.start;
+        }
+        duration = 1;
+      }
 
       return {
         time: absoluteStartTime,


### PR DESCRIPTION
Asserts start when their associated command starts but we want to represent them as starting and finishing at the same time when the command finishes. This is more evident now that failed commands have a `step:end` event.