### PR TITLE
Use commit fiber react annotation type to show React button (FE-1696)

### DIFF
--- a/src/ui/components/SecondaryToolbox/index.tsx
+++ b/src/ui/components/SecondaryToolbox/index.tsx
@@ -15,7 +15,7 @@ import { getSelectedPanel, getToolboxLayout } from "ui/reducers/layout";
 import { useAppDispatch, useAppSelector } from "ui/setup/hooks";
 import { SecondaryPanelName } from "ui/state/layout";
 import {
-  REACT_ANNOTATIONS_KIND,
+  REACT_ANNOTATIONS_COMMIT_KIND,
   REDUX_SETUP_ANNOTATIONS_KIND,
   annotationKindsCache,
 } from "ui/suspense/annotationsCaches";
@@ -155,7 +155,7 @@ function SecondaryToolbox() {
   const { value: hasReactAnnotations = false } = useImperativeCacheValue(
     annotationKindsCache,
     replayClient,
-    REACT_ANNOTATIONS_KIND
+    REACT_ANNOTATIONS_COMMIT_KIND
   );
 
   const { value: hasReduxAnnotations = false } = useImperativeCacheValue(

--- a/src/ui/suspense/annotationsCaches.ts
+++ b/src/ui/suspense/annotationsCaches.ts
@@ -32,6 +32,7 @@ export interface ParsedJumpToCodeAnnotation extends TimeStampedPoint {
 }
 
 export const REACT_ANNOTATIONS_KIND = "react-devtools-bridge";
+export const REACT_ANNOTATIONS_COMMIT_KIND = "react-devtools-hook:v1:commit-fiber-root";
 export const REDUX_SETUP_ANNOTATIONS_KIND = "redux-devtools-setup";
 export const REDUX_ANNOTATIONS_KIND = "redux-devtools-data";
 export const JUMP_ANNOTATION_KIND = "event-listeners-jump-location";


### PR DESCRIPTION
Related to [FE-1696](https://linear.app/replay/issue/FE-1696), uses the pre processing `react-devtools-hook:v1:commit-fiber-root` annotation kind instead of `react-devtools-bridge` to remove the delay.