### PR TITLE
Add back missing fields to GetTestRunRecordings graphql

### DIFF
--- a/src/ui/components/Library/Team/View/TestRuns/graphql/TestRunsGraphQL.ts
+++ b/src/ui/components/Library/Team/View/TestRuns/graphql/TestRunsGraphQL.ts
@@ -52,6 +52,8 @@ const GET_TEST_RUN_RECORDINGS = gql`
                 result
                 errors
                 durationMs
+                index
+                attempt
                 executions {
                   result
                   recordings {


### PR DESCRIPTION
`index` and `attempt` are expected for the tests within a test run but were dropped from the graphql for fetching test runs