### PR TITLE
Catch errors in consoleProps (FE-1555)

### DIFF
--- a/src/ui/components/TestSuite/suspense/consoleProps.ts
+++ b/src/ui/components/TestSuite/suspense/consoleProps.ts
@@ -79,7 +79,11 @@ export function getConsolePropsSuspense(client: ReplayClientInterface, step: Ann
         }
       }
     }
-  } catch {}
+  } catch (error) {
+    // TODO [FE-1555] RUN currently throws in some cases;
+    // degrade gracefully in this case by just disabling the details panel
+    console.error(error);
+  }
 
   return {
     consoleProps: undefined,


### PR DESCRIPTION
@bvaughn FE-1555 seems to be caused by a command error thrown by `framesCache.read()` in `getConsolePropsSuspense()`. I wasn't sure if this is the right place to handle errors from that function, I tried adding `<ErrorBoundary>`s at first but there are several places that use this and at some point I gave up finding them all.
I'm going to log off for today so feel free to merge if you approve.