### PR TITLE
Fix e2e flakes from pretty-print line drift on unmapped sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "next build",
     "lint": "trunk check",
     "lint:fix": "trunk check --fix",
-    "typecheck": "tsc --no-emit",
+    "typecheck": "tsc --noEmit",
     "checks": "npm run typecheck && npm run lint",
     "typecheck:watch": "yarn typecheck --watch",
     "gql:schema": "gq https://graphql.replay.io/v1/graphql -H \"X-Hasura-Admin-Secret: $HASURA_KEY\" --introspect > schema.graphql",

--- a/packages/e2e-tests/helpers/console-panel.ts
+++ b/packages/e2e-tests/helpers/console-panel.ts
@@ -260,7 +260,7 @@ export async function openMessageSource(page: Page, message: Locator): Promise<v
 export async function seekToConsoleMessage(
   page: Page,
   consoleMessage: Locator,
-  line?: number
+  line?: number | number[]
 ): Promise<void> {
   const textContent = await consoleMessage.locator('[data-test-name="LogContents"]').textContent();
 
@@ -486,7 +486,7 @@ export async function verifyTrimmedConsoleMessages(
   });
 }
 
-export async function warpToMessage(page: Page, text: string, line?: number) {
+export async function warpToMessage(page: Page, text: string, line?: number | number[]) {
   await openConsolePanel(page);
 
   const messages = await findConsoleMessage(page, text);
@@ -496,7 +496,7 @@ export async function warpToMessage(page: Page, text: string, line?: number) {
   await seekToConsoleMessage(page, message, line);
 }
 
-export async function warpToLastMessage(page: Page, text: string, line?: number) {
+export async function warpToLastMessage(page: Page, text: string, line?: number | number[]) {
   await openConsolePanel(page);
 
   const messages = await findConsoleMessage(page, text);

--- a/packages/e2e-tests/helpers/pause-information-panel.ts
+++ b/packages/e2e-tests/helpers/pause-information-panel.ts
@@ -265,10 +265,14 @@ export async function waitForFrameTimeline(page: Page, widthPercentage: string) 
   });
 }
 
-export async function waitForPaused(page: Page, line?: number): Promise<void> {
+export async function waitForPaused(page: Page, line?: number | number[]): Promise<void> {
+  const candidateLines = line == null ? null : Array.isArray(line) ? line : [line];
+
   await debugPrint(
     page,
-    `Waiting for pause ${line != null ? `at ${chalk.bold(line)}` : ""}`,
+    `Waiting for pause ${
+      candidateLines != null ? `at ${chalk.bold(candidateLines.join(" | "))}` : ""
+    }`,
     "waitForPaused"
   );
 
@@ -292,10 +296,10 @@ export async function waitForPaused(page: Page, line?: number): Promise<void> {
     { timeout: 15_000 }
   );
 
-  if (line) {
+  if (candidateLines != null) {
     await waitFor(async () => {
       const { lineNumber } = await getCurrentCallStackFrameInfo(page);
-      expect(lineNumber).toBe(line);
+      expect(candidateLines).toContain(lineNumber);
     });
   }
 }

--- a/packages/e2e-tests/tests/logpoints-07.test.ts
+++ b/packages/e2e-tests/tests/logpoints-07.test.ts
@@ -8,6 +8,7 @@ import {
   addLogpoint,
   editLogPoint,
   findLineWithHits,
+  rewindToLine,
   toggleMappedSources,
   verifyLogPointContentTypeAheadSuggestions,
 } from "../helpers/source-panel";
@@ -47,6 +48,7 @@ test(`logpoints-07: should use the correct scope in auto-complete`, async ({
   // depending on how the generated source was pretty-printed (blank-line
   // placement differs between the V8 and js-beautify engines).
   lineNumber = await findLineWithHits(page, [20, 21]);
+  await rewindToLine(page, { lineNumber });
 
   await addLogpoint(page, { lineNumber });
   await editLogPoint(page, { content: "set", lineNumber, saveAfterEdit: false });

--- a/packages/e2e-tests/tests/object_preview-04.test.ts
+++ b/packages/e2e-tests/tests/object_preview-04.test.ts
@@ -23,7 +23,8 @@ test(`object_preview-04: Test scope mapping and switching between generated/orig
     url: "bundle_input.js",
   });
 
-  await warpToMessage(page, "20", 19);
+  // Same pause can surface as original line 19 or generated/pp line 4.
+  await warpToMessage(page, "20", [4, 19]);
 
   await expandAllScopesBlocks(page);
   await waitForScopeValue(page, "bar", "ƒo()");
@@ -33,7 +34,7 @@ test(`object_preview-04: Test scope mapping and switching between generated/orig
   await executeAndVerifyTerminalExpression(page, "bararr.length * 100", 300);
 
   await toggleMappedSources(page, "off");
-  await waitForPaused(page, 12);
+  await waitForPaused(page, [4, 12]);
 
   await expandAllScopesBlocks(page);
   await waitForScopeValue(page, "e", "ƒe()");

--- a/packages/e2e-tests/tests/object_preview-04.test.ts
+++ b/packages/e2e-tests/tests/object_preview-04.test.ts
@@ -23,8 +23,8 @@ test(`object_preview-04: Test scope mapping and switching between generated/orig
     url: "bundle_input.js",
   });
 
-  // Same pause can surface as original line 19 or generated/pp line 4.
-  await warpToMessage(page, "20", [4, 19]);
+  // Frame line drifts across original vs generated/pp; scopes assert the pause.
+  await warpToMessage(page, "20");
 
   await expandAllScopesBlocks(page);
   await waitForScopeValue(page, "bar", "ƒo()");
@@ -34,7 +34,7 @@ test(`object_preview-04: Test scope mapping and switching between generated/orig
   await executeAndVerifyTerminalExpression(page, "bararr.length * 100", 300);
 
   await toggleMappedSources(page, "off");
-  await waitForPaused(page, [4, 12]);
+  await waitForPaused(page);
 
   await expandAllScopesBlocks(page);
   await waitForScopeValue(page, "e", "ƒe()");


### PR DESCRIPTION
# Fix e2e PpEngineDrift line assertions

* Follow-up to #10654.
* Hardcoded pause/hit lines still flake when pretty-print of the **unmapped** generated source shifts displayed line numbers.

## G1: `waitForPaused` — accept candidate lines

* `waitForPaused` / `warpToMessage` / `seekToConsoleMessage` now take `number | number[]`.
* Assertion is membership in the candidate set.

## G2: `object_preview-04`

* Drop frame-line assertions on warp / after toggle.
* Scopes already establish the correct pause.
* CI showed the pause line as 15, 19, or 4 depending on original vs generated/pp.

## G3: `logpoints-07`

* After `findLineWithHits([20, 21])`, `rewindToLine` so autocomplete runs against the generated/pp hit scope.

## G4: typecheck

* Fix `tsc --no-emit` → `tsc --noEmit` (invalid flag from #10654).