### PR TITLE
Extend focus window to contain the entire range of the selected test step

### DIFF
--- a/packages/shared/test-suites/RecordingTestMetadata.ts
+++ b/packages/shared/test-suites/RecordingTestMetadata.ts
@@ -13,6 +13,7 @@ import { insert } from "replay-next/src/utils/array";
 import { assertWithTelemetry, recordData } from "replay-next/src/utils/telemetry";
 import { ReplayClientInterface } from "shared/client/types";
 import { Annotation, PlaywrightTestSources, PlaywrightTestStacks } from "shared/graphql/types";
+import { maxTimeStampedPoint, minTimeStampedPoint } from "shared/utils/time";
 import {
   AnnotationsCache,
   PlaywrightAnnotationsCache,
@@ -1099,6 +1100,16 @@ export function getTestEventExecutionPoint(
 
 export function getTestEventTime(testEvent: RecordingTestMetadataV3.TestEvent): number | null {
   return getTestEventTimeStampedPoint(testEvent)?.time ?? null;
+}
+
+export function getUserActionEventRange(
+  userActionEvent: RecordingTestMetadataV3.UserActionEvent
+): TimeStampedPointRange {
+  const { afterStep, beforeStep, result, viewSource } = userActionEvent.data.timeStampedPoints;
+  return {
+    begin: minTimeStampedPoint([afterStep, beforeStep, result, viewSource])!,
+    end: maxTimeStampedPoint([afterStep, beforeStep, result, viewSource])!,
+  };
 }
 
 export function isGroupedTestCasesV1(

--- a/packages/shared/utils/time.ts
+++ b/packages/shared/utils/time.ts
@@ -1,7 +1,32 @@
-import { ExecutionPoint, PointRange, TimeStampedPointRange } from "@replayio/protocol";
+import {
+  ExecutionPoint,
+  PointRange,
+  TimeStampedPoint,
+  TimeStampedPointRange,
+} from "@replayio/protocol";
 
 const supportsPerformanceNow =
   typeof performance !== "undefined" && typeof performance.now === "function";
+
+export function minTimeStampedPoint(points: (TimeStampedPoint | null)[]): TimeStampedPoint | null {
+  let min: TimeStampedPoint | null = null;
+  for (const point of points) {
+    if (point) {
+      min = min === null ? point : BigInt(point.point) < BigInt(min.point) ? point : min;
+    }
+  }
+  return min;
+}
+
+export function maxTimeStampedPoint(points: (TimeStampedPoint | null)[]): TimeStampedPoint | null {
+  let max: TimeStampedPoint | null = null;
+  for (const point of points) {
+    if (point) {
+      max = max === null ? point : BigInt(point.point) > BigInt(max.point) ? point : max;
+    }
+  }
+  return max;
+}
 
 export function isRangeInRegions(
   range: TimeStampedPointRange | PointRange,


### PR DESCRIPTION
Fixes FE-2141.
We had already fixed a similar issue (FE-1756) but that fix only ensured that the `beforeStep` point is in the focus window. For FE-2141 we need to ensure that the `viewSource` point is also in the focus window.