### PR TITLE
accept a linux build filename when manually starting a test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,8 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      runtimeBuildId:
-        description: "Runtime build ID (include a leading dash if non-empty)"
+      linuxBuildFile:
+        description: "Linux Chromium Build File (.tar.xz)"
   push:
     branches:
       - main
@@ -93,7 +93,7 @@ jobs:
       - name: Install Replay Playwright
         run: npx @replayio/playwright install
         env:
-          RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE: linux-chromium${{ github.event.inputs.runtimeBuildId }}.tar.xz
+          RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE: ${{ github.event.inputs.linuxBuildFile }}
       - uses: replayio/action-playwright@main
         with:
           command: npx playwright test --shard ${{ matrix.shard }}/10 --reporter=@replayio/playwright/reporter,line tests/*.ts


### PR DESCRIPTION
There's documentation online for adding fields that GH will synthesize a UI from [here](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/).  This should let us kick off a manual test run where the e2e tests are run with the supplied chromium build.

Starting from this page: https://github.com/replayio/devtools/actions/workflows/test.yml

manually running the `test.yml` workflow from this branch I see:
![image](https://github.com/replayio/devtools/assets/24245/83233018-4004-4a82-bf4a-7cd8b729737c)

If I then enter the following (from https://buildkite.com/replay/chromium-build/builds/2564)
`linux-chromium-20231207-cde6ff4c667b-ad0834963a29.tar.xz`, when the workflow goes to download the browser, it fetches the correct build.

![image](https://github.com/replayio/devtools/assets/24245/89015fa7-6009-40cb-a85f-4d7c2c4bef5f)
