### PR TITLE
Fix cypress-01 e2e test

### DIFF
--- a/packages/e2e-tests/tests/cypress-01_basic-panel.test.ts
+++ b/packages/e2e-tests/tests/cypress-01_basic-panel.test.ts
@@ -75,7 +75,8 @@ test("cypress-01: Basic Test Suites panel functionality", async ({
 
   // Relative dates can change over time.
   // Check for either the "X units ago" text, or the literal date.
-  expect(await getTestSuiteDate(page).textContent()).toMatch(/ ago|(2\/12\/2023)/);
+  // But in order to account for timezone differences, we just check the year.
+  expect(await getTestSuiteDate(page).textContent()).toMatch(/ ago|\/2024/);
   expect(await getTestSuiteUser(page).textContent()).toMatch("ryanjduffy");
   expect(await getTestSuiteBranch(page).textContent()).toMatch("main");
   expect(await getTestSuiteDuration(page).textContent()).toMatch("0:11");


### PR DESCRIPTION
This test was re-recorded about two weeks ago (#10302) and for a while this check passed because the test date was displayed in relative units:
```js
expect(await getTestSuiteDate(page).textContent()).toMatch(/ ago|(2\/12\/2023)/);
```

But our formatter changed to showing the absolute date format after two weeks:
```js
// Show relative time if under 2 weeks, otherwise, use the template below.
if (daysSince > 14) {
  content = formatter.format(new Date(date));
}
```

And then the test began failing because it had been re-recorded in 2024. Unfortunately the error from CI showed:
> Expected pattern: / ago|(2/12/2023)/
> Received string:  "schedule2/12/2024"

But when I ran the test locally it failed with:
> Expected pattern: / ago|(2/12/2023)/
> Received string:  "schedule2/11/2024"

I attribute this to timezone differences between our CI and myself, so I have changed the check to only look for the year (2024) which is about as useful/useless as the "ago" check was before 🤷🏼 