### PR TITLE
Clicking eye icon in log point panel enables log point

### DIFF
--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.module.css
@@ -57,18 +57,16 @@
   align-items: center;
   gap: 1ch;
 }
-.ContentWrapper[data-logging-disabled] {
-  background-color: var(--point-panel-input-disabled-background-color);
-}
-.ContentWrapper:hover {
+.ContentWrapper[data-state-editable="true"]:hover {
   border-color: var(--point-panel-input-border-color-hover);
-}
-.ContentWrapper[data-logging-disabled] {
-  border-color: var(--point-panel-input-border-color);
 }
 .Panel[data-test-state="edit"] .ContentWrapper:focus,
 .Panel[data-test-state="edit"] .ContentWrapper:focus-within {
   border-color: var(--point-panel-input-border-color-focus);
+}
+.ContentWrapper[data-state-logging-enabled="false"] {
+  background-color: var(--point-panel-input-disabled-background-color);
+  border-color: var(--point-panel-input-border-color);
 }
 
 .ContentWrapperInvalid {
@@ -100,11 +98,12 @@
   flex-direction: row;
   align-items: center;
 
-  cursor: text;
-
   /* Firefox fixes */
   scrollbar-width: thin;
   scrollbar-color: var(--scroll-thumb-color) transparent;
+}
+.ContentWrapper[data-state-editable="true"] {
+  cursor: text;
 }
 .Content::-webkit-scrollbar {
   height: 0.5rem;
@@ -118,22 +117,27 @@
 
 .EditButton,
 .RemoveConditionalButton,
-.SaveButton {
+.SaveButton,
+.ToggleVisibilityButton {
   background: none;
   border: none;
   margin: 0;
   cursor: pointer;
+}
+.EditButton {
+  cursor: inherit;
 }
 .EditButton[data-invalid],
 .EditButton:disabled,
 .RemoveConditionalButton[data-invalid],
 .RemoveConditionalButton:disabled,
 .SaveButton[data-invalid],
-.SaveButton:disabled {
+.SaveButton:disabled .ToggleVisibilityButton:disabled {
   cursor: default;
 }
 
-.EditButton {
+.EditButton,
+.ToggleVisibilityButton {
   flex-grow: 0;
   flex-shrink: 0;
   display: flex;
@@ -142,7 +146,9 @@
   line-height: 1.5rem;
   color: var(--point-panel-input-edit-button-color);
 }
-.ContentWrapper:hover .EditButton {
+.ContentWrapper[data-state-editable="true"]:hover .EditButton,
+.EditButton:hover,
+.ToggleVisibilityButton:hover {
   color: var(--point-panel-input-edit-button-color-hover);
 }
 
@@ -164,7 +170,8 @@
   height: 1rem;
 }
 
-.EditButtonIcon {
+.EditButtonIcon,
+.ToggleVisibilityButtonIcon {
   height: 1rem;
   width: 1rem;
 }

--- a/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
+++ b/packages/replay-next/components/sources/log-point-panel/LogPointPanel.tsx
@@ -1,5 +1,6 @@
 import { TimeStampedPoint } from "@replayio/protocol";
 import {
+  MouseEvent,
   Suspense,
   unstable_useCacheRefresh as useCacheRefresh,
   useContext,
@@ -208,6 +209,13 @@ function PointPanelWithHitPoints({
     );
   };
 
+  const onClickEyeIcon = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    toggleShouldLog();
+  };
+
   let showTooManyPointsMessage = false;
   switch (hitPointStatus) {
     case "too-many-points-to-find":
@@ -307,7 +315,8 @@ function PointPanelWithHitPoints({
           <div className={styles.EditableContentWrapperRow}>
             <div
               className={isConditionValid ? styles.ContentWrapper : styles.ContentWrapperInvalid}
-              data-logging-disabled={!shouldLog || !editable || undefined}
+              data-state-editable={editable}
+              data-state-logging-enabled={shouldLog}
               data-test-name="PointPanel-ConditionalWrapper"
               onClick={
                 showTooManyPointsMessage && editable ? undefined : () => startEditing("condition")
@@ -382,7 +391,8 @@ function PointPanelWithHitPoints({
         ) : (
           <div
             className={isContentValid ? styles.ContentWrapper : styles.ContentWrapperInvalid}
-            data-logging-disabled={!shouldLog || !editable || undefined}
+            data-state-editable={editable}
+            data-state-logging-enabled={shouldLog}
             data-test-name="PointPanel-ContentWrapper"
             onClick={
               showTooManyPointsMessage && editable ? undefined : () => startEditing("content")
@@ -423,27 +433,27 @@ function PointPanelWithHitPoints({
                 <div className={styles.Content}>
                   <SyntaxHighlightedLine code={content} />
                 </div>
-                {editable ? (
-                  <button
-                    className={styles.EditButton}
-                    disabled={isPending}
-                    data-test-name="PointPanel-EditButton"
-                  >
-                    <Icon
-                      className={styles.EditButtonIcon}
-                      type={shouldLog ? "edit" : "toggle-off"}
-                    />
-                  </button>
-                ) : (
-                  <div className={styles.DisabledIconAndAvatar}>
-                    {shouldLog || <Icon className={styles.EditButtonIcon} type="toggle-off" />}
-                    <AvatarImage
-                      className={styles.CreatedByAvatar}
-                      src={user?.picture || undefined}
-                      title={user?.name || undefined}
-                    />
-                  </div>
-                )}
+                <div className={styles.DisabledIconAndAvatar}>
+                  {shouldLog || (
+                    <button className={styles.ToggleVisibilityButton} onClick={onClickEyeIcon}>
+                      <Icon className={styles.ToggleVisibilityButtonIcon} type="toggle-off" />
+                    </button>
+                  )}
+                  {editable && (
+                    <button
+                      className={styles.EditButton}
+                      data-test-name="PointPanel-EditButton"
+                      disabled={isPending}
+                    >
+                      <Icon className={styles.EditButtonIcon} type="edit" />
+                    </button>
+                  )}
+                  <AvatarImage
+                    className={styles.CreatedByAvatar}
+                    src={user?.picture || undefined}
+                    title={user?.name || undefined}
+                  />
+                </div>
               </>
             )}
           </div>


### PR DESCRIPTION
### [Loom overview of changes](https://www.loom.com/share/4fb38dd747e248e0a3cc0ba71bcfc323)

I think this is mostly a no-brainer good change, but there's an open question in my mind about the UX for the owner of the log point. (I would actually prefer that we remove the pencil icon entirely and just rely on cursor and hover border style changes to indicate "editable" but I realize that's more controversial.)

cc @jasonLaster, @jonbell-lot23 