### PR TITLE
Fix flaky logpoints-07 + retry example uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ test/.yarn/
 videos/
 .vercel
 packages/e2e-tests/test-results/
+
+dist
+tmp.*
+tmp/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "next build",
     "lint": "trunk check",
     "lint:fix": "trunk check --fix",
-    "typecheck": "tsc",
+    "typecheck": "tsc --no-emit",
     "checks": "npm run typecheck && npm run lint",
     "typecheck:watch": "yarn typecheck --watch",
     "gql:schema": "gq https://graphql.replay.io/v1/graphql -H \"X-Hasura-Admin-Secret: $HASURA_KEY\" --introspect > schema.graphql",
@@ -240,5 +240,6 @@
       "parser": "typescript",
       "style": "replay"
     }
-  }
+  },
+  "packageManager": "yarn@4.9.1+sha512.f95ce356460e05be48d66401c1ae64ef84d163dd689964962c6888a9810865e39097a5e9de748876c2e0bf89b232d583c33982773e9903ae7a76257270986538"
 }

--- a/packages/e2e-tests/helpers/source-panel.ts
+++ b/packages/e2e-tests/helpers/source-panel.ts
@@ -719,6 +719,31 @@ export async function waitForSourceLineHitCounts(page: Page, lineNumber: number)
   });
 }
 
+// Pretty-printing a generated source can shift a statement between adjacent lines
+// (blank-line placement differs between the V8 and js-beautify engines). Resolve the
+// candidate line that actually has hits so tests don't hardcode one layout.
+export async function findLineWithHits(page: Page, candidateLineNumbers: number[]): Promise<number> {
+  let lineWithHits: number | null = null;
+
+  await waitFor(async () => {
+    for (const lineNumber of candidateLineNumbers) {
+      await scrollUntilLineIsVisible(page, lineNumber);
+      await waitForSourceLineHitCounts(page, lineNumber);
+
+      const lineLocator = await getSourceLine(page, lineNumber);
+      const hasHits = await lineLocator.getAttribute("data-test-line-has-hits");
+      if (hasHits === "true") {
+        lineWithHits = lineNumber;
+        return;
+      }
+    }
+
+    throw Error(`None of the candidate lines ${candidateLineNumbers.join(", ")} have hits`);
+  });
+
+  return lineWithHits!;
+}
+
 // TODO [FE-626] Rewrite this helper to reduce complexity.
 export async function waitForSelectedSource(page: Page, url: string) {
   await waitFor(async () => {

--- a/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
+++ b/packages/e2e-tests/scripts/buildkite_run_fe_tests.ts
@@ -9,6 +9,7 @@ import difference from "lodash/difference";
 import size from "lodash/size";
 
 import { getSecret } from "./aws_secrets";
+import { withExponentialBackoff } from "./exponential-backoff";
 import { ExampleInfo, getStats } from "./get-stats";
 
 const CONFIG = {
@@ -312,19 +313,23 @@ export default async function run_fe_tests(
     console.time("SAVE-EXAMPLES time");
     {
       const examplesCfg = exampleFiles?.length ? ` --example=${exampleFiles.join(",")}` : "";
-      execSync(
-        `${envWrapper} ${path.join(
-          "scripts/save-examples.ts"
-        )} --runtime=chromium --target=browser ${examplesCfg}`,
-        {
-          cwd: TestRootPath,
-          stdio: "inherit",
-          env: {
-            ...process.env,
-            // Run the tests against the local dev server.
-            PLAYWRIGHT_TEST_BASE_URL: "http://localhost:3000",
-          },
-        }
+      const saveExamplesCmd = `${envWrapper} ${path.join(
+        "scripts/save-examples.ts"
+      )} --runtime=chromium --target=browser ${examplesCfg}`;
+
+      await withExponentialBackoff(
+        async () =>
+          execSync(saveExamplesCmd, {
+            cwd: TestRootPath,
+            stdio: "inherit",
+            env: {
+              ...process.env,
+              // Run the tests against the local dev server.
+              PLAYWRIGHT_TEST_BASE_URL: "http://localhost:3000",
+            },
+          }),
+        1000,
+        3
       );
 
       // Without the wait, the next xvfb-run command can fail.

--- a/packages/e2e-tests/scripts/exponential-backoff.ts
+++ b/packages/e2e-tests/scripts/exponential-backoff.ts
@@ -1,0 +1,24 @@
+export async function withExponentialBackoff<T>(
+  fn: () => Promise<T>,
+  baseBackoffMillis: number,
+  maxAttempts: number,
+  isRetryableError?: (e: unknown) => boolean
+): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    try {
+      return await fn();
+    } catch (e) {
+      attempt++;
+      if (
+        (typeof isRetryableError === "function" && !isRetryableError(e)) ||
+        attempt >= maxAttempts
+      ) {
+        throw e;
+      }
+      const delay = 2 ** attempt * (baseBackoffMillis / 2);
+      const jitter = Math.random() * (baseBackoffMillis / 2);
+      await new Promise(r => setTimeout(r, delay + jitter));
+    }
+  }
+}

--- a/packages/e2e-tests/tests/logpoints-07.test.ts
+++ b/packages/e2e-tests/tests/logpoints-07.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   addLogpoint,
   editLogPoint,
+  findLineWithHits,
   toggleMappedSources,
   verifyLogPointContentTypeAheadSuggestions,
 } from "../helpers/source-panel";
@@ -42,8 +43,10 @@ test(`logpoints-07: should use the correct scope in auto-complete`, async ({
   await toggleMappedSources(page, "off");
   await delay(1000);
 
-  // We expect that this line in the minified bundle will have hits.
-  lineNumber = 20;
+  // We expect the hit body in the minified bundle to land on line 20 or 21,
+  // depending on how the generated source was pretty-printed (blank-line
+  // placement differs between the V8 and js-beautify engines).
+  lineNumber = await findLineWithHits(page, [20, 21]);
 
   await addLogpoint(page, { lineNumber });
   await editLogPoint(page, { content: "set", lineNumber, saveAfterEdit: false });


### PR DESCRIPTION
# Fix flaky logpoints-07 + retry example uploads

## G1: logpoints-07 — resolve pretty-printed hit line dynamically

* `logpoints-07` hardcoded generated **pp** line `20` for hit counts after `toggleMappedSources("off")`.
  * **pp** = pretty-printed generated source from the backend source worker.
* The same bundle pretty-prints with different blank-line placement, shifting the hit body between line 20 and 21.
  * Divergence stems from `prettyPrintSource` engine choice.
    * V8 (`PrettyPrintNode`): no blank before the function; body on line 20.
    * js-beautify fallback: blank before the function; body on line 21.
  * Test failed whenever the layout put the function signature (no hits) on line 20.
* Fix
  * New `findLineWithHits` helper waits for and returns whichever candidate line actually has hits.
  * Test now passes `[20, 21]` instead of hardcoding `20`.

## G2: buildkite_run_fe_tests — retry example uploads

* `save-examples` upload failed intermittently under burst activity.
  * Cause: transient connectivity during bursts.
* Fix
  * Wrap the `save-examples` invocation in new `withExponentialBackoff` helper.
    * 3 attempts, 1s base, jittered.

## G3: Incidental tooling

* `package.json`
  * `typecheck` uses `tsc --no-emit`.
  * Pin `packageManager` to yarn 4.9.1.
* `.gitignore`
  * Ignore `dist`, `tmp.*`, `tmp/`.
