### PR TITLE
Comment UI/UX improvements

### DIFF
--- a/packages/bvaughn-architecture-demo/components/Icon.tsx
+++ b/packages/bvaughn-architecture-demo/components/Icon.tsx
@@ -14,6 +14,7 @@ export default function Icon({
     | "arrow-right"
     | "breakpoint"
     | "cancel"
+    | "chevron-right"
     | "close"
     | "comment"
     | "comments"
@@ -78,6 +79,9 @@ export default function Icon({
     case "cancel":
       path =
         "M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z";
+      break;
+    case "chevron-right":
+      path = "M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z";
       break;
     case "close":
       path =

--- a/packages/bvaughn-architecture-demo/components/comments/Comment.module.css
+++ b/packages/bvaughn-architecture-demo/components/comments/Comment.module.css
@@ -114,3 +114,27 @@
   color: var(--color-contrast);
   border-color: var(--color-error);
 }
+
+.Labels {
+  margin: 0.25rem;
+  background-color: var(--comment-card-source-preview-background-color);
+  border-radius: 0.25rem;
+  font-family: var(--font-family-monospace);
+  cursor: pointer;
+}
+.Labels:hover {
+  background-color: var(--comment-card-source-preview-background-color-hover);
+}
+
+.PrimaryLabel {
+  font-size: var(--font-size-small);
+  padding: 0.25rem 0.5rem;
+}
+
+.SecondaryLabel {
+  font-size: var(--font-size-regular);
+  padding: 0.25rem 0.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/bvaughn-architecture-demo/components/sources/PointPanel.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/PointPanel.tsx
@@ -11,6 +11,7 @@ import {
 
 import Icon from "bvaughn-architecture-demo/components/Icon";
 import CodeEditor from "bvaughn-architecture-demo/components/lexical/CodeEditor";
+import { createSourceLocationLabels } from "bvaughn-architecture-demo/components/sources/utils/createCommentLabels";
 import { FocusContext } from "bvaughn-architecture-demo/src/contexts/FocusContext";
 import { GraphQLClientContext } from "bvaughn-architecture-demo/src/contexts/GraphQLClientContext";
 import { InspectorContext } from "bvaughn-architecture-demo/src/contexts/InspectorContext";
@@ -311,11 +312,20 @@ function PointPanelWithHitPoints({
         }
         trackEvent("breakpoint.add_comment");
 
+        const { primaryLabel, secondaryLabel } = await createSourceLocationLabels(
+          client,
+          point.location.sourceId,
+          point.location.line,
+          point.location.column
+        );
+
         await addCommentGraphQL(graphQLClient, accessToken, recordingId, {
           content: "",
           hasFrames: true,
           isPublished: false,
           point: currentExecutionPoint,
+          primaryLabel,
+          secondaryLabel,
           sourceLocation: point.location,
           time: currentTime,
         });

--- a/packages/bvaughn-architecture-demo/components/sources/useSourceContextMenu.tsx
+++ b/packages/bvaughn-architecture-demo/components/sources/useSourceContextMenu.tsx
@@ -5,12 +5,14 @@ import ContextMenuDivider from "bvaughn-architecture-demo/components/context-men
 import ContextMenuItem from "bvaughn-architecture-demo/components/context-menu/ContextMenuItem";
 import useContextMenu from "bvaughn-architecture-demo/components/context-menu/useContextMenu";
 import { copyToClipboard } from "bvaughn-architecture-demo/components/sources/utils/clipboard";
+import { createSourceLocationLabels } from "bvaughn-architecture-demo/components/sources/utils/createCommentLabels";
 import { GraphQLClientContext } from "bvaughn-architecture-demo/src/contexts/GraphQLClientContext";
 import { InspectorContext } from "bvaughn-architecture-demo/src/contexts/InspectorContext";
 import { SessionContext } from "bvaughn-architecture-demo/src/contexts/SessionContext";
 import { TimelineContext } from "bvaughn-architecture-demo/src/contexts/TimelineContext";
 import { addComment as addCommentGraphQL } from "bvaughn-architecture-demo/src/graphql/Comments";
 import useLocalStorage from "bvaughn-architecture-demo/src/hooks/useLocalStorage";
+import { ReplayClientContext } from "shared/client/ReplayClientContext";
 
 export default function useSourceContextMenu({
   firstBreakableColumnIndex,
@@ -23,6 +25,7 @@ export default function useSourceContextMenu({
   sourceId: SourceId;
   sourceUrl: string | null;
 }) {
+  const client = useContext(ReplayClientContext);
   const graphQLClient = useContext(GraphQLClientContext);
   const { showCommentsPanel } = useContext(InspectorContext);
   const { accessToken, recordingId, trackEvent } = useContext(SessionContext);
@@ -45,11 +48,20 @@ export default function useSourceContextMenu({
       }
       trackEvent("breakpoint.add_comment");
 
+      const { primaryLabel, secondaryLabel } = await createSourceLocationLabels(
+        client,
+        sourceId,
+        lineNumber,
+        firstBreakableColumnIndex
+      );
+
       await addCommentGraphQL(graphQLClient, accessToken, recordingId, {
         content: "",
         hasFrames: true,
         isPublished: false,
         point: currentExecutionPoint,
+        primaryLabel,
+        secondaryLabel,
         sourceLocation: {
           column: firstBreakableColumnIndex != null ? firstBreakableColumnIndex : 0,
           line: lineNumber,

--- a/packages/bvaughn-architecture-demo/components/sources/utils/createCommentLabels.ts
+++ b/packages/bvaughn-architecture-demo/components/sources/utils/createCommentLabels.ts
@@ -1,0 +1,69 @@
+import { SourceId } from "@replayio/protocol";
+
+import {
+  getSourceAsync,
+  getStreamingSourceContentsAsync,
+} from "bvaughn-architecture-demo/src/suspense/SourcesCache";
+import { parseStreamingAsync } from "bvaughn-architecture-demo/src/suspense/SyntaxParsingCache";
+import { getSourceFileName } from "bvaughn-architecture-demo/src/utils/source";
+import { truncate } from "bvaughn-architecture-demo/src/utils/text";
+import { ReplayClientInterface } from "shared/client/types";
+
+type CommentLabels = {
+  primaryLabel: string | null;
+  secondaryLabel: string | null;
+};
+
+const MAX_LABEL_CHARS = 100;
+
+export async function createSourceLocationLabels(
+  replayClient: ReplayClientInterface,
+  sourceId: SourceId,
+  lineNumber: number,
+  columnIndex: number | null = null
+): Promise<CommentLabels> {
+  let primaryLabel: string | null = null;
+  let secondaryLabel: string | null = null;
+
+  // Primary label is used to store the source file name and line number
+  const source = await getSourceAsync(replayClient, sourceId);
+  if (source) {
+    const fileName = getSourceFileName(source);
+    if (fileName) {
+      primaryLabel =
+        columnIndex !== null
+          ? `${fileName}:${lineNumber}:${columnIndex}`
+          : `${fileName}:${lineNumber}`;
+
+      if (primaryLabel.length > MAX_LABEL_CHARS) {
+        primaryLabel = truncate(primaryLabel, { maxLength: MAX_LABEL_CHARS, position: "start" });
+      }
+    }
+  }
+
+  // Secondary label is used to store the syntax-highlighted markup for the line
+  const streamingSource = await getStreamingSourceContentsAsync(replayClient, sourceId);
+  if (streamingSource != null) {
+    const parsedSource = await parseStreamingAsync(streamingSource);
+    if (parsedSource != null) {
+      if (parsedSource.parsedLines.length < lineNumber) {
+        await new Promise<void>(resolve => {
+          parsedSource.subscribe(() => {
+            if (parsedSource.parsedLines.length >= lineNumber) {
+              resolve();
+            }
+          });
+        });
+      }
+
+      const rawLine = parsedSource.rawLines[lineNumber - 1];
+      if (rawLine.length > MAX_LABEL_CHARS) {
+        secondaryLabel = truncate(rawLine, { maxLength: MAX_LABEL_CHARS, position: "middle" });
+      } else {
+        secondaryLabel = parsedSource.parsedLines[lineNumber - 1] || null;
+      }
+    }
+  }
+
+  return { primaryLabel, secondaryLabel };
+}

--- a/packages/bvaughn-architecture-demo/pages/variables.css
+++ b/packages/bvaughn-architecture-demo/pages/variables.css
@@ -98,6 +98,9 @@
   --context-menu-background-color-divider: var(--background-color-contrast-2);
   --context-menu-background-color-hover: var(--background-color-contrast-2);
 
+  --comment-card-source-preview-background-color: #081221;
+  --comment-card-source-preview-background-color-hover: #3e434a;
+
   --object-inspector-go-to-definition-icon-color: #dddddd;
   --object-inspector-go-to-definition-icon-color-hover: #ffffff;
   --object-inspector-invoke-getter-icon-color: #dddddd;
@@ -253,6 +256,9 @@
   --context-menu-background-color: var(--background-color-default);
   --context-menu-background-color-divider: var(--background-color-contrast-1);
   --context-menu-background-color-hover: var(--background-color-contrast-1);
+
+  --comment-card-source-preview-background-color: #f2f3f2;
+  --comment-card-source-preview-background-color-hover: #e6e6e6;
 
   --object-inspector-go-to-definition-icon-color: #222222;
   --object-inspector-go-to-definition-icon-color-hover: #000000;

--- a/packages/bvaughn-architecture-demo/src/graphql/types.ts
+++ b/packages/bvaughn-architecture-demo/src/graphql/types.ts
@@ -1,5 +1,3 @@
-import { SourceLocation } from "@replayio/protocol";
-
 export enum Nag {
   FIRST_LOG_IN = "first_log_in",
   FIRST_REPLAY_2 = "first_replay_2",
@@ -37,6 +35,13 @@ export type UserInfo = {
   features: { library: boolean };
 };
 
+export interface CommentSourceLocation {
+  sourceUrl: string;
+  line: number;
+  column: number;
+  sourceId: string;
+}
+
 interface Remark {
   content: string;
   createdAt: string;
@@ -44,7 +49,7 @@ interface Remark {
   id: string;
   isPublished: boolean;
   point: string;
-  sourceLocation: SourceLocation | null;
+  sourceLocation: CommentSourceLocation | null;
   time: number;
   updatedAt: string;
   user: User;

--- a/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SourcesCache.ts
@@ -102,6 +102,14 @@ export async function getSourcesAsync(client: ReplayClientInterface): Promise<Pr
   }
 }
 
+export async function getSourceAsync(
+  client: ReplayClientInterface,
+  sourceId: ProtocolSourceId
+): Promise<ProtocolSource | null> {
+  await getSourcesAsync(client);
+  return getSource(client, sourceId);
+}
+
 export function getSource(
   client: ReplayClientInterface,
   sourceId: ProtocolSourceId
@@ -123,6 +131,25 @@ export function getCachedSourceContents(
 ): StreamingSourceContents | null {
   const record = sourceIdToStreamingSourceContentsMap.get(sourceId);
   return record?.status === STATUS_RESOLVED ? record.value : null;
+}
+
+export async function getStreamingSourceContentsAsync(
+  client: ReplayClientInterface,
+  sourceId: ProtocolSourceId
+): Promise<StreamingSourceContents | null> {
+  try {
+    return getStreamingSourceContentsSuspense(client, sourceId);
+  } catch (errorOrPromise) {
+    if (
+      errorOrPromise != null &&
+      typeof errorOrPromise === "object" &&
+      errorOrPromise.hasOwnProperty("then")
+    ) {
+      return errorOrPromise as Promise<StreamingSourceContents>;
+    } else {
+      throw errorOrPromise;
+    }
+  }
 }
 
 export function getStreamingSourceContentsSuspense(

--- a/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
+++ b/packages/bvaughn-architecture-demo/src/suspense/SyntaxParsingCache.ts
@@ -44,11 +44,14 @@ export const { getValueSuspense: parse } = createGenericCache<
   string[] | null
 >(highlighter, identity);
 
-export const { getValueSuspense: parseStreaming, getValueAsync: parseStreamingAsync } =
-  createGenericCache<[source: StreamingSourceContents, maxTime?: number], StreamingParser | null>(
-    streamingSourceContentsToStreamingParser,
-    identity
-  );
+export const {
+  getValueAsync: parseStreamingAsync,
+  getValueSuspense: parseStreaming,
+  getValueIfCached: getParsedValueIfCached,
+} = createGenericCache<[source: StreamingSourceContents, maxTime?: number], StreamingParser | null>(
+  streamingSourceContentsToStreamingParser,
+  identity
+);
 
 let cachedElement: HTMLElement | null = null;
 

--- a/packages/bvaughn-architecture-demo/src/utils/source.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/source.ts
@@ -26,7 +26,11 @@ export function getSourceFileName(
 }
 
 function getSourceFileNameFromUrl(url: string): string | null {
-  const fileName = url.split("/")?.pop();
+  let fileName = url.split("/")?.pop();
+  if (fileName == "") {
+    fileName = "(index)";
+  }
+
   return fileName || null;
 }
 

--- a/packages/bvaughn-architecture-demo/src/utils/text.test.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/text.test.ts
@@ -1,0 +1,56 @@
+import { truncate } from "bvaughn-architecture-demo/src/utils/text";
+
+describe("text utils", () => {
+  describe("truncate", () => {
+    it("should not truncate strings shorter than the max length", () => {
+      expect(truncate("12345", { maxLength: 10 })).toEqual("12345");
+      expect(truncate("1234567890", { maxLength: 10 })).toEqual("1234567890");
+    });
+
+    it('should truncate strings at position: "start"', () => {
+      expect(truncate("1234567890", { maxLength: 5, position: "start" })).toEqual("…7890");
+      expect(truncate("1234567890", { maxLength: 6, position: "start" })).toEqual("…67890");
+
+      // Should account for longer truncation markers
+      expect(
+        truncate("1234567890", { maxLength: 6, position: "start", truncationMarker: "..." })
+      ).toEqual("...890");
+    });
+
+    it('should truncate strings at position: "end"', () => {
+      expect(truncate("1234567890", { maxLength: 5, position: "end" })).toEqual("1234…");
+      expect(truncate("1234567890", { maxLength: 6, position: "end" })).toEqual("12345…");
+
+      // Should account for longer truncation markers
+      expect(
+        truncate("1234567890", { maxLength: 6, position: "end", truncationMarker: "..." })
+      ).toEqual("123...");
+    });
+
+    it('should truncate strings at position: "middle"', () => {
+      // Should account for even and odd lengths
+      expect(truncate("1234567890", { maxLength: 5, position: "middle" })).toEqual("12…90");
+      expect(truncate("1234567890", { maxLength: 6, position: "middle" })).toEqual("123…90");
+
+      // Should account for longer truncation markers
+      expect(
+        truncate("1234567890", { maxLength: 5, position: "middle", truncationMarker: "..." })
+      ).toEqual("1...0");
+      expect(
+        truncate("1234567890", { maxLength: 6, position: "middle", truncationMarker: "..." })
+      ).toEqual("12...0");
+    });
+
+    it("edge case handling that should not occur", () => {
+      expect(truncate("123", { maxLength: 2, position: "start", truncationMarker: "..." })).toEqual(
+        "..."
+      );
+      expect(
+        truncate("123", { maxLength: 2, position: "middle", truncationMarker: "..." })
+      ).toEqual("...");
+      expect(truncate("123", { maxLength: 2, position: "end", truncationMarker: "..." })).toEqual(
+        "..."
+      );
+    });
+  });
+});

--- a/packages/bvaughn-architecture-demo/src/utils/text.ts
+++ b/packages/bvaughn-architecture-demo/src/utils/text.ts
@@ -1,0 +1,32 @@
+export function truncate(
+  text: string,
+  options: {
+    maxLength: number;
+    position?: "start" | "end" | "middle";
+    truncationMarker?: string;
+  }
+) {
+  const { maxLength, position = "end", truncationMarker = "…" } = options;
+
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const effectiveMaxLength = maxLength - truncationMarker.length;
+
+  switch (position) {
+    case "start":
+      return `${truncationMarker}${text.substring(text.length - effectiveMaxLength)}`;
+      break;
+    case "middle":
+      const startString = text.substring(0, Math.ceil(effectiveMaxLength / 2));
+      const endString = text.substring(text.length - Math.floor(effectiveMaxLength / 2));
+
+      return `${startString}${truncationMarker}${endString}`;
+      break;
+    case "end":
+    default:
+      return `${text.substring(0, effectiveMaxLength)}${truncationMarker}`;
+      break;
+  }
+}

--- a/src/devtools/client/debugger/src/utils/quick-open.ts
+++ b/src/devtools/client/debugger/src/utils/quick-open.ts
@@ -5,14 +5,14 @@
 import { Dictionary } from "@reduxjs/toolkit";
 import type { FunctionMatch, Location } from "@replayio/protocol";
 
+import { truncate as truncateText } from "bvaughn-architecture-demo/src/utils/text";
 import { SourceDetails } from "ui/reducers/sources";
 import { LoadingStatus } from "ui/utils/LoadingStatus";
 
 import { FunctionDeclaration, SymbolEntry } from "../reducers/ast";
 import { SearchTypes } from "../reducers/quick-open";
 import { memoizeLast } from "./memoizeLast";
-import { getSourceClassnames, getSourceQueryString, getTruncatedFileName } from "./source";
-import { endTruncateStr } from "./text";
+import { getSourceClassnames, getTruncatedFileName } from "./source";
 
 export const MODIFIERS: Record<string, SearchTypes> = {
   "@": "functions",
@@ -64,7 +64,7 @@ export function parseLineColumn(query: string) {
 function formatSourceForList(source: SourceDetails, tabUrls: Set<string>) {
   const title = getTruncatedFileName(source);
   // `source.url` now includes query strings already
-  const subtitle = endTruncateStr(source.url!, 100);
+  const subtitle = truncateText(source.url!, { maxLength: 100, position: "start" });
   const value = source.url!;
   return {
     value,

--- a/src/devtools/client/debugger/src/utils/source.ts
+++ b/src/devtools/client/debugger/src/utils/source.ts
@@ -4,14 +4,13 @@
 
 //
 
+import { truncate as truncateText } from "bvaughn-architecture-demo/src/utils/text";
 import { getUnicodeUrl } from "devtools/client/shared/unicode-url";
 import { MiniSource, SourceContent } from "ui/reducers/sources";
 import { LoadingStatus } from "ui/utils/LoadingStatus";
 
 import type { SymbolDeclarations } from "../reducers/ast";
 import { getURL } from "./sources-tree/getURL";
-import { truncateMiddleText } from "./text";
-import { endTruncateStr } from "./text";
 import { parse as parseURL } from "./url";
 
 export { isMinified } from "./isMinified";
@@ -134,7 +133,7 @@ function resolveFileURL(
   if (!truncate) {
     return name;
   }
-  return endTruncateStr(name, 50);
+  return truncateText(name, { maxLength: 50, position: "start" });
 }
 
 export function getFormattedSourceId(id: string) {
@@ -162,7 +161,10 @@ export function getFilename(
  * Provides a middle-trunated filename
  */
 export function getTruncatedFileName(source: MiniSource, querystring = "", length = 30) {
-  return truncateMiddleText(`${getFilename(source)}${querystring}`, length);
+  return truncateText(`${getFilename(source)}${querystring}`, {
+    maxLength: length,
+    position: "middle",
+  });
 }
 
 /* Gets path for files with same filename for editor tabs, breakpoints, etc.

--- a/src/devtools/client/debugger/src/utils/text.ts
+++ b/src/devtools/client/debugger/src/utils/text.ts
@@ -8,7 +8,9 @@
  * Utils for keyboard command strings
  * @module utils/text
  */
+
 import Services from "devtools/shared/services";
+
 const { appinfo } = Services;
 
 const isMacOS = appinfo.OS === "Darwin";
@@ -37,31 +39,4 @@ export function formatKeyShortcut(shortcut: string) {
   return shortcut
     .replace(/CommandOrControl\+|CmdOrCtrl\+/g, `${"Ctrl"}+`)
     .replace(/Shift\+/g, "Shift+");
-}
-
-/**
- * Truncates the received text to the maxLength in the format:
- * Original: 'this is a very long text and ends here'
- * Truncated: 'this is a ver...and ends here'
- * @param {String} sourceText - Source text
- * @param {Number} maxLength - Max allowed length
- * @memberof utils/text
- * @static
- */
-export function truncateMiddleText(sourceText: string, maxLength: number) {
-  let truncatedText = sourceText;
-  if (sourceText.length > maxLength) {
-    truncatedText = `${sourceText.substring(
-      0,
-      Math.round(maxLength / 2) - 2
-    )}…${sourceText.substring(sourceText.length - Math.round(maxLength / 2 - 1))}`;
-  }
-  return truncatedText;
-}
-
-export function endTruncateStr(str: string, size: number) {
-  if (str.length > size) {
-    return `…${str.slice(str.length - size)}`;
-  }
-  return str;
 }

--- a/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
+++ b/src/ui/components/Comments/TranscriptComments/NetworkRequestPreview.tsx
@@ -1,15 +1,16 @@
-import classNames from "classnames";
 import React from "react";
 
+import Icon from "bvaughn-architecture-demo/components/Icon";
 import { setSelectedPanel } from "ui/actions/layout";
 import { selectAndFetchRequest } from "ui/actions/network";
-import MaterialIcon from "ui/components/shared/MaterialIcon";
 import { getSummaryById } from "ui/reducers/network";
 import { getFocusRegion } from "ui/reducers/timeline";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { UIState } from "ui/state";
 import { trackEvent } from "ui/utils/telemetry";
 import { isInFocusSpan } from "ui/utils/timeline";
+
+import styles from "./styles.module.css";
 
 export default function NetworkRequestPreview({ networkRequestId }: { networkRequestId: string }) {
   const dispatch = useAppDispatch();
@@ -32,32 +33,16 @@ export default function NetworkRequestPreview({ networkRequestId }: { networkReq
 
   return (
     <div
+      className={isSeekEnabled ? styles.LabelGroup : styles.LabelGroupDisabled}
       onClick={isSeekEnabled ? onClick : undefined}
-      className={classNames(
-        "group rounded-md border-gray-200 bg-chrome px-2 py-0.5",
-        isSeekEnabled && "cursor-pointer hover:bg-themeTextFieldBgcolor"
-      )}
+      title={isSeekEnabled ? "Show in the Network Monitor" : undefined}
     >
-      <div className="mono flex flex-col font-medium">
-        <div className="flex w-full flex-row justify-between space-x-1">
-          <div
-            className="cm-s-mozilla space-x-2 overflow-hidden whitespace-pre font-mono text-xs"
-            style={{ fontSize: "11px" }}
-          >
-            <span className="font-bold">{`[${method}]`}</span>
-            <span>{name}</span>
-          </div>
-          <div
-            className={classNames(
-              "flex flex-shrink-0 opacity-0 transition",
-              isSeekEnabled && "group-hover:opacity-100"
-            )}
-            title="Show in the Network Monitor"
-          >
-            <MaterialIcon iconSize="sm">keyboard_arrow_right</MaterialIcon>
-          </div>
+      <div className={styles.Labels}>
+        <div className={styles.PrimaryLabel}>
+          <span className={styles.NetworkRequestMethod}>{`[${method}]`}</span> {name}
         </div>
       </div>
+      <Icon className={styles.Icon} type="chevron-right" />
     </div>
   );
 }

--- a/src/ui/components/Comments/TranscriptComments/styles.module.css
+++ b/src/ui/components/Comments/TranscriptComments/styles.module.css
@@ -1,0 +1,59 @@
+.LabelGroup,
+.LabelGroupDisabled {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 0.25rem;
+  background-color: var(--comment-card-source-preview-background-color);
+  border-radius: 0.25rem;
+  font-family: var(--font-family-monospace);
+}
+.LabelGroupDisabled {
+  cursor: default;
+}
+.LabelGroup {
+  cursor: pointer;
+}
+.LabelGroup:hover {
+  background-color: var(--comment-card-source-preview-background-color-hover);
+}
+.LabelGroup:hover .Icon {
+  visibility: visible;
+}
+
+.Labels {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  overflow: hidden;
+  padding: 0.25rem 0.5rem;
+  gap: 0.25rem;
+}
+
+.PrimaryLabel,
+.SecondaryLabel {
+  font-family: var(--font-family-monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.PrimaryLabel {
+  font-size: var(--font-size-tiny);
+}
+.SecondaryLabel {
+  margin: 0;
+  font-size: var(--font-size-regular);
+  color: var(--color-dim);
+}
+
+.Icon {
+  flex: 0 0 1rem;
+  width: 1rem;
+  height: 1rem;
+  visibility: hidden;
+}
+
+.NetworkRequestMethod {
+  font-weight: bold;
+  color: var(--color-dim);
+}


### PR DESCRIPTION
## [Loom overview of changes](https://www.loom.com/share/2ff47773d1f1478cbecdf38140b806f1)

- [x] Source code comments can be added to non-breakable lines.
- [x] Source code comment primary and secondary labels are now (once again) pre-generated and stored in GraphQL
  - [x] Just-in-time generation is still done for comments without labels
- [x] Source code comment preview format has been changed slightly to include both location (file name and line/column numbers) and source code

### Preview rendering
| Before | After |
|:---|:---|
|  <img width="305" alt="Screen Shot 2022-12-13 at 11 21 44 AM" src="https://user-images.githubusercontent.com/29597/207387545-b9cc0f72-187b-4e11-844a-bf06abe635ac.png"> |  <img width="326" alt="Screen Shot 2022-12-13 at 11 21 53 AM" src="https://user-images.githubusercontent.com/29597/207387548-c293e35b-fc14-44e3-a8f2-69c22fece892.png"> |

### Loading sequence
| Before | After |
|:---|:---|
| ![Kapture 2022-12-13 at 11 19 10](https://user-images.githubusercontent.com/29597/207386929-aff0d689-cc1f-48c7-ba1d-33d0b65e272e.gif) |  ![Kapture 2022-12-13 at 11 19 53](https://user-images.githubusercontent.com/29597/207387077-d0b9c813-e70d-4fe3-b4bd-de73095b6644.gif) |