### PR TITLE
Allow jump-to-code-01 nav seek to round to 1%

### DIFF
--- a/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
+++ b/packages/e2e-tests/tests/jump-to-code-01_basic.test.ts
@@ -136,7 +136,7 @@ test(`jump-to-code-01: Test basic jumping functionality`, async ({
   await navigationEvent.click();
   await waitFor(async () => {
     const timelinePercent = await getTimelineCurrentPercent(page);
-    expect(Math.round(timelinePercent)).toBe(0);
+    expect(Math.round(timelinePercent)).toBeLessThanOrEqual(1);
   });
 
   debugPrint(page, "Checking that the first keypress J2C jumps to the correct line");


### PR DESCRIPTION
* `jump-to-code-01` treats a navigation-event seek as start-of-recording.
* `Math.round` of timeline percent expected `0`.

## Timeline percent rounding

* CI re-records the example each run.
* Observed seek: `13 / 2496` ms → `0.52%` → `Math.round` → `1`.
* Same test already treats later J2C percents as timing-dependent.
* Assert now `toBeLessThanOrEqual(1)`.

Made with [Cursor](https://cursor.com)