### PR TITLE
Authenticate e2e sessions with apiKey if present

### DIFF
--- a/packages/e2e-tests/helpers/index.ts
+++ b/packages/e2e-tests/helpers/index.ts
@@ -1,9 +1,12 @@
 import { Page } from "@playwright/test";
 import chalk from "chalk";
+import dotenv from "dotenv";
 
 import { RecordingTarget } from "replay-next/src/suspense/BuildIdCache";
 
 import { debugPrint } from "./utils";
+
+dotenv.config({ path: "../../.env" });
 
 const exampleRecordings = require("../examples.json");
 
@@ -34,10 +37,14 @@ export async function openViewerTab(page: Page) {
   await tab.click();
 }
 
-export async function startTest(page: Page, example: string) {
+export async function startTest(page: Page, example: string, apiKey?: string) {
   const recordingId = exampleRecordings[example];
   const base = process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:8080";
-  const url = `${base}/recording/${recordingId}?e2e=1`;
+
+  let url = `${base}/recording/${recordingId}?e2e=1`;
+  if (apiKey) {
+    url += `&apiKey=${apiKey}`;
+  }
 
   await debugPrint(page, `Navigating to ${chalk.bold(url)}`, "startTest");
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -53,7 +53,7 @@ function handleAuthError() {
 
 function AppUtilities({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const { isAuthenticated, getAccessTokenSilently, error } = useAuth0();
+  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
 
   _handleAuthError = async () => {
     // This handler attempts to handle the scenario in which the frontend and

--- a/src/ui/components/DevTools.tsx
+++ b/src/ui/components/DevTools.tsx
@@ -184,7 +184,7 @@ function _DevTools({
 
   useEffect(() => {
     let token: Promise<TokenState | void> = Promise.resolve();
-    if (isAuthenticated && !isTest()) {
+    if (isAuthenticated) {
       token = tokenManager.getToken();
     }
 

--- a/src/ui/utils/tokenManager.tsx
+++ b/src/ui/utils/tokenManager.tsx
@@ -3,6 +3,7 @@ import jwt_decode from "jwt-decode";
 import React, { ReactNode } from "react";
 
 import { Deferred, assert, defer } from "protocol/utils";
+import { isTest } from "ui/utils/environment";
 
 import { getAuthClientId, getAuthHost } from "./auth";
 import { listenForAccessToken } from "./browser";
@@ -49,13 +50,17 @@ class TokenManager {
   private listeners: TokenListener[] = [];
 
   constructor() {
-    // if (isTest()) {
-    //   this.currentState = {
-    //     loading: false,
-    //     token: "E2E-TEST-TOKEN",
-    //   };
-    //   this.deferredState.resolve(this.currentState);
-    // }
+    if (isTest()) {
+      const url = new URL(window.location.href);
+      const apiKey = url.searchParams.get("apiKey");
+      if (apiKey) {
+        this.currentState = {
+          loading: false,
+          token: apiKey,
+        };
+        this.deferredState.resolve(this.currentState);
+      }
+    }
 
     if (typeof window !== "undefined") {
       listenForAccessToken(token => {


### PR DESCRIPTION
Follow up to #8347; should be sufficient to unblock authenticated e2e tests