### PR TITLE
Remove redundant `key` from `FrameTimeline`

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/FrameTimeline.tsx
@@ -271,7 +271,6 @@ export default function FrameTimelineSuspenseWrapper() {
   const selectedFrameId = useAppSelector(getSelectedFrameId);
   return (
     <Suspense
-      key={selectedFrameId ? `${selectedFrameId.pauseId}:${selectedFrameId.frameId}` : null}
       fallback={
         <div
           data-tip="Frame Progress"


### PR DESCRIPTION
As @bvaughn observed [here](https://github.com/replayio/devtools/pull/10502#discussion_r1578079781) the fix wasn't strictly related to adding a `key` but rather just to triggering a new render here. That's already covered by passing new props to `FrameTimeline` so the `key` is redundant. 

I tested this locally in the same way as I did with the previous PR - by mocking this situation in code.